### PR TITLE
fix: device-discovery vlan default site

### DIFF
--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -252,6 +252,7 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
 
     vlan = VLAN(
         vid=int(vid),
+        site=defaults.site,
         name=vlan_name,
         group=group,
         tenant=tenant,

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -213,6 +213,7 @@ def test_translate_vlan(sample_defaults):
     assert vlan.vid == 1
     assert vlan.name == "Test VLAN"
     assert len(vlan.tags) == 3
+    assert vlan.site.name == "New York"
     assert vlan.comments == ""
 
 
@@ -237,4 +238,5 @@ def test_translate_vlan_with_defaults(sample_defaults):
     assert vlan.group.name == "Default Group"
     assert vlan.tenant.name == "Default Tenant"
     assert vlan.role.name == "Default Role"
+    assert vlan.site.name == "New York"
     assert len(vlan.tags) == 3


### PR DESCRIPTION
This pull request updates the `translate_vlan` function in `device_discovery/translate.py` to include the `site` attribute from the `Defaults` object when creating a VLAN. Corresponding test cases have been updated to validate this new behavior.

### Changes to `translate_vlan` function:

* Added the `site` attribute from the `Defaults` object to the `VLAN` initialization in the `translate_vlan` function. (`device-discovery/device_discovery/translate.py`, [device-discovery/device_discovery/translate.pyR255](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R255))

### Updates to test cases:

* Updated `test_translate_vlan` to assert that the `site.name` of the resulting VLAN is correctly set to "New York". (`device-discovery/tests/test_translate.py`, [device-discovery/tests/test_translate.pyR216](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R216))
* Updated `test_translate_vlan_with_defaults` to assert that the `site.name` of the resulting VLAN is correctly set to "New York". (`device-discovery/tests/test_translate.py`, [device-discovery/tests/test_translate.pyR241](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R241))