### PR TITLE
fix: submodules drivers load for custom napalm packages

### DIFF
--- a/device-discovery/pyproject.toml
+++ b/device-discovery/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "croniter~=5.0",
     "fastapi~=0.115",
     "httpx~=0.27",
-    "importlib-metadata~=8.5",
     "napalm~=5.0",
     "netboxlabs-diode-sdk~=0.4",
     "pydantic~=2.9",

--- a/device-discovery/tests/test_discovery.py
+++ b/device-discovery/tests/test_discovery.py
@@ -7,12 +7,14 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+from napalm.base.base import NetworkDriver
 
 from device_discovery.discovery import (
     discover_device_driver,
     napalm_driver_list,
     set_napalm_logs_level,
     supported_drivers,
+    walk_napalm_packages,
 )
 
 
@@ -22,12 +24,11 @@ def mock_get_network_driver():
     with patch("device_discovery.discovery.get_network_driver") as mock:
         yield mock
 
+
 @pytest.fixture
-def mock_importlib_metadata_packages_distributions():
-    """Mock the importlib_metadata.packages_distributions function."""
-    with patch(
-        "device_discovery.discovery.importlib_metadata.packages_distributions"
-    ) as mock:
+def mock_packages_distributions():
+    """Mock the importlib.metadata.packages_distributions function."""
+    with patch("device_discovery.discovery.packages_distributions") as mock:
         yield mock
 
 
@@ -36,6 +37,20 @@ def mock_loggers():
     """Mock the logging.getLogger function for various loggers."""
     with patch("device_discovery.discovery.logging.getLogger") as mock:
         yield mock
+
+
+@pytest.fixture
+def mock_import_module():
+    """Fixture to mock import_module."""
+    with patch("device_discovery.discovery.import_module") as mock_import:
+        yield mock_import
+
+
+@pytest.fixture
+def mock_walk_packages():
+    """Fixture to mock walk_packages."""
+    with patch("device_discovery.discovery.walk_packages") as mock_import:
+        yield mock_import
 
 
 def test_discover_device_driver_success(mock_get_network_driver):
@@ -149,24 +164,114 @@ def test_discover_device_driver_mixed_results(mock_get_network_driver):
     assert driver == "nxos", "Expected the 'ios' driver to be found"
 
 
-def test_napalm_driver_list(mock_importlib_metadata_packages_distributions):
+def test_napalm_driver_list(mock_packages_distributions, mock_import_module):
     """
     Test the napalm_driver_list function to ensure it correctly lists available NAPALM drivers.
 
     Args:
     ----
-        mock_importlib_metadata_packages_distributions: Mocked
-        importlib_metadata.packages_distributions function.
+        mock_packages_distributions: Mocked importlib.metadata.packages_distributions function.
+        mock_import_module: Mocked import_module function.
 
     """
     mock_distributions = [
         "napalm_srl",
         "napalm_fake_driver",
     ]
-    mock_importlib_metadata_packages_distributions.return_value = mock_distributions
+
+    class MockDriver(NetworkDriver):
+        pass
+
+    mock_module = MagicMock()
+    setattr(mock_module, "MockDriver", MockDriver)
+    mock_import_module.return_value = mock_module
+
+    mock_packages_distributions.return_value = mock_distributions
+
     expected_drivers = ["ios", "eos", "junos", "nxos", "srl", "fake_driver"]
     drivers = napalm_driver_list()
     assert drivers == expected_drivers, f"Expected {expected_drivers}, got {drivers}"
