### PR TITLE
feat: [device-discovery] add opentelemetry metrics support

### DIFF
--- a/.github/workflows/device-discovery-lint-tests.yaml
+++ b/.github/workflows/device-discovery-lint-tests.yaml
@@ -56,7 +56,7 @@ jobs:
         junitxml-path: ${{ env.BE_DIR }}/pytest.xml
 
     - name: Print Coverage File
-      run: cat  ${{ env.BE_DIR }}/pytest-coverage.txt
+      run: cat  orb-discovery/${{ env.BE_DIR }}/pytest-coverage.txt
 
     - name: Lint with Ruff
       run: |

--- a/.github/workflows/device-discovery-lint-tests.yaml
+++ b/.github/workflows/device-discovery-lint-tests.yaml
@@ -50,13 +50,27 @@ jobs:
         pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=device_discovery/ | tee pytest-coverage.txt
 
     - name: Pytest coverage comment
+      id: coverageComment
       uses: MishaKav/pytest-coverage-comment@81882822c5b22af01f91bd3eacb1cefb6ad73dc2 #v1.1.53
       with:
         pytest-coverage-path: ${{ env.BE_DIR }}/pytest-coverage.txt
         junitxml-path: ${{ env.BE_DIR }}/pytest.xml
 
-    - name: Print Coverage File
-      run: cat  orb-discovery/${{ env.BE_DIR }}/pytest-coverage.txt
+    - name: Check the output coverage
+      run: |
+          echo "Coverage Percentage - ${{ steps.coverageComment.outputs.coverage }}"
+          echo "Coverage Color - ${{ steps.coverageComment.outputs.color }}"
+          echo "Coverage Html - ${{ steps.coverageComment.outputs.coverageHtml }}"
+          echo "Summary Report - ${{ steps.coverageComment.outputs.summaryReport }}"
+      
+          echo "Coverage Warnings - ${{ steps.coverageComment.outputs.warnings }}"
+      
+          echo "Coverage Errors - ${{ steps.coverageComment.outputs.errors }}"
+          echo "Coverage Failures - ${{ steps.coverageComment.outputs.failures }}"
+          echo "Coverage Skipped - ${{ steps.coverageComment.outputs.skipped }}"
+          echo "Coverage Tests - ${{ steps.coverageComment.outputs.tests }}"
+          echo "Coverage Time - ${{ steps.coverageComment.outputs.time }}"
+          echo "Not Success Test Info - ${{ steps.coverageComment.outputs.notSuccessTestInfo }}"
 
     - name: Lint with Ruff
       run: |

--- a/.github/workflows/device-discovery-lint-tests.yaml
+++ b/.github/workflows/device-discovery-lint-tests.yaml
@@ -55,6 +55,9 @@ jobs:
         pytest-coverage-path: ${{ env.BE_DIR }}/pytest-coverage.txt
         junitxml-path: ${{ env.BE_DIR }}/pytest.xml
 
+    - name: Print Coverage File
+      run: cat  ${{ env.BE_DIR }}/pytest-coverage.txt
+
     - name: Lint with Ruff
       run: |
         ruff check --output-format=github device_discovery/ tests/

--- a/.github/workflows/device-discovery-lint-tests.yaml
+++ b/.github/workflows/device-discovery-lint-tests.yaml
@@ -56,22 +56,6 @@ jobs:
         pytest-coverage-path: ${{ env.BE_DIR }}/pytest-coverage.txt
         junitxml-path: ${{ env.BE_DIR }}/pytest.xml
 
-    - name: Check the output coverage
-      run: |
-          echo "Coverage Percentage - ${{ steps.coverageComment.outputs.coverage }}"
-          echo "Coverage Color - ${{ steps.coverageComment.outputs.color }}"
-          echo "Coverage Html - ${{ steps.coverageComment.outputs.coverageHtml }}"
-          echo "Summary Report - ${{ steps.coverageComment.outputs.summaryReport }}"
-      
-          echo "Coverage Warnings - ${{ steps.coverageComment.outputs.warnings }}"
-      
-          echo "Coverage Errors - ${{ steps.coverageComment.outputs.errors }}"
-          echo "Coverage Failures - ${{ steps.coverageComment.outputs.failures }}"
-          echo "Coverage Skipped - ${{ steps.coverageComment.outputs.skipped }}"
-          echo "Coverage Tests - ${{ steps.coverageComment.outputs.tests }}"
-          echo "Coverage Time - ${{ steps.coverageComment.outputs.time }}"
-          echo "Not Success Test Info - ${{ steps.coverageComment.outputs.notSuccessTestInfo }}"
-
     - name: Lint with Ruff
       run: |
         ruff check --output-format=github device_discovery/ tests/

