### PR TITLE
fix: device_discovery tags extend when it has value None

### DIFF
--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -57,7 +57,7 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
     comments = None
 
     if defaults.device:
-        tags.extend(defaults.device.tags)
+        tags.extend(defaults.device.tags or [])
         description = defaults.device.description
         comments = defaults.device.comments
 
@@ -104,7 +104,7 @@ def translate_interface(
     description = None
 
     if defaults.interface:
-        tags.extend(defaults.interface.tags)
+        tags.extend(defaults.interface.tags or [])
         description = defaults.interface.description
 
     description = interface_info.get("description", description)
@@ -170,7 +170,7 @@ def translate_interface_ips(
     prefix_vrf = None
 
     if defaults.ipaddress:
-        ip_tags.extend(defaults.ipaddress.tags)
+        ip_tags.extend(defaults.ipaddress.tags or [])
         ip_comments = defaults.ipaddress.comments
         ip_description = defaults.ipaddress.description
         ip_role = defaults.ipaddress.role
@@ -178,7 +178,7 @@ def translate_interface_ips(
         ip_vrf = defaults.ipaddress.vrf
 
     if defaults.prefix:
-        prefix_tags.extend(defaults.prefix.tags)
+        prefix_tags.extend(defaults.prefix.tags or [])
         prefix_comments = defaults.prefix.comments
         prefix_description = defaults.prefix.description
         prefix_role = defaults.prefix.role
@@ -235,7 +235,7 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
         defaults (Defaults): Default configuration.
 
     """
-    tags = defaults.tags if defaults.tags else []
+    tags = list(defaults.tags) if defaults.tags else []
     comments = None
     description = None
     group = None
@@ -243,7 +243,7 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
     role = None
 
     if defaults.vlan:
-        tags.extend(defaults.vlan.tags)
+        tags.extend(defaults.vlan.tags or [])
         comments = defaults.vlan.comments
         description = defaults.vlan.description
         group = defaults.vlan.group

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -87,7 +87,7 @@ def sample_defaults():
         interface=ObjectParameters(description="testing", tags=["inttag"]),
         ipaddress=IpamParameters(description="ip test", tags=["iptag"]),
         prefix=IpamParameters(description="prefix test", tags=["prefixtag"]),
-        vlan=VlanParameters(tags=["vlantag"]),
+        vlan=VlanParameters(comments="test"),
     )
 
 
@@ -212,9 +212,9 @@ def test_translate_vlan(sample_defaults):
 
     assert vlan.vid == 1
     assert vlan.name == "Test VLAN"
-    assert len(vlan.tags) == 3
+    assert len(vlan.tags) == 2
     assert vlan.site.name == "New York"
-    assert vlan.comments == ""
+    assert vlan.comments == "test"
 
 
 def test_translate_vlan_with_defaults(sample_defaults):


### PR DESCRIPTION
This pull request focuses on improving the handling of default values when translating device-related data and updating related test cases. The changes ensure robust handling of `None` values and improve test accuracy.

### Improvements to default value handling:
* Updated `translate_device`, `translate_interface`, `translate_interface_ips`, and `translate_vlan` functions in `device_discovery/translate.py` to use `tags or []` when extending tag lists, ensuring no errors occur if `tags` is `None`. [[1]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L60-R60) [[2]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L107-R107) [[3]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L173-R181) [[4]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L238-R246)
* Modified the initialization of `tags` in `translate_vlan` to explicitly convert `defaults.tags` to a list if it exists, ensuring consistent data type handling.

### Updates to test cases:
* Adjusted the `sample_defaults` function in `test_translate.py` to replace `vlan` tags with a `comments` field, reflecting updated test data.
* Updated the `test_translate_vlan` function in `test_translate.py` to validate the new behavior, including checking for accurate tag counts and the presence of comments.