### PR TITLE
Adds SNMPv2c to configuration in policy 

### DIFF
--- a/.github/workflows/snmp-discovery-tests.yaml
+++ b/.github/workflows/snmp-discovery-tests.yaml
@@ -38,9 +38,7 @@ jobs:
         run: go build ./...
       - name: Install additional dependencies
         run: |
-          go install github.com/mfridman/tparse@v0.14.0
-          sudo apt-get -y install nmap
-          sudo setcap cap_net_raw,cap_net_admin=eip $(which nmap)
+          make install-dev-tools
       - name: Run go test
         id: go-test
         run: |

--- a/snmp-discovery/Makefile
+++ b/snmp-discovery/Makefile
@@ -10,6 +10,7 @@ COMMIT_SHA := $(shell git rev-parse --short HEAD)
 install-dev-tools:
 	@go install github.com/mfridman/tparse@latest
 	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@go install github.com/jandelgado/gcov2lcov@latest
 	
 .PHONY: build
 clean:
@@ -37,7 +38,7 @@ test-coverage:
 	@go test -race -cover -json -coverprofile=.coverage/cover.out.tmp ./... | grep -Ev "cmd" | tparse -format=markdown > .coverage/test-report.md
 	@cat .coverage/cover.out.tmp | grep -Ev "cmd" > .coverage/cover.out
 	@go tool cover -func=.coverage/cover.out | grep total | awk '{print substr($$3, 1, length($$3)-1)}' > .coverage/coverage.txt
