### PR TITLE
maps linked objects

### DIFF
--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -74,4 +74,11 @@ type MappingEntry struct {
 	Description    string         `yaml:"description"`
 	MappingEntries []MappingEntry `yaml:"mapping_entries"`
 	IdentifierSize int            `yaml:"identifier_size"`
+	Relationship   Relationship   `yaml:"relationship"`
+}
+
+// Relationship represents a relationship between two entities
+type Relationship struct {
+	Type  string `yaml:"type"`
+	Field string `yaml:"field"`
 }

--- a/snmp-discovery/mapping/mapper_test.go
+++ b/snmp-discovery/mapping/mapper_test.go
@@ -1,0 +1,310 @@
+package mapping
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+)
+
+func TestIPAddressMapper_Map(t *testing.T) {
+	logger := slog.Default()
+	registry := NewEntityRegistry(logger)
+	mapper := &IPAddressMapper{}
+
+	tests := []struct {
+		name           string
+		values         map[ObjectIDIndex]*ObjectIDValue
+		mappingEntry   *mappingEntry
+		expectedEntity *diode.IPAddress
+		expectError    bool
+	}{
+		{
+			name: "successful mapping with all fields",
+			values: map[ObjectIDIndex]*ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   IPAddress,
+				},
+			},
+			mappingEntry: &mappingEntry{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mappingEntry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address: stringPtr("192.168.1.1/32"),
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with interface relationship",
+			values: map[ObjectIDIndex]*ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   IPAddress,
+				},
+				"1.3.6.1.2.1.4.20.1.2.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.2.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.2",
+					Value:  "1",
+					Type:   Integer,
+				},
+			},
+			mappingEntry: &mappingEntry{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mappingEntry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.2",
+						Entity: "ipAddress",
+						Field:  "assigned_object",
+						Relationship: config.Relationship{
+							Type: "interface",
+						},
+					},
+				},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address: stringPtr("192.168.1.1/32"),
+			},
+			expectError: false,
+		},
+		{
+			name:   "empty values map",
+			values: map[ObjectIDIndex]*ObjectIDValue{},
+			mappingEntry: &mappingEntry{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+			},
+			expectedEntity: &diode.IPAddress{},
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entity := mapper.Map(tt.values, tt.mappingEntry, registry, logger)
+
+			if tt.expectError {
+				assert.Nil(t, entity)
+				return
+			}
+
+			assert.NotNil(t, entity)
+			ipAddress, ok := entity.(*diode.IPAddress)
+			assert.True(t, ok)
+			assert.Equal(t, tt.expectedEntity.Address, ipAddress.Address)
+		})
+	}
+}
+
+func TestInterfaceMapper_Map(t *testing.T) {
+	tests := []struct {
+		name           string
+		values         map[ObjectIDIndex]*ObjectIDValue
+		mappingEntry   *mappingEntry
+		expectedEntity *diode.Interface
+		expectError    bool
+	}{
+		{
+			name: "successful mapping with all fields",
+			values: map[ObjectIDIndex]*ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.5.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.5.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.5",
+					Value:  "1000000",
+					Type:   Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.6.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.6.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.6",
+					Value:  "00:11:22:33:44:55",
+					Type:   OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.7.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.7.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.7",
+					Value:  "1",
+					Type:   Integer,
+				},
+			},
+			mappingEntry: &mappingEntry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mappingEntry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.5",
+						Entity: "interface",
+						Field:  "speed",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.6",
+						Entity: "interface",
+						Field:  "macAddress",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.7",
+						Entity: "interface",
+						Field:  "adminStatus",
+					},
+				},
+			},
+			expectedEntity: &diode.Interface{
+				Name:              stringPtr("eth0"),
+				Speed:             int64Ptr(1000000),
+				PrimaryMacAddress: &diode.MACAddress{MacAddress: stringPtr("00:11:22:33:44:55")},
+				Enabled:           boolPtr(true),
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with invalid speed value",
+			values: map[ObjectIDIndex]*ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.5.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.5.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.5",
+					Value:  "invalid",
+					Type:   Integer,
+				},
+			},
+			mappingEntry: &mappingEntry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mappingEntry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.5",
+						Entity: "interface",
+						Field:  "speed",
+					},
+				},
+			},
+			expectedEntity: &diode.Interface{},
+			expectError:    false,
+		},
+		{
+			name:   "empty values map",
+			values: map[ObjectIDIndex]*ObjectIDValue{},
+			mappingEntry: &mappingEntry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+			},
+			expectedEntity: &diode.Interface{},
+			expectError:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := slog.Default()
+			registry := NewEntityRegistry(logger)
+			mapper := &InterfaceMapper{}
+			entity := mapper.Map(tt.values, tt.mappingEntry, registry, logger)
+
+			if tt.expectError {
+				assert.Nil(t, entity)
+				return
+			}
+
+			assert.NotNil(t, entity)
+			iface, ok := entity.(*diode.Interface)
+			assert.True(t, ok)
+			assert.Equal(t, tt.expectedEntity.Name, iface.Name)
+			assert.Equal(t, tt.expectedEntity.Speed, iface.Speed)
+			if tt.expectedEntity.PrimaryMacAddress != nil {
+				assert.Equal(t, tt.expectedEntity.PrimaryMacAddress.MacAddress, iface.PrimaryMacAddress.MacAddress)
+			}
+			assert.Equal(t, tt.expectedEntity.Enabled, iface.Enabled)
+		})
+	}
+}
+
+// Helper functions to create pointers
+func stringPtr(s string) *string {
+	return &s
+}
+
+func int64Ptr(i int64) *int64 {
+	return &i
+}
+
+func boolPtr(b bool) *bool {
+	return &b
+}

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -13,8 +13,9 @@ import (
 
 // Value is a struct that contains a value and a type of an SNMP object
 type Value struct {
-	Value string
-	Type  Asn1BER
+	Value          string
+	Type           Asn1BER
+	IdentifierSize int
 }
 
 // Asn1BER is a type that represents the type of an SNMP object
@@ -46,13 +47,67 @@ const (
 	EndOfMibView      Asn1BER = 0x82
 )
 
+// EntityRegistry is a struct that contains a map of entities
+type EntityRegistry struct {
+	entities map[EntityType]map[ObjectIDIndex]diode.Entity
+	logger   *slog.Logger
+}
+
+// NewEntityRegistry creates a new EntityRegistry
+func NewEntityRegistry(logger *slog.Logger) *EntityRegistry {
+	return &EntityRegistry{
+		entities: make(map[EntityType]map[ObjectIDIndex]diode.Entity),
+		logger:   logger,
+	}
+}
+
+// GetOrCreateOrGetEntity returns an entity from the EntityRegistry
+func (r *EntityRegistry) GetOrCreateOrGetEntity(entityType EntityType, index ObjectIDIndex) diode.Entity {
+	r.logger.Debug("Getting entity", "entityType", entityType, "index", index, "from", r.entities)
+	if r.entities[entityType] == nil {
+		r.entities[entityType] = make(map[ObjectIDIndex]diode.Entity)
+	}
+	if r.entities[entityType][index] == nil {
+		r.entities[entityType][index] = makePlaceholderEntity(entityType)
+	}
+	return r.entities[entityType][index]
+}
+
+func makePlaceholderEntity(entityType EntityType) diode.Entity {
+	switch entityType {
+	case "ipAddress":
+		return &diode.IPAddress{}
+	case "interface":
+		return &diode.Interface{}
+	case "device":
+		return &diode.Device{}
+	}
+	panic("unimplemented")
+}
+
+// CreateOrGetEntity creates an entity in the EntityRegistry
+func (r *EntityRegistry) GetOrCreateEntity(entityType EntityType, index ObjectIDIndex, entity diode.Entity) diode.Entity {
+	r.logger.Debug("Creating entity", "entityType", entityType, "index", index, "entity", entity)
+	if r.entities[entityType] == nil {
+		r.entities[entityType] = make(map[ObjectIDIndex]diode.Entity)
+	}
+	if r.entities[entityType][index] == nil {
+		r.entities[entityType][index] = entity
+	}
+	return r.entities[entityType][index]
+}
+
 // ObjectIDValueMap is a map of ObjectIDs to their values
 type ObjectIDValueMap map[string]Value
 
+// EntityType is a type that represents an entity type
+type EntityType string
+
 // ObjectIDMapper is a struct that maps ObjectIDs to entities
 type ObjectIDMapper struct {
-	mapping map[string]*mappingEntry
-	logger  *slog.Logger
+	mapping  map[string]*mappingEntry
+	logger   *slog.Logger
+	registry *EntityRegistry
 }
 
 type mappingEntry struct {
@@ -62,20 +117,21 @@ type mappingEntry struct {
 	MappingEntries []mappingEntry
 	Mapper         orbToEntityMapper
 	IdentifierSize int
+	Relationship   config.Relationship
 }
 
 var entityMappers = map[string]orbToEntityMapper{
-	"ipAddress": &ipAddressMapper{},
-	"interface": &interfaceMapper{},
+	"ipAddress": &IPAddressMapper{},
+	"interface": &InterfaceMapper{},
 }
 
-func (m *mappingEntry) MapToEntity(object map[ObjectIDIndex]*ObjectIDValue, logger *slog.Logger) []diode.Entity {
-	logger.Debug("Mapping value to entity", "value", object)
+func (m *mappingEntry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistry *EntityRegistry, logger *slog.Logger) []diode.Entity {
+	logger.Debug("Mapping value to entity", "value", pdus)
 	if m.Mapper == nil {
 		logger.Warn("No mapper found for entity. Ignoring.", "entity", m.Entity)
 		return nil
 	}
-	entity := m.Mapper.Map(object, m, logger)
+	entity := m.Mapper.Map(pdus, m, entityRegistry, logger)
 	logger.Debug("Entity returned from mapper", "entity", entity)
 	if entity == nil {
 		logger.Warn("No entity returned from mapper. Ignoring.", "entity", m.Entity)
@@ -88,38 +144,51 @@ func (m *mappingEntry) MapToEntity(object map[ObjectIDIndex]*ObjectIDValue, logg
 func NewObjectIDMapper(mappings []config.MappingEntry, logger *slog.Logger) *ObjectIDMapper {
 	mapping := make(map[string]*mappingEntry)
 	for _, m := range mappings {
-		logger.Debug("Adding mapping", "oid", m.OID, "entity", m.Entity, "field", m.Field)
+		logger.Debug("Adding mapping", "oid", m.OID, "entity", m.Entity, "field", m.Field, "relationship", m.Relationship)
 		mappingEntry := newMappingEntry(m, logger)
 		if mappingEntry == nil {
 			continue
 		}
 		mapping[m.OID] = mappingEntry
-		logger.Debug("Mapping entry added", "oid", mappingEntry.OID, "entity", mappingEntry.Entity, "field", mappingEntry.Field)
 	}
 	return &ObjectIDMapper{
-		mapping: mapping,
-		logger:  logger,
+		mapping:  mapping,
+		logger:   logger,
+		registry: NewEntityRegistry(logger),
 	}
 }
 
 type orbToEntityMapper interface {
-	Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, logger *slog.Logger) diode.Entity
+	Map(pdus map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity
 }
 
-type ipAddressMapper struct{}
+type IPAddressMapper struct{}
 
-func (m *ipAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, logger *slog.Logger) diode.Entity {
+func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
 	logger.Debug("Mapping values to ipAddress entity", "values", values, "mappingEntry", mappingEntry)
 	ipAddress := diode.IPAddress{}
 
 	// for each value in the map, map it to the ip address entity
 	for objectID, value := range values {
+		logger.Debug("Mapping value to ipAddress entity", "objectID", objectID, "value", value)
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(mappingEntry.OID) {
 				switch propertyMappingEntry.Field {
 				case "address":
-					addressCopy := value.Value
-					ipAddress.Address = &addressCopy
+					x := fmt.Sprintf("%s/32", string(value.Index))
+					ipAddress.Address = &x
+				case "assigned_object":
+					if propertyMappingEntry.Relationship != (config.Relationship{}) {
+						linkedEntity := entityRegistry.GetOrCreateOrGetEntity(EntityType(propertyMappingEntry.Relationship.Type), ObjectIDIndex(value.Value))
+						if linkedEntity == nil {
+							logger.Warn("No linked entity found while mapping assigned object", "relationship", propertyMappingEntry.Relationship)
+							continue
+						}
+						// Handle relationship mapping
+						if propertyMappingEntry.Relationship.Type == "interface" {
+							ipAddress.AssignedObject = linkedEntity.(*diode.Interface)
+						}
+					}
 				default:
 					logger.Warn("Unknown field", "field", mappingEntry.Field)
 				}
@@ -129,11 +198,12 @@ func (m *ipAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	return &ipAddress
 }
 
-type interfaceMapper struct{}
+type InterfaceMapper struct{}
 
-func (m *interfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, logger *slog.Logger) diode.Entity {
+func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
 	logger.Debug("Mapping values to interface entity", "values", values, "mappingEntry", mappingEntry)
-	interfaceEntity := diode.Interface{}
+	interfaceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values), &diode.Interface{}).(*diode.Interface)
+
 	for objectID, value := range values {
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(propertyMappingEntry.OID) {
@@ -145,6 +215,7 @@ func (m *interfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					speed, err := strconv.Atoi(value.Value)
 					if err != nil {
 						logger.Warn("Error converting speed to int", "error", err, "value", value.Value)
+						continue
 					}
 					speed64 := int64(speed)
 					interfaceEntity.Speed = &speed64
@@ -161,7 +232,14 @@ func (m *interfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 			}
 		}
 	}
-	return &interfaceEntity
+	return interfaceEntity
+}
+
+func getIndex(values map[ObjectIDIndex]*ObjectIDValue) ObjectIDIndex {
+	for _, pdu := range values {
+		return pdu.Index
+	}
+	return ""
 }
 
 func newMappingEntry(m config.MappingEntry, logger *slog.Logger) *mappingEntry {
@@ -177,17 +255,20 @@ func newMappingEntry(m config.MappingEntry, logger *slog.Logger) *mappingEntry {
 		Mapper:         mapper,
 		IdentifierSize: m.IdentifierSize,
 		MappingEntries: newChildMappingEntries(m.MappingEntries, logger),
+		Relationship:   m.Relationship,
 	}
 }
 
 func newChildMappingEntries(configMappingEntries []config.MappingEntry, logger *slog.Logger) []mappingEntry {
 	childMappingEntries := make([]mappingEntry, 0, len(configMappingEntries))
 	for _, m := range configMappingEntries {
+		logger.Debug("Adding child mapping entry", "oid", m.OID, "entity", m.Entity, "field", m.Field, "relationship", m.Relationship)
 		child := &mappingEntry{
 			OID:            m.OID,
 			Entity:         m.Entity,
 			Field:          m.Field,
 			MappingEntries: newChildMappingEntries(m.MappingEntries, logger),
+			Relationship:   m.Relationship,
 		}
 		childMappingEntries = append(childMappingEntries, *child)
 	}
@@ -225,28 +306,19 @@ func NewObjectIDIndexDetails(index string) *ObjectIDIndexDetails {
 	}
 }
 
-// getIDSize returns the number of parts to use as ID based on the value type
-func getIDSize(value Value) int {
-	if value.Type == IPAddress {
-		return 4
-	}
-	return 1
-}
-
 // MapObjectIDsToEntity maps ObjectIDs to entities
 func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diode.Entity {
 	objectIDIndexMap := m.groupByObjectIDIndex(objectIDs)
 
-	m.logger.Debug("ObjectIDIndexMap", "objectIDIndexMap", objectIDIndexMap)
-
 	entities := make([]diode.Entity, 0, len(objectIDIndexMap))
-	for _, value := range objectIDIndexMap {
+	for index, value := range objectIDIndexMap {
+		m.logger.Debug("Mapping objectIDIndex", "objectIDIndex", index, "values", value.Values)
 		mappingEntry, err := m.getMappingEntry(value.Index)
 		if err != nil {
 			m.logger.Warn("Error finding mapping entry", "error", err, "objectID", value.Index)
 			continue
 		}
-		entities = append(entities, mappingEntry.MapToEntity(value.Values, m.logger)...)
+		entities = append(entities, mappingEntry.MapToEntity(value.Values, m.registry, m.logger)...)
 	}
 	return entities
 }
@@ -270,14 +342,13 @@ func (m *ObjectIDMapper) groupByObjectIDIndex(objectIDs ObjectIDValueMap) map[Ob
 
 func newObjectIDValue(objectID string, value Value) (*ObjectIDValue, error) {
 	parts := strings.Split(objectID, ".")
-	idSize := getIDSize(value)
-	if len(parts) <= idSize {
+	if len(parts) <= value.IdentifierSize {
 		return nil, fmt.Errorf("invalid ObjectID length for type")
 	}
 	objectIDValue := ObjectIDValue{
 		OID:    objectID,
-		Index:  ObjectIDIndex(strings.Join(parts[len(parts)-idSize:], ".")),
-		Parent: strings.Join(parts[:len(parts)-idSize], "."),
+		Index:  ObjectIDIndex(strings.Join(parts[len(parts)-value.IdentifierSize:], ".")),
+		Parent: strings.Join(parts[:len(parts)-value.IdentifierSize], "."),
 		Value:  value.Value,
 		Type:   value.Type,
 	}
@@ -290,7 +361,6 @@ func (m *ObjectIDMapper) getMappingEntry(objectID string) (*mappingEntry, error)
 	for k := range m.mapping {
 		mappingKeys = append(mappingKeys, k)
 	}
-	m.logger.Debug("Getting mapping entry for objectID", "objectID", objectID, "mappingKeys", mappingKeys)
 
 	for {
 		if value, found := m.mapping[objectID]; found {
@@ -307,10 +377,14 @@ func (m *ObjectIDMapper) getMappingEntry(objectID string) (*mappingEntry, error)
 }
 
 // ObjectIDs returns the ObjectIDs that the ObjectIDMapper can map
-func (m *ObjectIDMapper) ObjectIDs() []string {
-	objectIDs := make([]string, 0, len(m.mapping))
+func (m *ObjectIDMapper) ObjectIDs() map[string]int {
+	objectIDs := make(map[string]int)
 	for objectID := range m.mapping {
-		objectIDs = append(objectIDs, objectID)
+		if m.mapping[objectID].IdentifierSize == 0 {
+			objectIDs[objectID] = 1
+		} else {
+			objectIDs[objectID] = m.mapping[objectID].IdentifierSize
+		}
 	}
 	return objectIDs
 }

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -61,40 +61,33 @@ func NewEntityRegistry(logger *slog.Logger) *EntityRegistry {
 	}
 }
 
-// GetOrCreateOrGetEntity returns an entity from the EntityRegistry
-func (r *EntityRegistry) GetOrCreateOrGetEntity(entityType EntityType, index ObjectIDIndex) diode.Entity {
+// GetOrCreateEntity returns an entity from the EntityRegistry or creates a new one if it doesn't exist
+func (r *EntityRegistry) GetOrCreateEntity(entityType EntityType, index ObjectIDIndex) diode.Entity {
 	r.logger.Debug("Getting entity", "entityType", entityType, "index", index, "from", r.entities)
 	if r.entities[entityType] == nil {
 		r.entities[entityType] = make(map[ObjectIDIndex]diode.Entity)
 	}
 	if r.entities[entityType][index] == nil {
-		r.entities[entityType][index] = makePlaceholderEntity(entityType)
-	}
-	return r.entities[entityType][index]
-}
-
-func makePlaceholderEntity(entityType EntityType) diode.Entity {
-	switch entityType {
-	case "ipAddress":
-		return &diode.IPAddress{}
-	case "interface":
-		return &diode.Interface{}
-	case "device":
-		return &diode.Device{}
-	}
-	panic("unimplemented")
-}
-
-// CreateOrGetEntity creates an entity in the EntityRegistry
-func (r *EntityRegistry) GetOrCreateEntity(entityType EntityType, index ObjectIDIndex, entity diode.Entity) diode.Entity {
-	r.logger.Debug("Creating entity", "entityType", entityType, "index", index, "entity", entity)
-	if r.entities[entityType] == nil {
-		r.entities[entityType] = make(map[ObjectIDIndex]diode.Entity)
-	}
-	if r.entities[entityType][index] == nil {
+		entity, err := createEntity(entityType)
+		if err != nil {
+			r.logger.Warn("Error creating entity", "error", err, "entityType", entityType, "index", index)
+			return nil
+		}
 		r.entities[entityType][index] = entity
 	}
 	return r.entities[entityType][index]
+}
+
+func createEntity(entityType EntityType) (diode.Entity, error) {
+	switch entityType {
+	case "ipAddress":
+		return &diode.IPAddress{}, nil
+	case "interface":
+		return &diode.Interface{}, nil
+	case "device":
+		return &diode.Device{}, nil
+	}
+	return nil, fmt.Errorf("unimplemented entity type: %s", entityType)
 }
 
 // ObjectIDValueMap is a map of ObjectIDs to their values
@@ -162,8 +155,10 @@ type orbToEntityMapper interface {
 	Map(pdus map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity
 }
 
+// IPAddressMapper is a struct that maps IP addresses to entities
 type IPAddressMapper struct{}
 
+// Map maps IP addresses to entities
 func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
 	logger.Debug("Mapping values to ipAddress entity", "values", values, "mappingEntry", mappingEntry)
 	ipAddress := diode.IPAddress{}
@@ -179,7 +174,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					ipAddress.Address = &x
 				case "assigned_object":
 					if propertyMappingEntry.Relationship != (config.Relationship{}) {
-						linkedEntity := entityRegistry.GetOrCreateOrGetEntity(EntityType(propertyMappingEntry.Relationship.Type), ObjectIDIndex(value.Value))
+						linkedEntity := entityRegistry.GetOrCreateEntity(EntityType(propertyMappingEntry.Relationship.Type), ObjectIDIndex(value.Value))
 						if linkedEntity == nil {
 							logger.Warn("No linked entity found while mapping assigned object", "relationship", propertyMappingEntry.Relationship)
 							continue
@@ -198,11 +193,13 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	return &ipAddress
 }
 
+// InterfaceMapper is a struct that maps interfaces to entities
 type InterfaceMapper struct{}
 
+// Map maps interfaces to entities
 func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
 	logger.Debug("Mapping values to interface entity", "values", values, "mappingEntry", mappingEntry)
-	interfaceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values), &diode.Interface{}).(*diode.Interface)
+	interfaceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values)).(*diode.Interface)
 
 	for objectID, value := range values {
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
@@ -357,11 +354,6 @@ func newObjectIDValue(objectID string, value Value) (*ObjectIDValue, error) {
 
 // Gets the mapper for the closest parent objectID
 func (m *ObjectIDMapper) getMappingEntry(objectID string) (*mappingEntry, error) {
-	mappingKeys := make([]string, 0, len(m.mapping))
-	for k := range m.mapping {
-		mappingKeys = append(mappingKeys, k)
-	}
-
 	for {
 		if value, found := m.mapping[objectID]; found {
 			return value, nil

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -52,14 +52,14 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 				},
 			},
 			objectIDs: mapping.ObjectIDValueMap{
-				".1.3.6.1.2.1.2.2.1.2.999": mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString)},
-				".1.3.6.1.2.1.2.2.1.5.999": mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer)},
-				".1.3.6.1.2.1.2.2.1.6.999": mapping.Value{Value: "00:00:00:00:00:00", Type: mapping.Asn1BER(mapping.OctetString)},
-				".1.3.6.1.2.1.2.2.1.7.999": mapping.Value{Value: "1", Type: mapping.Asn1BER(mapping.Integer)},
-				".1.3.6.1.2.1.2.2.1.2.555": mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString)},
-				".1.3.6.1.2.1.2.2.1.5.555": mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer)},
-				".1.3.6.1.2.1.2.2.1.6.555": mapping.Value{Value: "00:00:00:00:00:11", Type: mapping.Asn1BER(mapping.OctetString)},
-				".1.3.6.1.2.1.2.2.1.7.555": mapping.Value{Value: "0", Type: mapping.Asn1BER(mapping.Integer)},
+				".1.3.6.1.2.1.2.2.1.2.999": mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.5.999": mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.6.999": mapping.Value{Value: "00:00:00:00:00:00", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.7.999": mapping.Value{Value: "1", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.2.555": mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.5.555": mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.6.555": mapping.Value{Value: "00:00:00:00:00:11", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.7.555": mapping.Value{Value: "0", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
 			},
 			expected: []diode.Entity{
 				&diode.Interface{
@@ -130,11 +130,11 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 				},
 			},
 			objectIDs: mapping.ObjectIDValueMap{
-				".1.3.6.1.2.1.2.2.1.2.999":          mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString)},
-				".1.3.6.1.2.1.2.2.1.5.999":          mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer)},
-				".1.3.6.1.2.1.2.2.1.6.999":          mapping.Value{Value: "00:00:00:00:00:00", Type: mapping.Asn1BER(mapping.OctetString)},
-				".1.3.6.1.2.1.2.2.1.7.999":          mapping.Value{Value: "1", Type: mapping.Asn1BER(mapping.Integer)},
-				".1.3.6.1.2.1.4.20.1.1.192.168.1.2": mapping.Value{Value: "192.168.1.2", Type: mapping.Asn1BER(mapping.IPAddress)},
+				".1.3.6.1.2.1.2.2.1.2.999":          mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.5.999":          mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.6.999":          mapping.Value{Value: "00:00:00:00:00:00", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.7.999":          mapping.Value{Value: "1", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
+				".1.3.6.1.2.1.4.20.1.1.192.168.1.2": mapping.Value{Value: "192.168.1.2", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4},
 			},
 			expected: []diode.Entity{
 				&diode.Interface{
@@ -146,7 +146,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 					Enabled: &[]bool{true}[0],
 				},
 				&diode.IPAddress{
-					Address: diode.String("192.168.1.2"),
+					Address: diode.String("192.168.1.2/32"),
 				},
 			},
 		},
@@ -168,11 +168,11 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 				},
 			},
 			objectIDs: mapping.ObjectIDValueMap{
-				".1.3.6.1.2.1.4.20.1.1.192.168.1.2": mapping.Value{Value: "192.168.1.2", Type: mapping.Asn1BER(mapping.IPAddress)},
+				".1.3.6.1.2.1.4.20.1.1.192.168.1.2": mapping.Value{Value: "192.168.1.2", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4},
 			},
 			expected: []diode.Entity{
 				&diode.IPAddress{
-					Address: diode.String("192.168.1.2"),
+					Address: diode.String("192.168.1.2/32"),
 				},
 			},
 		},
@@ -205,6 +205,70 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 			},
 			expected: []diode.Entity{},
 		},
