### PR TITLE
fix: move retries configuration to a more appropriate config section

### DIFF
--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -13,7 +13,6 @@ type Status struct {
 type Scope struct {
 	Targets        []Target       `yaml:"targets"`
 	Authentication Authentication `yaml:"authentication"`
-	Retries        int            `yaml:"retries"`
 	MappingConfig  string         `yaml:"mapping_config,omitempty"`
 	Mappings       []MappingEntry `yaml:"mappings,omitempty"`
 }
@@ -49,6 +48,7 @@ type PolicyConfig struct {
 	Defaults    Defaults `yaml:"defaults"`
 	Timeout     int      `yaml:"timeout"`
 	DevicesFile string   `yaml:"devices_file,omitempty"`
+	Retries     int      `yaml:"retries"`
 }
 
 // Policy represents a snmp-discovery policy

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -91,7 +91,7 @@ func (r *Runner) run() {
 	entities := make([]diode.Entity, 0)
 
 	for _, target := range r.scope.Targets {
-		host := snmp.NewHost(target.Host, target.Port, r.scope.Retries, &r.scope.Authentication, r.logger, r.ClientFactory)
+		host := snmp.NewHost(target.Host, target.Port, r.config.Retries, &r.scope.Authentication, r.logger, r.ClientFactory)
 		oids, err := host.Walk(objectIDs)
 		if err != nil {
 			r.logger.Warn("Error crawling host", "host", target.Host, "error", err)


### PR DESCRIPTION
This pull request refactors how the `Retries` configuration is handled in the `snmp-discovery` project. The `Retries` field has been removed from the `Scope` struct and added to the `PolicyConfig` struct, aligning it with other high-level configuration parameters. The `Runner` logic has been updated to use the new location of the `Retries` value.

### Configuration changes:

* Removed the `Retries` field from the `Scope` struct in `snmp-discovery/config/config.go` (`type Scope struct`). (`[snmp-discovery/config/config.goL16](diffhunk://#diff-6ca23964054f973f61443ee3c52410a7bdcc1215394ef455d5d7d62a56676cd2L16)`)
* Added the `Retries` field to the `PolicyConfig` struct in `snmp-discovery/config/config.go` (`type PolicyConfig struct`). (`[snmp-discovery/config/config.goR51](diffhunk://#diff-6ca23964054f973f61443ee3c52410a7bdcc1215394ef455d5d7d62a56676cd2R51)`)

### Code logic updates:

* Updated the `run` method in `snmp-discovery/policy/runner.go` to use `r.config.Retries` instead of `r.scope.Retries` when creating a new `snmp.Host`. (`[snmp-discovery/policy/runner.goL94-R94](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL94-R94)`)