-
+	@gcov2lcov -infile=.coverage/cover.out -outfile=.coverage/lcov.info
 
 .PHONY: test
 test:

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -11,8 +11,8 @@ type Status struct {
 
 // Scope represents the scope of a policy
 type Scope struct {
-	Targets        []Target        `yaml:"targets"`
-	Authentication *Authentication `yaml:"authentication"`
+	Targets        []Target       `yaml:"targets"`
+	Authentication Authentication `yaml:"authentication"`
 }
 
 // Target represents a target host to crawl

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import "time"
 
-// Status represents the status of the network-discovery service
+// Status represents the status of the snmp-discovery service
 type Status struct {
 	StartTime     time.Time `json:"start_time"`
 	UpTimeSeconds int64     `json:"up_time_seconds"`
@@ -11,7 +11,20 @@ type Status struct {
 
 // Scope represents the scope of a policy
 type Scope struct {
-	Targets []string `yaml:"targets"`
+	Targets        []Target        `yaml:"targets"`
+	Authentication *Authentication `yaml:"authentication"`
+}
+
+// Target represents a target host to crawl
+type Target struct {
+	Host string `yaml:"host"`
+	Port uint16 `yaml:"port" default:"161"`
+}
+
+// Authentication represents the authentication credentials for a target host
+type Authentication struct {
+	ProtocolVersion string `yaml:"protocol_version"`
+	Community       string `yaml:"community"`
 }
 
 // Defaults represents the supported default values for a policy

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -44,7 +44,7 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 
 	for name, policy := range payload.Policies {
 		if policy.Scope.Authentication.ProtocolVersion == "" || policy.Scope.Authentication.Community == "" {
-			return nil, fmt.Errorf("policy '%s' is missing authentication details", name)
+			return nil, fmt.Errorf("%s : missing authentication details", name)
 		}
 	}
 

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -42,6 +42,12 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 		return nil, errors.New("no policies found in the request")
 	}
 
+	for name, policy := range payload.Policies {
+		if policy.Scope.Authentication.ProtocolVersion == "" || policy.Scope.Authentication.Community == "" {
+			return nil, fmt.Errorf("policy '%s' is missing authentication details", name)
+		}
+	}
+
 	return payload.Policies, nil
 }
 

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -74,7 +74,7 @@ func TestManagerParsePolicies(t *testing.T) {
 
 		_, err := manager.ParsePolicies(yamlData)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "policy 'policy1' is missing authentication")
+		assert.Contains(t, err.Error(), "policy1 : missing authentication details")
 	})
 
 	t.Run("No Policies", func(t *testing.T) {

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
 )
 
 // MockRunner mocks the Runner
@@ -47,6 +48,9 @@ func TestManagerParsePolicies(t *testing.T) {
               targets:
                 - host: 192.168.1.1
                   port: 162
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
        `)
 
 		policies, err := manager.ParsePolicies(yamlData)
@@ -54,6 +58,23 @@ func TestManagerParsePolicies(t *testing.T) {
 		assert.Contains(t, policies, "policy1")
 		assert.Equal(t, "192.168.1.1", policies["policy1"].Scope.Targets[0].Host)
 		assert.Equal(t, uint16(162), policies["policy1"].Scope.Targets[0].Port)
+		assert.Equal(t, snmp.ProtocolVersion2c, policies["policy1"].Scope.Authentication.ProtocolVersion)
+		assert.Equal(t, "public", policies["policy1"].Scope.Authentication.Community)
+	})
+
+	t.Run("Missing Authentication", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  port: 162
+    `)
+
+		_, err := manager.ParsePolicies(yamlData)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "policy 'policy1' is missing authentication")
 	})
 
 	t.Run("No Policies", func(t *testing.T) {
@@ -73,13 +94,22 @@ func TestManagerPolicyLifecycle(t *testing.T) {
             scope:
               targets:
                 - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
           policy2:
             scope:
               targets:
                 - host: 192.168.2.1
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
           policy3:
             scope:
               targets: []
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
        `)
 
 	policies, err := manager.ParsePolicies(yamlData)

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -45,13 +45,15 @@ func TestManagerParsePolicies(t *testing.T) {
                 comments: test
             scope:
               targets:
-                - 192.168.1.1
+                - host: 192.168.1.1
+                  port: 162
        `)
 
 		policies, err := manager.ParsePolicies(yamlData)
 		assert.NoError(t, err)
 		assert.Contains(t, policies, "policy1")
-		assert.Equal(t, "test", policies["policy1"].Config.Defaults.Comments)
+		assert.Equal(t, "192.168.1.1", policies["policy1"].Scope.Targets[0].Host)
+		assert.Equal(t, uint16(162), policies["policy1"].Scope.Targets[0].Port)
 	})
 
 	t.Run("No Policies", func(t *testing.T) {
@@ -70,11 +72,11 @@ func TestManagerPolicyLifecycle(t *testing.T) {
           policy1:
             scope:
               targets:
-                - 192.168.1.1
+                - host: 192.168.1.1
           policy2:
             scope:
               targets:
-                - 192.168.2.1
+                - host: 192.168.2.1
           policy3:
             scope:
               targets: []

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -23,29 +23,29 @@ const (
 
 // Runner represents the policy runner
 type Runner struct {
-	scheduler         gocron.Scheduler
-	ctx               context.Context
-	task              gocron.Task
-	client            diode.Client
-	logger            *slog.Logger
-	timeout           time.Duration
-	scope             config.Scope
-	config            config.PolicyConfig
-	snmpClientFactory func(host string) snmp.Walker
+	scheduler     gocron.Scheduler
+	ctx           context.Context
+	task          gocron.Task
+	client        diode.Client
+	logger        *slog.Logger
+	timeout       time.Duration
+	scope         config.Scope
+	config        config.PolicyConfig
+	ClientFactory snmp.ClientFactory
 }
 
 // NewRunner returns a new policy runner
-func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, client diode.Client, snmpClientFactory func(host string) snmp.Walker) (*Runner, error) {
+func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, client diode.Client, ClientFactory snmp.ClientFactory) (*Runner, error) {
 	s, err := gocron.NewScheduler()
 	if err != nil {
 		return nil, err
 	}
 
 	runner := &Runner{
-		scheduler:         s,
-		client:            client,
-		logger:            logger,
-		snmpClientFactory: snmpClientFactory,
+		scheduler:     s,
+		client:        client,
+		logger:        logger,
+		ClientFactory: ClientFactory,
 	}
 
 	runner.task = gocron.NewTask(runner.run)
@@ -78,8 +78,8 @@ func (r *Runner) run() {
 	entities := make([]diode.Entity, 0)
 
 	for _, target := range r.scope.Targets {
-		host := snmp.NewHost(target, r.logger, r.snmpClientFactory, mapper.ObjectIDs())
-		oids, err := host.Walk(target)
+		host := snmp.NewHost(target.Host, target.Port, r.scope.Authentication, r.logger, r.ClientFactory, mapper.ObjectIDs())
+		oids, err := host.Walk()
 		if err != nil {
 			r.logger.Warn("Error crawling host", "ip", target, "error", err)
 			continue

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -81,7 +81,7 @@ func (r *Runner) run() {
 		host := snmp.NewHost(target.Host, target.Port, &r.scope.Authentication, r.logger, r.ClientFactory, mapper.ObjectIDs())
 		oids, err := host.Walk()
 		if err != nil {
-			r.logger.Warn("Error crawling host", "ip", target, "error", err)
+			r.logger.Warn("Error crawling host", "host", target.Host, "error", err)
 			continue
 		}
 		entitiesForTarget := mapper.MapObjectIDsToEntity(oids)

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -78,7 +78,7 @@ func (r *Runner) run() {
 	entities := make([]diode.Entity, 0)
 
 	for _, target := range r.scope.Targets {
-		host := snmp.NewHost(target.Host, target.Port, r.scope.Authentication, r.logger, r.ClientFactory, mapper.ObjectIDs())
+		host := snmp.NewHost(target.Host, target.Port, &r.scope.Authentication, r.logger, r.ClientFactory, mapper.ObjectIDs())
 		oids, err := host.Walk()
 		if err != nil {
 			r.logger.Warn("Error crawling host", "ip", target, "error", err)

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -98,6 +98,10 @@ func TestRunnerRun(t *testing.T) {
 							Port: 161,
 						},
 					},
+					Authentication: config.Authentication{
+						ProtocolVersion: snmp.ProtocolVersion2c,
+						Community:       "public",
+					},
 				},
 			}
 			ctx := context.Background()
@@ -147,6 +151,10 @@ func TestRunnerWithOptions(t *testing.T) {
 							Host: "localhost",
 							Port: 161,
 						},
+					},
+					Authentication: config.Authentication{
+						ProtocolVersion: snmp.ProtocolVersion2c,
+						Community:       "public",
 					},
 				},
 			},

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -41,7 +41,12 @@ func TestNewRunner(t *testing.T) {
 			Schedule: &cron,
 		},
 		Scope: config.Scope{
-			Targets: []string{"localhost"},
+			Targets: []config.Target{
+				{
+					Host: "localhost",
+					Port: 161,
+				},
+			},
 		},
 	}
 	ctx := context.Background()
@@ -87,7 +92,12 @@ func TestRunnerRun(t *testing.T) {
 					},
 				},
 				Scope: config.Scope{
-					Targets: []string{"localhost"},
+					Targets: []config.Target{
+						{
+							Host: "localhost",
+							Port: 161,
+						},
+					},
 				},
 			}
 			ctx := context.Background()
@@ -132,16 +142,12 @@ func TestRunnerWithOptions(t *testing.T) {
 			policy: config.Policy{
 				Config: config.PolicyConfig{},
 				Scope: config.Scope{
-					Targets: []string{"localhost"},
-				},
-			},
-		},
-		{
-			name: "with SNMPv3 credentials",
-			policy: config.Policy{
-				Config: config.PolicyConfig{},
-				Scope: config.Scope{
-					Targets: []string{"localhost"},
+					Targets: []config.Target{
+						{
+							Host: "localhost",
+							Port: 161,
+						},
+					},
 				},
 			},
 		},
@@ -190,7 +196,11 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	policyConfig := config.Policy{
 		Config: config.PolicyConfig{},
 		Scope: config.Scope{
-			Targets: []string{"192.168.1.1"},
+			Targets: []config.Target{
+				{
+					Host: "192.168.1.1",
+				},
+			},
 		},
 	}
 

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -92,7 +92,7 @@ func TestServerCreateDeletePolicy(t *testing.T) {
             site: New York NY
         scope:
           targets: 
-            - 192.168.31.1
+            - host: 192.168.31.1
     `)
 
 	w := httptest.NewRecorder()

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -93,6 +93,9 @@ func TestServerCreateDeletePolicy(t *testing.T) {
         scope:
           targets: 
             - host: 192.168.31.1
+          authentication:
+            protocol_version: SNMPv2c
+            community: public
     `)
 
 	w := httptest.NewRecorder()

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -108,6 +108,33 @@ func TestServerCreateDeletePolicy(t *testing.T) {
 	assert.Equal(t, http.StatusCreated, w.Code)
 	assert.Contains(t, w.Body.String(), `policies [test-policy] were started`)
 
+	// Try to create the same policy again
+	body = []byte(`
+    policies:
+      test-pol:
+        scope:
+          targets: 
+            - host: 192.168.31.1
+          authentication:
+            protocol_version: SNMPv2c
+            community: public
+      test-policy:
+        scope:
+          targets: 
+            - host: 192.168.31.1
+          authentication:
+            protocol_version: SNMPv2c
+            community: public
+    `)
+	w = httptest.NewRecorder()
+	request, _ = http.NewRequest(http.MethodPost, "/api/v1/policies", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/x-yaml")
+
+	srv.Router().ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusConflict, w.Code)
+	assert.Contains(t, w.Body.String(), `policy 'test-policy' already exists`)
+
 	// Delete policy
 	w = httptest.NewRecorder()
 	request, _ = http.NewRequest(http.MethodDelete, "/api/v1/policies/test-policy", nil)
@@ -115,4 +142,114 @@ func TestServerCreateDeletePolicy(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	assert.Contains(t, w.Body.String(), `policy 'test-policy' was deleted`)
+
+	// Try to delete the same policy again
+	w = httptest.NewRecorder()
+	request, _ = http.NewRequest(http.MethodDelete, "/api/v1/policies/test-policy", nil)
+	srv.Router().ServeHTTP(w, request)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+	assert.Contains(t, w.Body.String(), `policy not found`)
+}
+
+func TestServerCreateInvalidPolicy(t *testing.T) {
+	tests := []struct {
+		desc          string
+		contentType   string
+		body          []byte
+		returnCode    int
+		returnMessage string
+	}{
+		{
+			desc:          "invalid content type",
+			contentType:   "application/json",
+			body:          []byte(``),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `invalid Content-Type. Only 'application/x-yaml' is supported`,
+		},
+		{
+			desc:          "invalid YAML",
+			contentType:   "application/x-yaml",
+			body:          []byte(`invalid`),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `yaml: unmarshal errors:`,
+		},
+		{
+			desc:        "no policies found",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies: {}
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `no policies found in the request`,
+		},
+		{
+			desc:        "no targets found",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies:
+              test-policy:
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+                  authentication:
+                    protocol_version: SNMPv2c
+                    community: public
+              test-policy-invalid:
+                config:
+                  defaults:
+                    site: New York NY
+                scope:
+                  ports: [80, 443]
+                  authentication:
+                    protocol_version: SNMPv2c
+                    community: public
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `test-policy-invalid : no targets found in the policy`,
+		},
+		{
+			desc:        "missing authentication",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies:
+              test-policy:
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+                  authentication:
+                    protocol_version: SNMPv2c
+                    community: public
+              test-policy-invalid:
+                config:
+                  defaults:
+                    site: New York NY
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `test-policy-invalid : missing authentication details`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			ctx := context.Background()
+			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+			client := new(MockClient)
+			policyManager := policy.NewManager(ctx, logger, client)
+
+			srv := server.NewServer("localhost", 8073, logger, policyManager, "1.0.0")
+
+			// Create invalid policy request
+			w := httptest.NewRecorder()
+			request, _ := http.NewRequest(http.MethodPost, "/api/v1/policies", bytes.NewReader(tt.body))
+			request.Header.Set("Content-Type", tt.contentType)
+
+			srv.Router().ServeHTTP(w, request)
+
+			assert.Equal(t, tt.returnCode, w.Code)
+			assert.Contains(t, w.Body.String(), tt.returnMessage)
+		})
+	}
 }

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -26,6 +26,6 @@ func (n *FakeSNMPWalker) Walk(oid string) (ObjectIDValueMap, error) {
 }
 
 // NewFakeSNMPWalker creates a new FakeSNMPWalker
-func NewFakeSNMPWalker(_ string, _ uint16, _ *config.Authentication) Walker {
-	return &FakeSNMPWalker{}
+func NewFakeSNMPWalker(_ string, _ uint16, _ *config.Authentication) (Walker, error) {
+	return &FakeSNMPWalker{}, nil
 }

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -1,6 +1,8 @@
 package snmp
 
-// FakeSNMPWalker is a no-op implementation of Walker
+import "github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+
+// FakeSNMPWalker is a no-op implementation of SNMPWalker
 type FakeSNMPWalker struct{}
 
 // Connect implements Walker interface
@@ -24,6 +26,6 @@ func (n *FakeSNMPWalker) Walk(oid string) (ObjectIDValueMap, error) {
 }
 
 // NewFakeSNMPWalker creates a new FakeSNMPWalker
-func NewFakeSNMPWalker(_ string) Walker {
+func NewFakeSNMPWalker(_ string, _ uint16, _ *config.Authentication) Walker {
 	return &FakeSNMPWalker{}
 }

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -157,9 +157,9 @@ func NewClient(host string, port uint16, authentication *config.Authentication) 
 				Version:   gosnmp.Version2c,
 				Timeout:   time.Duration(2) * time.Second,
 			},
-		}
+		}, nil
 	}