+
+
+def test_walk_napalm_packages_success(mock_import_module, mock_walk_packages):
+    """
+    Test walk_napalm_packages function with valid modules.
+
+    Args:
+    ----
+        mock_import_module: Mocked import_module function.
+        mock_walk_packages: Mocked walk_packages function.
+
+    """
+
+    class MockDriver(NetworkDriver):
+        pass
+
+    mock_module = MagicMock()
+    setattr(mock_module, "MockDriver", MockDriver)
+    mock_module.__path__ = ["mock/path"]
+    mock_module.__name__ = "napalm_test"
+    mock_package = MagicMock()
+    mock_package.name = "napalm_test.test_driver"
+
+    mock_import_module.return_value = mock_module
+    mock_walk_packages.return_value = [mock_package]
+
+    result = walk_napalm_packages(mock_module, "napalm_", ["ios"])
+    assert result == ["ios", "test.test_driver"]
+
+
+def test_walk_napalm_packages_no_drivers(mock_import_module, mock_walk_packages):
+    """
+    Test walk_napalm_packages function when no valid drivers are found.
+
+    Args:
+    ----
+        mock_import_module: Mocked import_module function.
+        mock_walk_packages: Mocked walk_packages function.
+
+    """
+    mock_module = MagicMock()
+    mock_module.__path__ = ["mock/path"]
+    mock_module.__name__ = "napalm"
+    mock_package = MagicMock()
+    mock_package.name = "napalm.invalid_driver"
+
+    mock_import_module.return_value = MagicMock()
+    mock_walk_packages.return_value = [mock_package]
+
+    with patch("device_discovery.discovery.inspect.getmembers", return_value=[]):
+        result = walk_napalm_packages(mock_module, "napalm.", [])
+        assert result == [], f"Expected an empty list, got {result}"
+
+
+def test_walk_napalm_packages_exception_handling(
+    mock_import_module, mock_walk_packages
+):
+    """
+    Test walk_napalm_packages function with exceptions during module import.
+
+    Args:
+    ----
+        mock_import_module: Mocked import_module function.
+        mock_walk_packages: Mocked walk_packages function.
+
+    """
+    mock_module = MagicMock()
+    mock_module.__path__ = ["mock/path"]
+    mock_module.__name__ = "napalm"
+    mock_package = MagicMock()
+    mock_package.name = "napalm.error_driver"
+
+    mock_import_module.side_effect = Exception("Import failed")
+    mock_walk_packages.return_value = [mock_package]
+
+    with patch("device_discovery.discovery.logger") as mock_logger:
+        result = walk_napalm_packages(mock_module, "napalm.", [])
+        mock_logger.error.assert_called_once_with(
+            f"Error importing module {mock_package.name}: Import failed"
+        )
+        assert result == [], f"Expected an empty list, got {result}"
 
 
 def test_set_napalm_logs_level(mock_loggers):


### PR DESCRIPTION
This pull request includes several changes to enhance the discovery of NAPALM drivers and improve the testing framework. The most important changes include the addition of a new function to walk through NAPALM packages, modifications to the `napalm_driver_list` function, and updates to the test cases to ensure comprehensive coverage.

Enhancements to NAPALM driver discovery:

* [`device-discovery/device_discovery/discovery.py`](diffhunk://#diff-e67715c692935d72f4e8d7a2bad0ea79604b0cf6f5068a3c828a19e38a1fab87R5-R53): Added the `walk_napalm_packages` function to walk through directory trees and identify NAPALM network driver classes.
* [`device-discovery/device_discovery/discovery.py`](diffhunk://#diff-e67715c692935d72f4e8d7a2bad0ea79604b0cf6f5068a3c828a19e38a1fab87L31-R84): Modified the `napalm_driver_list` function to use the new `walk_napalm_packages` function for discovering additional NAPALM drivers.

Dependency updates:

* [`device-discovery/pyproject.toml`](diffhunk://#diff-c3df0d5da015312295fa2fdd2c07560e9b424071533c1e579856a8d757072d58L32): Removed the `importlib-metadata` dependency as it is no longer needed.

Improvements to test cases:

* [`device-discovery/tests/test_discovery.py`](diffhunk://#diff-e3d649e280b9e049c2db823088c5816e5c7fcfe44144029025b3e8429415edc6L152-R276): Added new test cases to validate the functionality of the `walk_napalm_packages` function, including scenarios for successful discovery, no drivers found, and exception handling.
* [`device-discovery/tests/test_discovery.py`](diffhunk://#diff-e3d649e280b9e049c2db823088c5816e5c7fcfe44144029025b3e8429415edc6R27-R31): Updated existing test cases to mock the `packages_distributions` function and ensure compatibility with the new implementation. [[1]](diffhunk://#diff-e3d649e280b9e049c2db823088c5816e5c7fcfe44144029025b3e8429415edc6R27-R31) [[2]](diffhunk://#diff-e3d649e280b9e049c2db823088c5816e5c7fcfe44144029025b3e8429415edc6R42-R55)