+		{
+			name: "IPAddress with assigned interface",
+			mapping: []config.MappingEntry{
+				{
+					OID:            ".1.3.6.1.2.1.2.2.1",
+					Entity:         "interface",
+					Field:          "_id",
+					IdentifierSize: 1,
+					MappingEntries: []config.MappingEntry{
+						{
+							OID:    ".1.3.6.1.2.1.2.2.1.2",
+							Entity: "interface",
+							Field:  "name",
+						},
+						{
+							OID:    ".1.3.6.1.2.1.2.2.1.5",
+							Entity: "interface",
+							Field:  "speed",
+						},
+					},
+				},
+				{
+					OID:            ".1.3.6.1.2.1.4.20.1",
+					Entity:         "ipAddress",
+					Field:          "_id",
+					IdentifierSize: 4,
+					MappingEntries: []config.MappingEntry{
+						{
+							OID:    ".1.3.6.1.2.1.4.20.1.1",
+							Entity: "ipAddress",
+							Field:  "address",
+						},
+						{
+							OID:    ".1.3.6.1.2.1.4.20.1.2",
+							Entity: "ipAddress",
+							Field:  "assigned_object",
+							Relationship: config.Relationship{
+								Type:  "interface",
+								Field: "_id",
+							},
+						},
+					},
+				},
+			},
+			objectIDs: mapping.ObjectIDValueMap{
+				".1.3.6.1.2.1.2.2.1.2.999":          mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.5.999":          mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
+				".1.3.6.1.2.1.4.20.1.1.192.168.1.2": mapping.Value{Value: "192.168.1.2", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4},
+				".1.3.6.1.2.1.4.20.1.2.192.168.1.2": mapping.Value{Value: "999", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 4},
+			},
+			expected: []diode.Entity{
+				&diode.Interface{
+					Speed: &[]int64{1000000000}[0],
+					Name:  diode.String("GigabitEthernet1/0/1"),
+				},
+				&diode.IPAddress{
+					Address: diode.String("192.168.1.2/32"),
+					AssignedObject: &diode.Interface{
+						Speed: &[]int64{1000000000}[0],
+						Name:  diode.String("GigabitEthernet1/0/1"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -221,19 +285,20 @@ func TestObjectIDs(t *testing.T) {
 	tests := []struct {
 		name         string
 		mapping      []config.MappingEntry
-		expectedOIDs []string
+		expectedOIDs map[string]int
 	}{
 		{
 			name: "Single OID",
 			mapping: []config.MappingEntry{
 				{
-					OID:    "1.3.6.1.2.1.4.20.1.1",
-					Entity: "ipAddress",
-					Field:  "address",
+					OID:            "1.3.6.1.2.1.4.20.1.1",
+					Entity:         "ipAddress",
+					Field:          "address",
+					IdentifierSize: 4,
 				},
 			},
-			expectedOIDs: []string{
-				"1.3.6.1.2.1.4.20.1.1",
+			expectedOIDs: map[string]int{
+				"1.3.6.1.2.1.4.20.1.1": 4,
 			},
 		},
 		{
@@ -257,8 +322,8 @@ func TestObjectIDs(t *testing.T) {
 					},
 				},
 			},
-			expectedOIDs: []string{
-				".1.3.6.1.2.1.2.2.1",
+			expectedOIDs: map[string]int{
+				".1.3.6.1.2.1.2.2.1": 1,
 			},
 		},
 	}
@@ -268,7 +333,7 @@ func TestObjectIDs(t *testing.T) {
 			mapper := mapping.NewObjectIDMapper(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})))
 			objectIDs := mapper.ObjectIDs()
 
-			assert.ElementsMatch(t, tt.expectedOIDs, objectIDs)
+			assert.Equal(t, tt.expectedOIDs, objectIDs)
 		})
 	}
 }

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"path/filepath"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"gopkg.in/yaml.v3"
@@ -63,16 +62,25 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 		payload.Policies[name] = updatedPolicy
 	}
 
