### PR TITLE
feat: adds SNMPv3 support

### DIFF
--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -25,6 +25,12 @@ type Target struct {
 type Authentication struct {
 	ProtocolVersion string `yaml:"protocol_version"`
 	Community       string `yaml:"community"`
+	SecurityLevel   string `yaml:"security_level"`
+	Username        string `yaml:"username"`
+	AuthProtocol    string `yaml:"auth_protocol"`
+	AuthPassphrase  string `yaml:"auth_passphrase"`
+	PrivProtocol    string `yaml:"priv_protocol"`
+	PrivPassphrase  string `yaml:"priv_passphrase"`
 }
 
 // Defaults represents the supported default values for a policy

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -13,6 +13,7 @@ type Status struct {
 type Scope struct {
 	Targets        []Target       `yaml:"targets"`
 	Authentication Authentication `yaml:"authentication"`
+	Retries        int            `yaml:"retries"`
 }
 
 // Target represents a target host to crawl

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -43,12 +43,52 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 	}
 
 	for name, policy := range payload.Policies {
-		if policy.Scope.Authentication.ProtocolVersion == "" || policy.Scope.Authentication.Community == "" {
-			return nil, fmt.Errorf("%s : missing authentication details", name)
+		if err := validatePolicy(policy); err != nil {
+			return nil, fmt.Errorf("%s : invalid policy : %w", name, err)
 		}
 	}
 
 	return payload.Policies, nil
+}
+
+func validatePolicy(policy config.Policy) error {
+	if policy.Scope.Authentication.ProtocolVersion == "" {
+		return fmt.Errorf("missing protocol version")
+	}
+
+	if policy.Scope.Authentication.ProtocolVersion != "SNMPv1" && policy.Scope.Authentication.ProtocolVersion != "SNMPv2c" && policy.Scope.Authentication.ProtocolVersion != "SNMPv3" {
+		return fmt.Errorf("unsupported protocol version")
+	}
+
+	if policy.Scope.Authentication.ProtocolVersion == "SNMPv2c" || policy.Scope.Authentication.ProtocolVersion == "SNMPv1" {
+		if policy.Scope.Authentication.Community == "" {
+			return fmt.Errorf("missing community")
+		}
+	}
+
+	if policy.Scope.Authentication.ProtocolVersion == "SNMPv3" {
+		if policy.Scope.Authentication.Username == "" {
+			return fmt.Errorf("missing username")
+		}
+
+		if policy.Scope.Authentication.AuthPassphrase == "" {
+			return fmt.Errorf("missing auth passphrase")
+		}
+
+		if policy.Scope.Authentication.PrivPassphrase == "" {
+			return fmt.Errorf("missing priv passphrase")
+		}
+
+		if policy.Scope.Authentication.AuthProtocol == "" {
+			return fmt.Errorf("missing auth protocol")
+		}
+
+		if policy.Scope.Authentication.PrivProtocol == "" {
+			return fmt.Errorf("missing priv protocol")
+		}
+	}
+
+	return nil
 }
 
 // HasPolicy checks if the policy exists

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -43,7 +43,7 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 	}
 
 	for name, policy := range payload.Policies {
-		if err := validatePolicy(policy); err != nil {
+		if err := m.validatePolicy(policy); err != nil {
 			return nil, fmt.Errorf("%s : invalid policy : %w", name, err)
 		}
 	}
@@ -51,7 +51,7 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 	return payload.Policies, nil
 }
 