--- a/.github/workflows/device-discovery-lint-tests.yaml
+++ b/.github/workflows/device-discovery-lint-tests.yaml
@@ -50,7 +50,6 @@ jobs:
         pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=device_discovery/ | tee pytest-coverage.txt
 
     - name: Pytest coverage comment
-      id: coverageComment
       uses: MishaKav/pytest-coverage-comment@81882822c5b22af01f91bd3eacb1cefb6ad73dc2 #v1.1.53
       with:
         pytest-coverage-path: ${{ env.BE_DIR }}/pytest-coverage.txt

--- a/device-discovery/device_discovery/main.py
+++ b/device-discovery/device_discovery/main.py
@@ -11,6 +11,7 @@ import netboxlabs.diode.sdk.version as SdkVersion
 import uvicorn
 
 from device_discovery.client import Client
+from device_discovery.metrics import setup_metrics_export
 from device_discovery.server import app
 from device_discovery.version import version_semver
 
@@ -70,6 +71,21 @@ def main():
         required=False,
     )
 
+    parser.add_argument(
+        "--otel-endpoint",
+        help="OpenTelemetry exporter endpoint",
+        type=str,
+        required=False,
+    )
+
+    parser.add_argument(
+        "--otel-export-period",
+        help="Period in seconds between OpenTelemetry exports (default: 60)",
+        type=int,
+        default=60,
+        required=False,
+    )
+
     try:
         args = parser.parse_args()
         api_key = args.diode_api_key
@@ -77,10 +93,14 @@ def main():
             env_var = api_key[2:-1]
             api_key = os.getenv(env_var, api_key)
 
+        if args.otel_endpoint:
+            setup_metrics_export(args.otel_endpoint, args.otel_export_period)
+
         client = Client()
         client.init_client(
             prefix=args.diode_app_name_prefix, target=args.diode_target, api_key=api_key
         )
