### PR TITLE
feat: adds basic default support (descriptions and tags)

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -34,7 +34,7 @@ config:
     tags:  # Optional: Global tags for all entities
       - "global"
       - "snmp"
-    ipAddress:  # Optional: Defaults specific to IP addresses
+    ip_address:  # Optional: Defaults specific to IP addresses
       description: "IP Address description"
       comments: "IP Address comments"
       tags:
@@ -55,7 +55,7 @@ scope:
     - host: "192.168.1.1"  # Required: Hostname or IP address
       port: 161  # Optional: SNMP port (default: 161)
   authentication:  # SNMP authentication settings
-    protocolVersion: "2c"  # Required: SNMP protocol version ("1", "2c", or "3")
+    protocol_version: "2c"  # Required: SNMP protocol version ("1", "2c", or "3")
     community: "public"  # Required for v1/v2c: SNMP community string
     # Optional for v3:
     # username: "user"

--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -20,3 +20,117 @@ options:
   -a DIODE_APP_NAME_PREFIX, --diode-app-name-prefix DIODE_APP_NAME_PREFIX
                         Diode producer_app_name prefix
 ```
+
+## Configuration
+
+The SNMP discovery service is configured using a YAML file. The configuration file has the following structure:
+
+```yaml
+config:
+  schedule: "*/5 * * * *"  # Optional: Cron expression for scheduling
+  defaults:  # Optional: Default values for entities
+    description: "Global description"  # Optional: Global description for all entities
+    comments: "Global comments"  # Optional: Global comments for all entities
+    tags:  # Optional: Global tags for all entities
+      - "global"
+      - "snmp"
+    ipAddress:  # Optional: Defaults specific to IP addresses
+      description: "IP Address description"
+      comments: "IP Address comments"
+      tags:
+        - "ip"
+        - "default"
+    interface:  # Optional: Defaults specific to interfaces
+      description: "Interface description"
+      tags:
+        - "interface"
+        - "default"
+    device:  # Optional: Defaults specific to devices
+      description: "Device description"
+      tags:
+        - "device"
+        - "default"
+scope:
+  targets:  # List of SNMP targets to discover
+    - host: "192.168.1.1"  # Required: Hostname or IP address
+      port: 161  # Optional: SNMP port (default: 161)
+  authentication:  # SNMP authentication settings
+    protocolVersion: "2c"  # Required: SNMP protocol version ("1", "2c", or "3")
+    community: "public"  # Required for v1/v2c: SNMP community string
+    # Optional for v3:
+    # username: "user"
+    # authProtocol: "SHA"
+    # authKey: "authkey"
+    # privProtocol: "AES"
+    # privKey: "privkey"
+  retries: 3  # Optional: Number of SNMP retries (default: 3)
+  mappings:  # List of SNMP OID mappings
+    - oid: "iso.3.6.1.2.1.2.2.1"  # Required: SNMP OID to map
+      entity: "interface"  # Required: Entity type to map to
+      field: "_id"  # Required: Field to map to
+      identifierSize: 1  # Optional: Size of the identifier in the OID (default: 1)
+      mappingEntries:  # Optional: Nested mappings
+        - oid: "iso.3.6.1.2.1.2.2.1.2"
+          entity: "interface"
+          field: "name"
+        - oid: "iso.3.6.1.2.1.2.2.1.5"
+          entity: "interface"
+          field: "speed"
+        - oid: "iso.3.6.1.2.1.2.2.1.6"
+          entity: "interface"
+          field: "macAddress"
+        - oid: "iso.3.6.1.2.1.2.2.1.7"
+          entity: "interface"
+          field: "adminStatus"
+```
+
+### Defaults
+
+The `defaults` section allows you to specify default values for entities discovered by SNMP. These defaults can be applied globally to all entities or specifically to certain entity types.
+
+#### Global Defaults
+
+Global defaults are applied to all entities if they don't have entity-specific defaults:
+
+- `description`: A global description for all entities
+- `comments`: Global comments for all entities
+- `tags`: Global tags for all entities
+
+#### Entity-Specific Defaults
+
+Entity-specific defaults override global defaults for their respective entity types:
+
+- `ipAddress`: Defaults for IP addresses
+  - `description`: Description for IP addresses
+  - `comments`: Comments for IP addresses
+  - `tags`: Tags for IP addresses
+
+- `interface`: Defaults for interfaces
+  - `description`: Description for interfaces
+  - `tags`: Tags for interfaces
+
+- `device`: Defaults for devices
+  - `description`: Description for devices
+  - `tags`: Tags for devices
+
+### Mappings
+
+The `mappings` section defines how SNMP OIDs are mapped to entities. Each mapping entry has the following fields:
+
+- `oid`: The SNMP OID to map
+- `entity`: The entity type to map to (e.g., "interface", "ipAddress", "device")
+- `field`: The field to map to
+- `identifierSize`: The size of the identifier in the OID (default: 1)
+- `mappingEntries`: Optional nested mappings for additional fields
+
+### Authentication
+
+The `authentication` section configures SNMP authentication settings:
+
+- `protocolVersion`: The SNMP protocol version ("1", "2c", or "3")
+- `community`: The SNMP community string (required for v1/v2c)
+- `username`: The SNMP username (required for v3)
+- `authProtocol`: The authentication protocol (required for v3)
+- `authKey`: The authentication key (required for v3)
+- `privProtocol`: The privacy protocol (required for v3)
+- `privKey`: The privacy key (required for v3)

--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -55,33 +55,16 @@ scope:
     - host: "192.168.1.1"  # Required: Hostname or IP address
       port: 161  # Optional: SNMP port (default: 161)
   authentication:  # SNMP authentication settings
-    protocol_version: "2c"  # Required: SNMP protocol version ("1", "2c", or "3")
+    protocol_version: "SNMPv2c"  # Required: SNMP protocol version ("SNMPv1", "SNMPv2c", or "SNMPv3")
     community: "public"  # Required for v1/v2c: SNMP community string
     # Optional for v3:
     # username: "user"
-    # authProtocol: "SHA"
-    # authKey: "authkey"
-    # privProtocol: "AES"
-    # privKey: "privkey"
-  retries: 3  # Optional: Number of SNMP retries (default: 3)
-  mappings:  # List of SNMP OID mappings
-    - oid: "iso.3.6.1.2.1.2.2.1"  # Required: SNMP OID to map
-      entity: "interface"  # Required: Entity type to map to
-      field: "_id"  # Required: Field to map to
-      identifierSize: 1  # Optional: Size of the identifier in the OID (default: 1)
-      mappingEntries:  # Optional: Nested mappings
-        - oid: "iso.3.6.1.2.1.2.2.1.2"
-          entity: "interface"
-          field: "name"
-        - oid: "iso.3.6.1.2.1.2.2.1.5"
-          entity: "interface"
-          field: "speed"
-        - oid: "iso.3.6.1.2.1.2.2.1.6"
-          entity: "interface"
-          field: "macAddress"
-        - oid: "iso.3.6.1.2.1.2.2.1.7"
-          entity: "interface"
-          field: "adminStatus"
+    # security_level: authPriv # Allowed values: ("NoAuthNoPriv", "AuthNoPriv", "AuthPriv")
+    # auth_protocol: "SHA"
+    # auth_passphrase: "authkey"
+    # priv_protocol: "AES"
+    # priv_passphrase: "privkey"
+  retries: 3  # Optional: Number of SNMP retries (default: 0)
 ```
 
 ### Defaults

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -36,11 +36,21 @@ type Authentication struct {
 	PrivPassphrase  string `yaml:"priv_passphrase"`
 }
 