-func validatePolicy(policy config.Policy) error {
+func (m *Manager) validatePolicy(policy config.Policy) error {
 	if policy.Scope.Authentication.ProtocolVersion == "" {
 		return fmt.Errorf("missing protocol version")
 	}
@@ -66,25 +66,35 @@ func validatePolicy(policy config.Policy) error {
 		}
 	}
 
+	// m.logger.Info("validating policy", "policy", policy.Scope.Authentication)
+
 	if policy.Scope.Authentication.ProtocolVersion == "SNMPv3" {
-		if policy.Scope.Authentication.Username == "" {
-			return fmt.Errorf("missing username")
+		if policy.Scope.Authentication.SecurityLevel != "noAuthNoPriv" &&
+			policy.Scope.Authentication.SecurityLevel != "authNoPriv" &&
+			policy.Scope.Authentication.SecurityLevel != "authPriv" {
+			return fmt.Errorf("invalid security level %s", policy.Scope.Authentication.SecurityLevel)
 		}
+		if policy.Scope.Authentication.SecurityLevel == "authNoPriv" || policy.Scope.Authentication.SecurityLevel == "authPriv" {
+			if policy.Scope.Authentication.Username == "" {
+				return fmt.Errorf("missing username")
+			}
 
-		if policy.Scope.Authentication.AuthPassphrase == "" {
-			return fmt.Errorf("missing auth passphrase")
+			if policy.Scope.Authentication.AuthPassphrase == "" {
+				return fmt.Errorf("missing auth passphrase")
+			}
+
+			if policy.Scope.Authentication.AuthProtocol == "" {
+				return fmt.Errorf("missing auth protocol")
+			}
 		}
+		if policy.Scope.Authentication.SecurityLevel == "authPriv" {
+			if policy.Scope.Authentication.PrivPassphrase == "" {
+				return fmt.Errorf("missing priv passphrase")
+			}
 
-		if policy.Scope.Authentication.PrivPassphrase == "" {
-			return fmt.Errorf("missing priv passphrase")
-		}
-
-		if policy.Scope.Authentication.AuthProtocol == "" {
-			return fmt.Errorf("missing auth protocol")
-		}
-
-		if policy.Scope.Authentication.PrivProtocol == "" {
-			return fmt.Errorf("missing priv protocol")
+			if policy.Scope.Authentication.PrivProtocol == "" {
+				return fmt.Errorf("missing priv protocol")
+			}
 		}
 	}
 

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -62,7 +62,7 @@ func TestManagerParsePolicies(t *testing.T) {
 		assert.Equal(t, "public", policies["policy1"].Scope.Authentication.Community)
 	})
 
-	t.Run("Missing Authentication", func(t *testing.T) {
+	t.Run("Invalid Policy", func(t *testing.T) {
 		yamlData := []byte(`
         policies:
           policy1:
@@ -74,7 +74,7 @@ func TestManagerParsePolicies(t *testing.T) {
 
 		_, err := manager.ParsePolicies(yamlData)
 		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "policy1 : missing authentication details")
+		assert.Contains(t, err.Error(), "policy1 : invalid policy : missing protocol version")
 	})
 
 	t.Run("No Policies", func(t *testing.T) {

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -60,6 +60,7 @@ func TestManagerParsePolicies(t *testing.T) {
 		assert.Equal(t, uint16(162), policies["policy1"].Scope.Targets[0].Port)
 		assert.Equal(t, snmp.ProtocolVersion2c, policies["policy1"].Scope.Authentication.ProtocolVersion)
 		assert.Equal(t, "public", policies["policy1"].Scope.Authentication.Community)
+		assert.Equal(t, 0, policies["policy1"].Scope.Retries)
 	})
 
 	t.Run("Invalid Policy", func(t *testing.T) {

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -78,7 +78,7 @@ func (r *Runner) run() {
 	entities := make([]diode.Entity, 0)
 
 	for _, target := range r.scope.Targets {
-		host := snmp.NewHost(target.Host, target.Port, &r.scope.Authentication, r.logger, r.ClientFactory)
+		host := snmp.NewHost(target.Host, target.Port, r.scope.Retries, &r.scope.Authentication, r.logger, r.ClientFactory)
 		oids, err := host.Walk(mapper.ObjectIDs())
 		if err != nil {
 			r.logger.Warn("Error crawling host", "host", target.Host, "error", err)

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -78,8 +78,8 @@ func (r *Runner) run() {
 	entities := make([]diode.Entity, 0)
 
 	for _, target := range r.scope.Targets {
-		host := snmp.NewHost(target.Host, target.Port, &r.scope.Authentication, r.logger, r.ClientFactory, mapper.ObjectIDs())
-		oids, err := host.Walk()
+		host := snmp.NewHost(target.Host, target.Port, &r.scope.Authentication, r.logger, r.ClientFactory)
+		oids, err := host.Walk(mapper.ObjectIDs())
 		if err != nil {
 			r.logger.Warn("Error crawling host", "host", target.Host, "error", err)
 			continue

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -288,7 +288,7 @@ func TestRunnerWalkError(t *testing.T) {
 	mockHost.On("Walk", mock.Anything).Return(nil, errors.New("walk error"))
 
 	// Create a mock client factory that returns the mock host
-	mockClientFactory := func(host string, port uint16, retries int, authentication *config.Authentication) (snmp.Walker, error) {
+	mockClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
 		return mockHost, nil
 	}
 

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -32,6 +32,25 @@ func (m *MockDiodeClient) Close() error {
 	return args.Error(0)
 }
 
+// MockHost is a mock implementation of the snmp.Walker interface
+// to simulate errors during the Walk method.
+type MockHost struct {
+	mock.Mock
+}
+
+func (m *MockHost) Walk(objectID string) (snmp.ObjectIDValueMap, error) {
+	args := m.Called(objectID)
+	return nil, args.Error(1)
+}
+
+func (m *MockHost) Connect() error {
+	return nil
+}
+
+func (m *MockHost) Close() error {
+	return nil
+}
+
 func TestNewRunner(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
 	mockClient := new(MockDiodeClient)
@@ -241,4 +260,64 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	// Stop the process
 	err = runner.Stop()
 	assert.NoError(t, err)
+}
+
+func TestRunnerWalkError(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	mockClient := new(MockDiodeClient)
+	ctx := context.Background()
+
+	policyConfig := config.Policy{
+		Config: config.PolicyConfig{},
+		Scope: config.Scope{
+			Targets: []config.Target{
+				{
+					Host: "localhost",
+					Port: 161,
+				},
+			},
+			Authentication: config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion2c,
+				Community:       "public",
+			},
+		},
+	}
+
+	// Create a mock host that returns an error on Walk
+	mockHost := new(MockHost)
+	mockHost.On("Walk", mock.Anything).Return(nil, errors.New("walk error"))
+
+	// Create a mock client factory that returns the mock host
+	mockClientFactory := func(host string, port uint16, retries int, authentication *config.Authentication) (snmp.Walker, error) {
+		return mockHost, nil
+	}
+
+	// Create runner with the mock client factory
+	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, mockClientFactory)
+	assert.NoError(t, err)
+
+	// Use a channel to signal that Ingest was called
+	ingestCalled := make(chan bool, 1)
+
+	mockClient.On("Ingest", mock.Anything, mock.Anything).Run(func(_ mock.Arguments) {
+		ingestCalled <- true
+	}).Return(&diodepb.IngestResponse{}, nil)
+
+	// Start the process
+	runner.Start()
+
+	// Wait for Ingest to be called or timeout
+	select {
+	case <-ingestCalled:
+		// Ingest was called, proceed
+	case <-time.After(10 * time.Second):
+		t.Fatal("Timeout: Ingest was not called")
+	}
+
+	// Stop the process
+	err = runner.Stop()
+	assert.NoError(t, err, "Runner.Stop should not return an error")
+
+	// Verify that the logger captured the error
+	// This part depends on how you want to verify the log output
 }

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -263,7 +263,7 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
 			returnMessage: `test-policy : invalid policy : missing community`,
 		},
 		{
-			desc:        "missing username for SNMPv3",
+			desc:        "invalid security level",
 			contentType: "application/x-yaml",
 			body: []byte(`
             policies:
@@ -273,16 +273,18 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                     - host: 192.168.31.1
                   authentication:
                     protocol_version: SNMPv3
+                    security_level: invalid
+                    username: user
                     auth_passphrase: pass
-                    priv_passphrase: pass
                     auth_protocol: MD5
+                    priv_passphrase: pass
                     priv_protocol: DES
             `),
 			returnCode:    http.StatusBadRequest,
-			returnMessage: `test-policy : invalid policy : missing username`,
+			returnMessage: `test-policy : invalid policy : invalid security level`,
 		},
 		{
-			desc:        "missing auth passphrase for SNMPv3",
+			desc:        "missing security level for SNMPv3",
 			contentType: "application/x-yaml",
 			body: []byte(`
             policies:
@@ -293,15 +295,16 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                   authentication:
                     protocol_version: SNMPv3
                     username: user
-                    priv_passphrase: pass
+                    auth_passphrase: pass
                     auth_protocol: MD5
+                    priv_passphrase: pass
                     priv_protocol: DES
             `),
 			returnCode:    http.StatusBadRequest,
-			returnMessage: `test-policy : invalid policy : missing auth passphrase`,
+			returnMessage: `test-policy : invalid policy : invalid security level`,
 		},
 		{
-			desc:        "missing priv passphrase for SNMPv3",
+			desc:        "missing username for SNMPv3 with authNoPriv",
 			contentType: "application/x-yaml",
 			body: []byte(`
             policies:
@@ -311,6 +314,61 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                     - host: 192.168.31.1
                   authentication:
                     protocol_version: SNMPv3
+                    security_level: authNoPriv
+                    auth_passphrase: pass
+                    auth_protocol: MD5
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `test-policy : invalid policy : missing username`,
+		},
+		{
+			desc:        "missing auth passphrase for SNMPv3 with authNoPriv",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies:
+              test-policy:
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+                  authentication:
+                    protocol_version: SNMPv3
+                    security_level: authNoPriv
+                    username: user
+                    auth_protocol: MD5
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `test-policy : invalid policy : missing auth passphrase`,
+		},
+		{
+			desc:        "missing auth protocol for SNMPv3 with authNoPriv",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies:
+              test-policy:
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+                  authentication:
+                    protocol_version: SNMPv3
+                    security_level: authNoPriv
+                    username: user
+                    auth_passphrase: pass
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `test-policy : invalid policy : missing auth protocol`,
+		},
+		{
+			desc:        "missing priv passphrase for SNMPv3 with authPriv",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies:
+              test-policy:
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+                  authentication:
+                    protocol_version: SNMPv3
+                    security_level: authPriv
                     username: user
                     auth_passphrase: pass
                     auth_protocol: MD5
@@ -320,7 +378,7 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
 			returnMessage: `test-policy : invalid policy : missing priv passphrase`,
 		},
 		{
-			desc:        "missing auth protocol for SNMPv3",
+			desc:        "missing priv protocol for SNMPv3 with authPriv",
 			contentType: "application/x-yaml",
 			body: []byte(`
             policies:
@@ -330,29 +388,11 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                     - host: 192.168.31.1
                   authentication:
                     protocol_version: SNMPv3
+                    security_level: authPriv
                     username: user
                     auth_passphrase: pass
-                    priv_passphrase: pass
-                    priv_protocol: DES
-            `),
-			returnCode:    http.StatusBadRequest,
-			returnMessage: `test-policy : invalid policy : missing auth protocol`,
-		},
-		{
-			desc:        "missing priv protocol for SNMPv3",
-			contentType: "application/x-yaml",
-			body: []byte(`
-            policies:
-              test-policy:
-                scope:
-                  targets:
-                    - host: 192.168.31.1
-                  authentication:
-                    protocol_version: SNMPv3
-                    username: user
-                    auth_passphrase: pass
-                    priv_passphrase: pass
                     auth_protocol: MD5
+                    priv_passphrase: pass
             `),
 			returnCode:    http.StatusBadRequest,
 			returnMessage: `test-policy : invalid policy : missing priv protocol`,

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -229,7 +229,7 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                     - host: 192.168.31.1
             `),
 			returnCode:    http.StatusBadRequest,
-			returnMessage: `test-policy-invalid : missing authentication details`,
+			returnMessage: `test-policy-invalid : invalid policy : missing protocol version`,
 		},
 	}
 	for _, tt := range tests {

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -231,6 +231,132 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
 			returnCode:    http.StatusBadRequest,
 			returnMessage: `test-policy-invalid : invalid policy : missing protocol version`,
 		},
+		{
+			desc:        "unsupported protocol version",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies:
+              test-policy:
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+                  authentication:
+                    protocol_version: SNMPv4
+                    community: public
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `test-policy : invalid policy : unsupported protocol version`,
+		},
+		{
+			desc:        "missing community",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies:
+              test-policy:
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+                  authentication:
+                    protocol_version: SNMPv2c
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `test-policy : invalid policy : missing community`,
+		},
+		{
+			desc:        "missing username for SNMPv3",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies:
+              test-policy:
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+                  authentication:
+                    protocol_version: SNMPv3
+                    auth_passphrase: pass
+                    priv_passphrase: pass
+                    auth_protocol: MD5
+                    priv_protocol: DES
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `test-policy : invalid policy : missing username`,
+		},
+		{
+			desc:        "missing auth passphrase for SNMPv3",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies:
+              test-policy:
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+                  authentication:
+                    protocol_version: SNMPv3
+                    username: user
+                    priv_passphrase: pass
+                    auth_protocol: MD5
+                    priv_protocol: DES
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `test-policy : invalid policy : missing auth passphrase`,
+		},
+		{
+			desc:        "missing priv passphrase for SNMPv3",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies:
+              test-policy:
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+                  authentication:
+                    protocol_version: SNMPv3
+                    username: user
+                    auth_passphrase: pass
+                    auth_protocol: MD5
+                    priv_protocol: DES
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `test-policy : invalid policy : missing priv passphrase`,
+		},
+		{
+			desc:        "missing auth protocol for SNMPv3",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies:
+              test-policy:
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+                  authentication:
+                    protocol_version: SNMPv3
+                    username: user
+                    auth_passphrase: pass
+                    priv_passphrase: pass
+                    priv_protocol: DES
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `test-policy : invalid policy : missing auth protocol`,
+		},
+		{
+			desc:        "missing priv protocol for SNMPv3",
+			contentType: "application/x-yaml",
+			body: []byte(`
+            policies:
+              test-policy:
+                scope:
+                  targets:
+                    - host: 192.168.31.1
+                  authentication:
+                    protocol_version: SNMPv3
+                    username: user
+                    auth_passphrase: pass
+                    priv_passphrase: pass
+                    auth_protocol: MD5
+            `),
+			returnCode:    http.StatusBadRequest,
+			returnMessage: `test-policy : invalid policy : missing priv protocol`,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -26,6 +26,6 @@ func (n *FakeSNMPWalker) Walk(oid string) (ObjectIDValueMap, error) {
 }
 
 // NewFakeSNMPWalker creates a new FakeSNMPWalker
-func NewFakeSNMPWalker(_ string, _ uint16, _ *config.Authentication) (Walker, error) {
+func NewFakeSNMPWalker(_ string, _ uint16, _ int, _ *config.Authentication) (Walker, error) {
 	return &FakeSNMPWalker{}, nil
 }

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -57,11 +57,10 @@ type Host struct {
 	objects        map[string]string
 	logger         *slog.Logger
 	ClientFactory  ClientFactory
-	objectIDs      []string
 }
 
 // NewHost creates a new Host
-func NewHost(host string, port uint16, authentication *config.Authentication, logger *slog.Logger, ClientFactory ClientFactory, objectIDs []string) *Host {
+func NewHost(host string, port uint16, authentication *config.Authentication, logger *slog.Logger, ClientFactory ClientFactory) *Host {
 	return &Host{
 		address:        host,
 		port:           port,
@@ -69,12 +68,11 @@ func NewHost(host string, port uint16, authentication *config.Authentication, lo
 		objects:        make(map[string]string),
 		logger:         logger,
 		ClientFactory:  ClientFactory,
-		objectIDs:      objectIDs,
 	}
 }
 
 // Walk walks the SNMP host
-func (s *Host) Walk() (ObjectIDValueMap, error) {
+func (s *Host) Walk(objectIDs []string) (ObjectIDValueMap, error) {
 	s.logger.Info("Scanning", "host", s.address)
 
 	snmpClient, err := s.ClientFactory(s.address, s.port, s.authentication)
@@ -94,7 +92,7 @@ func (s *Host) Walk() (ObjectIDValueMap, error) {
 	}
 
 	output := make(ObjectIDValueMap)
-	for _, objectID := range s.objectIDs {
+	for _, objectID := range objectIDs {
 		pdu, err := snmpClient.Walk(objectID)
 		if err != nil {
 			s.logger.Warn("Error walking ObjectID", "objectID", objectID, "error", err)

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -53,16 +53,18 @@ func (m *ObjectIDMapper) ObjectIDs() []string {
 type Host struct {
 	address        string
 	port           uint16
+	retries        int
 	authentication *config.Authentication
 	logger         *slog.Logger
 	ClientFactory  ClientFactory
 }
 
 // NewHost creates a new Host
-func NewHost(host string, port uint16, authentication *config.Authentication, logger *slog.Logger, ClientFactory ClientFactory) *Host {
+func NewHost(host string, port uint16, retries int, authentication *config.Authentication, logger *slog.Logger, ClientFactory ClientFactory) *Host {
 	return &Host{
 		address:        host,
 		port:           port,
+		retries:        retries,
 		authentication: authentication,
 		logger:         logger,
 		ClientFactory:  ClientFactory,
@@ -73,7 +75,7 @@ func NewHost(host string, port uint16, authentication *config.Authentication, lo
 func (s *Host) Walk(objectIDs []string) (ObjectIDValueMap, error) {
 	s.logger.Info("Scanning", "host", s.address)
 
-	snmpClient, err := s.ClientFactory(s.address, s.port, s.authentication)
+	snmpClient, err := s.ClientFactory(s.address, s.port, s.retries, s.authentication)
 	if err != nil {
 		return nil, err
 	}
@@ -145,10 +147,10 @@ const (
 )
 
 // ClientFactory is a function that creates a new SNMPClient
-type ClientFactory func(host string, port uint16, authentication *config.Authentication) (Walker, error)
+type ClientFactory func(host string, port uint16, retries int, authentication *config.Authentication) (Walker, error)
 
 // NewClient creates a new SNMPClient for the given target host
-func NewClient(host string, port uint16, authentication *config.Authentication) (Walker, error) {
+func NewClient(host string, port uint16, retries int, authentication *config.Authentication) (Walker, error) {
 	switch authentication.ProtocolVersion {
 	case ProtocolVersion1:
 		return &Client{
@@ -177,6 +179,7 @@ func NewClient(host string, port uint16, authentication *config.Authentication) 
 				Port:    port,
 				Version: gosnmp.Version3,
 				Timeout: time.Duration(2) * time.Second,
+				Retries: retries,
 				SecurityParameters: &gosnmp.UsmSecurityParameters{
 					UserName:                 authentication.Username,
 					AuthenticationProtocol:   getAuthProtocol(authentication.AuthProtocol),

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -136,6 +136,8 @@ func (c *Client) Walk(objectID string) (ObjectIDValueMap, error) {
 }
 
 const (
+	// ProtocolVersion1 is the SNMPv1 protocol version
+	ProtocolVersion1 = "SNMPv1"
 	// ProtocolVersion2c is the SNMPv2c protocol version
 	ProtocolVersion2c = "SNMPv2c"
 	// ProtocolVersion3 is the SNMPv3 protocol version
@@ -147,7 +149,18 @@ type ClientFactory func(host string, port uint16, authentication *config.Authent
 
 // NewClient creates a new SNMPClient for the given target host
 func NewClient(host string, port uint16, authentication *config.Authentication) (Walker, error) {
-	if authentication.ProtocolVersion == ProtocolVersion2c {
+	switch authentication.ProtocolVersion {
+	case ProtocolVersion1:
+		return &Client{
+			&gosnmp.GoSNMP{
+				Target:    host,
+				Port:      port,
+				Community: authentication.Community,
+				Version:   gosnmp.Version1,
+				Timeout:   time.Duration(2) * time.Second,
+			},
+		}, nil
+	case ProtocolVersion2c:
 		return &Client{
 			&gosnmp.GoSNMP{
 				Target:    host,
@@ -157,8 +170,48 @@ func NewClient(host string, port uint16, authentication *config.Authentication) 
 				Timeout:   time.Duration(2) * time.Second,
 			},
 		}, nil
+	case ProtocolVersion3:
+		return &Client{
+			&gosnmp.GoSNMP{
+				Target:  host,
+				Port:    port,
+				Version: gosnmp.Version3,
+				Timeout: time.Duration(2) * time.Second,
+				SecurityParameters: &gosnmp.UsmSecurityParameters{
+					UserName:                 authentication.Username,
+					AuthenticationProtocol:   getAuthProtocol(authentication.AuthProtocol),
+					AuthenticationPassphrase: authentication.AuthPassphrase,
+					PrivacyProtocol:          getPrivProtocol(authentication.PrivProtocol),
+					PrivacyPassphrase:        authentication.PrivPassphrase,
+				},
+			},
+		}, nil
 	}
-	return nil, fmt.Errorf("unsupported protocol version: %s. Currently only SNMPv2c is supported", authentication.ProtocolVersion)
+	return nil, fmt.Errorf("unsupported protocol version: %s", authentication.ProtocolVersion)
+}
+
+func getAuthProtocol(authProtocol string) gosnmp.SnmpV3AuthProtocol {
+	switch authProtocol {
+	case "NoAuth":
+		return gosnmp.NoAuth
+	case "MD5":
+		return gosnmp.MD5
+	case "SHA":
+		return gosnmp.SHA
+	}
+	return gosnmp.NoAuth
+}
+
+func getPrivProtocol(privProtocol string) gosnmp.SnmpV3PrivProtocol {
+	switch privProtocol {
+	case "NoPriv":
+		return gosnmp.NoPriv
+	case "DES":
+		return gosnmp.DES
+	case "AES":
+		return gosnmp.AES
+	}
+	return gosnmp.AES
 }
 
 // Walker interface defines methods for walking SNMP trees

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -54,7 +54,6 @@ type Host struct {
 	address        string
 	port           uint16
 	authentication *config.Authentication
-	objects        map[string]string
 	logger         *slog.Logger
 	ClientFactory  ClientFactory
 }
@@ -65,7 +64,6 @@ func NewHost(host string, port uint16, authentication *config.Authentication, lo
 		address:        host,
 		port:           port,
 		authentication: authentication,
-		objects:        make(map[string]string),
 		logger:         logger,
 		ClientFactory:  ClientFactory,
 	}

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -173,6 +173,14 @@ func NewClient(host string, port uint16, retries int, authentication *config.Aut
 			},
 		}, nil
 	case ProtocolVersion3:
+		authProtocol, err := getAuthProtocol(authentication.AuthProtocol)
+		if err != nil {
+			return nil, err
+		}
+		privProtocol, err := getPrivProtocol(authentication.PrivProtocol)
+		if err != nil {
+			return nil, err
+		}
 		return &Client{
 			&gosnmp.GoSNMP{
 				Target:  host,
@@ -182,9 +190,9 @@ func NewClient(host string, port uint16, retries int, authentication *config.Aut
 				Retries: retries,
 				SecurityParameters: &gosnmp.UsmSecurityParameters{
 					UserName:                 authentication.Username,
-					AuthenticationProtocol:   getAuthProtocol(authentication.AuthProtocol),
+					AuthenticationProtocol:   authProtocol,
 					AuthenticationPassphrase: authentication.AuthPassphrase,
-					PrivacyProtocol:          getPrivProtocol(authentication.PrivProtocol),
+					PrivacyProtocol:          privProtocol,
 					PrivacyPassphrase:        authentication.PrivPassphrase,
 				},
 			},
@@ -193,28 +201,28 @@ func NewClient(host string, port uint16, retries int, authentication *config.Aut
 	return nil, fmt.Errorf("unsupported protocol version: %s", authentication.ProtocolVersion)
 }
 
-func getAuthProtocol(authProtocol string) gosnmp.SnmpV3AuthProtocol {
+func getAuthProtocol(authProtocol string) (gosnmp.SnmpV3AuthProtocol, error) {
 	switch authProtocol {
 	case "NoAuth":
-		return gosnmp.NoAuth
+		return gosnmp.NoAuth, nil
 	case "MD5":
-		return gosnmp.MD5
+		return gosnmp.MD5, nil
 	case "SHA":
-		return gosnmp.SHA
+		return gosnmp.SHA, nil
 	}
-	return gosnmp.NoAuth
+	return gosnmp.NoAuth, fmt.Errorf("unsupported authentication protocol: %s", authProtocol)
 }
 
-func getPrivProtocol(privProtocol string) gosnmp.SnmpV3PrivProtocol {
+func getPrivProtocol(privProtocol string) (gosnmp.SnmpV3PrivProtocol, error) {
 	switch privProtocol {
 	case "NoPriv":
-		return gosnmp.NoPriv
+		return gosnmp.NoPriv, nil
 	case "DES":
-		return gosnmp.DES
+		return gosnmp.DES, nil
 	case "AES":
-		return gosnmp.AES
+		return gosnmp.AES, nil
 	}
-	return gosnmp.AES
+	return gosnmp.NoPriv, fmt.Errorf("unsupported privacy protocol: %s", privProtocol)
 }
 
 // Walker interface defines methods for walking SNMP trees

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -53,10 +53,12 @@ func TestSNMPHost(t *testing.T) {
 		// Setup
 		objectIDsToQuery := []string{ipAddressObjectID}
 		fakeWalker, _ := snmp.NewFakeSNMPWalker("192.168.1.1", 161, nil)
-		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) { return fakeWalker, nil }, objectIDsToQuery)
+		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) {
+			return fakeWalker, nil
+		})
 
 		// Execute
-		oids, err := host.Walk()
+		oids, err := host.Walk(objectIDsToQuery)
 
 		// Assert
 		assert.NoError(t, err)
@@ -69,10 +71,12 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker := &MockSNMP{}
 		mockWalker.On("Connect").Return(assert.AnError)
 		mockWalker.On("Close").Return(nil)
-		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) { return mockWalker, nil }, []string{"1.3.6.1.2.1.4.20.1.1"})
+		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) {
+			return mockWalker, nil
+		})
 
 		// Execute
-		oids, err := host.Walk()
+		oids, err := host.Walk([]string{"1.3.6.1.2.1.4.20.1.1"})
 
 		// Assert
 		assert.Error(t, err)
@@ -86,10 +90,12 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
 		mockWalker.On("Walk", mock.Anything).Return(nil, assert.AnError)
-		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) { return mockWalker, nil }, []string{ipAddressObjectID})
+		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) {
+			return mockWalker, nil
+		})
 
 		// Execute
-		oids, err := host.Walk()
+		oids, err := host.Walk([]string{ipAddressObjectID})
 
 		// Assert
 		assert.Error(t, err)
@@ -105,10 +111,10 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Walk", mock.Anything).Return(nil, assert.AnError)
 		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) {
 			return nil, fmt.Errorf("error creating client")
-		}, []string{ipAddressObjectID})
+		})
 
 		// Execute
-		oids, err := host.Walk()
+		oids, err := host.Walk([]string{ipAddressObjectID})
 
 		// Assert
 		assert.Error(t, err)

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -52,10 +52,11 @@ func TestSNMPHost(t *testing.T) {
 	t.Run("Successfully walks a host", func(t *testing.T) {
 		// Setup
 		objectIDsToQuery := []string{ipAddressObjectID}
-		fakeWalker, _ := snmp.NewFakeSNMPWalker("192.168.1.1", 161, nil)
-		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
+			fakeWalker, _ := snmp.NewFakeSNMPWalker("192.168.1.1", 161, 3, nil)
 			return fakeWalker, nil
-		})
+		}
+		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
 
 		// Execute
 		oids, err := host.Walk(objectIDsToQuery)
@@ -71,9 +72,10 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker := &MockSNMP{}
 		mockWalker.On("Connect").Return(assert.AnError)
 		mockWalker.On("Close").Return(nil)
-		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
 			return mockWalker, nil
-		})
+		}
+		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
 
 		// Execute
 		oids, err := host.Walk([]string{"1.3.6.1.2.1.4.20.1.1"})
@@ -90,9 +92,10 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
 		mockWalker.On("Walk", mock.Anything).Return(nil, assert.AnError)
-		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
 			return mockWalker, nil
-		})
+		}
+		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
 
 		// Execute
 		oids, err := host.Walk([]string{ipAddressObjectID})
@@ -109,9 +112,10 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
 		mockWalker.On("Walk", mock.Anything).Return(nil, assert.AnError)
-		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
 			return nil, fmt.Errorf("error creating client")
-		})
+		}
+		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
 
 		// Execute
 		oids, err := host.Walk([]string{ipAddressObjectID})
@@ -172,7 +176,7 @@ func TestNewClient(t *testing.T) {
 			ProtocolVersion: snmp.ProtocolVersion1,
 			Community:       "public",
 		}
-		client, err := snmp.NewClient("192.168.1.1", 161, auth)
+		client, err := snmp.NewClient("192.168.1.1", 161, 3, auth)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
@@ -183,7 +187,7 @@ func TestNewClient(t *testing.T) {
 			ProtocolVersion: snmp.ProtocolVersion2c,
 			Community:       "public",
 		}
-		client, err := snmp.NewClient("192.168.1.1", 161, auth)
+		client, err := snmp.NewClient("192.168.1.1", 161, 3, auth)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
@@ -198,7 +202,7 @@ func TestNewClient(t *testing.T) {
 			PrivProtocol:    "AES",
 			PrivPassphrase:  "testpass",
 		}
-		client, err := snmp.NewClient("192.168.1.1", 161, auth)
+		client, err := snmp.NewClient("192.168.1.1", 161, 3, auth)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, client)
@@ -208,7 +212,7 @@ func TestNewClient(t *testing.T) {
 		auth := &config.Authentication{
 			ProtocolVersion: "SNMPv4",
 		}
-		client, err := snmp.NewClient("192.168.1.1", 161, auth)
+		client, err := snmp.NewClient("192.168.1.1", 161, 3, auth)
 
 		assert.Error(t, err)
 		assert.Nil(t, client)

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -218,6 +218,35 @@ func TestNewClient(t *testing.T) {
 			},
 			expectError: false,
 		},
+
+		{
+			name: "Invalid SNMPv3 auth protocol",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "InvalidProtocol",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "DES",
+				PrivPassphrase:  "testpass",
+				SecurityLevel:   "authPriv",
+			},
+			expectError:    true,
+			expectedErrMsg: "unsupported authentication protocol: InvalidProtocol",
+		},
+		{
+			name: "Invalid SNMPv3 priv protocol",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "MD5",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "InvalidProtocol",
+				PrivPassphrase:  "testpass",
+				SecurityLevel:   "authPriv",
+			},
+			expectError:    true,
+			expectedErrMsg: "unsupported privacy protocol: InvalidProtocol",
+		},
 		{
 			name: "Returns error for unsupported protocol version",
 			auth: &config.Authentication{

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -2,6 +2,7 @@ package snmp_test
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"os"
 	"testing"
@@ -95,6 +96,24 @@ func TestSNMPHost(t *testing.T) {
 		assert.Nil(t, oids)
 		mockWalker.AssertExpectations(t)
 	})
+
+	t.Run("Handles SNMP client creation error", func(t *testing.T) {
+		// Setup
+		mockWalker := &MockSNMP{}
+		mockWalker.On("Connect").Return(nil)
+		mockWalker.On("Close").Return(nil)
+		mockWalker.On("Walk", mock.Anything).Return(nil, assert.AnError)
+		host := snmp.NewHost("192.168.1.1", 161, nil, logger, func(_ string, _ uint16, _ *config.Authentication) (snmp.Walker, error) {
+			return nil, fmt.Errorf("error creating client")
+		}, []string{ipAddressObjectID})
+
+		// Execute
+		oids, err := host.Walk()
+
+		// Assert
+		assert.Error(t, err)
+		assert.Nil(t, oids)
+	})
 }
 
 // Connect implements Walker interface
@@ -139,4 +158,28 @@ func TestObjectIDs(t *testing.T) {
 	objectIDs := mapper.ObjectIDs()
 
 	assert.ElementsMatch(t, expectedObjectIDs, objectIDs)
+}
+
+func TestNewClient(t *testing.T) {
+	t.Run("Creates SNMPv2c client successfully", func(t *testing.T) {
+		auth := &config.Authentication{
+			ProtocolVersion: snmp.ProtocolVersion2c,
+			Community:       "public",
+		}
+		client, err := snmp.NewClient("192.168.1.1", 161, auth)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+
+	t.Run("Returns error for unsupported protocol version", func(t *testing.T) {
+		auth := &config.Authentication{
+			ProtocolVersion: "SNMPv1",
+		}
+		client, err := snmp.NewClient("192.168.1.1", 161, auth)
+
+		assert.Error(t, err)
+		assert.Nil(t, client)
+		assert.Equal(t, "unsupported protocol version: SNMPv1. Currently only SNMPv2c is supported", err.Error())
+	})
 }

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -171,51 +171,75 @@ func TestObjectIDs(t *testing.T) {
 }
 
 func TestNewClient(t *testing.T) {
-	t.Run("Creates SNMPv1 client successfully", func(t *testing.T) {
-		auth := &config.Authentication{
-			ProtocolVersion: snmp.ProtocolVersion1,
-			Community:       "public",
-		}
-		client, err := snmp.NewClient("192.168.1.1", 161, 3, auth)
+	testCases := []struct {
+		name           string
+		auth           *config.Authentication
+		expectError    bool
+		expectedErrMsg string
+	}{
+		{
+			name: "Creates SNMPv1 client successfully",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion1,
+				Community:       "public",
+			},
+			expectError: false,
+		},
+		{
+			name: "Creates SNMPv2c client successfully",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion2c,
+				Community:       "public",
+			},
+			expectError: false,
+		},
+		{
+			name: "Creates SNMPv3 client successfully with SHA/AES",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "SHA",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "AES",
+				PrivPassphrase:  "testpass",
+			},
+			expectError: false,
+		},
+		{
+			name: "Creates SNMPv3 client successfully with MD5/DES",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "MD5",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "DES",
+				PrivPassphrase:  "testpass",
+				SecurityLevel:   "authPriv",
+			},
+			expectError: false,
+		},
+		{
+			name: "Returns error for unsupported protocol version",
+			auth: &config.Authentication{
+				ProtocolVersion: "SNMPv4",
+			},
+			expectError:    true,
+			expectedErrMsg: "unsupported protocol version: SNMPv4",
+		},
+	}
 
-		assert.NoError(t, err)
-		assert.NotNil(t, client)
-	})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, err := snmp.NewClient("192.168.1.1", 161, 3, tc.auth)
 
-	t.Run("Creates SNMPv2c client successfully", func(t *testing.T) {
-		auth := &config.Authentication{
-			ProtocolVersion: snmp.ProtocolVersion2c,
-			Community:       "public",
-		}
-		client, err := snmp.NewClient("192.168.1.1", 161, 3, auth)
-
-		assert.NoError(t, err)
-		assert.NotNil(t, client)
-	})
-
-	t.Run("Creates SNMPv3 client successfully", func(t *testing.T) {
-		auth := &config.Authentication{
-			ProtocolVersion: snmp.ProtocolVersion3,
-			Username:        "testuser",
-			AuthProtocol:    "SHA",
-			AuthPassphrase:  "testpass",
-			PrivProtocol:    "AES",
-			PrivPassphrase:  "testpass",
-		}
-		client, err := snmp.NewClient("192.168.1.1", 161, 3, auth)
-
-		assert.NoError(t, err)
-		assert.NotNil(t, client)
-	})
-
-	t.Run("Returns error for unsupported protocol version", func(t *testing.T) {
-		auth := &config.Authentication{
-			ProtocolVersion: "SNMPv4",
-		}
-		client, err := snmp.NewClient("192.168.1.1", 161, 3, auth)
-
-		assert.Error(t, err)
-		assert.Nil(t, client)
-		assert.Equal(t, "unsupported protocol version: SNMPv4", err.Error())
-	})
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Nil(t, client)
+				assert.Equal(t, tc.expectedErrMsg, err.Error())
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, client)
+			}
+		})
+	}
 }

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -169,6 +169,17 @@ func TestObjectIDs(t *testing.T) {
 func TestNewClient(t *testing.T) {
 	t.Run("Creates SNMPv2c client successfully", func(t *testing.T) {
 		auth := &config.Authentication{
+			ProtocolVersion: snmp.ProtocolVersion1,
+			Community:       "public",
+		}
+		client, err := snmp.NewClient("192.168.1.1", 161, auth)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+
+	t.Run("Creates SNMPv2c client successfully", func(t *testing.T) {
+		auth := &config.Authentication{
 			ProtocolVersion: snmp.ProtocolVersion2c,
 			Community:       "public",
 		}
@@ -178,14 +189,29 @@ func TestNewClient(t *testing.T) {
 		assert.NotNil(t, client)
 	})
 
+	t.Run("Creates SNMPv3 client successfully", func(t *testing.T) {
+		auth := &config.Authentication{
+			ProtocolVersion: snmp.ProtocolVersion3,
+			Username:        "testuser",
+			AuthProtocol:    "SHA",
+			AuthPassphrase:  "testpass",
+			PrivProtocol:    "AES",
+			PrivPassphrase:  "testpass",
+		}
+		client, err := snmp.NewClient("192.168.1.1", 161, auth)
+
+		assert.NoError(t, err)
+		assert.NotNil(t, client)
+	})
+
 	t.Run("Returns error for unsupported protocol version", func(t *testing.T) {
 		auth := &config.Authentication{
-			ProtocolVersion: "SNMPv1",
+			ProtocolVersion: "SNMPv4",
 		}
 		client, err := snmp.NewClient("192.168.1.1", 161, auth)
 
 		assert.Error(t, err)
 		assert.Nil(t, client)
-		assert.Equal(t, "unsupported protocol version: SNMPv1. Currently only SNMPv2c is supported", err.Error())
+		assert.Equal(t, "unsupported protocol version: SNMPv4", err.Error())
 	})
 }

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -167,7 +167,7 @@ func TestObjectIDs(t *testing.T) {
 }
 
 func TestNewClient(t *testing.T) {
-	t.Run("Creates SNMPv2c client successfully", func(t *testing.T) {
+	t.Run("Creates SNMPv1 client successfully", func(t *testing.T) {
 		auth := &config.Authentication{
 			ProtocolVersion: snmp.ProtocolVersion1,
 			Community:       "public",


### PR DESCRIPTION
This pull request introduces several enhancements and fixes to the SNMP discovery module, focusing on improved support for SNMPv3, enhanced validation for policies, and better test coverage. Key updates include the addition of retries for SNMP operations, expanded authentication fields, and a more robust validation mechanism for SNMP policies.

### Enhancements to SNMP Configuration and Authentication:
* Added a `Retries` field to the `Scope` struct to support configurable retry attempts for SNMP operations. (`snmp-discovery/config/config.go`, [snmp-discovery/config/config.goR16](diffhunk://#diff-6ca23964054f973f61443ee3c52410a7bdcc1215394ef455d5d7d62a56676cd2R16))
* Expanded the `Authentication` struct to include fields for SNMPv3-specific parameters such as `SecurityLevel`, `Username`, `AuthProtocol`, `AuthPassphrase`, `PrivProtocol`, and `PrivPassphrase`. (`snmp-discovery/config/config.go`, [snmp-discovery/config/config.goR29-R34](diffhunk://#diff-6ca23964054f973f61443ee3c52410a7bdcc1215394ef455d5d7d62a56676cd2R29-R34))

### Policy Validation Improvements:
* Introduced a `validatePolicy` function to enforce stricter validation of SNMP policies, including checks for protocol version and required authentication fields based on the selected version. (`snmp-discovery/policy/manager.go`, [snmp-discovery/policy/manager.goL46-R93](diffhunk://#diff-97d32253107e3c811caf8c6de6078b90fc18fbfecca66691424c657d8b77651cL46-R93))
* Updated error messages in tests to reflect the new validation logic, providing more granular feedback for invalid policies. (`snmp-discovery/policy/manager_test.go`, [snmp-discovery/policy/manager_test.goL77-R78](diffhunk://#diff-d7a8cc6613db677701db042f45e16e5c7b23bea87c2a21ccfce2a36e66bbd6b7L77-R78))

### SNMPv3 Support and Client Enhancements:
* Enhanced the `NewClient` function to support SNMPv1, SNMPv2c, and SNMPv3, including the use of `UsmSecurityParameters` for SNMPv3. (`snmp-discovery/snmp/snmp.go`, [snmp-discovery/snmp/snmp.goR175-R217](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R175-R217))
* Added helper functions `getAuthProtocol` and `getPrivProtocol` to map string representations of protocols to their corresponding SNMP library constants. (`snmp-discovery/snmp/snmp.go`, [snmp-discovery/snmp/snmp.goR175-R217](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R175-R217))

### Updates to SNMP Host and Walker:
* Modified the `Host` struct and its `Walk` method to include the `Retries` parameter and accept object IDs dynamically instead of storing them in the struct. (`snmp-discovery/snmp/snmp.go`, [[1]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R56-R78) [[2]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L97-R95)
* Updated the `FakeSNMPWalker` and related test cases to accommodate the new `Retries` parameter. (`snmp-discovery/snmp/mocks.go`, [snmp-discovery/snmp/mocks.goL29-R29](diffhunk://#diff-ca04d639e95ac1098548f63ed2dcc476d1fd18379c7a3d4bccadeae762362138L29-R29))

### Expanded Test Coverage:
* Added comprehensive test cases for SNMPv1, SNMPv2c, and SNMPv3 client creation, as well as error handling for unsupported protocol versions. (`snmp-discovery/snmp/snmp_test.go`, [snmp-discovery/snmp/snmp_test.goR172-R221](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58R172-R221))
* Introduced additional test scenarios for invalid policies, including missing or incorrect SNMPv3 parameters. (`snmp-discovery/server/server_test.go`, [snmp-discovery/server/server_test.goL232-R358](diffhunk://#diff-dd2e681eb687c29c248a79d49e7ff2634765985bdba868594effaf8b485bf614L232-R358))

These changes collectively improve the robustness, configurability, and feature set of the SNMP discovery module, particularly with the addition of SNMPv3 support and enhanced validation mechanisms.