+
         uvicorn.run(
             app,
             host=args.host,

--- a/device-discovery/device_discovery/metrics.py
+++ b/device-discovery/device_discovery/metrics.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python
+# Copyright 2024 NetBox Labs Inc
+"""Device Discovery Metrics."""
+
+import logging
+from typing import Any
+
+from opentelemetry import metrics as otlp_metrics
+from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import (
+    PeriodicExportingMetricReader,
+)
+
+from device_discovery.version import version_semver
+
+# Set up logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# Global variables to store the provider and meter
+_meter_provider = None
+_meter = None
+_metrics_cache = {}
+_metrics_enabled = False
+_metric_factories = {}
+
+
+def _init_metric_factories(meter):
+    """Initialize the metric factory dictionary."""
+    global _metric_factories
+
+    _metric_factories = {
+        "discovery_attempts": lambda: meter.create_counter(
+            name="discovery_attempts",
+            description="Number of device discovery attempts",
+            unit="1",
+        ),
+        "discovery_success": lambda: meter.create_counter(
+            name="discovery_success",
+            description="Number of successful device discoveries",
+            unit="1",
+        ),
+        "discovery_failure": lambda: meter.create_counter(
+            name="discovery_failure",
+            description="Number of failed device discoveries",
+            unit="1",
+        ),
+        "policy_executions": lambda: meter.create_counter(
+            name="policy_executions",
+            description="Number of policy executions",
+            unit="1",
+        ),
+        "api_requests": lambda: meter.create_counter(
+            name="api_requests",
+            description="Number of API requests",
+            unit="1",
+        ),
+        "discovery_latency": lambda: meter.create_histogram(
+            name="discovery_latency",
+            description="Time taken for the discovery process",
+            unit="ms",
+        ),
+        "device_connection_latency": lambda: meter.create_histogram(
+            name="device_connection_latency",
+            description="Time taken to connect to devices",
+            unit="ms",
+        ),
+        "api_response_latency": lambda: meter.create_histogram(
+            name="api_response_latency",
+            description="Time taken to respond to API requests",
+            unit="ms",
+        ),
+        "active_policies": lambda: meter.create_up_down_counter(
+            name="active_policies",
+            description="Number of currently active policies",
+            unit="1",
+        ),
+    }
+
+
+def get_metric(metric_name: str) -> Any:
+    """
+    Get a metric by name, lazily initializing it if needed.
+
+    Args:
+    ----
+        metric_name: Name of the metric to retrieve
+
+    Returns:
+    -------
+        The requested metric object or None if metrics are not configured
+
+    """
+    global _metrics_enabled, _meter, _metric_factories
+
+    if not _metrics_enabled or _meter is None:
+        # Metrics not configured, return a no-op implementation
+        return None
+
+    # Initialize the factories if not done already
+    if not _metric_factories:
+        _init_metric_factories(_meter)
+
+    # Return cached metric if available
+    if metric_name in _metrics_cache:
+        return _metrics_cache[metric_name]
+
+    # Create and cache the metric if the factory exists
+    if metric_name in _metric_factories:
+        _metrics_cache[metric_name] = _metric_factories[metric_name]()
+        return _metrics_cache[metric_name]
+
+    raise ValueError(f"Unknown metric: {metric_name}")
+
+
+def setup_metrics_export(endpoint: str | None, export_period_seconds: int) -> None:
+    """
+    Setup metrics exporter with the proper endpoint.
+
+    Args:
+    ----
+        endpoint (str, optional): OTLP endpoint for metrics export.
+        export_period_seconds (int): Period in seconds between exports.
+
+    """
+    global _meter_provider, _meter, _metrics_enabled
+
+    # Clear any existing metrics configuration
+    _meter_provider = None
+    _meter = None
+    _metrics_cache.clear()
+    _metrics_enabled = False
+
+    if not endpoint:
+        logger.info("No metrics endpoint provided, metrics collection is disabled")
+        return
+
+    try:
+        # Set up the exporter with the provided endpoint and timeouts
+        exporter = OTLPMetricExporter(
+            endpoint=endpoint,
+            timeout=10,  # Add timeout to prevent hangs on connection issues
+            insecure=True if endpoint.startswith("grpc://") else False,
+        )
+        logger.info(f"OTLP metrics exporter configured with endpoint: {endpoint}")
+
+        export_period_millis = export_period_seconds * 1000
+        reader = PeriodicExportingMetricReader(
+            exporter=exporter, export_interval_millis=export_period_millis
+        )
+
+        # Create a new MeterProvider with the updated reader
+        _meter_provider = MeterProvider(metric_readers=[reader])
+        try:
+            otlp_metrics.set_meter_provider(_meter_provider)
+            # Create the meter with the new provider
+            _meter = _meter_provider.get_meter("device-discovery", version_semver())
+            _metrics_enabled = True
+            logger.info(
+                f"Metrics export configured with period: {export_period_seconds} seconds"
+            )
+        except Exception as e:
+            logger.warning(f"Could not set meter provider: {e}")
+            return
+    except Exception as e:
+        logger.error(f"Failed to setup metrics export: {e}")
+        return

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -3,6 +3,7 @@
 """Device Discovery Policy Runner."""
 
 import logging
+import time
 import uuid
 from datetime import datetime, timedelta
 
@@ -13,7 +14,8 @@ from napalm import get_network_driver
 
 from device_discovery.client import Client
 from device_discovery.discovery import discover_device_driver, supported_drivers
-from device_discovery.policy.models import Config, Defaults, Napalm, Status
+from device_discovery.metrics import get_metric
+from device_discovery.policy.models import Config, Napalm, Status
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -42,7 +44,7 @@ class PolicyRunner:
             scopes: scope data for the devices.
 
         """
-        self.name = name.replace('\r\n', '').replace('\n', '')
+        self.name = name.replace("\r\n", "").replace("\n", "")
         self.config = config
 
         if self.config is None:
@@ -51,8 +53,9 @@ class PolicyRunner:
             self.config.defaults = {}
 
         self.scheduler.start()
+        set_telemetry = True
         for scope in scopes:
-            sanitized_hostname = scope.hostname.replace('\r\n', '').replace('\n', '')
+            sanitized_hostname = scope.hostname.replace("\r\n", "").replace("\n", "")
             if scope.driver and scope.driver not in supported_drivers:
                 self.scheduler.shutdown()
                 raise Exception(
@@ -76,8 +79,102 @@ class PolicyRunner:
             self.scheduler.add_job(
                 self.run, id=id, trigger=trigger, args=[id, scope, self.config]
             )
-
+            if set_telemetry:
+                set_telemetry = False
+                self.scheduler.add_job(
+                    self.telemetry,
+                    id=str(uuid.uuid4()),
+                    trigger=trigger,
+                )
             self.status = Status.RUNNING
+
+        active_policies = get_metric("active_policies")
+        if active_policies:
+            active_policies.add(1, {"policy": self.name})
+
+    def telemetry(self):
+        """Telemetry job."""
+        policy_executions = get_metric("policy_executions")
+        if policy_executions:
+            policy_executions.add(1, {"policy": self.name})
+
+    def _discover_driver(self, scope: Napalm, sanitized_hostname: str) -> bool:
+        """
+        Discover the device driver if not provided.
+
+        Args:
+        ----
+            scope: Scope data for the device.
+            sanitized_hostname: Sanitized hostname for logging.
+
+        Returns:
+        -------
+            bool: True if driver discovery succeeded or wasn't needed, False otherwise.
+
+        """
+        if scope.driver is None:
+            logger.info(
+                f"Policy {self.name}, Hostname {sanitized_hostname}: Driver not informed, discovering it"
+            )
+            scope.driver = discover_device_driver(scope)
+            if scope.driver is None:
+                self.status = Status.FAILED
+                logger.error(
+                    f"Policy {self.name}, Hostname {sanitized_hostname}: Not able to discover device driver"
+                )
+                return False
+        return True
+
+    def _collect_device_data(self, scope: Napalm, sanitized_hostname: str, config: Config):
+        """
+        Connect to device and collect data.
+
+        Args:
+        ----
+            scope: Scope data for the device.
+            sanitized_hostname: Sanitized hostname for logging.
+            config: Configuration data containing site information.
+
+        """
+        np_driver = get_network_driver(scope.driver)
+        logger.info(
+            f"Policy {self.name}, Hostname {sanitized_hostname}: Getting information"
+        )
+
+        # Measure device connection time
+        connection_start_time = time.perf_counter()
+        with np_driver(
+            scope.hostname,
+            scope.username,
+            scope.password,
+            scope.timeout,
+            scope.optional_args,
+        ) as device:
+            connection_duration = (
+                time.perf_counter() - connection_start_time
+            ) * 1000
+            device_connection_latency = get_metric("device_connection_latency")
+            if device_connection_latency:
+                device_connection_latency.record(
+                    connection_duration,
+                    {
+                        "policy": self.name,
+                        "hostname": sanitized_hostname,
+                        "driver": scope.driver,
+                    },
+                )
+
+            data = {
+                "driver": scope.driver,
+                "device": device.get_facts(),
+                "interface": device.get_interfaces(),
+                "interface_ip": device.get_interfaces_ip(),
+                "defaults": config.defaults,
+            }
+            Client().ingest(scope.hostname, data)
+            discovery_success = get_metric("discovery_success")
+            if discovery_success:
+                discovery_success.add(1, {"policy": self.name})
 
     def run(self, id: str, scope: Napalm, config: Config):
         """
@@ -90,53 +187,68 @@ class PolicyRunner:
             config: Configuration data containing site information.
 
         """
-        sanitized_hostname = scope.hostname.replace('\r\n', '').replace('\n', '')
-        if scope.driver is None:
-            logger.info(
-                f"Policy {self.name}, Hostname {sanitized_hostname}: Driver not informed, discovering it"
-            )
-            scope.driver = discover_device_driver(scope)
-            if scope.driver is None:
-                self.status = Status.FAILED
+        discovery_start_time = time.perf_counter()
+        sanitized_hostname = scope.hostname.replace("\r\n", "").replace("\n", "")
+
+        # Try to discover driver if needed
+        if not self._discover_driver(scope, sanitized_hostname):
+            try:
+                self.scheduler.remove_job(id)
+            except Exception as e:
                 logger.error(
-                    f"Policy {self.name}, Hostname {sanitized_hostname}: Not able to discover device driver"
+                    f"Policy {self.name}, Hostname {sanitized_hostname}: Error removing job: {e}"
                 )
-                try:
-                    self.scheduler.remove_job(id)
-                except Exception as e:
-                    logger.error(
-                        f"Policy {self.name}, Hostname {sanitized_hostname}: Error removing job: {e}"
-                    )
-                return
+            return
 
         logger.info(
             f"Policy {self.name}, Hostname {sanitized_hostname}: Get driver '{scope.driver}'"
         )
 
         try:
-            np_driver = get_network_driver(scope.driver)
-            logger.info(
-                f"Policy {self.name}, Hostname {sanitized_hostname}: Getting information"
-            )
-            with np_driver(
-                scope.hostname,
-                scope.username,
-                scope.password,
-                scope.timeout,
-                scope.optional_args,
-            ) as device:
-                data = {
-                    "driver": scope.driver,
-                    "device": device.get_facts(),
-                    "interface": device.get_interfaces(),
-                    "interface_ip": device.get_interfaces_ip(),
-                    "defaults": config.defaults,
-                }
-                Client().ingest(scope.hostname, data)
+            discovery_attempts = get_metric("discovery_attempts")
+            if discovery_attempts:
+                discovery_attempts.add(1, {"policy": self.name})
+
+            # Collect data from device
+            self._collect_device_data(scope, sanitized_hostname, config)
+
+            # Record total discovery duration
+            discovery_latency = get_metric("discovery_latency")
+            if discovery_latency:
+                discovery_duration = (time.perf_counter() - discovery_start_time) * 1000
+                discovery_latency.record(
+                    discovery_duration,
+                    {
+                        "policy": self.name,
+                        "hostname": sanitized_hostname,
+                        "driver": scope.driver,
+                    },
+                )
+
         except Exception as e:
+            discovery_failure = get_metric("discovery_failure")
+            if discovery_failure:
+                discovery_failure.add(1, {"policy": self.name})
             logger.error(f"Policy {self.name}, Hostname {sanitized_hostname}: {e}")
+
+            # Still record discovery duration on failure
+            discovery_latency = get_metric("discovery_latency")
+            if discovery_latency:
+                discovery_duration = (time.perf_counter() - discovery_start_time) * 1000
+                discovery_latency.record(
+                    discovery_duration,
+                    {
+                        "policy": self.name,
+                        "hostname": sanitized_hostname,
+                        "driver": str(scope.driver),
+                        "status": "failed",
+                    },
+                )
 
     def stop(self):
         """Stop the policy runner."""
         self.scheduler.shutdown()
+        active_policies = get_metric("active_policies")
+        if active_policies:
+            active_policies.add(-1, {"policy": self.name})
         self.status = Status.FINISHED

--- a/device-discovery/device_discovery/server.py
+++ b/device-discovery/device_discovery/server.py
@@ -3,6 +3,7 @@
 """Device Discovery Server."""
 
 
+import time
 from contextlib import asynccontextmanager
 from datetime import datetime
 
@@ -11,6 +12,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request
 from pydantic import ValidationError
 
 from device_discovery.discovery import supported_drivers
+from device_discovery.metrics import get_metric
 from device_discovery.policy.manager import PolicyManager
 from device_discovery.policy.models import PolicyRequest
 from device_discovery.version import version_semver
@@ -36,6 +38,44 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(lifespan=lifespan)
+
+
+# Add middleware to track API requests and latency
+@app.middleware("http")
+async def add_metrics(request: Request, call_next):
+    """
+    Add middleware to track API requests and latency.
+
+    Args:
+    ----
+        request (Request): The request object.
+        call_next: The next middleware or route handler.
+
+    Returns:
+    -------
+        response: The response object.
+
+    """
+    api_requests = get_metric("api_requests")
+    api_response_latency = get_metric("api_response_latency")
+    if api_requests is None or api_response_latency is None:
+        return await call_next(request)
+    api_requests.add(1, {"path": request.url.path, "method": request.method})
+
+    start_time = time.perf_counter()
+    response = await call_next(request)
+    duration = (time.perf_counter() - start_time) * 1000
+
+    api_response_latency.record(
+        duration,
+        {
+            "path": request.url.path,
+            "method": request.method,
+            "status_code": response.status_code,
+        },
+    )
+
+    return response
 
 
 async def parse_yaml_body(request: Request) -> PolicyRequest:

--- a/device-discovery/pyproject.toml
+++ b/device-discovery/pyproject.toml
@@ -41,7 +41,7 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = ["black", "check-manifest", "ruff"]
-test = ["coverage", "pytest", "pytest-cov"]
+test = ["coverage", "pytest", "pytest-cov==6.0.0"]
 
 [project.urls]
 "Homepage" = "https://netboxlabs.com/"

--- a/device-discovery/pyproject.toml
+++ b/device-discovery/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
     "pydantic~=2.9",
     "python-dotenv~=1.0",
     "uvicorn~=0.32",
+    "opentelemetry-api~=1.32",
+    "opentelemetry-sdk~=1.32",
+    "opentelemetry-exporter-otlp~=1.32",
 ]
 
 [project.optional-dependencies]

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -69,7 +69,9 @@ def test_setup_policy_runner_with_one_time_run(policy_runner, sample_scopes):
 def test_setup_with_unsupported_driver_raises_error(policy_runner, sample_scopes):
     """Test setup raises error if driver is unsupported."""
     sample_scopes[0].driver = "unsupported_driver"
-    with patch("device_discovery.policy.runner.supported_drivers", ["ios"]), pytest.raises(
+    with patch(
+        "device_discovery.policy.runner.supported_drivers", ["ios"]
+    ), pytest.raises(
         Exception, match="specified driver 'unsupported_driver' was not found"
     ):
         policy_runner.setup("policy1", Config(), sample_scopes)
@@ -146,3 +148,116 @@ def test_stop_policy_runner(policy_runner):
         # Ensure scheduler shutdown is called and status is updated
         mock_shutdown.assert_called_once()
         assert policy_runner.status == Status.FINISHED
+
+
+def test_metrics_during_policy_lifecycle(policy_runner, sample_config, sample_scopes):
+    """Test that metrics are properly updated during the policy lifecycle."""
+    # Create mock metrics
+    mock_active_policies = MagicMock()
+    mock_policy_executions = MagicMock()
+    mock_discovery_attempts = MagicMock()
+    mock_discovery_success = MagicMock()
+    mock_discovery_failure = MagicMock()
+    mock_device_connection_latency = MagicMock()
+    mock_discovery_latency = MagicMock()
+
+    # Map of metric names to mock objects
+    mock_metrics = {
+        "active_policies": mock_active_policies,
+        "policy_executions": mock_policy_executions,
+        "discovery_attempts": mock_discovery_attempts,
+        "discovery_success": mock_discovery_success,
+        "discovery_failure": mock_discovery_failure,
+        "device_connection_latency": mock_device_connection_latency,
+        "discovery_latency": mock_discovery_latency,
+    }
+
+    # Setup mock for get_metric function
+    def mock_get_metric(name):
+        return mock_metrics.get(name)
+
+    with patch(
+        "device_discovery.policy.runner.get_metric", side_effect=mock_get_metric
+    ), patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ), patch(
+        "device_discovery.policy.runner.get_network_driver"
+    ), patch(
+        "device_discovery.client.Client.ingest"
+    ):
+
+        # Test setup - should increment active_policies
+        policy_runner.setup("test_policy", sample_config, sample_scopes)
+        mock_active_policies.add.assert_called_once_with(1, {"policy": "test_policy"})
+
+        # Test telemetry job - should increment policy_executions
+        policy_runner.telemetry()
+        mock_policy_executions.add.assert_called_once_with(1, {"policy": "test_policy"})
+
+        # Test run - should record attempts, success, and latency
+        policy_runner.run("test_id", sample_scopes[0], sample_config)
+
+        mock_discovery_attempts.add.assert_called_once_with(
+            1, {"policy": "test_policy"}
+        )
+        mock_discovery_success.add.assert_called_once_with(1, {"policy": "test_policy"})
+        mock_device_connection_latency.record.assert_called_once()
+        mock_discovery_latency.record.assert_called_once()
+
+        # Verify connection latency recorded with correct values
+        latency_args = mock_device_connection_latency.record.call_args[0][0]
+        latency_kwargs = mock_device_connection_latency.record.call_args[0][1]
+        assert latency_args > 0.01  # 0.1 seconds in milliseconds
+        assert latency_kwargs["policy"] == "test_policy"
+        assert latency_kwargs["driver"] == "ios"
+
+        # Test stop - should decrement active_policies
+        with patch.object(policy_runner.scheduler, "shutdown") as mock_shutdown:
+            policy_runner.stop()
+            mock_shutdown.assert_called_once()
+            mock_active_policies.add.assert_called_with(-1, {"policy": "test_policy"})
+
+
+def test_metrics_during_failed_discovery(policy_runner, sample_config):
+    """Test that metrics are properly updated when discovery fails."""
+    # Create a scope with no driver to force discovery
+    scope = Napalm(
+        driver=None, hostname="router1", username="admin", password="password"
+    )
+
+    mock_discovery_attempts = MagicMock()
+    mock_discovery_failure = MagicMock()
+    mock_discovery_latency = MagicMock()
+
+    mock_metrics = {
+        "discovery_attempts": mock_discovery_attempts,
+        "discovery_failure": mock_discovery_failure,
+        "discovery_latency": mock_discovery_latency,
+    }
+
+    def mock_get_metric(name):
+        return mock_metrics.get(name)
+
+    with patch(
+        "device_discovery.policy.runner.get_metric", side_effect=mock_get_metric
+    ), patch(
+        "device_discovery.policy.runner.discover_device_driver", return_value="ios"
+    ), patch(
+        "device_discovery.policy.runner.get_network_driver",
+        side_effect=Exception("Connection error"),
+    ), patch.object(
+        policy_runner.scheduler, "remove_job"
+    ):
+
+        # Run the device with discovery that will fail
+        policy_runner.run("test_id", scope, sample_config)
+
+        # Verify failure metric was called
+        mock_discovery_failure.add.assert_called_once_with(1, {"policy": ""})
+
+        # Verify discovery latency recorded with failure status
+        mock_discovery_latency.record.assert_called_once()
+        latency_args = mock_discovery_latency.record.call_args[0][0]
+        latency_kwargs = mock_discovery_latency.record.call_args[0][1]
+        assert latency_args > 0.01
+        assert latency_kwargs["status"] == "failed"

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -46,7 +46,7 @@ def test_setup_policy_runner_with_cron(policy_runner, sample_config, sample_scop
 
         # Ensure scheduler starts and job is added
         mock_start.assert_called_once()
-        mock_add_job.assert_called_once()
+        mock_add_job.assert_called()
         assert policy_runner.status == Status.RUNNING
 
 

--- a/device-discovery/tests/test_metrics.py
+++ b/device-discovery/tests/test_metrics.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python
+# Copyright 2024 NetBox Labs Inc
+"""NetBox Labs - Metrics Unit Tests."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from device_discovery.metrics import get_metric, setup_metrics_export
+
+
+@pytest.fixture
+def mock_opentelemetry():
+    """Mock the OpenTelemetry SDK imports and components."""
+    with patch("device_discovery.metrics.OTLPMetricExporter") as mock_exporter, patch(
+        "device_discovery.metrics.PeriodicExportingMetricReader"
+    ) as mock_reader, patch("opentelemetry.sdk.metrics.Meter") as mock_meter, patch(
+        "device_discovery.metrics.MeterProvider"
+    ) as mock_provider:
+        # Setup return values
+        mock_provider.return_value.get_meter.return_value = mock_meter
+
+        yield {
+            "exporter": mock_exporter,
+            "reader": mock_reader,
+            "meter": mock_meter,
+            "provider": mock_provider,
+        }
+
+
+@pytest.fixture
+def reset_metrics_cache():
+    """Reset the metrics cache before test."""
+    with patch("device_discovery.metrics._metrics_cache", {}), \
+         patch("device_discovery.metrics._metric_factories", {}), \
+         patch("device_discovery.metrics._metrics_enabled", True):
+        yield
+
+
+def test_setup_metrics_export(mock_opentelemetry):
+    """Test that metrics export setup creates the correct OpenTelemetry components."""
+    endpoint = "http://localhost:4317"
+    export_period = 30
+
+    setup_metrics_export(endpoint, export_period)
+
+    # Verify exporter was created with correct endpoint
+    mock_opentelemetry["exporter"].assert_called_once()
+    args, kwargs = mock_opentelemetry["exporter"].call_args
+    assert kwargs["endpoint"] == endpoint
+
+    # Verify reader was created with correct exporter and export interval
+    mock_opentelemetry["reader"].assert_called_once()
+    args, kwargs = mock_opentelemetry["reader"].call_args
+    assert kwargs["export_interval_millis"] == export_period * 1000
+
+    # Verify meter provider was configured
+    mock_opentelemetry["provider"].assert_called_once()
+
+    # Verify meter was created
+    mock_opentelemetry["provider"].return_value.get_meter.assert_called_once_with(
+        "device-discovery", "0.0.0"
+    )
+
+
+def test_get_metric_returns_counter(reset_metrics_cache):
+    """Test that get_metric returns a counter for counter-type metrics."""
+    mock_counter = MagicMock()
+    mock_meter = MagicMock()
+    mock_meter.create_counter.return_value = mock_counter
+
+    with patch("device_discovery.metrics._meter", mock_meter):
+        # Test accessing a counter metric
+        metric = get_metric("api_requests")
+
+        # Verify counter was created with correct name and description
+        mock_meter.create_counter.assert_called_once()
+        args, kwargs = mock_meter.create_counter.call_args
+        assert kwargs["name"] == "api_requests"
+        assert "description" in kwargs
+
+        # Should return the mock counter
+        assert metric == mock_counter
+
+
+def test_get_metric_returns_histogram(reset_metrics_cache):
+    """Test that get_metric returns a histogram for latency-type metrics."""
+    mock_histogram = MagicMock()
+    mock_meter = MagicMock()
+    mock_meter.create_histogram.return_value = mock_histogram
+
+    with patch("device_discovery.metrics._meter", mock_meter):
+        # Test accessing a histogram metric
+        metric = get_metric("api_response_latency")
+
+        # Verify histogram was created with correct name and description
+        mock_meter.create_histogram.assert_called_once()
+        args, kwargs = mock_meter.create_histogram.call_args
+        assert kwargs["name"] == "api_response_latency"
+        assert "description" in kwargs
+
+        # Should return the mock histogram
+        assert metric == mock_histogram
+
+
+def test_get_metric_returns_none_when_not_initialized():
+    """Test that get_metric returns None when metrics are not initialized."""
+    with patch("device_discovery.metrics._meter", None):
+        metric = get_metric("api_requests")
+        assert metric is None
+
+
+def test_get_metric_creates_metric_only_once(reset_metrics_cache):
+    """Test that get_metric only creates a metric once and returns cached value."""
+    mock_counter = MagicMock()
+    mock_meter = MagicMock()
+    mock_meter.create_counter.return_value = mock_counter
+
+    with patch("device_discovery.metrics._meter", mock_meter), patch(
+        "device_discovery.metrics._metrics_cache", {}
+    ):
+
+        # First call should create the metric
+        metric1 = get_metric("api_requests")
+        assert metric1 == mock_counter
+        mock_meter.create_counter.assert_called_once()
+
+        # Reset the mock to check if it's called again
+        mock_meter.create_counter.reset_mock()
+
+        # Second call should return cached metric without creating it again
+        metric2 = get_metric("api_requests")
+        assert metric2 == mock_counter
+        mock_meter.create_counter.assert_not_called()
+
+
+def test_all_expected_metrics_exist(reset_metrics_cache):
+    """Test that all expected metrics can be retrieved."""
+    expected_metrics = [
+        "api_requests",
+        "api_response_latency",
+        "active_policies",
+        "policy_executions",
+        "discovery_attempts",
+        "discovery_success",
+        "discovery_failure",
+        "discovery_latency",
+        "device_connection_latency",
+    ]
+
+    mock_meter = MagicMock()
+    mock_meter.create_counter.return_value = MagicMock()
+    mock_meter.create_histogram.return_value = MagicMock()
+
+    with patch("device_discovery.metrics._meter", mock_meter), patch(
+        "device_discovery.metrics._metrics_cache", {}
+    ):
+
+        for metric_name in expected_metrics:
+            metric = get_metric(metric_name)
+            assert metric is not None, f"Expected metric {metric_name} to exist"

--- a/device-discovery/tests/test_metrics.py
+++ b/device-discovery/tests/test_metrics.py
@@ -63,6 +63,27 @@ def test_setup_metrics_export(mock_opentelemetry):
     )
 
 
