### PR TITLE
fix: proper compare interface name and interface ips

### DIFF
--- a/device-discovery/README.md
+++ b/device-discovery/README.md
@@ -5,11 +5,11 @@ Orb device discovery backend
 ```bash
 usage: device-discovery [-h] [-V] [-s HOST] [-p PORT] -t DIODE_TARGET -k DIODE_API_KEY
 
-Orb Discovery Backend
+Orb Device Discovery Backend
 
 options:
   -h, --help            show this help message and exit
-  -V, --version         Display Discovery, NAPALM and Diode SDK versions
+  -V, --version         Display Device Discovery, NAPALM and Diode SDK versions
   -s HOST, --host HOST  Server host
   -p PORT, --port PORT  Server port
   -t DIODE_TARGET, --diode-target DIODE_TARGET

--- a/device-discovery/device_discovery/__init__.py
+++ b/device-discovery/device_discovery/__init__.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 # Copyright 2024 NetBox Labs Inc
-"""NetBox Labs - Orb Discovery namespace."""
+"""NetBox Labs - Device Discovery namespace."""

--- a/device-discovery/device_discovery/main.py
+++ b/device-discovery/device_discovery/main.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2024 NetBox Labs Inc
-"""Orb Discovery entry point."""
+"""Device Discovery entry point."""
 
 import argparse
 import os
@@ -21,14 +21,14 @@ def main():
 
     Parses command-line arguments and starts the backend.
     """
-    parser = argparse.ArgumentParser(description="Orb Discovery Backend")
+    parser = argparse.ArgumentParser(description="Orb Device Discovery Backend")
     parser.add_argument(
         "-V",
         "--version",
         action="version",
-        version=f"Discovery version: {version_semver()}, NAPALM version: {version('napalm')}, "
+        version=f"Device Discovery version: {version_semver()}, NAPALM version: {version('napalm')}, "
         f"Diode SDK version: {SdkVersion.version_semver()}",
-        help="Display Discovery, NAPALM and Diode SDK versions",
+        help="Display Device Discovery, NAPALM and Diode SDK versions",
     )
     parser.add_argument(
         "-s",

--- a/device-discovery/device_discovery/policy/manager.py
+++ b/device-discovery/device_discovery/policy/manager.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2024 NetBox Labs Inc
-"""Orb Discovery Policy Manager."""
+"""Device Discovery Policy Manager."""
 
 import logging
 import os

--- a/device-discovery/device_discovery/policy/models.py
+++ b/device-discovery/device_discovery/policy/models.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2024 NetBox Labs Inc
-"""Orb Discovery Policy Models."""
+"""Device Discovery Policy Models."""
 
 from enum import Enum
 from typing import Any

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2024 NetBox Labs Inc
-"""Orb Discovery Policy Runner."""
+"""Device Discovery Policy Runner."""
 
 import logging
 import uuid

--- a/device-discovery/device_discovery/server.py
+++ b/device-discovery/device_discovery/server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # Copyright 2024 NetBox Labs Inc
-"""Orb Discovery Server."""
+"""Device Discovery Server."""
 
 
 from contextlib import asynccontextmanager

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -166,7 +166,7 @@ def translate_interface_ips(
     ip_entities = []
 
     for if_ip_name, ip_info in interfaces_ip.items():
-        if interface.name in if_ip_name:
+        if interface.name == if_ip_name:
             for ip_version, default_prefix in (("ipv4", 32), ("ipv6", 128)):
                 for ip, details in ip_info.get(ip_version, {}).items():
                     ip_address = f"{ip}/{details.get('prefix_length', default_prefix)}"


### PR DESCRIPTION
Proper compare interface name and interface ips

### Code Updates:

* Fixed a bug in `translate_interface_ips` to correctly compare interface names using `==` instead of `in`. (`device-discovery/device_discovery/translate.py`)

### Renaming Components:

* Updated the README to reflect the new name "Orb Device Discovery Backend" and corrected the version display description. (`device-discovery/README.md`)
* Changed the namespace and entry point descriptions from "Orb Discovery" to "Device Discovery" in the `__init__.py` and `main.py` files. (`device-discovery/device_discovery/__init__.py`, `device-discovery/device_discovery/main.py`) [[1]](diffhunk://#diff-e0d1cfc0122fcfab0b83ba9a216adf777f20d383ab0fb57614da48f507a8aaddL3-R3) [[2]](diffhunk://#diff-1999bab46324c3ee0f3648305dd694f66fea0998ed4e291ba704b6d4b9598faaL3-R3) [[3]](diffhunk://#diff-1999bab46324c3ee0f3648305dd694f66fea0998ed4e291ba704b6d4b9598faaL24-R31)
* Renamed policy manager, models, and runner descriptions to "Device Discovery." (`device-discovery/device_discovery/policy/manager.py`, `device-discovery/device_discovery/policy/models.py`, `device-discovery/device_discovery/policy/runner.py`) [[1]](diffhunk://#diff-c8715c972ae43ba4cd45bd2bb597597f0a2242b48b232aeeff05795199d04724L3-R3) [[2]](diffhunk://#diff-6a336230783aebcdf213f14e3c6628fe4b4c705e8e65a7367e072ea77836b684L3-R3) [[3]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fL3-R3)
* Updated the server description to "Device Discovery Server." (`device-discovery/device_discovery/server.py`)

### Test Enhancements:

* Added a new interface to the sample device info and adjusted the sample interface info to include the new interface. (`device-discovery/tests/test_translate.py`) [[1]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4L27-R27) [[2]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R41-R47) [[3]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4L62-R69)
* Updated test cases to verify the translation of the new interface data. (`device-discovery/tests/test_translate.py`) [[1]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R154-R166) [[2]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4L167-R192)