-// Defaults represents the supported default values for a policy
-type Defaults struct {
+// EntityDefaults represents default values for a specific entity type
+type EntityDefaults struct {
 	Description string   `yaml:"description,omitempty"`
 	Comments    string   `yaml:"comments,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
+}
+
+// Defaults represents the supported default values for a policy
+type Defaults struct {
+	Description string         `yaml:"description,omitempty"`
+	Comments    string         `yaml:"comments,omitempty"`
+	Tags        []string       `yaml:"tags,omitempty"`
+	IPAddress   EntityDefaults `yaml:"ip_address,omitempty"`
+	Interface   EntityDefaults `yaml:"interface,omitempty"`
+	Device      EntityDefaults `yaml:"device,omitempty"`
 }
 
 // PolicyConfig represents the configuration of a policy

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -16,7 +16,7 @@ import (
 type IPAddressMapper struct{}
 
 // Map maps IP addresses to entities
-func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
+func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *MappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
 	logger.Debug("Mapping values to ipAddress entity", "values", values, "mappingEntry", mappingEntry)
 	ipAddress := diode.IPAddress{}
 
@@ -47,6 +47,42 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 			}
 		}
 	}
+
+	// Apply defaults if available
+	if defaults := entityRegistry.GetDefaults(); defaults != nil {
+		// Apply IP address specific defaults
+		if defaults.IPAddress.Description != "" {
+			ipAddress.Description = &defaults.IPAddress.Description
+		}
+		if defaults.IPAddress.Comments != "" {
+			ipAddress.Comments = &defaults.IPAddress.Comments
+		}
+		var tags []*diode.Tag
+		// Add entity-specific tags
+		if len(defaults.IPAddress.Tags) > 0 {
+			for _, tag := range defaults.IPAddress.Tags {
+				tags = append(tags, &diode.Tag{Name: &tag})
+			}
+		}
+		// Add global tags
+		if len(defaults.Tags) > 0 {
+			for _, tag := range defaults.Tags {
+				tags = append(tags, &diode.Tag{Name: &tag})
+			}
+		}
+		if len(tags) > 0 {
+			ipAddress.Tags = tags
+		}
+
+		// Apply global defaults if not overridden by entity-specific defaults
+		if ipAddress.Description == nil && defaults.Description != "" {
+			ipAddress.Description = &defaults.Description
+		}
+		if ipAddress.Comments == nil && defaults.Comments != "" {
+			ipAddress.Comments = &defaults.Comments
+		}
+	}
+
 	return &ipAddress
 }
 
@@ -54,7 +90,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 type InterfaceMapper struct{}
 
 // Map maps interfaces to entities
-func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
+func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *MappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
 	logger.Debug("Mapping values to interface entity", "values", values, "mappingEntry", mappingEntry)
 	interfaceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values)).(*diode.Interface)
 
@@ -86,6 +122,36 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 			}
 		}
 	}
+
+	// Apply defaults if available
+	if defaults := entityRegistry.GetDefaults(); defaults != nil {
+		// Apply interface specific defaults
+		if defaults.Interface.Description != "" {
+			interfaceEntity.Description = &defaults.Interface.Description
+		}
+		var tags []*diode.Tag
+		// Add entity-specific tags
+		if len(defaults.Interface.Tags) > 0 {
+			for _, tag := range defaults.Interface.Tags {
+				tags = append(tags, &diode.Tag{Name: &tag})
+			}
+		}
+		// Add global tags
+		if len(defaults.Tags) > 0 {
+			for _, tag := range defaults.Tags {
+				tags = append(tags, &diode.Tag{Name: &tag})
+			}
+		}
+		if len(tags) > 0 {
+			interfaceEntity.Tags = tags
+		}
+
+		// Apply global defaults if not overridden by entity-specific defaults
+		if interfaceEntity.Description == nil && defaults.Description != "" {
+			interfaceEntity.Description = &defaults.Description
+		}
+	}
+
 	return interfaceEntity
 }
 
@@ -94,10 +160,17 @@ type DeviceMapper struct {
 	devices data.DeviceDataRetreiver
 }
 
+// NewDeviceMapper creates a new DeviceMapper
+func NewDeviceMapper(devices data.DeviceDataRetreiver) *DeviceMapper {
+	return &DeviceMapper{
+		devices: devices,
+	}
+}
+
 // Map maps devices to entities
-func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, _ *EntityRegistry, logger *slog.Logger) diode.Entity {
+func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *MappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
 	logger.Debug("Mapping values to device entity", "values", values, "mappingEntry", mappingEntry)
-	device := diode.Device{}
+	deviceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values)).(*diode.Device)
 
 	for objectID, value := range values {
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
@@ -105,33 +178,35 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 				logger.Debug("Mapping value to device entity with mapper", "objectID", objectID, "value", value, "mappingEntry", propertyMappingEntry)
 				switch propertyMappingEntry.Field {
 				case "name":
-					device.Name = &value.Value
+					deviceEntity.Name = &value.Value
 				case "platform":
+					// Use getDeviceIDs to get the manufacturer and model
 					manufacturerID, modelID, err := m.getDeviceIDs(value.Value)
 					if err != nil {
-						logger.Warn("Error getting device IDs, skipping", "error", err, "objectID", objectID, "value", value.Value)
+						logger.Warn("Error getting device IDs", "error", err, "value", value.Value)
 						continue
 					}
 					manufacturer, err := m.devices.GetManufacturer(manufacturerID)
 					if err != nil {
-						logger.Warn("Error getting manufacturer, skipping", "error", err, "objectID", objectID, "value", value.Value)
+						logger.Warn("Error getting manufacturer", "error", err, "manufacturerID", manufacturerID)
 						continue
 					}
-					device.Platform = &diode.Platform{
-						Manufacturer: &diode.Manufacturer{
-							Name: diode.String(manufacturer),
-						},
+
+					manufacturerEntity := diode.Manufacturer{
+						Name: &manufacturer,
 					}
-					model, err := m.devices.GetDeviceModel(modelID)
+
+					deviceEntity.Platform = &diode.Platform{
+						Manufacturer: &manufacturerEntity,
+					}
+
+					deviceModel, err := m.devices.GetDeviceModel(modelID)
 					if err != nil {
-						logger.Warn("Error getting device model, assigning default model", "error", err, "objectID", objectID, "value", value.Value)
-						continue
+						logger.Warn("Error getting device model", "error", err, "modelID", modelID)
 					}
-					device.DeviceType = &diode.DeviceType{
-						Manufacturer: &diode.Manufacturer{
-							Name: diode.String(manufacturer),
-						},
-						Model: &model,
+					deviceEntity.DeviceType = &diode.DeviceType{
+						Model:        &deviceModel,
+						Manufacturer: &manufacturerEntity,
 					}
 				default:
 					logger.Warn("Unknown field", "field", propertyMappingEntry.Field)
@@ -139,7 +214,37 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 			}
 		}
 	}
-	return &device
+
+	// Apply defaults if available
+	if defaults := entityRegistry.GetDefaults(); defaults != nil {
+		// Apply device specific defaults
+		if defaults.Device.Description != "" {
+			deviceEntity.Description = &defaults.Device.Description
+		}
+		var tags []*diode.Tag
+		// Add entity-specific tags
+		if len(defaults.Device.Tags) > 0 {
+			for _, tag := range defaults.Device.Tags {
+				tags = append(tags, &diode.Tag{Name: &tag})
+			}
+		}
+		// Add global tags
+		if len(defaults.Tags) > 0 {
+			for _, tag := range defaults.Tags {
+				tags = append(tags, &diode.Tag{Name: &tag})
+			}
+		}
+		if len(tags) > 0 {
+			deviceEntity.Tags = tags
+		}
+
+		// Apply global defaults if not overridden by entity-specific defaults
+		if deviceEntity.Description == nil && defaults.Description != "" {
+			deviceEntity.Description = &defaults.Description
+		}
+	}
+
+	return deviceEntity
 }
 
 func (m *DeviceMapper) getDeviceIDs(objectID string) (int, int, error) {

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -20,6 +20,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	logger.Debug("Mapping values to ipAddress entity", "values", values, "mappingEntry", mappingEntry)
 	ipAddress := diode.IPAddress{}
 
+	fieldFound := false
 	// for each value in the map, map it to the ip address entity
 	for objectID, value := range values {
 		logger.Debug("Mapping value to ipAddress entity", "objectID", objectID, "value", value)
@@ -29,6 +30,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				case "address":
 					x := fmt.Sprintf("%s/32", string(value.Index))
 					ipAddress.Address = &x
+					fieldFound = true
 				case "assigned_object":
 					if propertyMappingEntry.Relationship != (config.Relationship{}) {
 						linkedEntity := entityRegistry.GetOrCreateEntity(EntityType(propertyMappingEntry.Relationship.Type), ObjectIDIndex(value.Value))
@@ -39,6 +41,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 						// Handle relationship mapping
 						if propertyMappingEntry.Relationship.Type == "interface" {
 							ipAddress.AssignedObject = linkedEntity.(*diode.Interface)
+							fieldFound = true
 						}
 					}
 				default:
@@ -49,7 +52,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	}
 
 	// Apply defaults if available
-	if defaults := entityRegistry.GetDefaults(); defaults != nil {
+	if defaults := entityRegistry.GetDefaults(); defaults != nil && fieldFound {
 		// Apply IP address specific defaults
 		if defaults.IPAddress.Description != "" {
 			ipAddress.Description = &defaults.IPAddress.Description
@@ -94,6 +97,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	logger.Debug("Mapping values to interface entity", "values", values, "mappingEntry", mappingEntry)
 	interfaceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values)).(*diode.Interface)
 
+	fieldFound := false
 	for objectID, value := range values {
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(propertyMappingEntry.OID) {
@@ -101,6 +105,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				switch propertyMappingEntry.Field {
 				case "name":
 					interfaceEntity.Name = &value.Value
+					fieldFound = true
 				case "speed":
 					speed, err := strconv.Atoi(value.Value)
 					if err != nil {
@@ -109,13 +114,16 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					}
 					speed64 := int64(speed)
 					interfaceEntity.Speed = &speed64
+					fieldFound = true
 				case "macAddress":
 					interfaceEntity.PrimaryMacAddress = &diode.MACAddress{
 						MacAddress: &value.Value,
 					}
+					fieldFound = true
 				case "adminStatus":
 					enabled := value.Value == "1"
 					interfaceEntity.Enabled = &enabled
+					fieldFound = true
 				default:
 					logger.Warn("Unknown field", "field", propertyMappingEntry.Field)
 				}
@@ -124,7 +132,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	}
 
 	// Apply defaults if available
-	if defaults := entityRegistry.GetDefaults(); defaults != nil {
+	if defaults := entityRegistry.GetDefaults(); defaults != nil && fieldFound {
 		// Apply interface specific defaults
 		if defaults.Interface.Description != "" {
 			interfaceEntity.Description = &defaults.Interface.Description
@@ -172,6 +180,7 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 	logger.Debug("Mapping values to device entity", "values", values, "mappingEntry", mappingEntry)
 	deviceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values)).(*diode.Device)
 
+	fieldFound := false
 	for objectID, value := range values {
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(propertyMappingEntry.OID) {
@@ -179,6 +188,7 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 				switch propertyMappingEntry.Field {
 				case "name":
 					deviceEntity.Name = &value.Value
+					fieldFound = true
 				case "platform":
 					// Use getDeviceIDs to get the manufacturer and model
 					manufacturerID, modelID, err := m.getDeviceIDs(value.Value)
@@ -208,6 +218,7 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 						Model:        &deviceModel,
 						Manufacturer: &manufacturerEntity,
 					}
+					fieldFound = true
 				default:
 					logger.Warn("Unknown field", "field", propertyMappingEntry.Field)
 				}
@@ -216,7 +227,7 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 	}
 
 	// Apply defaults if available
-	if defaults := entityRegistry.GetDefaults(); defaults != nil {
+	if defaults := entityRegistry.GetDefaults(); fieldFound && defaults != nil {
 		// Apply device specific defaults
 		if defaults.Device.Description != "" {
 			deviceEntity.Description = &defaults.Device.Description

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -16,7 +16,7 @@ import (
 type IPAddressMapper struct{}
 
 // Map maps IP addresses to entities
-func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *MappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
+func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
 	logger.Debug("Mapping values to ipAddress entity", "values", values, "mappingEntry", mappingEntry)
 	ipAddress := diode.IPAddress{}
 
@@ -90,7 +90,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 type InterfaceMapper struct{}
 
 // Map maps interfaces to entities
-func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *MappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
+func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
 	logger.Debug("Mapping values to interface entity", "values", values, "mappingEntry", mappingEntry)
 	interfaceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values)).(*diode.Interface)
 
@@ -168,7 +168,7 @@ func NewDeviceMapper(devices data.DeviceDataRetreiver) *DeviceMapper {
 }
 
 // Map maps devices to entities
-func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *MappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
+func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
 	logger.Debug("Mapping values to device entity", "values", values, "mappingEntry", mappingEntry)
 	deviceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values)).(*diode.Device)
 

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -15,13 +15,12 @@ import (
 
 func TestIPAddressMapper_Map(t *testing.T) {
 	logger := slog.Default()
-	registry := mapping.NewEntityRegistry(logger)
-	mapper := &mapping.IPAddressMapper{}
 
 	tests := []struct {
 		name           string
 		values         map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
 		mappingEntry   *mapping.Entry
+		defaults       *config.Defaults
 		expectedEntity *diode.IPAddress
 		expectError    bool
 	}{
@@ -53,8 +52,143 @@ func TestIPAddressMapper_Map(t *testing.T) {
 					},
 				},
 			},
+			defaults: nil,
 			expectedEntity: &diode.IPAddress{
 				Address: stringPtr("192.168.1.1/32"),
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with global defaults",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   mapping.IPAddress,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Description: "Global description",
+				Tags:        []string{"global-tag1", "global-tag2"},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address:     stringPtr("192.168.1.1/32"),
+				Description: stringPtr("Global description"),
+				Tags: []*diode.Tag{
+					{Name: stringPtr("global-tag1")},
+					{Name: stringPtr("global-tag2")},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with entity-specific defaults",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   mapping.IPAddress,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				IPAddress: config.EntityDefaults{
+					Description: "IP Address specific description",
+					Tags:        []string{"ip-tag1", "ip-tag2"},
+				},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address:     stringPtr("192.168.1.1/32"),
+				Description: stringPtr("IP Address specific description"),
+				Tags: []*diode.Tag{
+					{Name: stringPtr("ip-tag1")},
+					{Name: stringPtr("ip-tag2")},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with both global and entity-specific defaults",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   mapping.IPAddress,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Description: "Global description",
+				Tags:        []string{"global-tag1", "global-tag2"},
+				IPAddress: config.EntityDefaults{
+					Description: "IP Address specific description",
+					Tags:        []string{"ip-tag1", "ip-tag2"},
+				},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address:     stringPtr("192.168.1.1/32"),
+				Description: stringPtr("IP Address specific description"),
+				Tags: []*diode.Tag{
+					{Name: stringPtr("ip-tag1")},
+					{Name: stringPtr("ip-tag2")},
+					{Name: stringPtr("global-tag1")},
+					{Name: stringPtr("global-tag2")},
+				},
 			},
 			expectError: false,
 		},
@@ -76,6 +210,7 @@ func TestIPAddressMapper_Map(t *testing.T) {
 					Type:   mapping.Integer,
 				},
 			},
+			defaults: nil,
 			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.4.20.1.1",
 				Entity: "ipAddress",
@@ -121,6 +256,9 @@ func TestIPAddressMapper_Map(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			registry := mapping.NewEntityRegistry(logger)
+			mapper := &mapping.IPAddressMapper{}
+			registry.SetDefaults(tt.defaults)
 			entity := mapper.Map(tt.values, tt.mappingEntry, registry, logger)
 
 			if tt.expectError {
@@ -132,6 +270,13 @@ func TestIPAddressMapper_Map(t *testing.T) {
 			ipAddress, ok := entity.(*diode.IPAddress)
 			assert.True(t, ok)
 			assert.Equal(t, tt.expectedEntity.Address, ipAddress.Address)
+			assert.Equal(t, tt.expectedEntity.Description, ipAddress.Description)
+			if tt.expectedEntity.Tags != nil {
+				assert.Equal(t, len(tt.expectedEntity.Tags), len(ipAddress.Tags))
+				for i, tag := range tt.expectedEntity.Tags {
+					assert.Equal(t, tag.Name, ipAddress.Tags[i].Name)
+				}
+			}
 		})
 	}
 }
@@ -141,6 +286,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 		name           string
 		values         map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
 		mappingEntry   *mapping.Entry
+		defaults       *config.Defaults
 		expectedEntity *diode.Interface
 		expectError    bool
 	}{
@@ -215,11 +361,167 @@ func TestInterfaceMapper_Map(t *testing.T) {
 					},
 				},
 			},
+			defaults: nil,
 			expectedEntity: &diode.Interface{
 				Name:              stringPtr("eth0"),
 				Speed:             int64Ptr(1000000),
 				PrimaryMacAddress: &diode.MACAddress{MacAddress: stringPtr("00:11:22:33:44:55")},
 				Enabled:           boolPtr(true),
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with global defaults",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Description: "Global description",
+				Tags:        []string{"global-tag1", "global-tag2"},
+			},
+			expectedEntity: &diode.Interface{
+				Name:        stringPtr("eth0"),
+				Description: stringPtr("Global description"),
+				Tags: []*diode.Tag{
+					{Name: stringPtr("global-tag1")},
+					{Name: stringPtr("global-tag2")},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with entity-specific defaults",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Interface: config.EntityDefaults{
+					Description: "Interface specific description",
+					Tags:        []string{"interface-tag1", "interface-tag2"},
+				},
+			},
+			expectedEntity: &diode.Interface{
+				Name:        stringPtr("eth0"),
+				Description: stringPtr("Interface specific description"),
+				Tags: []*diode.Tag{
+					{Name: stringPtr("interface-tag1")},
+					{Name: stringPtr("interface-tag2")},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with both global and entity-specific defaults",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Description: "Global description",
+				Tags:        []string{"global-tag1", "global-tag2"},
+				Interface: config.EntityDefaults{
+					Description: "Interface specific description",
+					Tags:        []string{"interface-tag1", "interface-tag2"},
+				},
+			},
+			expectedEntity: &diode.Interface{
+				Name:        stringPtr("eth0"),
+				Description: stringPtr("Interface specific description"),
+				Tags: []*diode.Tag{
+					{Name: stringPtr("interface-tag1")},
+					{Name: stringPtr("interface-tag2")},
+					{Name: stringPtr("global-tag1")},
+					{Name: stringPtr("global-tag2")},
+				},
 			},
 			expectError: false,
 		},
@@ -278,6 +580,9 @@ func TestInterfaceMapper_Map(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := slog.Default()
 			registry := mapping.NewEntityRegistry(logger)
+			if tt.defaults != nil {
+				registry.SetDefaults(tt.defaults)
+			}
 			mapper := &mapping.InterfaceMapper{}
 			entity := mapper.Map(tt.values, tt.mappingEntry, registry, logger)
 
@@ -295,13 +600,19 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				assert.Equal(t, tt.expectedEntity.PrimaryMacAddress.MacAddress, iface.PrimaryMacAddress.MacAddress)
 			}
 			assert.Equal(t, tt.expectedEntity.Enabled, iface.Enabled)
+			assert.Equal(t, tt.expectedEntity.Description, iface.Description)
+			if tt.expectedEntity.Tags != nil {
+				assert.Equal(t, len(tt.expectedEntity.Tags), len(iface.Tags))
+				for i, tag := range tt.expectedEntity.Tags {
+					assert.Equal(t, tag.Name, iface.Tags[i].Name)
+				}
+			}
 		})
 	}
 }
 
 func TestDeviceMapper_Map(t *testing.T) {
 	logger := slog.Default()
-	registry := mapping.NewEntityRegistry(logger)
 
 	// Create a mock manufacturer data retriever
 	mockManufacturers := &MockManufacturerDataRetriever{}
@@ -317,6 +628,7 @@ func TestDeviceMapper_Map(t *testing.T) {
 		name           string
 		values         map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
 		mappingEntry   *mapping.Entry
+		defaults       *config.Defaults
 		expectedEntity *diode.Device
 		expectError    bool
 	}{
@@ -355,6 +667,7 @@ func TestDeviceMapper_Map(t *testing.T) {
 					},
 				},
 			},
+			defaults: nil,
 			expectedEntity: &diode.Device{
 				Name: stringPtr("router1"),
 				DeviceType: &diode.DeviceType{
@@ -367,6 +680,125 @@ func TestDeviceMapper_Map(t *testing.T) {
 					Manufacturer: &diode.Manufacturer{
 						Name: stringPtr("Cisco"),
 					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with global defaults",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.1.5.0": {
+					OID:    "1.3.6.1.2.1.1.5.0",
+					Index:  "0",
+					Parent: "1.3.6.1.2.1.1.5",
+					Value:  "router1",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.1",
+				Entity: "device",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.1.5",
+						Entity: "device",
+						Field:  "name",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Description: "Global description",
+				Tags:        []string{"global-tag1", "global-tag2"},
+			},
+			expectedEntity: &diode.Device{
+				Name:        stringPtr("router1"),
+				Description: stringPtr("Global description"),
+				Tags: []*diode.Tag{
+					{Name: stringPtr("global-tag1")},
+					{Name: stringPtr("global-tag2")},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with entity-specific defaults",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.1.5.0": {
+					OID:    "1.3.6.1.2.1.1.5.0",
+					Index:  "0",
+					Parent: "1.3.6.1.2.1.1.5",
+					Value:  "router1",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.1",
+				Entity: "device",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.1.5",
+						Entity: "device",
+						Field:  "name",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Device: config.EntityDefaults{
+					Description: "Device specific description",
+					Tags:        []string{"device-tag1", "device-tag2"},
+				},
+			},
+			expectedEntity: &diode.Device{
+				Name:        stringPtr("router1"),
+				Description: stringPtr("Device specific description"),
+				Tags: []*diode.Tag{
+					{Name: stringPtr("device-tag1")},
+					{Name: stringPtr("device-tag2")},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with both global and entity-specific defaults",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.1.5.0": {
+					OID:    "1.3.6.1.2.1.1.5.0",
+					Index:  "0",
+					Parent: "1.3.6.1.2.1.1.5",
+					Value:  "router1",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.1",
+				Entity: "device",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.1.5",
+						Entity: "device",
+						Field:  "name",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Description: "Global description",
+				Tags:        []string{"global-tag1", "global-tag2"},
+				Device: config.EntityDefaults{
+					Description: "Device specific description",
+					Tags:        []string{"device-tag1", "device-tag2"},
+				},
+			},
+			expectedEntity: &diode.Device{
+				Name:        stringPtr("router1"),
+				Description: stringPtr("Device specific description"),
+				Tags: []*diode.Tag{
+					{Name: stringPtr("device-tag1")},
+					{Name: stringPtr("device-tag2")},
+					{Name: stringPtr("global-tag1")},
+					{Name: stringPtr("global-tag2")},
 				},
 			},
 			expectError: false,
@@ -389,6 +821,7 @@ func TestDeviceMapper_Map(t *testing.T) {
 					Type:   mapping.ObjectIdentifier,
 				},
 			},
+			defaults: nil,
 			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.1",
 				Entity: "device",
@@ -426,6 +859,8 @@ func TestDeviceMapper_Map(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			registry := mapping.NewEntityRegistry(logger)
+			registry.SetDefaults(tt.defaults)
 			entity := mapper.Map(tt.values, tt.mappingEntry, registry, logger)
 
 			if tt.expectError {
@@ -443,6 +878,13 @@ func TestDeviceMapper_Map(t *testing.T) {
 			}
 			if tt.expectedEntity.Platform != nil {
 				assert.Equal(t, tt.expectedEntity.Platform.Manufacturer.Name, device.Platform.Manufacturer.Name)
+			}
+			assert.Equal(t, tt.expectedEntity.Description, device.Description)
+			if tt.expectedEntity.Tags != nil {
+				assert.Equal(t, len(tt.expectedEntity.Tags), len(device.Tags))
+				for i, tag := range tt.expectedEntity.Tags {
+					assert.Equal(t, tag.Name, device.Tags[i].Name)
+				}
 			}
 		})
 	}

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -1,4 +1,4 @@
-package mapping
+package mapping_test
 
 import (
 	"fmt"
@@ -10,36 +10,37 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
 )
 
 func TestIPAddressMapper_Map(t *testing.T) {
 	logger := slog.Default()
-	registry := NewEntityRegistry(logger)
-	mapper := &IPAddressMapper{}
+	registry := mapping.NewEntityRegistry(logger)
+	mapper := &mapping.IPAddressMapper{}
 
 	tests := []struct {
 		name           string
-		values         map[ObjectIDIndex]*ObjectIDValue
-		mappingEntry   *mappingEntry
+		values         map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
+		mappingEntry   *mapping.MappingEntry
 		expectedEntity *diode.IPAddress
 		expectError    bool
 	}{
 		{
 			name: "successful mapping with all fields",
-			values: map[ObjectIDIndex]*ObjectIDValue{
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
 					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
 					Index:  "192.168.1.1",
 					Parent: "1.3.6.1.2.1.4.20.1.1",
 					Value:  "192.168.1.1",
-					Type:   IPAddress,
+					Type:   mapping.IPAddress,
 				},
 			},
-			mappingEntry: &mappingEntry{
+			mappingEntry: &mapping.MappingEntry{
 				OID:    "1.3.6.1.2.1.4.20.1.1",
 				Entity: "ipAddress",
 				Field:  "_id",
-				MappingEntries: []mappingEntry{
+				MappingEntries: []mapping.MappingEntry{
 					{
 						OID:    "1.3.6.1.2.1.4.20.1.1",
 						Entity: "ipAddress",
@@ -59,27 +60,27 @@ func TestIPAddressMapper_Map(t *testing.T) {
 		},
 		{
 			name: "mapping with interface relationship",
-			values: map[ObjectIDIndex]*ObjectIDValue{
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
 					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
 					Index:  "192.168.1.1",
 					Parent: "1.3.6.1.2.1.4.20.1.1",
 					Value:  "192.168.1.1",
-					Type:   IPAddress,
+					Type:   mapping.IPAddress,
 				},
 				"1.3.6.1.2.1.4.20.1.2.192.168.1.1": {
 					OID:    "1.3.6.1.2.1.4.20.1.2.192.168.1.1",
 					Index:  "192.168.1.1",
 					Parent: "1.3.6.1.2.1.4.20.1.2",
 					Value:  "1",
-					Type:   Integer,
+					Type:   mapping.Integer,
 				},
 			},
-			mappingEntry: &mappingEntry{
+			mappingEntry: &mapping.MappingEntry{
 				OID:    "1.3.6.1.2.1.4.20.1.1",
 				Entity: "ipAddress",
 				Field:  "_id",
-				MappingEntries: []mappingEntry{
+				MappingEntries: []mapping.MappingEntry{
 					{
 						OID:    "1.3.6.1.2.1.4.20.1.1",
 						Entity: "ipAddress",
@@ -107,8 +108,8 @@ func TestIPAddressMapper_Map(t *testing.T) {
 		},
 		{
 			name:   "empty values map",
-			values: map[ObjectIDIndex]*ObjectIDValue{},
-			mappingEntry: &mappingEntry{
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{},
+			mappingEntry: &mapping.MappingEntry{
 				OID:    "1.3.6.1.2.1.4.20.1.1",
 				Entity: "ipAddress",
 				Field:  "_id",
@@ -138,55 +139,55 @@ func TestIPAddressMapper_Map(t *testing.T) {
 func TestInterfaceMapper_Map(t *testing.T) {
 	tests := []struct {
 		name           string
-		values         map[ObjectIDIndex]*ObjectIDValue
-		mappingEntry   *mappingEntry
+		values         map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
+		mappingEntry   *mapping.MappingEntry
 		expectedEntity *diode.Interface
 		expectError    bool
 	}{
 		{
 			name: "successful mapping with all fields",
-			values: map[ObjectIDIndex]*ObjectIDValue{
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.2.2.1.1.1": {
 					OID:    "1.3.6.1.2.1.2.2.1.1.1",
 					Index:  "1",
 					Parent: "1.3.6.1.2.1.2.2.1.1",
 					Value:  "1",
-					Type:   Integer,
+					Type:   mapping.Integer,
 				},
 				"1.3.6.1.2.1.2.2.1.2.1": {
 					OID:    "1.3.6.1.2.1.2.2.1.2.1",
 					Index:  "1",
 					Parent: "1.3.6.1.2.1.2.2.1.2",
 					Value:  "eth0",
-					Type:   OctetString,
+					Type:   mapping.OctetString,
 				},
 				"1.3.6.1.2.1.2.2.1.5.1": {
 					OID:    "1.3.6.1.2.1.2.2.1.5.1",
 					Index:  "1",
 					Parent: "1.3.6.1.2.1.2.2.1.5",
 					Value:  "1000000",
-					Type:   Integer,
+					Type:   mapping.Integer,
 				},
 				"1.3.6.1.2.1.2.2.1.6.1": {
 					OID:    "1.3.6.1.2.1.2.2.1.6.1",
 					Index:  "1",
 					Parent: "1.3.6.1.2.1.2.2.1.6",
 					Value:  "00:11:22:33:44:55",
-					Type:   OctetString,
+					Type:   mapping.OctetString,
 				},
 				"1.3.6.1.2.1.2.2.1.7.1": {
 					OID:    "1.3.6.1.2.1.2.2.1.7.1",
 					Index:  "1",
 					Parent: "1.3.6.1.2.1.2.2.1.7",
 					Value:  "1",
-					Type:   Integer,
+					Type:   mapping.Integer,
 				},
 			},
-			mappingEntry: &mappingEntry{
+			mappingEntry: &mapping.MappingEntry{
 				OID:    "1.3.6.1.2.1.2.2.1.1",
 				Entity: "interface",
 				Field:  "_id",
-				MappingEntries: []mappingEntry{
+				MappingEntries: []mapping.MappingEntry{
 					{
 						OID:    "1.3.6.1.2.1.2.2.1.1",
 						Entity: "interface",
@@ -224,27 +225,27 @@ func TestInterfaceMapper_Map(t *testing.T) {
 		},
 		{
 			name: "mapping with invalid speed value",
-			values: map[ObjectIDIndex]*ObjectIDValue{
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.2.2.1.1.1": {
 					OID:    "1.3.6.1.2.1.2.2.1.1.1",
 					Index:  "1",
 					Parent: "1.3.6.1.2.1.2.2.1.1",
 					Value:  "1",
-					Type:   Integer,
+					Type:   mapping.Integer,
 				},
 				"1.3.6.1.2.1.2.2.1.5.1": {
 					OID:    "1.3.6.1.2.1.2.2.1.5.1",
 					Index:  "1",
 					Parent: "1.3.6.1.2.1.2.2.1.5",
 					Value:  "invalid",
-					Type:   Integer,
+					Type:   mapping.Integer,
 				},
 			},
-			mappingEntry: &mappingEntry{
+			mappingEntry: &mapping.MappingEntry{
 				OID:    "1.3.6.1.2.1.2.2.1.1",
 				Entity: "interface",
 				Field:  "_id",
-				MappingEntries: []mappingEntry{
+				MappingEntries: []mapping.MappingEntry{
 					{
 						OID:    "1.3.6.1.2.1.2.2.1.1",
 						Entity: "interface",
@@ -262,8 +263,8 @@ func TestInterfaceMapper_Map(t *testing.T) {
 		},
 		{
 			name:   "empty values map",
-			values: map[ObjectIDIndex]*ObjectIDValue{},
-			mappingEntry: &mappingEntry{
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{},
+			mappingEntry: &mapping.MappingEntry{
 				OID:    "1.3.6.1.2.1.2.2.1.1",
 				Entity: "interface",
 				Field:  "_id",
@@ -276,8 +277,8 @@ func TestInterfaceMapper_Map(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := slog.Default()
-			registry := NewEntityRegistry(logger)
-			mapper := &InterfaceMapper{}
+			registry := mapping.NewEntityRegistry(logger)
+			mapper := &mapping.InterfaceMapper{}
 			entity := mapper.Map(tt.values, tt.mappingEntry, registry, logger)
 
 			if tt.expectError {
@@ -300,7 +301,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 
 func TestDeviceMapper_Map(t *testing.T) {
 	logger := slog.Default()
-	registry := NewEntityRegistry(logger)
+	registry := mapping.NewEntityRegistry(logger)
 
 	// Create a mock manufacturer data retriever
 	mockManufacturers := &MockManufacturerDataRetriever{}
@@ -310,40 +311,38 @@ func TestDeviceMapper_Map(t *testing.T) {
 	mockManufacturers.On("GetDeviceModel", 1234).Return("cisco4000", nil)
 	mockManufacturers.On("GetDeviceModel", 999).Return("", fmt.Errorf("device model not found"))
 
-	mapper := &DeviceMapper{
-		devices: mockManufacturers,
-	}
+	mapper := mapping.NewDeviceMapper(mockManufacturers)
 
 	tests := []struct {
 		name           string
-		values         map[ObjectIDIndex]*ObjectIDValue
-		mappingEntry   *mappingEntry
+		values         map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
+		mappingEntry   *mapping.MappingEntry
 		expectedEntity *diode.Device
 		expectError    bool
 	}{
 		{
 			name: "successful mapping with name and platform",
-			values: map[ObjectIDIndex]*ObjectIDValue{
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.1.5.0": {
 					OID:    "1.3.6.1.2.1.1.5.0",
 					Index:  "0",
 					Parent: "1.3.6.1.2.1.1.5",
 					Value:  "router1",
-					Type:   OctetString,
+					Type:   mapping.OctetString,
 				},
 				"1.3.6.1.2.1.1.2.0": {
 					OID:    "1.3.6.1.2.1.1.2.0",
 					Index:  "0",
 					Parent: "1.3.6.1.2.1.1.2",
 					Value:  "1.3.6.1.4.1.9.1.1234",
-					Type:   ObjectIdentifier,
+					Type:   mapping.ObjectIdentifier,
 				},
 			},
-			mappingEntry: &mappingEntry{
+			mappingEntry: &mapping.MappingEntry{
 				OID:    "1.3.6.1.2.1.1",
 				Entity: "device",
 				Field:  "_id",
-				MappingEntries: []mappingEntry{
+				MappingEntries: []mapping.MappingEntry{
 					{
 						OID:    "1.3.6.1.2.1.1.5",
 						Entity: "device",
@@ -360,34 +359,46 @@ func TestDeviceMapper_Map(t *testing.T) {
 				Name: stringPtr("router1"),
 				DeviceType: &diode.DeviceType{
 					Manufacturer: &diode.Manufacturer{
-						Name: diode.String("Cisco"),
+						Name: stringPtr("Cisco"),
 					},
-					Model: diode.String("cisco4000"),
+					Model: stringPtr("cisco4000"),
 				},
 				Platform: &diode.Platform{
 					Manufacturer: &diode.Manufacturer{
-						Name: diode.String("Cisco"),
+						Name: stringPtr("Cisco"),
 					},
 				},
 			},
 			expectError: false,
 		},
 		{
-			name: "mapping with unknown manufacturer",
-			values: map[ObjectIDIndex]*ObjectIDValue{
+			name: "mapping with invalid platform OID",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.1.5.0": {
+					OID:    "1.3.6.1.2.1.1.5.0",
+					Index:  "0",
+					Parent: "1.3.6.1.2.1.1.5",
+					Value:  "router1",
+					Type:   mapping.OctetString,
+				},
 				"1.3.6.1.2.1.1.2.0": {
 					OID:    "1.3.6.1.2.1.1.2.0",
 					Index:  "0",
 					Parent: "1.3.6.1.2.1.1.2",
-					Value:  "1.3.6.1.4.1.999.1.1234",
-					Type:   ObjectIdentifier,
+					Value:  "invalid",
+					Type:   mapping.ObjectIdentifier,
 				},
 			},
-			mappingEntry: &mappingEntry{
+			mappingEntry: &mapping.MappingEntry{
 				OID:    "1.3.6.1.2.1.1",
 				Entity: "device",
 				Field:  "_id",
-				MappingEntries: []mappingEntry{
+				MappingEntries: []mapping.MappingEntry{
+					{
+						OID:    "1.3.6.1.2.1.1.5",
+						Entity: "device",
+						Field:  "name",
+					},
 					{
 						OID:    "1.3.6.1.2.1.1.2",
 						Entity: "device",
@@ -396,62 +407,20 @@ func TestDeviceMapper_Map(t *testing.T) {
 				},
 			},
 			expectedEntity: &diode.Device{
-				Platform: &diode.Platform{
-					Manufacturer: &diode.Manufacturer{
-						Name: diode.String("unknown"),
-					},
-				},
+				Name: stringPtr("router1"),
 			},
 			expectError: false,
 		},
 		{
 			name:   "empty values map",
-			values: map[ObjectIDIndex]*ObjectIDValue{},
-			mappingEntry: &mappingEntry{
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{},
+			mappingEntry: &mapping.MappingEntry{
 				OID:    "1.3.6.1.2.1.1",
 				Entity: "device",
 				Field:  "_id",
 			},
 			expectedEntity: &diode.Device{},
 			expectError:    false,
-		},
-		{
-			name: "invalid OID format",
-			values: map[ObjectIDIndex]*ObjectIDValue{
-				"1.3.6.1.2.1.1.2.0": {
-					OID:    "1.3.6.1.2.1.1.2.0",
-					Index:  "0",
-					Parent: "1.3.6.1.2.1.1.2",
-					Value:  "invalid.oid",
-					Type:   ObjectIdentifier,
-				},
-			},
-			mappingEntry: &mappingEntry{
-				OID:    "1.3.6.1.2.1.1",
-				Entity: "device",
-				Field:  "_id",
-				MappingEntries: []mappingEntry{
-					{
-						OID:    "1.3.6.1.2.1.1.2",
-						Entity: "device",
-						Field:  "platform",
-					},
-				},
-			},
-			expectedEntity: &diode.Device{
-				DeviceType: &diode.DeviceType{
-					Manufacturer: &diode.Manufacturer{
-						Name: diode.String("unknown"),
-					},
-					Model: diode.String("unknown"),
-				},
-				Platform: &diode.Platform{
-					Manufacturer: &diode.Manufacturer{
-						Name: diode.String("unknown"),
-					},
-				},
-			},
-			expectError: false,
 		},
 	}
 
@@ -468,7 +437,11 @@ func TestDeviceMapper_Map(t *testing.T) {
 			device, ok := entity.(*diode.Device)
 			assert.True(t, ok)
 			assert.Equal(t, tt.expectedEntity.Name, device.Name)
-			if tt.expectedEntity.Platform != nil && device.Platform != nil {
+			if tt.expectedEntity.DeviceType != nil {
+				assert.Equal(t, tt.expectedEntity.DeviceType.Manufacturer.Name, device.DeviceType.Manufacturer.Name)
+				assert.Equal(t, tt.expectedEntity.DeviceType.Model, device.DeviceType.Model)
+			}
+			if tt.expectedEntity.Platform != nil {
 				assert.Equal(t, tt.expectedEntity.Platform.Manufacturer.Name, device.Platform.Manufacturer.Name)
 			}
 		})

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -21,7 +21,7 @@ func TestIPAddressMapper_Map(t *testing.T) {
 	tests := []struct {
 		name           string
 		values         map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
-		mappingEntry   *mapping.MappingEntry
+		mappingEntry   *mapping.Entry
 		expectedEntity *diode.IPAddress
 		expectError    bool
 	}{
@@ -36,11 +36,11 @@ func TestIPAddressMapper_Map(t *testing.T) {
 					Type:   mapping.IPAddress,
 				},
 			},
-			mappingEntry: &mapping.MappingEntry{
+			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.4.20.1.1",
 				Entity: "ipAddress",
 				Field:  "_id",
-				MappingEntries: []mapping.MappingEntry{
+				MappingEntries: []mapping.Entry{
 					{
 						OID:    "1.3.6.1.2.1.4.20.1.1",
 						Entity: "ipAddress",
@@ -76,11 +76,11 @@ func TestIPAddressMapper_Map(t *testing.T) {
 					Type:   mapping.Integer,
 				},
 			},
-			mappingEntry: &mapping.MappingEntry{
+			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.4.20.1.1",
 				Entity: "ipAddress",
 				Field:  "_id",
-				MappingEntries: []mapping.MappingEntry{
+				MappingEntries: []mapping.Entry{
 					{
 						OID:    "1.3.6.1.2.1.4.20.1.1",
 						Entity: "ipAddress",
@@ -109,7 +109,7 @@ func TestIPAddressMapper_Map(t *testing.T) {
 		{
 			name:   "empty values map",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{},
-			mappingEntry: &mapping.MappingEntry{
+			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.4.20.1.1",
 				Entity: "ipAddress",
 				Field:  "_id",
@@ -140,7 +140,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 	tests := []struct {
 		name           string
 		values         map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
-		mappingEntry   *mapping.MappingEntry
+		mappingEntry   *mapping.Entry
 		expectedEntity *diode.Interface
 		expectError    bool
 	}{
@@ -183,11 +183,11 @@ func TestInterfaceMapper_Map(t *testing.T) {
 					Type:   mapping.Integer,
 				},
 			},
-			mappingEntry: &mapping.MappingEntry{
+			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.2.2.1.1",
 				Entity: "interface",
 				Field:  "_id",
-				MappingEntries: []mapping.MappingEntry{
+				MappingEntries: []mapping.Entry{
 					{
 						OID:    "1.3.6.1.2.1.2.2.1.1",
 						Entity: "interface",
@@ -241,11 +241,11 @@ func TestInterfaceMapper_Map(t *testing.T) {
 					Type:   mapping.Integer,
 				},
 			},
-			mappingEntry: &mapping.MappingEntry{
+			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.2.2.1.1",
 				Entity: "interface",
 				Field:  "_id",
-				MappingEntries: []mapping.MappingEntry{
+				MappingEntries: []mapping.Entry{
 					{
 						OID:    "1.3.6.1.2.1.2.2.1.1",
 						Entity: "interface",
@@ -264,7 +264,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 		{
 			name:   "empty values map",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{},
-			mappingEntry: &mapping.MappingEntry{
+			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.2.2.1.1",
 				Entity: "interface",
 				Field:  "_id",
@@ -316,7 +316,7 @@ func TestDeviceMapper_Map(t *testing.T) {
 	tests := []struct {
 		name           string
 		values         map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
-		mappingEntry   *mapping.MappingEntry
+		mappingEntry   *mapping.Entry
 		expectedEntity *diode.Device
 		expectError    bool
 	}{
@@ -338,11 +338,11 @@ func TestDeviceMapper_Map(t *testing.T) {
 					Type:   mapping.ObjectIdentifier,
 				},
 			},
-			mappingEntry: &mapping.MappingEntry{
+			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.1",
 				Entity: "device",
 				Field:  "_id",
-				MappingEntries: []mapping.MappingEntry{
+				MappingEntries: []mapping.Entry{
 					{
 						OID:    "1.3.6.1.2.1.1.5",
 						Entity: "device",
@@ -389,11 +389,11 @@ func TestDeviceMapper_Map(t *testing.T) {
 					Type:   mapping.ObjectIdentifier,
 				},
 			},
-			mappingEntry: &mapping.MappingEntry{
+			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.1",
 				Entity: "device",
 				Field:  "_id",
-				MappingEntries: []mapping.MappingEntry{
+				MappingEntries: []mapping.Entry{
 					{
 						OID:    "1.3.6.1.2.1.1.5",
 						Entity: "device",
@@ -414,7 +414,7 @@ func TestDeviceMapper_Map(t *testing.T) {
 		{
 			name:   "empty values map",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{},
-			mappingEntry: &mapping.MappingEntry{
+			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.1",
 				Entity: "device",
 				Field:  "_id",

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -51,6 +51,7 @@ const (
 type EntityRegistry struct {
 	entities map[EntityType]map[ObjectIDIndex]diode.Entity
 	logger   *slog.Logger
+	defaults *config.Defaults
 }
 
 // NewEntityRegistry creates a new EntityRegistry
@@ -59,6 +60,16 @@ func NewEntityRegistry(logger *slog.Logger) *EntityRegistry {
 		entities: make(map[EntityType]map[ObjectIDIndex]diode.Entity),
 		logger:   logger,
 	}
+}
+
+// SetDefaults sets the defaults for the registry
+func (r *EntityRegistry) SetDefaults(defaults *config.Defaults) {
+	r.defaults = defaults
+}
+
+// GetDefaults returns the defaults for the registry
+func (r *EntityRegistry) GetDefaults() *config.Defaults {
+	return r.defaults
 }
 
 // GetOrCreateEntity returns an entity from the EntityRegistry or creates a new one if it doesn't exist
@@ -98,22 +109,24 @@ type EntityType string
 
 // ObjectIDMapper is a struct that maps ObjectIDs to entities
 type ObjectIDMapper struct {
-	mapping  map[string]*mappingEntry
+	mapping  map[string]*MappingEntry
 	logger   *slog.Logger
 	registry *EntityRegistry
 }
 
-type mappingEntry struct {
+// MappingEntry is a struct that contains a mapping entry
+type MappingEntry struct {
 	OID            string
 	Entity         string
 	Field          string
-	MappingEntries []mappingEntry
+	MappingEntries []MappingEntry
 	Mapper         orbToEntityMapper
 	IdentifierSize int
 	Relationship   config.Relationship
 }
 
-func (m *mappingEntry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistry *EntityRegistry, logger *slog.Logger) []diode.Entity {
+// MapToEntity maps a value to an entity
+func (m *MappingEntry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistry *EntityRegistry, logger *slog.Logger) []diode.Entity {
 	logger.Debug("Mapping value to entity", "value", pdus)
 	if m.Mapper == nil {
 		logger.Warn("No mapper found for entity. Ignoring.", "entity", m.Entity)
@@ -129,7 +142,7 @@ func (m *mappingEntry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entity
 }
 
 // NewObjectIDMapper creates a new ObjectIDMapper
-func NewObjectIDMapper(mappings []config.MappingEntry, logger *slog.Logger, devices data.DeviceDataRetreiver) *ObjectIDMapper {
+func NewObjectIDMapper(mappings []config.MappingEntry, logger *slog.Logger, devices data.DeviceDataRetreiver, defaults *config.Defaults) *ObjectIDMapper {
 	entityMappers := map[string]orbToEntityMapper{
 		"ipAddress": &IPAddressMapper{},
 		"interface": &InterfaceMapper{},
@@ -137,25 +150,30 @@ func NewObjectIDMapper(mappings []config.MappingEntry, logger *slog.Logger, devi
 			devices: devices,
 		},
 	}
-	mapping := make(map[string]*mappingEntry)
+	mapping := make(map[string]*MappingEntry)
 	for _, m := range mappings {
 		logger.Debug("Adding mapping", "oid", m.OID, "entity", m.Entity, "field", m.Field, "relationship", m.Relationship)
-		mappingEntry := newMappingEntry(m, logger, entityMappers)
-		if mappingEntry == nil {
+		MappingEntry := newMappingEntry(m, logger, entityMappers)
+		if MappingEntry == nil {
 			continue
 		}
-		mapping[m.OID] = mappingEntry
+		mapping[m.OID] = MappingEntry
+	}
+
+	registry := NewEntityRegistry(logger)
+	if defaults != nil {
+		registry.SetDefaults(defaults)
 	}
 
 	return &ObjectIDMapper{
 		mapping:  mapping,
 		logger:   logger,
-		registry: NewEntityRegistry(logger),
+		registry: registry,
 	}
 }
 
 type orbToEntityMapper interface {
-	Map(pdus map[ObjectIDIndex]*ObjectIDValue, mappingEntry *mappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity
+	Map(pdus map[ObjectIDIndex]*ObjectIDValue, MappingEntry *MappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity
 }
 
 func getIndex(values map[ObjectIDIndex]*ObjectIDValue) ObjectIDIndex {
@@ -165,13 +183,13 @@ func getIndex(values map[ObjectIDIndex]*ObjectIDValue) ObjectIDIndex {
 	return ""
 }
 
-func newMappingEntry(m config.MappingEntry, logger *slog.Logger, entityMappers map[string]orbToEntityMapper) *mappingEntry {
+func newMappingEntry(m config.MappingEntry, logger *slog.Logger, entityMappers map[string]orbToEntityMapper) *MappingEntry {
 	mapper := entityMappers[m.Entity]
 	if mapper == nil {
 		logger.Warn("No mapper found for entity. Ignoring.", "entity", m.Entity)
 		return nil
 	}
-	return &mappingEntry{
+	return &MappingEntry{
 		OID:            m.OID,
 		Entity:         m.Entity,
 		Field:          m.Field,
@@ -182,11 +200,11 @@ func newMappingEntry(m config.MappingEntry, logger *slog.Logger, entityMappers m
 	}
 }
 
-func newChildMappingEntries(configMappingEntries []config.MappingEntry, logger *slog.Logger) []mappingEntry {
-	childMappingEntries := make([]mappingEntry, 0, len(configMappingEntries))
+func newChildMappingEntries(configMappingEntries []config.MappingEntry, logger *slog.Logger) []MappingEntry {
+	childMappingEntries := make([]MappingEntry, 0, len(configMappingEntries))
 	for _, m := range configMappingEntries {
 		logger.Debug("Adding child mapping entry", "oid", m.OID, "entity", m.Entity, "field", m.Field, "relationship", m.Relationship)
-		child := &mappingEntry{
+		child := &MappingEntry{
 			OID:            m.OID,
 			Entity:         m.Entity,
 			Field:          m.Field,
@@ -236,12 +254,12 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 	entities := make([]diode.Entity, 0, len(objectIDIndexMap))
 	for index, value := range objectIDIndexMap {
 		m.logger.Debug("Mapping objectIDIndex", "objectIDIndex", index, "values", value.Values)
-		mappingEntry, err := m.getMappingEntry(value.Index)
+		MappingEntry, err := m.getMappingEntry(value.Index)
 		if err != nil {
 			m.logger.Warn("Error finding mapping entry", "error", err, "objectID", value.Index)
 			continue
 		}
-		entities = append(entities, mappingEntry.MapToEntity(value.Values, m.registry, m.logger)...)
+		entities = append(entities, MappingEntry.MapToEntity(value.Values, m.registry, m.logger)...)
 	}
 	return entities
 }
@@ -279,7 +297,7 @@ func newObjectIDValue(objectID string, value Value) (*ObjectIDValue, error) {
 }
 
 // Gets the mapper for the closest parent objectID
-func (m *ObjectIDMapper) getMappingEntry(objectID string) (*mappingEntry, error) {
+func (m *ObjectIDMapper) getMappingEntry(objectID string) (*MappingEntry, error) {
 	for {
 		if value, found := m.mapping[objectID]; found {
 			return value, nil

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -109,24 +109,24 @@ type EntityType string
 
 // ObjectIDMapper is a struct that maps ObjectIDs to entities
 type ObjectIDMapper struct {
-	mapping  map[string]*MappingEntry
+	mapping  map[string]*Entry
 	logger   *slog.Logger
 	registry *EntityRegistry
 }
 
-// MappingEntry is a struct that contains a mapping entry
-type MappingEntry struct {
+// Entry is a struct that contains a mapping entry
+type Entry struct {
 	OID            string
 	Entity         string
 	Field          string
-	MappingEntries []MappingEntry
+	MappingEntries []Entry
 	Mapper         orbToEntityMapper
 	IdentifierSize int
 	Relationship   config.Relationship
 }
 
 // MapToEntity maps a value to an entity
-func (m *MappingEntry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistry *EntityRegistry, logger *slog.Logger) []diode.Entity {
+func (m *Entry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistry *EntityRegistry, logger *slog.Logger) []diode.Entity {
 	logger.Debug("Mapping value to entity", "value", pdus)
 	if m.Mapper == nil {
 		logger.Warn("No mapper found for entity. Ignoring.", "entity", m.Entity)
@@ -150,14 +150,14 @@ func NewObjectIDMapper(mappings []config.MappingEntry, logger *slog.Logger, devi
 			devices: devices,
 		},
 	}
-	mapping := make(map[string]*MappingEntry)
+	mapping := make(map[string]*Entry)
 	for _, m := range mappings {
 		logger.Debug("Adding mapping", "oid", m.OID, "entity", m.Entity, "field", m.Field, "relationship", m.Relationship)
-		MappingEntry := newMappingEntry(m, logger, entityMappers)
-		if MappingEntry == nil {
+		Entry := newMappingEntry(m, logger, entityMappers)
+		if Entry == nil {
 			continue
 		}
-		mapping[m.OID] = MappingEntry
+		mapping[m.OID] = Entry
 	}
 
 	registry := NewEntityRegistry(logger)
@@ -173,7 +173,7 @@ func NewObjectIDMapper(mappings []config.MappingEntry, logger *slog.Logger, devi
 }
 
 type orbToEntityMapper interface {
-	Map(pdus map[ObjectIDIndex]*ObjectIDValue, MappingEntry *MappingEntry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity
+	Map(pdus map[ObjectIDIndex]*ObjectIDValue, Entry *Entry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity
 }
 
 func getIndex(values map[ObjectIDIndex]*ObjectIDValue) ObjectIDIndex {
@@ -183,13 +183,13 @@ func getIndex(values map[ObjectIDIndex]*ObjectIDValue) ObjectIDIndex {
 	return ""
 }
 
-func newMappingEntry(m config.MappingEntry, logger *slog.Logger, entityMappers map[string]orbToEntityMapper) *MappingEntry {
+func newMappingEntry(m config.MappingEntry, logger *slog.Logger, entityMappers map[string]orbToEntityMapper) *Entry {
 	mapper := entityMappers[m.Entity]
 	if mapper == nil {
 		logger.Warn("No mapper found for entity. Ignoring.", "entity", m.Entity)
 		return nil
 	}
-	return &MappingEntry{
+	return &Entry{
 		OID:            m.OID,
 		Entity:         m.Entity,
 		Field:          m.Field,
@@ -200,11 +200,11 @@ func newMappingEntry(m config.MappingEntry, logger *slog.Logger, entityMappers m
 	}
 }
 
-func newChildMappingEntries(configMappingEntries []config.MappingEntry, logger *slog.Logger) []MappingEntry {
-	childMappingEntries := make([]MappingEntry, 0, len(configMappingEntries))
+func newChildMappingEntries(configMappingEntries []config.MappingEntry, logger *slog.Logger) []Entry {
+	childMappingEntries := make([]Entry, 0, len(configMappingEntries))
 	for _, m := range configMappingEntries {
 		logger.Debug("Adding child mapping entry", "oid", m.OID, "entity", m.Entity, "field", m.Field, "relationship", m.Relationship)
-		child := &MappingEntry{
+		child := &Entry{
 			OID:            m.OID,
 			Entity:         m.Entity,
 			Field:          m.Field,
@@ -254,12 +254,12 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 	entities := make([]diode.Entity, 0, len(objectIDIndexMap))
 	for index, value := range objectIDIndexMap {
 		m.logger.Debug("Mapping objectIDIndex", "objectIDIndex", index, "values", value.Values)
-		MappingEntry, err := m.getMappingEntry(value.Index)
+		Entry, err := m.getMappingEntry(value.Index)
 		if err != nil {
 			m.logger.Warn("Error finding mapping entry", "error", err, "objectID", value.Index)
 			continue
 		}
-		entities = append(entities, MappingEntry.MapToEntity(value.Values, m.registry, m.logger)...)
+		entities = append(entities, Entry.MapToEntity(value.Values, m.registry, m.logger)...)
 	}
 	return entities
 }
@@ -297,7 +297,7 @@ func newObjectIDValue(objectID string, value Value) (*ObjectIDValue, error) {
 }
 
 // Gets the mapper for the closest parent objectID
-func (m *ObjectIDMapper) getMappingEntry(objectID string) (*MappingEntry, error) {
+func (m *ObjectIDMapper) getMappingEntry(objectID string) (*Entry, error) {
 	for {
 		if value, found := m.mapping[objectID]; found {
 			return value, nil

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -341,7 +341,12 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mapper := mapping.NewObjectIDMapper(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{})
+			mapper := mapping.NewObjectIDMapper(
+				tt.mapping,
+				slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})),
+				&FakeManufacturers{},
+				&config.Defaults{},
+			)
 			entities := mapper.MapObjectIDsToEntity(tt.objectIDs)
 
 			assert.ElementsMatch(t, tt.expected, entities)
@@ -398,7 +403,12 @@ func TestObjectIDs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mapper := mapping.NewObjectIDMapper(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{})
+			mapper := mapping.NewObjectIDMapper(
+				tt.mapping,
+				slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})),
+				&FakeManufacturers{},
+				&config.Defaults{},
+			)
 			objectIDs := mapper.ObjectIDs()
 
 			assert.Equal(t, tt.expectedOIDs, objectIDs)

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -85,7 +85,7 @@ func (r *Runner) run() {
 	ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 	defer cancel()
 
-	mapper := mapping.NewObjectIDMapper(r.scope.Mappings, r.logger, r.manufacturers)
+	mapper := mapping.NewObjectIDMapper(r.scope.Mappings, r.logger, r.manufacturers, &r.config.Defaults)
 	objectIDs := mapper.ObjectIDs()
 	r.logger.Info("Starting SNMP crawl of targets", slog.Any("targetCount", len(r.scope.Targets)), slog.Any("objectCount", len(objectIDs)))
 	entities := make([]diode.Entity, 0)

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -122,6 +122,19 @@ func TestRunnerRun(t *testing.T) {
 						Description: "Test",
 						Comments:    "This is a test",
 						Tags:        []string{"test", "snmp"},
+						IPAddress: config.EntityDefaults{
+							Description: "IP Address Default",
+							Comments:    "IP Address Comment",
+							Tags:        []string{"ip", "default"},
+						},
+						Interface: config.EntityDefaults{
+							Description: "Interface Default",
+							Tags:        []string{"interface", "default"},
+						},
+						Device: config.EntityDefaults{
+							Description: "Device Default",
+							Tags:        []string{"device", "default"},
+						},
 					},
 				},
 				Scope: config.Scope{
@@ -188,7 +201,26 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	ctx := context.Background()
 
 	policyConfig := config.Policy{
-		Config: config.PolicyConfig{},
+		Config: config.PolicyConfig{
+			Defaults: config.Defaults{
+				Description: "Test",
+				Comments:    "This is a test",
+				Tags:        []string{"test", "snmp"},
+				IPAddress: config.EntityDefaults{
+					Description: "IP Address Default",
+					Comments:    "IP Address Comment",
+					Tags:        []string{"ip", "default"},
+				},
+				Interface: config.EntityDefaults{
+					Description: "Interface Default",
+					Tags:        []string{"interface", "default"},
+				},
+				Device: config.EntityDefaults{
+					Description: "Device Default",
+					Tags:        []string{"device", "default"},
+				},
+			},
+		},
 		Scope: config.Scope{
 			Targets: []config.Target{
 				{
@@ -219,7 +251,18 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	// Use a channel to signal that Ingest was called
 	ingestCalled := make(chan bool, 1)
 
-	expectedEntities := []diode.Entity{&diode.Interface{Name: diode.String("GigabitEthernet1/0/1")}}
+	expectedEntities := []diode.Entity{
+		&diode.Interface{
+			Name:        diode.String("GigabitEthernet1/0/1"),
+			Description: diode.String("Interface Default"),
+			Tags: []*diode.Tag{
+				{Name: diode.String("interface")},
+				{Name: diode.String("default")},
+				{Name: diode.String("test")},
+				{Name: diode.String("snmp")},
+			},
+		},
+	}
 
 	mockClient.On("Ingest", mock.Anything, expectedEntities).Run(func(args mock.Arguments) {
 		ingestCalled <- true
@@ -233,14 +276,14 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	// Wait for Ingest to be called or timeout
 	select {
 	case <-ingestCalled:
-		// Success
+		// Ingest was called, proceed
 	case <-time.After(10 * time.Second):
 		t.Fatal("Timeout: Ingest was not called")
 	}
 
 	// Stop the process
 	err = runner.Stop()
-	assert.NoError(t, err)
+	assert.NoError(t, err, "Runner.Stop should not return an error")
 }
 
 func TestRunnerWalkError(t *testing.T) {


### PR DESCRIPTION
This pull request introduces significant enhancements to the SNMP discovery service, including the addition of configuration options, support for entity-specific default values, and improvements to the mapping logic. It also includes updates to tests to reflect these changes. Below is a summary of the most important changes:

### Configuration Enhancements

* Added detailed documentation in `snmp-discovery/README.md` for configuring the SNMP discovery service using a YAML file. This includes sections for `defaults`, `mappings`, `authentication`, and `scope`. The `defaults` section allows specifying global and entity-specific default values for discovered entities.

### Code Enhancements

* Introduced the `EntityDefaults` struct in `snmp-discovery/config/config.go` to support entity-specific default values for `IPAddress`, `Interface`, and `Device` entities. These defaults include `description`, `comments`, and `tags`.
* Updated the `Map` methods in `snmp-discovery/mapping/mappers.go` for `IPAddressMapper`, `InterfaceMapper`, and `DeviceMapper` to apply global and entity-specific defaults during the mapping process. This ensures that discovered entities inherit appropriate default values if not explicitly provided. [[1]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR50-R93) [[2]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR125-R154) [[3]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR163-R247)

### Refactoring and Simplification

* Replaced the use of `mappingEntry` with the updated `MappingEntry` type in `snmp-discovery/mapping/mappers.go` for consistency and improved readability.
* Added a `NewDeviceMapper` constructor in `snmp-discovery/mapping/mappers.go` to simplify the creation of `DeviceMapper` instances.

### Test Updates

* Refactored `snmp-discovery/mapping/mappers_test.go` to use the `mapping` package explicitly, ensuring consistency with the updated codebase. Updated test cases to reflect the new `MappingEntry` type and added test coverage for default value application. [[1]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L1-R1) [[2]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R13-R43) [[3]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L62-R83) [[4]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L279-R281) [[5]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L313-R345)