### PR TITLE
feat: add more nmap options to network discovery

### DIFF
--- a/.github/workflows/network-discovery-tests.yaml
+++ b/.github/workflows/network-discovery-tests.yaml
@@ -40,6 +40,7 @@ jobs:
         run: |
           go install github.com/mfridman/tparse@v0.14.0
           sudo apt-get -y install nmap
+          sudo setcap cap_net_raw,cap_net_admin=eip $(which nmap)
       - name: Run go test
         id: go-test
         run: |

--- a/network-discovery/README.md
+++ b/network-discovery/README.md
@@ -62,7 +62,15 @@ make bin
 build/network-discovery --diode-target grpc://192.168.31.114:8080/diode  --diode-api-key '${DIODE_API_KEY}'
 ```
 
-## Docker Image
+### ⚠️ Warning
+Be **AWARE** that executing a policy with only targets defined is equivalent to running `nmap <targets>`, which in turn is the same as executing `nmap -sS -p1-1000 --open -T3 <target>`:
+
+- `-sS` → SYN scan (stealth scan, requires root privileges)
+- `-p1-1000` → Scans the top 1000 most common ports
+- `--open` → Only shows open ports
+- `-T3` → Uses the default timing template (T3 is the standard speed)
+
+### Docker Image
 device-discovery can be build and run using docker:
 ```sh
 cd network-discovery/

--- a/network-discovery/README.md
+++ b/network-discovery/README.md
@@ -37,7 +37,7 @@ policies:
       exclude_ports: [23, 9000-12000] # --exclude-ports 
       scan_types: [connect, udp, fin ] # -sT -sU -sF
       top_ports: 10 # --top-ports
-      ping_scan: False # default True if no options provided
+      ping_scan: True # -sn
       max_retries: 1 # --max-retries
   discover_once: # will run only once
     scope:

--- a/network-discovery/README.md
+++ b/network-discovery/README.md
@@ -1,5 +1,13 @@
 # network-discovery