+	// Load the mapping config
+	for name, policy := range payload.Policies {
+		mappingConfig, err := m.loadMappingConfig(policy)
+		if err != nil {
+			return nil, fmt.Errorf("%s : invalid policy : %w", name, err)
+		}
+
+		// Create a new policy with updated mappings
+		updatedPolicy := payload.Policies[name]
+		updatedPolicy.Scope.Mappings = mappingConfig.Entries
+		payload.Policies[name] = updatedPolicy
+	}
+
 	return payload.Policies, nil
 }
 
 func (m *Manager) loadMappingConfig(policy config.Policy) (config.Mapping, error) {
 	m.logger.Debug("Loading mapping config", "mappingConfig", policy.Scope.MappingConfig)
-	mappingFilePath, err := filepath.Abs(policy.Scope.MappingConfig)
-	if err != nil {
-		return config.Mapping{}, fmt.Errorf("failed to get absolute path for mapping config: %w", err)
-	}
-	mappingConfigFileContents, err := os.ReadFile(mappingFilePath)
+	mappingConfigFileContents, err := os.ReadFile(policy.Scope.MappingConfig)
 	if err != nil {
 		return config.Mapping{}, fmt.Errorf("failed to read mapping config file: %w", err)
 	}
@@ -137,12 +145,7 @@ func (m *Manager) validatePolicy(policy config.Policy) error {
 		return fmt.Errorf("missing mapping configuration file")
 	}
 
-	mappingFilePath, err := filepath.Abs(policy.Scope.MappingConfig)
-	if err != nil {
-		return fmt.Errorf("failed to get absolute path for mapping config: %w", err)
-	}
-
-	if _, err := os.Stat(mappingFilePath); os.IsNotExist(err) {
+	if _, err := os.Stat(policy.Scope.MappingConfig); os.IsNotExist(err) {
 		return fmt.Errorf("mapping configuration file does not exist")
 	}
 
@@ -158,8 +161,13 @@ func (m *Manager) HasPolicy(name string) bool {
 // StartPolicy starts the policy
 func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 	m.logger.Debug("Starting policy", "policy", policy)
+	m.logger.Debug("Starting policy", "policy", policy)
 	if len(policy.Scope.Targets) == 0 {
 		return fmt.Errorf("%s : no targets found in the policy", name)
+	}
+
+	if len(policy.Scope.Mappings) == 0 {
+		return fmt.Errorf("%s : no mappings found in the policy", name)
 	}
 
 	if len(policy.Scope.Mappings) == 0 {

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -266,7 +266,7 @@ func TestRunnerWalkError(t *testing.T) {
 
 	// Create a mock host that returns an error on Walk
 	mockHost := new(MockHost)
-	mockHost.On("Walk", mock.Anything).Return(nil, errors.New("walk error"))
+	mockHost.On("Walk", mock.Anything, mock.Anything).Return(nil, errors.New("walk error"))
 
 	// Create a mock client factory that returns the mock host
 	mockClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
-	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
 )
@@ -39,9 +38,9 @@ type MockHost struct {
 	mock.Mock
 }
 
-func (m *MockHost) Walk(objectID string) (mapping.ObjectIDValueMap, error) {
-	args := m.Called(objectID)
-	return nil, args.Error(1)
+func (m *MockHost) Walk(objectID string, identifierSize int) (map[string]snmp.PDU, error) {
+	args := m.Called(objectID, identifierSize)
+	return args.Get(0).(map[string]snmp.PDU), args.Error(1)
 }
 
 func (m *MockHost) Connect() error {

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -19,7 +19,7 @@ func (n *FakeSNMPWalker) Close() error {
 }
 
 // Walk implements Walker interface
-func (n *FakeSNMPWalker) Walk(oid string) (mapping.ObjectIDValueMap, error) {
+func (n *FakeSNMPWalker) Walk(oid string, _ int) (mapping.ObjectIDValueMap, error) {
 	if oid == "1.3.6.1.2.1.4.20.1.1" {
 		return mapping.ObjectIDValueMap{
 			"1.3.6.1.2.1.4.20.1.1": mapping.Value{Value: "192.168.1.1", Type: mapping.Asn1BER(mapping.IPAddress)},

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -1,8 +1,8 @@
 package snmp
 
 import (
+	"github.com/gosnmp/gosnmp"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
-	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
 )
 
 // FakeSNMPWalker is a no-op implementation of SNMPWalker
@@ -19,19 +19,19 @@ func (n *FakeSNMPWalker) Close() error {
 }
 
 // Walk implements Walker interface
-func (n *FakeSNMPWalker) Walk(oid string, _ int) (mapping.ObjectIDValueMap, error) {
+func (n *FakeSNMPWalker) Walk(oid string, _ int) (map[string]PDU, error) {
 	if oid == "1.3.6.1.2.1.4.20.1.1" {
-		return mapping.ObjectIDValueMap{
-			"1.3.6.1.2.1.4.20.1.1": mapping.Value{Value: "192.168.1.1", Type: mapping.Asn1BER(mapping.IPAddress)},
+		return map[string]PDU{
+			"1.3.6.1.2.1.4.20.1.1": PDU{Value: "192.168.1.1", Type: gosnmp.IPAddress},
 		}, nil
 	}
 
 	if oid == "iso.3.6.1.2.1.2.2.1" {
-		return mapping.ObjectIDValueMap{
-			"iso.3.6.1.2.1.2.2.1.2.999": mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString)},
+		return map[string]PDU{
+			"iso.3.6.1.2.1.2.2.1.2.999": PDU{Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString},
 		}, nil
 	}
-	return make(mapping.ObjectIDValueMap), nil
+	return make(map[string]PDU), nil
 }
 
 // NewFakeSNMPWalker creates a new FakeSNMPWalker

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -2,6 +2,7 @@ package snmp
 
 import (
 	"github.com/gosnmp/gosnmp"
+
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 )
 
@@ -22,13 +23,13 @@ func (n *FakeSNMPWalker) Close() error {
 func (n *FakeSNMPWalker) Walk(oid string, _ int) (map[string]PDU, error) {
 	if oid == "1.3.6.1.2.1.4.20.1.1" {
 		return map[string]PDU{
-			"1.3.6.1.2.1.4.20.1.1": PDU{Value: "192.168.1.1", Type: gosnmp.IPAddress},
+			"1.3.6.1.2.1.4.20.1.1": {Value: "192.168.1.1", Type: gosnmp.IPAddress},
 		}, nil
 	}
 
 	if oid == "iso.3.6.1.2.1.2.2.1" {
 		return map[string]PDU{
-			"iso.3.6.1.2.1.2.2.1.2.999": PDU{Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString},
+			"iso.3.6.1.2.1.2.2.1.2.999": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString},
 		}, nil
 	}
 	return make(map[string]PDU), nil

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -61,7 +61,7 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 			return nil, err
 		}
 		for k, value := range pdu {
-			s.logger.Debug("PDU", "objectID", k, "value", value)
+			s.logger.Debug("Mapping PDU", "objectID", k, "value", value)
 			value, err := MapPDU(value)
 			if err != nil {
 				s.logger.Warn("Error mapping PDU", "objectID", k, "error", err)

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -61,8 +61,10 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 			return nil, err
 		}
 		for k, value := range pdu {
-			if _, exists := output[k]; exists {
-				s.logger.Warn("Duplicate ObjectID", "objectID", k)
+			s.logger.Debug("PDU", "objectID", k, "value", value)
+			value, err := mapPDU(value)
+			if err != nil {
+				s.logger.Warn("Error mapping PDU", "objectID", k, "error", err)
 				continue
 			}
 			output[k] = value
@@ -70,6 +72,50 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 	}
 
 	return output, nil
+}
+
+func mapPDU(pdu PDU) (mapping.Value, error) {
+	var value string
+	switch pdu.Type {
+	case gosnmp.OctetString:
+		if str, ok := pdu.Value.(string); ok {
+			value = str
+		} else if bytes, ok := pdu.Value.([]byte); ok {
+			value = string(bytes)
+		}
+	case gosnmp.Integer:
+		if intVal, ok := pdu.Value.(int); ok {
+			value = fmt.Sprintf("%d", intVal)
+		}
+	case gosnmp.IPAddress:
+		if ip, ok := pdu.Value.(string); ok {
+			value = ip
+		}
+	case gosnmp.ObjectIdentifier:
+		if oid, ok := pdu.Value.(string); ok {
+			value = oid
+		}
+	case gosnmp.TimeTicks:
+		if ticks, ok := pdu.Value.(uint32); ok {
+			value = fmt.Sprintf("%d", ticks)
+		}
+	case gosnmp.Counter32, gosnmp.Gauge32:
+		if val, ok := pdu.Value.(uint32); ok {
+			value = fmt.Sprintf("%d", val)
+		}
+	case gosnmp.Counter64:
+		if val, ok := pdu.Value.(uint64); ok {
+			value = fmt.Sprintf("%d", val)
+		}
+	default:
+		slog.Warn("Unhandled SNMP type", "name", pdu.Name, "type", pdu.Type)
+		return mapping.Value{}, fmt.Errorf("unhandled SNMP type: %s", pdu.Type)
+	}
+	return mapping.Value{
+		Type:           mapping.Asn1BER(pdu.Type),
+		Value:          value,
+		IdentifierSize: pdu.IdentifierSize,
+	}, nil
 }
 
 // Client wraps gosnmp.GoSNMP to implement the Walker interface
@@ -83,56 +129,28 @@ func (c *Client) Close() error {
 }
 
 // Walk implements the Walker interface by walking the SNMP tree
-func (c *Client) Walk(objectIDs string, identifierSize int) (mapping.ObjectIDValueMap, error) {
+func (c *Client) Walk(objectIDs string, identifierSize int) (map[string]PDU, error) {
 	pdu, err := c.WalkAll(objectIDs)
 	if err != nil {
 		return nil, err
 	}
-	output := make(mapping.ObjectIDValueMap)
+	output := make(map[string]PDU)
 	for _, pdu := range pdu {
-		var value string
-		switch pdu.Type {
-		case gosnmp.OctetString:
-			if str, ok := pdu.Value.(string); ok {
-				value = str
-			} else if bytes, ok := pdu.Value.([]byte); ok {
-				value = string(bytes)
-			}
-		case gosnmp.Integer:
-			if intVal, ok := pdu.Value.(int); ok {
-				value = fmt.Sprintf("%d", intVal)
-			}
-		case gosnmp.IPAddress:
-			if ip, ok := pdu.Value.(string); ok {
-				value = ip
-			}
-		case gosnmp.ObjectIdentifier:
-			if oid, ok := pdu.Value.(string); ok {
-				value = oid
-			}
-		case gosnmp.TimeTicks:
-			if ticks, ok := pdu.Value.(uint32); ok {
-				value = fmt.Sprintf("%d", ticks)
-			}
-		case gosnmp.Counter32, gosnmp.Gauge32:
-			if val, ok := pdu.Value.(uint32); ok {
-				value = fmt.Sprintf("%d", val)
-			}
-		case gosnmp.Counter64:
-			if val, ok := pdu.Value.(uint64); ok {
-				value = fmt.Sprintf("%d", val)
-			}
-		default:
-			slog.Warn("Unhandled SNMP type", "name", pdu.Name, "type", pdu.Type)
-			continue
-		}
-		output[pdu.Name] = mapping.Value{
-			Value:          value,
-			Type:           mapping.Asn1BER(pdu.Type),
+		output[pdu.Name] = PDU{
+			Name:           pdu.Name,
+			Type:           pdu.Type,
+			Value:          pdu.Value,
 			IdentifierSize: identifierSize,
 		}
 	}
 	return output, nil
+}
+
+type PDU struct {
+	Name           string
+	Type           gosnmp.Asn1BER
+	Value          any
+	IdentifierSize int
 }
 
 const (
@@ -227,7 +245,7 @@ func getPrivProtocol(privProtocol string) (gosnmp.SnmpV3PrivProtocol, error) {
 // It allows for connecting to SNMP devices, traversing ObjectID trees,
 // and properly closing connections when finished
 type Walker interface {
-	Walk(objectID string, identifierSize int) (mapping.ObjectIDValueMap, error)
+	Walk(objectID string, identifierSize int) (map[string]PDU, error)
 	Connect() error
 	Close() error
 }

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -68,6 +68,7 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 				continue
 			}
 			output[k] = value
+			output[k] = value
 		}
 	}
 
@@ -147,6 +148,7 @@ func (c *Client) Walk(objectIDs string, identifierSize int) (map[string]PDU, err
 	return output, nil
 }
 
+// PDU is a struct that represents an SNMP PDU
 type PDU struct {
 	Name           string
 	Type           gosnmp.Asn1BER

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -34,7 +34,7 @@ func NewHost(host string, port uint16, retries int, authentication *config.Authe
 }
 
 // Walk walks the SNMP host
-func (s *Host) Walk(objectIDs []string) (mapping.ObjectIDValueMap, error) {
+func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) {
 	s.logger.Info("Scanning", "host", s.address)
 
 	snmpClient, err := s.ClientFactory(s.address, s.port, s.retries, s.authentication)
@@ -54,8 +54,8 @@ func (s *Host) Walk(objectIDs []string) (mapping.ObjectIDValueMap, error) {
 	}
 
 	output := make(mapping.ObjectIDValueMap)
-	for _, objectID := range objectIDs {
-		pdu, err := snmpClient.Walk(objectID)
+	for objectID, identifierSize := range objectIDs {
+		pdu, err := snmpClient.Walk(objectID, identifierSize)
 		if err != nil {
 			s.logger.Warn("Error walking ObjectID", "objectID", objectID, "error", err)
 			return nil, err
@@ -83,8 +83,8 @@ func (c *Client) Close() error {
 }
 
 // Walk implements the Walker interface by walking the SNMP tree
-func (c *Client) Walk(objectID string) (mapping.ObjectIDValueMap, error) {
-	pdu, err := c.WalkAll(objectID)
+func (c *Client) Walk(objectIDs string, identifierSize int) (mapping.ObjectIDValueMap, error) {
+	pdu, err := c.WalkAll(objectIDs)
 	if err != nil {
 		return nil, err
 	}
@@ -127,8 +127,9 @@ func (c *Client) Walk(objectID string) (mapping.ObjectIDValueMap, error) {
 			continue
 		}
 		output[pdu.Name] = mapping.Value{
-			Value: value,
-			Type:  mapping.Asn1BER(pdu.Type),
+			Value:          value,
+			Type:           mapping.Asn1BER(pdu.Type),
+			IdentifierSize: identifierSize,
 		}
 	}
 	return output, nil
@@ -226,7 +227,7 @@ func getPrivProtocol(privProtocol string) (gosnmp.SnmpV3PrivProtocol, error) {
 // It allows for connecting to SNMP devices, traversing ObjectID trees,
 // and properly closing connections when finished
 type Walker interface {
-	Walk(objectID string) (mapping.ObjectIDValueMap, error)
+	Walk(objectID string, identifierSize int) (mapping.ObjectIDValueMap, error)
 	Connect() error
 	Close() error
 }

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -62,7 +62,7 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 		}
 		for k, value := range pdu {
 			s.logger.Debug("PDU", "objectID", k, "value", value)
-			value, err := mapPDU(value)
+			value, err := MapPDU(value)
 			if err != nil {
 				s.logger.Warn("Error mapping PDU", "objectID", k, "error", err)
 				continue
@@ -74,7 +74,8 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 	return output, nil
 }
 
-func mapPDU(pdu PDU) (mapping.Value, error) {
+// MapPDU maps a PDU to a mapping.Value
+func MapPDU(pdu PDU) (mapping.Value, error) {
 	var value string
 	switch pdu.Type {
 	case gosnmp.OctetString:

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -23,8 +23,6 @@ type MockSNMP struct {
 	mock.Mock
 }
 
-<<<<<<< HEAD
-=======
 // Connect implements Walker interface
 func (m *MockSNMP) Connect() error {
 	args := m.Called()
@@ -43,7 +41,6 @@ func (m *MockSNMP) Walk(oid string, identifierSize int) (map[string]snmp.PDU, er
 	return args.Get(0).(map[string]snmp.PDU), args.Error(1)
 }
 
->>>>>>> 78c6cdd (refactors to make adding more snmp tests easier)
 // MockConn is a mock for the connection
 type MockConn struct {
 	mock.Mock
@@ -79,7 +76,6 @@ func TestSNMPHost(t *testing.T) {
 
 	t.Run("Successfully walks a host", func(t *testing.T) {
 		// Setup
-		objectIDsToQuery := []string{ipAddressObjectID}
 		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
 			fakeWalker, _ := snmp.NewFakeSNMPWalker("192.168.1.1", 161, 3, nil)
 			return fakeWalker, nil
@@ -164,7 +160,7 @@ func TestSNMPHost(t *testing.T) {
 		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
 
 		// Execute
-		oids, err := host.Walk([]string{"1.3.6.1.2.1.4.20.1.1"})
+		oids, err := host.Walk(objectIDsToQuery)
 
 		// Assert
 		assert.Error(t, err)
@@ -177,18 +173,14 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker := &MockSNMP{}
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
-<<<<<<< HEAD
-		mockWalker.On("Walk", mock.Anything).Return(nil, assert.AnError)
-=======
 		mockWalker.On("Walk", mock.Anything, mock.Anything).Return(make(map[string]snmp.PDU), assert.AnError)
->>>>>>> 78c6cdd (refactors to make adding more snmp tests easier)
 		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
 
 		// Execute
-		oids, err := host.Walk([]string{ipAddressObjectID})
+		oids, err := host.Walk(objectIDsToQuery)
 
 		// Assert
 		assert.Error(t, err)
@@ -233,37 +225,19 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker := &MockSNMP{}
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
-		mockWalker.On("Walk", mock.Anything).Return(nil, assert.AnError)
+		mockWalker.On("Walk", mock.Anything, mock.Anything).Return(nil, assert.AnError)
 		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
 			return nil, fmt.Errorf("error creating client")
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
 
 		// Execute
-		oids, err := host.Walk([]string{ipAddressObjectID})
+		oids, err := host.Walk(objectIDsToQuery)
 
 		// Assert
 		assert.Error(t, err)
 		assert.Nil(t, oids)
 	})
-}
-
-// Connect implements Walker interface
-func (m *MockSNMP) Connect() error {
-	args := m.Called()
-	return args.Error(0)
-}
-
-// Close implements Walker interface
-func (m *MockSNMP) Close() error {
-	args := m.Called()
-	return args.Error(0)
-}
-
-// Walk implements Walker interface
-func (m *MockSNMP) Walk(oid string) (mapping.ObjectIDValueMap, error) {
-	args := m.Called(oid)
-	return nil, args.Error(1)
 }
 
 func TestNewClient(t *testing.T) {

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/gosnmp/gosnmp"
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
 	"github.com/stretchr/testify/assert"
@@ -22,6 +23,27 @@ type MockSNMP struct {
 	mock.Mock
 }
 
+<<<<<<< HEAD
+=======
+// Connect implements Walker interface
+func (m *MockSNMP) Connect() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+// Close implements Walker interface
+func (m *MockSNMP) Close() error {
+	args := m.Called()
+	return args.Error(0)
+}
+
+// Walk implements Walker interface
+func (m *MockSNMP) Walk(oid string, identifierSize int) (map[string]snmp.PDU, error) {
+	args := m.Called(oid, identifierSize)
+	return args.Get(0).(map[string]snmp.PDU), args.Error(1)
+}
+
+>>>>>>> 78c6cdd (refactors to make adding more snmp tests easier)
 // MockConn is a mock for the connection
 type MockConn struct {
 	mock.Mock
@@ -50,6 +72,11 @@ func (m *MockClient) Ingest(context.Context, []diode.Entity) (*diodepb.IngestRes
 func TestSNMPHost(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	const ipAddressObjectID = "1.3.6.1.2.1.4.20.1.1"
+	const interfaceObjectID = "1.3.6.1.2.1.2.2.1"
+	objectIDsToQuery := make(map[string]int)
+	objectIDsToQuery[ipAddressObjectID] = 4
+	objectIDsToQuery[interfaceObjectID] = 1
+
 	t.Run("Successfully walks a host", func(t *testing.T) {
 		// Setup
 		objectIDsToQuery := []string{ipAddressObjectID}
@@ -60,12 +87,93 @@ func TestSNMPHost(t *testing.T) {
 		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
 
 		// Execute
+		oids, err := host.Walk(map[string]int{
+			ipAddressObjectID: 4,
+		})
+
+		// Assert
+		assert.NoError(t, err)
+		assert.Equal(t, 1, len(oids))
+		assert.Equal(t, mapping.Value{Value: "192.168.1.1", Type: mapping.Asn1BER(mapping.IPAddress)}, oids[ipAddressObjectID])
+	})
+
+	t.Run("Handles multiple OIDs with different types", func(t *testing.T) {
+		// Setup
+		mockWalker := &MockSNMP{}
+		mockWalker.On("Connect").Return(nil)
+		mockWalker.On("Close").Return(nil)
+		mockWalker.On("Walk", ipAddressObjectID, 4).Return(map[string]snmp.PDU{
+			ipAddressObjectID: {Value: "192.168.1.1", Type: gosnmp.IPAddress, IdentifierSize: 4},
+		}, nil)
+		mockWalker.On("Walk", interfaceObjectID, 1).Return(map[string]snmp.PDU{
+			interfaceObjectID + ".1": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString, IdentifierSize: 1},
+			interfaceObjectID + ".2": {Value: 1000000, Type: gosnmp.Integer, IdentifierSize: 1},
+		}, nil)
+
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
+			return mockWalker, nil
+		}
+		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
+
+		// Execute
 		oids, err := host.Walk(objectIDsToQuery)
 
 		// Assert
 		assert.NoError(t, err)
-		assert.Equal(t, len(objectIDsToQuery), len(oids))
-		assert.Equal(t, mapping.Value{Value: "192.168.1.1", Type: mapping.Asn1BER(mapping.IPAddress)}, oids[ipAddressObjectID])
+		assert.Equal(t, 3, len(oids))
+		assert.Equal(t, mapping.Value{Value: "192.168.1.1", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4}, oids[ipAddressObjectID])
+		assert.Equal(t, mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1}, oids[interfaceObjectID+".1"])
+		assert.Equal(t, mapping.Value{Value: "1000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1}, oids[interfaceObjectID+".2"])
+		mockWalker.AssertExpectations(t)
+	})
+
+	// t.Run("Handles PDU mapping errors", func(t *testing.T) {
+	// 	// Setup
+	// 	mockWalker := &MockSNMP{}
+	// 	mockWalker.On("Connect").Return(nil)
+	// 	mockWalker.On("Close").Return(nil)
+	// 	mockWalker.On("Walk", ipAddressObjectID, 4).Return(map[string]snmp.PDU{
+	// 		ipAddressObjectID: {Value: "invalid", Type: gosnmp.IPAddress, IdentifierSize: 4}, // Invalid IP address
+	// 	}, nil)
+
+	// 	snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
+	// 		return mockWalker, nil
+	// 	}
+	// 	host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
+
+	// 	// Execute
+	// 	oids, err := host.Walk(objectIDsToQuery)
+
+	// 	// Assert
+	// 	assert.NoError(t, err)
+	// 	assert.Equal(t, 0, len(oids)) // Should skip invalid PDU
+	// 	mockWalker.AssertExpectations(t)
+	// })
+
+	t.Run("Handles connection close errors", func(t *testing.T) {
+		// Setup
+		mockWalker := &MockSNMP{}
+		mockWalker.On("Connect").Return(nil)
+		mockWalker.On("Close").Return(fmt.Errorf("close error"))
+		mockWalker.On("Walk", ipAddressObjectID, 4).Return(map[string]snmp.PDU{
+			ipAddressObjectID: {Value: "192.168.1.1", Type: gosnmp.IPAddress, IdentifierSize: 4},
+		}, nil)
+
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
+			return mockWalker, nil
+		}
+		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
+
+		// Execute
+		oids, err := host.Walk(map[string]int{
+			ipAddressObjectID: 4,
+		})
+
+		// Assert
+		assert.NoError(t, err) // Close error should be logged but not returned
+		assert.Equal(t, 1, len(oids))
+		assert.Equal(t, mapping.Value{Value: "192.168.1.1", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4}, oids[ipAddressObjectID])
+		mockWalker.AssertExpectations(t)
 	})
 
 	t.Run("Handles SNMP connection error", func(t *testing.T) {
@@ -92,7 +200,11 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker := &MockSNMP{}
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
+<<<<<<< HEAD
 		mockWalker.On("Walk", mock.Anything).Return(nil, assert.AnError)
+=======
+		mockWalker.On("Walk", mock.Anything, mock.Anything).Return(make(map[string]snmp.PDU), assert.AnError)
+>>>>>>> 78c6cdd (refactors to make adding more snmp tests easier)
 		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
 			return mockWalker, nil
 		}

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -127,29 +127,6 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.AssertExpectations(t)
 	})
 
-	// t.Run("Handles PDU mapping errors", func(t *testing.T) {
-	// 	// Setup
-	// 	mockWalker := &MockSNMP{}
-	// 	mockWalker.On("Connect").Return(nil)
-	// 	mockWalker.On("Close").Return(nil)
-	// 	mockWalker.On("Walk", ipAddressObjectID, 4).Return(map[string]snmp.PDU{
-	// 		ipAddressObjectID: {Value: "invalid", Type: gosnmp.IPAddress, IdentifierSize: 4}, // Invalid IP address
-	// 	}, nil)
-
-	// 	snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
-	// 		return mockWalker, nil
-	// 	}
-	// 	host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
-
-	// 	// Execute
-	// 	oids, err := host.Walk(objectIDsToQuery)
-
-	// 	// Assert
-	// 	assert.NoError(t, err)
-	// 	assert.Equal(t, 0, len(oids)) // Should skip invalid PDU
-	// 	mockWalker.AssertExpectations(t)
-	// })
-
 	t.Run("Handles connection close errors", func(t *testing.T) {
 		// Setup
 		mockWalker := &MockSNMP{}
@@ -216,6 +193,38 @@ func TestSNMPHost(t *testing.T) {
 		// Assert
 		assert.Error(t, err)
 		assert.Nil(t, oids)
+		mockWalker.AssertExpectations(t)
+	})
+
+	t.Run("Handles PDU mapping error", func(t *testing.T) {
+		// Setup
+		mockWalker := &MockSNMP{}
+		mockWalker.On("Connect").Return(nil)
+		mockWalker.On("Close").Return(nil)
+		mockWalker.On("Walk", ipAddressObjectID, 4).Return(map[string]snmp.PDU{
+			ipAddressObjectID: {Value: "192.168.1.1", Type: gosnmp.IPAddress, IdentifierSize: 4},
+		}, nil)
+		mockWalker.On("Walk", interfaceObjectID, 1).Return(map[string]snmp.PDU{
+			interfaceObjectID + ".1": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString, IdentifierSize: 1},
+			interfaceObjectID + ".2": {Value: "invalid", Type: gosnmp.Asn1BER(255), IdentifierSize: 1}, // Invalid type
+		}, nil)
+
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
+			return mockWalker, nil
+		}
+		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
+
+		// Execute
+		oids, err := host.Walk(objectIDsToQuery)
+
+		// Assert
+		assert.NoError(t, err)        // Walk should continue despite PDU mapping error
+		assert.Equal(t, 2, len(oids)) // Should have 2 valid PDUs
+		assert.Equal(t, mapping.Value{Value: "192.168.1.1", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4}, oids[ipAddressObjectID])
+		assert.Equal(t, mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1}, oids[interfaceObjectID+".1"])
+		// The invalid PDU should be skipped
+		_, exists := oids[interfaceObjectID+".2"]
+		assert.False(t, exists)
 		mockWalker.AssertExpectations(t)
 	})
 

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -359,3 +359,182 @@ func TestNewClient(t *testing.T) {
 		})
 	}
 }
+
+func TestMapPDU(t *testing.T) {
+	testCases := []struct {
+		name          string
+		pdu           snmp.PDU
+		expectedValue mapping.Value
+		expectError   bool
+	}{
+		{
+			name: "OctetString as string",
+			pdu: snmp.PDU{
+				Name:  "test.1",
+				Type:  gosnmp.OctetString,
+				Value: "test string",
+			},
+			expectedValue: mapping.Value{
+				Type:  mapping.Asn1BER(gosnmp.OctetString),
+				Value: "test string",
+			},
+			expectError: false,
+		},
+		{
+			name: "OctetString as bytes",
+			pdu: snmp.PDU{
+				Name:  "test.2",
+				Type:  gosnmp.OctetString,
+				Value: []byte("test bytes"),
+			},
+			expectedValue: mapping.Value{
+				Type:  mapping.Asn1BER(gosnmp.OctetString),
+				Value: "test bytes",
+			},
+			expectError: false,
+		},
+		{
+			name: "Integer",
+			pdu: snmp.PDU{
+				Name:  "test.3",
+				Type:  gosnmp.Integer,
+				Value: 42,
+			},
+			expectedValue: mapping.Value{
+				Type:  mapping.Asn1BER(gosnmp.Integer),
+				Value: "42",
+			},
+			expectError: false,
+		},
+		{
+			name: "IPAddress",
+			pdu: snmp.PDU{
+				Name:  "test.4",
+				Type:  gosnmp.IPAddress,
+				Value: "192.168.1.1",
+			},
+			expectedValue: mapping.Value{
+				Type:  mapping.Asn1BER(gosnmp.IPAddress),
+				Value: "192.168.1.1",
+			},
+			expectError: false,
+		},
+		{
+			name: "ObjectIdentifier",
+			pdu: snmp.PDU{
+				Name:  "test.5",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: "1.3.6.1.2.1.1.1.0",
+			},
+			expectedValue: mapping.Value{
+				Type:  mapping.Asn1BER(gosnmp.ObjectIdentifier),
+				Value: "1.3.6.1.2.1.1.1.0",
+			},
+			expectError: false,
+		},
+		{
+			name: "TimeTicks",
+			pdu: snmp.PDU{
+				Name:  "test.6",
+				Type:  gosnmp.TimeTicks,
+				Value: uint32(123456),
+			},
+			expectedValue: mapping.Value{
+				Type:  mapping.Asn1BER(gosnmp.TimeTicks),
+				Value: "123456",
+			},
+			expectError: false,
+		},
+		{
+			name: "Counter32",
+			pdu: snmp.PDU{
+				Name:  "test.7",
+				Type:  gosnmp.Counter32,
+				Value: uint32(4294967295),
+			},
+			expectedValue: mapping.Value{
+				Type:  mapping.Asn1BER(gosnmp.Counter32),
+				Value: "4294967295",
+			},
+			expectError: false,
+		},
+		{
+			name: "Gauge32",
+			pdu: snmp.PDU{
+				Name:  "test.8",
+				Type:  gosnmp.Gauge32,
+				Value: uint32(65535),
+			},
+			expectedValue: mapping.Value{
+				Type:  mapping.Asn1BER(gosnmp.Gauge32),
+				Value: "65535",
+			},
+			expectError: false,
+		},
+		{
+			name: "Counter64",
+			pdu: snmp.PDU{
+				Name:  "test.9",
+				Type:  gosnmp.Counter64,
+				Value: uint64(18446744073709551615),
+			},
+			expectedValue: mapping.Value{
+				Type:  mapping.Asn1BER(gosnmp.Counter64),
+				Value: "18446744073709551615",
+			},
+			expectError: false,
+		},
+		{
+			name: "Unhandled type",
+			pdu: snmp.PDU{
+				Name:  "test.10",
+				Type:  gosnmp.Asn1BER(255), // Invalid type
+				Value: "test",
+			},
+			expectedValue: mapping.Value{},
+			expectError:   true,
+		},
+		{
+			name: "Empty OctetString",
+			pdu: snmp.PDU{
+				Name:  "test.11",
+				Type:  gosnmp.OctetString,
+				Value: "",
+			},
+			expectedValue: mapping.Value{
+				Type:  mapping.Asn1BER(gosnmp.OctetString),
+				Value: "",
+			},
+			expectError: false,
+		},
+		{
+			name: "Zero Integer",
+			pdu: snmp.PDU{
+				Name:  "test.12",
+				Type:  gosnmp.Integer,
+				Value: 0,
+			},
+			expectedValue: mapping.Value{
+				Type:  mapping.Asn1BER(gosnmp.Integer),
+				Value: "0",
+			},
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := snmp.MapPDU(tc.pdu)
+
+			if tc.expectError {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tc.expectedValue.Type, result.Type)
+				assert.Equal(t, tc.expectedValue.Value, result.Value)
+				assert.Equal(t, tc.pdu.IdentifierSize, result.IdentifierSize)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pull request introduces enhancements to the SNMP discovery system, focusing on improving entity mapping capabilities, adding support for relationships between entities, and enhancing test coverage. The changes include the addition of a `Relationship` struct, an `EntityRegistry` for managing entities, updates to mappers for handling relationships, and new test cases for IP address and interface mappings.

### Enhancements to Entity Mapping and Relationships:
* Added a `Relationship` struct to define relationships between entities, with fields for `Type` and `Field` (`snmp-discovery/config/config.go`).
* Updated the `mappingEntry` struct to include the `Relationship` field for defining relationships in mapping configurations (`snmp-discovery/mapping/mapping.go`).
* Implemented `EntityRegistry` for centralized management of entities, including methods to create or retrieve entities based on their type and index (`snmp-discovery/mapping/mapping.go`).

### Updates to Mappers:
* Enhanced `IPAddressMapper` and `InterfaceMapper` to support relationship-based mappings, enabling linked entities (e.g., associating an IP address with an interface) (`snmp-discovery/mapping/mapping.go`). [[1]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L132-R203) [[2]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L164-R239)
* Modified the `ObjectIDMapper` to utilize the `EntityRegistry` and handle relationships during the mapping process (`snmp-discovery/mapping/mapping.go`).

### Test Coverage Improvements:
* Added comprehensive test cases for `IPAddressMapper` and `InterfaceMapper`, covering scenarios such as successful mappings, relationship-based mappings, and edge cases like invalid or empty input (`snmp-discovery/mapping/mapper_test.go`).

These changes enhance the flexibility and robustness of the SNMP discovery system, particularly in managing complex relationships between entities and ensuring reliable mapping functionality.