-	panic("Unsupported protocol version. Currently only SNMPv2c is supported")
+	return nil, fmt.Errorf("unsupported protocol version: %s. Currently only SNMPv2c is supported", authentication.ProtocolVersion)
 }
 
 // Walker interface defines methods for walking SNMP trees

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -7,10 +7,8 @@ import (
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/netboxlabs/diode-sdk-go/diode"
-)
 
-const (
-	community = "public"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 )
 
 // ObjectIDMapping is a map of ObjectIDs to entity types
@@ -53,44 +51,48 @@ func (m *ObjectIDMapper) ObjectIDs() []string {
 
 // Host is a struct that represents an SNMP host
 type Host struct {
-	address           string
-	objects           map[string]string
-	logger            *slog.Logger
-	snmpClientFactory func(host string) Walker
-	objectIDs         []string
+	address        string
+	port           uint16
+	authentication *config.Authentication
+	objects        map[string]string
+	logger         *slog.Logger
+	ClientFactory  ClientFactory
+	objectIDs      []string
 }
 
 // NewHost creates a new Host
-func NewHost(host string, logger *slog.Logger, snmpClientFactory func(host string) Walker, objectIDs []string) *Host {
+func NewHost(host string, port uint16, authentication *config.Authentication, logger *slog.Logger, ClientFactory ClientFactory, objectIDs []string) *Host {
 	return &Host{
-		address:           host,
-		objects:           make(map[string]string),
-		logger:            logger,
-		snmpClientFactory: snmpClientFactory,
-		objectIDs:         objectIDs,
+		address:        host,
+		port:           port,
+		authentication: authentication,
+		objects:        make(map[string]string),
+		logger:         logger,
+		ClientFactory:  ClientFactory,
+		objectIDs:      objectIDs,
 	}
 }
 
 // Walk walks the SNMP host
-func (s *Host) Walk(host string) (ObjectIDValueMap, error) {
-	s.logger.Info("Scanning", "host", host)
+func (s *Host) Walk() (ObjectIDValueMap, error) {
+	s.logger.Info("Scanning", "host", s.address)
 
-	Client := s.snmpClientFactory(host)
+	snmpClient := s.ClientFactory(s.address, s.port, s.authentication)
 	defer func() {
-		if err := Client.Close(); err != nil {
-			s.logger.Warn("Error closing SNMP connection", "host", host, "error", err)
+		if err := snmpClient.Close(); err != nil {
+			s.logger.Warn("Error closing SNMP connection", "host", s.address, "error", err)
 		}
 	}()
 
-	err := Client.Connect()
+	err := snmpClient.Connect()
 	if err != nil {
-		s.logger.Warn("Could not connect to host", "host", host, "error", err)
+		s.logger.Warn("Could not connect to host", "host", s.address, "error", err)
 		return nil, err
 	}
 
 	output := make(ObjectIDValueMap)
 	for _, objectID := range s.objectIDs {
-		pdu, err := Client.Walk(objectID)
+		pdu, err := snmpClient.Walk(objectID)
 		if err != nil {
 			s.logger.Warn("Error walking ObjectID", "objectID", objectID, "error", err)
 			return nil, err
@@ -134,17 +136,30 @@ func (c *Client) Walk(objectID string) (ObjectIDValueMap, error) {
 	return output, nil
 }
 
-// NewClient creates a new Client for the given target host
-func NewClient(host string) Walker {
-	return &Client{
-		&gosnmp.GoSNMP{
-			Target:    host,
-			Port:      161,
-			Community: community,
-			Version:   gosnmp.Version2c,
-			Timeout:   time.Duration(2) * time.Second,
-		},
+const (
+	// ProtocolVersion2c is the SNMPv2c protocol version
+	ProtocolVersion2c = "SNMPv2c"
+	// ProtocolVersion3 is the SNMPv3 protocol version
+	ProtocolVersion3 = "SNMPv3"
+)
+
+// ClientFactory is a function that creates a new SNMPClient
+type ClientFactory func(host string, port uint16, authentication *config.Authentication) Walker
+
+// NewClient creates a new SNMPClient for the given target host
+func NewClient(host string, port uint16, authentication *config.Authentication) Walker {
+	if authentication.ProtocolVersion == ProtocolVersion2c {
+		return &Client{
+			&gosnmp.GoSNMP{
+				Target:    host,
+				Port:      port,
+				Community: authentication.Community,
+				Version:   gosnmp.Version2c,
+				Timeout:   time.Duration(2) * time.Second,
+			},
+		}
 	}
+	panic("Unsupported protocol version. Currently only SNMPv2c is supported")
 }
 
 // Walker interface defines methods for walking SNMP trees

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -77,14 +77,17 @@ func NewHost(host string, port uint16, authentication *config.Authentication, lo
 func (s *Host) Walk() (ObjectIDValueMap, error) {
 	s.logger.Info("Scanning", "host", s.address)
 
-	snmpClient := s.ClientFactory(s.address, s.port, s.authentication)
+	snmpClient, err := s.ClientFactory(s.address, s.port, s.authentication)
+	if err != nil {
+		return nil, err
+	}
 	defer func() {
 		if err := snmpClient.Close(); err != nil {
 			s.logger.Warn("Error closing SNMP connection", "host", s.address, "error", err)
 		}
 	}()
 
-	err := snmpClient.Connect()
+	err = snmpClient.Connect()
 	if err != nil {
 		s.logger.Warn("Could not connect to host", "host", s.address, "error", err)
 		return nil, err
@@ -144,10 +147,10 @@ const (
 )
 
 // ClientFactory is a function that creates a new SNMPClient
-type ClientFactory func(host string, port uint16, authentication *config.Authentication) Walker
+type ClientFactory func(host string, port uint16, authentication *config.Authentication) (Walker, error)
 
 // NewClient creates a new SNMPClient for the given target host
-func NewClient(host string, port uint16, authentication *config.Authentication) Walker {
+func NewClient(host string, port uint16, authentication *config.Authentication) (Walker, error) {
 	if authentication.ProtocolVersion == ProtocolVersion2c {
 		return &Client{
 			&gosnmp.GoSNMP{

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -51,8 +51,8 @@ func TestSNMPHost(t *testing.T) {
 	t.Run("Successfully walks a host", func(t *testing.T) {
 		// Setup
 		objectIDsToQuery := []string{ipAddressObjectID}
-		fakeWalker := snmp.NewFakeSNMPWalker("192.168.1.1", 161, nil)
-		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) snmp.Walker { return fakeWalker }, objectIDsToQuery)
+		fakeWalker, _ := snmp.NewFakeSNMPWalker("192.168.1.1", 161, nil)
+		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) { return fakeWalker, nil }, objectIDsToQuery)
 
 		// Execute
 		oids, err := host.Walk()
@@ -68,7 +68,7 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker := &MockSNMP{}
 		mockWalker.On("Connect").Return(assert.AnError)
 		mockWalker.On("Close").Return(nil)
-		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) snmp.Walker { return mockWalker }, []string{"1.3.6.1.2.1.4.20.1.1"})
+		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) { return mockWalker, nil }, []string{"1.3.6.1.2.1.4.20.1.1"})
 
 		// Execute
 		oids, err := host.Walk()
@@ -85,7 +85,7 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
 		mockWalker.On("Walk", mock.Anything).Return(nil, assert.AnError)
-		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) snmp.Walker { return mockWalker }, []string{ipAddressObjectID})
+		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) { return mockWalker, nil }, []string{ipAddressObjectID})
 
 		// Execute
 		oids, err := host.Walk()

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
 )
 
@@ -50,11 +51,11 @@ func TestSNMPHost(t *testing.T) {
 	t.Run("Successfully walks a host", func(t *testing.T) {
 		// Setup
 		objectIDsToQuery := []string{ipAddressObjectID}
-		fakeWalker := snmp.NewFakeSNMPWalker("")
-		host := snmp.NewHost("192.168.1.1", logger, func(_ string) snmp.Walker { return fakeWalker }, objectIDsToQuery)
+		fakeWalker := snmp.NewFakeSNMPWalker("192.168.1.1", 161, nil)
+		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) snmp.Walker { return fakeWalker }, objectIDsToQuery)
 
 		// Execute
-		oids, err := host.Walk("192.168.1.1")
+		oids, err := host.Walk()
 
 		// Assert
 		assert.NoError(t, err)
@@ -67,10 +68,10 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker := &MockSNMP{}
 		mockWalker.On("Connect").Return(assert.AnError)
 		mockWalker.On("Close").Return(nil)
-		host := snmp.NewHost("192.168.1.1", logger, func(_ string) snmp.Walker { return mockWalker }, []string{"1.3.6.1.2.1.4.20.1.1"})
+		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) snmp.Walker { return mockWalker }, []string{"1.3.6.1.2.1.4.20.1.1"})
 
 		// Execute
-		oids, err := host.Walk("192.168.1.1")
+		oids, err := host.Walk()
 
 		// Assert
 		assert.Error(t, err)
@@ -84,10 +85,10 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
 		mockWalker.On("Walk", mock.Anything).Return(nil, assert.AnError)
-		host := snmp.NewHost("192.168.1.1", logger, func(_ string) snmp.Walker { return mockWalker }, []string{ipAddressObjectID})
+		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) snmp.Walker { return mockWalker }, []string{ipAddressObjectID})
 
 		// Execute
-		oids, err := host.Walk("192.168.1.1")
+		oids, err := host.Walk()
 
 		// Assert
 		assert.Error(t, err)


### PR DESCRIPTION
This pull request introduces significant updates to the `snmp-discovery` service, focusing on enhancing SNMP target configuration, improving authentication support, and refactoring the codebase for better maintainability. The changes include replacing simple target strings with structured `Target` objects, adding support for SNMP authentication, and updating related tests and implementations accordingly.

### Enhancements to SNMP Target Configuration and Authentication:

* Updated `config.Scope` to use a new `Target` struct, which includes `Host` and `Port` fields, and added an optional `Authentication` field for SNMP credentials. (`snmp-discovery/config/config.go`, [snmp-discovery/config/config.goL14-R27](diffhunk://#diff-6ca23964054f973f61443ee3c52410a7bdcc1215394ef455d5d7d62a56676cd2L14-R27))
* Refactored `snmp.NewHost` to accept `Target` details and authentication parameters, and updated the `Walk` method to use these new fields. (`snmp-discovery/snmp/snmp.go`, [[1]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R55-R95) [[2]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L137-R163)
* Added a `ClientFactory` type to create SNMP clients with authentication, supporting SNMPv2c and laying groundwork for future protocol versions. (`snmp-discovery/snmp/snmp.go`, [snmp-discovery/snmp/snmp.goL137-R163](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L137-R163))

### Code Refactoring:

* Replaced `snmpClientFactory` with `ClientFactory` in `Runner` and related methods to align with the new authentication and target structure. (`snmp-discovery/policy/runner.go`, [[1]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL34-R38) [[2]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL81-R82)
* Updated `FakeSNMPWalker` and `NewFakeSNMPWalker` to match the new `Target` and `Authentication` structure. (`snmp-discovery/snmp/mocks.go`, [[1]](diffhunk://#diff-ca04d639e95ac1098548f63ed2dcc476d1fd18379c7a3d4bccadeae762362138L3-R5) [[2]](diffhunk://#diff-ca04d639e95ac1098548f63ed2dcc476d1fd18379c7a3d4bccadeae762362138L27-R29)

### Test Updates:

* Modified tests across multiple files to use the new `Target` struct and validate the updated `Walk` method and SNMP client creation. (`snmp-discovery/policy/manager_test.go`, [[1]](diffhunk://#diff-d7a8cc6613db677701db042f45e16e5c7b23bea87c2a21ccfce2a36e66bbd6b7L48-R56); `snmp-discovery/policy/runner_test.go`, [[2]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL44-R49) [[3]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL193-R203); `snmp-discovery/snmp/snmp_test.go`, [[4]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L53-R58) [[5]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L87-R91)

These changes improve the flexibility and scalability of the `snmp-discovery` service by allowing more granular target configurations and paving the way for enhanced SNMP protocol support.