+def test_setup_metrics_export_no_endpoint(mock_opentelemetry, reset_metrics_cache):
+    """Test that metrics export setup is properly disabled when no endpoint is provided."""
+    with patch("device_discovery.metrics.logger") as mock_logger:
+        # Call with None endpoint
+        setup_metrics_export(None, 30)
+
+        # Verify logger message
+        mock_logger.info.assert_called_once_with(
+            "No metrics endpoint provided, metrics collection is disabled"
+        )
+
+        # Verify no OpenTelemetry components were created
+        mock_opentelemetry["exporter"].assert_not_called()
+        mock_opentelemetry["reader"].assert_not_called()
+        mock_opentelemetry["provider"].assert_not_called()
+
+        # Verify get_metric returns None after setup with no endpoint
+        metric = get_metric("api_requests")
+        assert metric is None
+
+
 def test_get_metric_returns_counter(reset_metrics_cache):
     """Test that get_metric returns a counter for counter-type metrics."""
     mock_counter = MagicMock()
@@ -159,3 +180,34 @@ def test_all_expected_metrics_exist(reset_metrics_cache):
         for metric_name in expected_metrics:
             metric = get_metric(metric_name)
             assert metric is not None, f"Expected metric {metric_name} to exist"
+
+
+def test_setup_metrics_export_meter_provider_error(mock_opentelemetry, reset_metrics_cache):
+    """Test handling of errors when setting the meter provider."""
+    endpoint = "http://localhost:4317"
+    export_period = 30
+
+    # Mock set_meter_provider to raise an exception
+    with patch("device_discovery.metrics.otlp_metrics.set_meter_provider",
+              side_effect=Exception("Provider error")), \
+         patch("device_discovery.metrics.logger") as mock_logger:
+
+        # Call function
+        setup_metrics_export(endpoint, export_period)
+
+        # Verify components were created but meter provider wasn't set
+        mock_opentelemetry["exporter"].assert_called_once()
+        mock_opentelemetry["reader"].assert_called_once()
+        mock_opentelemetry["provider"].assert_called_once()
+
+        # Verify warning was logged
+        mock_logger.warning.assert_called_once()
+        warning_message = mock_logger.warning.call_args[0][0]
+        assert "Could not set meter provider" in warning_message
+
+        # Verify meter was not created
+        mock_opentelemetry["provider"].return_value.get_meter.assert_not_called()
+
+        # Verify metrics are not enabled and get_metric returns None
+        metric = get_metric("api_requests")
+        assert metric is None