-Orb network discovery backend
+Orb network discovery backend, which is a wrapper over [NMAP](https://nmap.org/) scanner.
+
+### Requirements
+network discovery requires [NMAP](https://nmap.org/) to be installed on the machine. To enable full feature support, `nmap` must have the necessary capabilities to perform raw socket operations. However, for default usage, this is not required.
+
+On UNIX systems, users can enable raw socket operations for nmap by running the following command:
+```sh
+sudo setcap cap_net_raw,cap_net_admin=eip $(which nmap)
+```
 
 ### Usage
 ```sh

--- a/network-discovery/README.md
+++ b/network-discovery/README.md
@@ -38,6 +38,7 @@ policies:
       scan_types: [connect, udp, fin ] # -sT -sU -sF
       top_ports: 10 # --top-ports
       ping_scan: False # default True if no options provided
+      max_retries: 1 # --max-retries
   discover_once: # will run only once
     scope:
        targets: 

--- a/network-discovery/README.md
+++ b/network-discovery/README.md
@@ -30,12 +30,14 @@ policies:
       schedule: "* * * * *" #Cron expression
       timeout: 5 #default 2 minutes
     scope:
-      targets: [192.168.1.0/24] # only REQUIRED param
+      targets: [192.168.1.0/24] # REQUIRED param
       fast_mode: True # -F 
       timing: 2 # -T [0-5]
       ports: [22,161,162,443,500-600,8080] # -p
       exclude_ports: [23, 9000-12000] # --exclude-ports 
       scan_types: [connect, udp, fin ] # -sT -sU -sF
+      top_ports: 10 # --top-ports
+      ping_scan: False # default True if no options provided
   discover_once: # will run only once
     scope:
        targets: 

--- a/network-discovery/README.md
+++ b/network-discovery/README.md
@@ -30,7 +30,12 @@ policies:
       schedule: "* * * * *" #Cron expression
       timeout: 5 #default 2 minutes
     scope:
-      targets: [192.168.1.0/24]
+      targets: [192.168.1.0/24] # only REQUIRED param
+      fast_mode: True # -F 
+      timing: 2 # -T [0-5]
+      ports: [22,161,162,443,500-600,8080] # -p
+      exclude_ports: [23, 9000-12000] # --exclude-ports 
+      scan_types: [connect, udp, fin ] # -sT -sU -sF
   discover_once: # will run only once
     scope:
        targets: 

--- a/network-discovery/config/config.go
+++ b/network-discovery/config/config.go
@@ -18,7 +18,7 @@ type Scope struct {
 	FastMode     *bool    `yaml:"fast_mode,omitempty"`
 	PingScan     *bool    `yaml:"ping_scan,omitempty"`
 	TopPorts     *int     `yaml:"top_ports,omitempty"`
-	L4Mode       *string  `yaml:"l4_mode,omitempty"`
+	ScanTypes    []string `yaml:"scan_types,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy

--- a/network-discovery/config/config.go
+++ b/network-discovery/config/config.go
@@ -11,7 +11,14 @@ type Status struct {
 
 // Scope represents the scope of a policy
 type Scope struct {
-	Targets []string `yaml:"targets"`
+	Targets      []string `yaml:"targets"`
+	Ports        []string `yaml:"ports,omitempty"`
+	ExcludePorts []string `yaml:"exclude_ports,omitempty"`
+	Timing       *int     `yaml:"timing,omitempty"`
+	FastMode     *bool    `yaml:"fast_mode,omitempty"`
+	PingScan     *bool    `yaml:"ping_scan,omitempty"`
+	TopPorts     *int     `yaml:"top_ports,omitempty"`
+	L4Mode       *string  `yaml:"l4_mode,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy

--- a/network-discovery/config/config.go
+++ b/network-discovery/config/config.go
@@ -19,6 +19,7 @@ type Scope struct {
 	PingScan     *bool    `yaml:"ping_scan,omitempty"`
 	TopPorts     *int     `yaml:"top_ports,omitempty"`
 	ScanTypes    []string `yaml:"scan_types,omitempty"`
+	MaxRetries   *int     `yaml:"max_retries,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy

--- a/network-discovery/policy/manager.go
+++ b/network-discovery/policy/manager.go
@@ -91,5 +91,5 @@ func (m *Manager) Stop() error {
 
 // GetCapabilities returns the capabilities of network-discovery
 func (m *Manager) GetCapabilities() []string {
-	return []string{"targets, ports"}
+	return []string{"targets, ports, exclude_ports, timing, fast_mode, ping_scan, top_ports, scan_types, max_retries"}
 }

--- a/network-discovery/policy/manager_test.go
+++ b/network-discovery/policy/manager_test.go
@@ -121,5 +121,5 @@ func TestManagerGetCapabilities(t *testing.T) {
 	manager := &policy.Manager{}
 
 	capabilities := manager.GetCapabilities()
-	assert.Equal(t, []string{"targets, ports"}, capabilities)
+	assert.Equal(t, []string{"targets, ports, exclude_ports, timing, fast_mode, ping_scan, top_ports, scan_types, max_retries"}, capabilities)
 }

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -142,6 +142,10 @@ func (r *Runner) run() {
 
 	}
 
+	if r.scope.MaxRetries != nil {
+		options = append(options, nmap.WithMaxRetries(*r.scope.MaxRetries))
+	}
+
 	if r.scope.PingScan != nil && *r.scope.PingScan {
 		options = append(options, nmap.WithPingScan())
 	}

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -94,7 +94,12 @@ func (r *Runner) run() {
 		options = append(options, nmap.WithMostCommonPorts(*r.scope.TopPorts))
 	}
 
-	if len(options) == 0 || (r.scope.PingScan != nil && *r.scope.PingScan) {
+	if r.scope.PingScan != nil && *r.scope.PingScan {
+		options = append(options, nmap.WithPingScan())
+	}
+
+	if len(options) == 0 {
+		r.logger.Info("no custom options set, using ping scan (icmp)", slog.Any("policy", r.ctx.Value(policyKey)))
 		options = append(options, nmap.WithPingScan())
 	}
 	options = append(options, nmap.WithNonInteractive())

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -94,6 +94,8 @@ func (r *Runner) run() {
 		options = append(options, nmap.WithMostCommonPorts(*r.scope.TopPorts))
 	}
 
+	hasOtherScans := false
+	selectedTCPScan := ""
 	if len(r.scope.ScanTypes) > 0 {
 		privilegedScans := map[string]func() nmap.Option{
 			"udp":              nmap.WithUDPScan,
@@ -113,9 +115,6 @@ func (r *Runner) run() {
 			"maimon":  nmap.WithMaimonScan,
 		}
 
-		hasOtherScans := false
-		selectedTCPScan := ""
-
 		for _, scanType := range r.scope.ScanTypes {
 			if fn, exists := tcpScans[scanType]; exists {
 				if selectedTCPScan == "" { // Pick only one TCP scan
@@ -125,10 +124,9 @@ func (r *Runner) run() {
 						hasOtherScans = true
 					}
 				} else {
-					r.logger.Warn("Skipping additional TCP scan due to conflict",
-						"skipped_scan", scanType,
-						"selected_scan", selectedTCPScan,
-					)
+					r.logger.Warn("Skipping additional TCP scan due to conflict", "skipped_scan", scanType,
+						"selected_scan", selectedTCPScan, slog.Any("policy", r.ctx.Value(policyKey)))
+
 				}
 			} else if fn, exists := privilegedScans[scanType]; exists {
 				options = append(options, fn())
@@ -139,7 +137,6 @@ func (r *Runner) run() {
 		if hasOtherScans {
 			options = append(options, nmap.WithPrivileged())
 		}
-
 	}
 
 	if r.scope.MaxRetries != nil {
@@ -147,7 +144,12 @@ func (r *Runner) run() {
 	}
 
 	if r.scope.PingScan != nil && *r.scope.PingScan {
-		options = append(options, nmap.WithPingScan())
+		if hasOtherScans || selectedTCPScan != "" {
+			r.logger.Warn("Skipping ping scan because it is not valid with any other scan types",
+				slog.Any("policy", r.ctx.Value(policyKey)))
+		} else {
+			options = append(options, nmap.WithPingScan())
+		}
 	}
 
 	if len(options) == 0 {

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -95,34 +95,51 @@ func (r *Runner) run() {
 	}
 
 	if len(r.scope.ScanTypes) > 0 {
+		privilegedScans := map[string]func() nmap.Option{
+			"udp":              nmap.WithUDPScan,
+			"sctp_init":        nmap.WithSCTPInitScan,
+			"sctp_cookie_echo": nmap.WithSCTPCookieEchoScan,
+			"ip_protocol":      nmap.WithIPProtocolScan,
+		}
+
+		tcpScans := map[string]func() nmap.Option{
+			"connect": nmap.WithConnectScan,
+			"syn":     nmap.WithSYNScan,
+			"ack":     nmap.WithACKScan,
+			"window":  nmap.WithWindowScan,
+			"null":    nmap.WithTCPNullScan,
+			"fin":     nmap.WithTCPFINScan,
+			"xmas":    nmap.WithTCPXmasScan,
+			"maimon":  nmap.WithMaimonScan,
+		}
+
+		hasOtherScans := false
+		selectedTCPScan := ""
+
 		for _, scanType := range r.scope.ScanTypes {
-			switch scanType {
-			case "connect":
-				options = append(options, nmap.WithConnectScan())
-			case "udp":
-				options = append(options, nmap.WithUDPScan())
-			case "syn":
-				options = append(options, nmap.WithSYNScan())
-			case "ack":
-				options = append(options, nmap.WithACKScan())
-			case "window":
-				options = append(options, nmap.WithWindowScan())
-			case "null":
-				options = append(options, nmap.WithTCPNullScan())
-			case "fin":
-				options = append(options, nmap.WithTCPFINScan())
-			case "xmas":
-				options = append(options, nmap.WithTCPXmasScan())
-			case "maimon":
-				options = append(options, nmap.WithMaimonScan())
-			case "sctp_init":
-				options = append(options, nmap.WithSCTPInitScan())
-			case "sctp_cookie_echo":
-				options = append(options, nmap.WithSCTPCookieEchoScan())
-			case "ip_protocol":
-				options = append(options, nmap.WithIPProtocolScan())
+			if fn, exists := tcpScans[scanType]; exists {
+				if selectedTCPScan == "" { // Pick only one TCP scan
+					options = append(options, fn())
+					selectedTCPScan = scanType
+					if scanType != "connect" {
+						hasOtherScans = true
+					}
+				} else {
+					r.logger.Warn("Skipping additional TCP scan due to conflict",
+						"skipped_scan", scanType,
+						"selected_scan", selectedTCPScan,
+					)
+				}
+			} else if fn, exists := privilegedScans[scanType]; exists {
+				options = append(options, fn())
+				hasOtherScans = true
 			}
 		}
+
+		if hasOtherScans {
+			options = append(options, nmap.WithPrivileged())
+		}
+
 	}
 
 	if r.scope.PingScan != nil && *r.scope.PingScan {

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -126,7 +126,6 @@ func (r *Runner) run() {
 				} else {
 					r.logger.Warn("Skipping additional TCP scan due to conflict", "skipped_scan", scanType,
 						"selected_scan", selectedTCPScan, slog.Any("policy", r.ctx.Value(policyKey)))
-
 				}
 			} else if fn, exists := privilegedScans[scanType]; exists {
 				options = append(options, fn())

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -71,12 +71,36 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 func (r *Runner) run() {
 	ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 	defer cancel()
-	scanner, err := nmap.NewScanner(
-		ctx,
-		nmap.WithTargets(r.scope.Targets...),
-		nmap.WithPingScan(),
-		nmap.WithNonInteractive(),
-	)
+
+	var options []nmap.Option
+
+	if len(r.scope.Ports) > 0 {
+		nmap.WithPorts(r.scope.Ports...)
+	}
+
+	if len(r.scope.ExcludePorts) > 0 {
+		nmap.WithPortExclusions(r.scope.ExcludePorts...)
+	}
+
+	if r.scope.FastMode != nil && *r.scope.FastMode {
+		options = append(options, nmap.WithFastMode())
+	}
+
+	if r.scope.Timing != nil {
+		options = append(options, nmap.WithTimingTemplate(nmap.Timing(*r.scope.Timing)))
+	}
+
+	if r.scope.TopPorts != nil {
+		options = append(options, nmap.WithMostCommonPorts(*r.scope.TopPorts))
+	}
+
+	if len(options) == 0 || (r.scope.PingScan != nil && *r.scope.PingScan) {
+		options = append(options, nmap.WithPingScan())
+	}
+	options = append(options, nmap.WithNonInteractive())
+	options = append(options, nmap.WithTargets(r.scope.Targets...))
+
+	scanner, err := nmap.NewScanner(ctx, options...)
 	if err != nil {
 		r.logger.Error("error creating scanner", slog.Any("error", err), slog.Any("policy", r.ctx.Value(policyKey)))
 		return

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -151,10 +151,6 @@ func (r *Runner) run() {
 		}
 	}
 
-	if len(options) == 0 {
-		r.logger.Info("no custom options set, using ping scan (icmp)", slog.Any("policy", r.ctx.Value(policyKey)))
-		options = append(options, nmap.WithPingScan())
-	}
 	options = append(options, nmap.WithNonInteractive())
 	options = append(options, nmap.WithTargets(r.scope.Targets...))
 

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -94,6 +94,37 @@ func (r *Runner) run() {
 		options = append(options, nmap.WithMostCommonPorts(*r.scope.TopPorts))
 	}
 
+	if len(r.scope.ScanTypes) > 0 {
+		for _, scanType := range r.scope.ScanTypes {
+			switch scanType {
+			case "connect":
+				options = append(options, nmap.WithConnectScan())
+			case "udp":
+				options = append(options, nmap.WithUDPScan())
+			case "syn":
+				options = append(options, nmap.WithSYNScan())
+			case "ack":
+				options = append(options, nmap.WithACKScan())
+			case "window":
+				options = append(options, nmap.WithWindowScan())
+			case "null":
+				options = append(options, nmap.WithTCPNullScan())
+			case "fin":
+				options = append(options, nmap.WithTCPFINScan())
+			case "xmas":
+				options = append(options, nmap.WithTCPXmasScan())
+			case "maimon":
+				options = append(options, nmap.WithMaimonScan())
+			case "sctp_init":
+				options = append(options, nmap.WithSCTPInitScan())
+			case "sctp_cookie_echo":
+				options = append(options, nmap.WithSCTPCookieEchoScan())
+			case "ip_protocol":
+				options = append(options, nmap.WithIPProtocolScan())
+			}
+		}
+	}
+
 	if r.scope.PingScan != nil && *r.scope.PingScan {
 		options = append(options, nmap.WithPingScan())
 	}

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -159,6 +159,16 @@ func TestRunnerWithOptions(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with scan types",
+			policy: config.Policy{
+				Config: config.PolicyConfig{},
+				Scope: config.Scope{
+					Targets:   []string{"localhost"},
+					ScanTypes: []string{"connect", "udp"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -119,3 +119,87 @@ func TestRunnerRun(t *testing.T) {
 		})
 	}
 }
+
+func TestRunnerWithOptions(t *testing.T) {
+	tests := []struct {
+		name     string
+		policy   config.Policy
+		expected []string
+	}{
+		{
+			name: "with ports and exclude ports",
+			policy: config.Policy{
+				Config: config.PolicyConfig{},
+				Scope: config.Scope{
+					Targets:      []string{"localhost"},
+					Ports:        []string{"80", "443"},
+					ExcludePorts: []string{"22"},
+				},
+			},
+		},
+		{
+			name: "with fast mode and timing",
+			policy: config.Policy{
+				Config: config.PolicyConfig{},
+				Scope: config.Scope{
+					Targets:  []string{"localhost"},
+					FastMode: boolPtr(true),
+					Timing:   intPtr(3),
+				},
+			},
+		},
+		{
+			name: "with top ports and ping scan",
+			policy: config.Policy{
+				Config: config.PolicyConfig{},
+				Scope: config.Scope{
+					Targets:  []string{"localhost"},
+					TopPorts: intPtr(100),
+					PingScan: boolPtr(true),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			mockClient := new(MockClient)
+			ctx := context.Background()
+
+			// Create runner
+			runner, err := policy.NewRunner(ctx, logger, "test-policy", tt.policy, mockClient)
+			assert.NoError(t, err)
+
+			// Use a channel to signal that Ingest was called
+			ingestCalled := make(chan bool, 1)
+
+			mockClient.On("Ingest", mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
+				ingestCalled <- true
+			}).Return(&diodepb.IngestResponse{}, nil)
+
+			// Start the process
+			runner.Start()
+
+			// Wait for Ingest to be called or timeout
+			select {
+			case <-ingestCalled:
+				// Success
+			case <-time.After(10 * time.Second):
+				t.Fatal("Timeout: Ingest was not called")
+			}
+
+			// Stop the process
+			err = runner.Stop()
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func intPtr(i int) *int {
+	return &i
+}

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -160,12 +160,13 @@ func TestRunnerWithOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "with scan types",
+			name: "with scan types and max retries",
 			policy: config.Policy{
 				Config: config.PolicyConfig{},
 				Scope: config.Scope{
-					Targets:   []string{"localhost"},
-					ScanTypes: []string{"connect", "udp", "fin", "xmas"},
+					Targets:    []string{"localhost"},
+					ScanTypes:  []string{"connect", "udp", "fin", "xmas"},
+					MaxRetries: intPtr(0),
 				},
 			},
 		},

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -166,6 +166,7 @@ func TestRunnerWithOptions(t *testing.T) {
 				Scope: config.Scope{
 					Targets:    []string{"localhost"},
 					ScanTypes:  []string{"connect", "udp", "fin", "xmas"},
+					PingScan:   boolPtr(true),
 					MaxRetries: intPtr(0),
 				},
 			},

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -165,7 +165,7 @@ func TestRunnerWithOptions(t *testing.T) {
 				Config: config.PolicyConfig{},
 				Scope: config.Scope{
 					Targets:   []string{"localhost"},
-					ScanTypes: []string{"connect", "udp"},
+					ScanTypes: []string{"connect"},
 				},
 			},
 		},

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -165,7 +165,7 @@ func TestRunnerWithOptions(t *testing.T) {
 				Config: config.PolicyConfig{},
 				Scope: config.Scope{
 					Targets:   []string{"localhost"},
-					ScanTypes: []string{"connect"},
+					ScanTypes: []string{"connect", "udp", "fin", "xmas"},
 				},
 			},
 		},


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the network discovery functionality. The changes include updates to configuration parameters, improvements to the policy runner, and new tests to ensure the functionality works as expected.

### Configuration Enhancements:
* Added new configuration parameters such as `Ports`, `ExcludePorts`, `Timing`, `FastMode`, `PingScan`, `TopPorts`, `ScanTypes`, and `MaxRetries` to the `Scope` struct in `network-discovery/config/config.go`.

### Policy Runner Improvements:
* Updated the `run` method in `network-discovery/policy/runner.go` to handle the new configuration parameters and apply them to the nmap scanner options. This includes logic for handling different scan types, timing templates, and other scanning options.

### Testing Enhancements:
* Added a new test function `TestRunnerWithOptions` in `network-discovery/policy/runner_test.go` to cover various combinations of the new configuration parameters and ensure they are correctly applied in the policy runner.

### Documentation Updates:
* Updated the `network-discovery/README.md` file to document the new configuration parameters and their usage.

### Workflow Improvements:
* Modified the `.github/workflows/network-discovery-tests.yaml` file to include a command that sets the necessary capabilities for `nmap` to run with elevated privileges.