### PR TITLE
feat: add location and tenant support for device

### DIFF
--- a/device-discovery/device_discovery/policy/models.py
+++ b/device-discovery/device_discovery/policy/models.py
@@ -57,6 +57,8 @@ class Defaults(BaseModel):
     site: str | None = Field(default="undefined", description="Site name, optional")
     role: str | None = Field(default="undefined", description="Device Role name, optional")
     if_type: str | None = Field(default="other", description="Interface type, optional")
+    location: str | None = Field(default=None, description="Location name, optional")
+    tenant: str | None = Field(default=None, description="Tenant name, optional")
     tags: list[str] | None = Field(default=None, description="Tags, optional")
     device: ObjectParameters | None = Field(default=None, description="Device parameters, optional")
     interface: ObjectParameters | None = Field(default=None, description="Interface parameters, optional")

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -12,6 +12,7 @@ from netboxlabs.diode.sdk.ingester import (
     Entity,
     Interface,
     IPAddress,
+    Location,
     Platform,
     Prefix,
 )
@@ -73,6 +74,8 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
         status="active",
         site=defaults.site,
         tags=tags,
+        location=Location(name=defaults.location, site=defaults.site),
+        tenant=defaults.tenant,
         description=description,
         comments=comments,
     )
@@ -105,7 +108,11 @@ def translate_interface(
         description = defaults.interface.description
 
     description = interface_info.get("description", description)
-    mac_address = interface_info.get("mac_address") if interface_info.get("mac_address") != "" else None
+    mac_address = (
+        interface_info.get("mac_address")
+        if interface_info.get("mac_address") != ""
+        else None
+    )
 
     interface = Interface(
         device=device,
@@ -190,7 +197,6 @@ def translate_interface_ips(
                         Entity(
                             prefix=Prefix(
                                 prefix=str(network),
-                                scope_site=defaults.site,
                                 vrf=prefix_vrf,
                                 role=prefix_role,
                                 tenant=prefix_tenant,

--- a/device-discovery/tests/test_client.py
+++ b/device-discovery/tests/test_client.py
@@ -48,6 +48,8 @@ def sample_data():
             role=None,
             tags=None,
             if_type="other",
+            location="local",
+            tenant="test",
             device=None,
             interface=None,
             ipaddress=None,

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -81,6 +81,8 @@ def sample_defaults():
         site="New York",
         tags=["tag1", "tag2"],
         if_type="other",
+        location="local",
+        tenant="test",
         device=ObjectParameters(comments="testing", tags=["devtag"]),
         interface=ObjectParameters(description="testing", tags=["inttag"]),
         ipaddress=IpamParameters(description="ip test", tags=["iptag"]),
@@ -99,6 +101,9 @@ def test_translate_device(sample_device_info, sample_defaults):
     assert device.site.name == "New York"
     assert device.comments == "testing"
     assert device.role.name == "undefined"
+    assert device.location.name == "local"
+    assert device.location.site.name == "New York"
+    assert device.tenant.name == "test"
     assert len(device.tags) == 3
 
 


### PR DESCRIPTION
This pull request introduces enhancements to the `device-discovery` module by adding support for `location` and `tenant` fields in the `Defaults` model, updating the translation logic to include these fields, and expanding test coverage to validate the changes. The most important changes are grouped below:

### Enhancements to `Defaults` Model:
* Added `location` and `tenant` fields to the `Defaults` model in `device_discovery/policy/models.py` with appropriate default values and descriptions.

### Updates to Translation Logic:
* Updated the `translate_device` function in `device_discovery/translate.py` to include `location` and `tenant` fields when creating a `Device` object.
* Modified the `translate_interface` function to improve readability of the `mac_address` assignment logic.
* Removed `scope_site` from the `translate_interface_ips` function, as it is no longer required.

### Test Coverage Improvements:
* Updated `sample_data` in `test_client.py` and `sample_defaults` in `test_translate.py` to include `location` and `tenant` fields for testing. [[1]](diffhunk://#diff-789d829d42fd212662651b5283987a29ba2d55791fa8dd3aae5d29deda176671R51-R52) [[2]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R84-R85)
* Added assertions in `test_translate_device` to validate that `location` and `tenant` fields are correctly translated.