### PR DESCRIPTION
This pull request introduces OpenTelemetry metrics integration to the device discovery service, enabling detailed monitoring of various operations. Key changes include adding metrics setup and export functionality, integrating metrics into the policy runner, and updating dependencies to include OpenTelemetry packages.

### Metrics Integration:

* [`device-discovery/device_discovery/metrics.py`](diffhunk://#diff-7945675f26721f34133f6f7da72eecd422943f4b666b44683aa0adbd49752859R1-R168): Created a new module for setting up and exporting OpenTelemetry metrics, including counters and histograms for various device discovery operations.

### Policy Runner Modifications:

* [`device-discovery/device_discovery/policy/runner.py`](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fL16-R18): Integrated metrics into the policy runner to track discovery attempts, successes, failures, policy executions, and latencies. Added new methods for telemetry and data collection. [[1]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fL16-R18) [[2]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fL79-L93) [[3]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fR175-R253)

### Server Middleware:

* [`device-discovery/device_discovery/server.py`](diffhunk://#diff-80291323eff883c98ddb82a96c56a5c1370ae747db1a027f78b034186cbb8563R43-R80): Added middleware to track API requests and response latencies, integrating with the new metrics system.

### Dependency Updates:

* [`device-discovery/pyproject.toml`](diffhunk://#diff-c3df0d5da015312295fa2fdd2c07560e9b424071533c1e579856a8d757072d58R37-R39): Updated dependencies to include OpenTelemetry API, SDK, and OTLP exporter packages.

### Main Script Enhancements:

* [`device-discovery/device_discovery/main.py`](diffhunk://#diff-1999bab46324c3ee0f3648305dd694f66fea0998ed4e291ba704b6d4b9598faaR74-R103): Added command-line arguments for OpenTelemetry endpoint and export period, and integrated metrics setup in the main function.