### PR TITLE
fix: network-discovery verbosity when no host is discovered

### DIFF
--- a/.github/golangci.yaml
+++ b/.github/golangci.yaml
@@ -1,40 +1,37 @@
+version: "2"
 run:
-  timeout: 5m
   modules-download-mode: readonly
-
-output:
-  formats: colored-line-number
-
 linters:
   enable:
-    - revive
-    - errcheck
-    - unused
-    - staticcheck
-    - ineffassign
-    - govet
-    - gosimple
     - bodyclose
+    - revive
+  exclusions:
+    generated: lax
+    rules:
+      - linters:
+          - revive
+        path: /*.go
+        text: 'package-comments: should have a package comment'
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+severity:
+  default: error
+formatters:
+  enable:
     - gci
     - gofumpt
-
-issues:
-  exclude-use-default: false
-  exclude-rules:
-    - path: /*.go
-      text: "package-comments: should have a package comment"
-      linters:
-        - revive
-
-severity:
-  default-severity: error
-
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/netboxlabs/orb-discovery)
-    custom-order: true
-  go-fumpt:
-    extra-rules: true
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/netboxlabs/orb-agent)
+      custom-order: true
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/.github/workflows/network-discovery-lint.yaml
+++ b/.github/workflows/network-discovery-lint.yaml
@@ -23,11 +23,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
           check-latest: true
       - name: Lint
-        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 #v6.1.1
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0
         with:
-          version: v1.62
+          version: v2.1.6
           working-directory: network-discovery
           args: --config ../.github/golangci.yaml

--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -14,7 +14,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.24'
   APP_NAME: network-discovery
 
 permissions:

--- a/.github/workflows/network-discovery-tests.yaml
+++ b/.github/workflows/network-discovery-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
           check-latest: true
       - name: Run go build
         run: go build ./...

--- a/network-discovery/cmd/main.go
+++ b/network-discovery/cmd/main.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-
 	"github.com/netboxlabs/orb-discovery/network-discovery/config"
 	"github.com/netboxlabs/orb-discovery/network-discovery/metrics"
 	"github.com/netboxlabs/orb-discovery/network-discovery/policy"

--- a/network-discovery/config/logger_test.go
+++ b/network-discovery/config/logger_test.go
@@ -4,10 +4,9 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/netboxlabs/orb-discovery/network-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/netboxlabs/orb-discovery/network-discovery/config"
 )
 
 func TestNewLogger(t *testing.T) {

--- a/network-discovery/docker/Dockerfile
+++ b/network-discovery/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.23
+ARG GO_VERSION=1.24
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 

--- a/network-discovery/go.mod
+++ b/network-discovery/go.mod
@@ -1,8 +1,6 @@
 module github.com/netboxlabs/orb-discovery/network-discovery
 
-go 1.23.4
-
-toolchain go1.23.8
+go 1.24.2
 
 require (
 	github.com/Ullaakut/nmap/v3 v3.0.4

--- a/network-discovery/metrics/metrics_test.go
+++ b/network-discovery/metrics/metrics_test.go
@@ -6,12 +6,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/netboxlabs/orb-discovery/network-discovery/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/metric/noop"
-
-	"github.com/netboxlabs/orb-discovery/network-discovery/metrics"
 )
 
 func TestSetupMetricsExport(t *testing.T) {

--- a/network-discovery/policy/manager.go
+++ b/network-discovery/policy/manager.go
@@ -7,9 +7,8 @@ import (
 	"log/slog"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"gopkg.in/yaml.v3"
-
 	"github.com/netboxlabs/orb-discovery/network-discovery/config"
+	"gopkg.in/yaml.v3"
 )
 
 // Manager represents the policy manager

--- a/network-discovery/policy/manager_test.go
+++ b/network-discovery/policy/manager_test.go
@@ -7,11 +7,10 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/network-discovery/config"
 	"github.com/netboxlabs/orb-discovery/network-discovery/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // MockRunner mocks the Runner

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -223,8 +223,16 @@ func (r *Runner) run() {
 	}
 
 	entities := make([]diode.Entity, 0, len(result.Hosts))
+	if len(result.Hosts) == 0 {
+		r.logger.Warn("discovery complete: no hosts found", slog.Any("targets", r.scope.Targets),
+			slog.String("policy", policyName))
+		return
+	}
+	r.logger.Info("discovery complete", slog.Int("hosts_found", len(result.Hosts)), slog.String("policy", policyName))
 
 	for _, host := range result.Hosts {
+		r.logger.Debug("processing host", slog.Any("host_address", host.Addresses), slog.Any("host_ports", host.Ports),
+			slog.Any("host_hostnames", host.Hostnames), slog.String("policy", policyName))
 		ip := &diode.IPAddress{
 			Address: diode.String(host.Addresses[0].Addr + "/32"),
 		}

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -10,11 +10,10 @@ import (
 	"github.com/Ullaakut/nmap/v3"
 	"github.com/go-co-op/gocron/v2"
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
-
 	"github.com/netboxlabs/orb-discovery/network-discovery/config"
 	"github.com/netboxlabs/orb-discovery/network-discovery/metrics"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // Define a custom type for the context key

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -10,12 +10,11 @@ import (
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/network-discovery/config"
 	"github.com/netboxlabs/orb-discovery/network-discovery/metrics"
 	"github.com/netboxlabs/orb-discovery/network-discovery/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type MockClient struct {
@@ -288,6 +287,45 @@ func TestRunnerMetrics(t *testing.T) {
 		// Validate active policies metric decrement
 		activePolicies.Add(ctx, -1)
 	})
+}
+
+func TestRunnerNoHosts(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+	mockClient := new(MockClient)
+
+	// Set up policy with target and port configuration likely to result in no hosts found
+	policyConfig := config.Policy{
+		Config: config.PolicyConfig{
+			Schedule: nil, // Run immediately
+		},
+		Scope: config.Scope{
+			Targets:    []string{"10.0.0.2"},
+			Ports:      []string{"1"}, // Port 1 is typically not open
+			FastMode:   boolPtr(true), // Speed up the scan for test purposes
+			MaxRetries: intPtr(0),     // Don't retry to keep the test fast
+		},
+	}
+	ctx := context.Background()
+
+	// Create runner
+	runner, err := policy.NewRunner(ctx, logger, "test-no-hosts", policyConfig, mockClient)
+	assert.NoError(t, err, "policy.NewRunner should not return an error")
+
+	// Configure mock to verify Ingest is NOT called
+	mockClient.On("Close").Return(nil)
+
+	// Start the runner
+	runner.Start()
+
+	// Wait for a short time to allow the scan to run
+	time.Sleep(2 * time.Second)
+
+	// Stop the runner
+	err = runner.Stop()
+	assert.NoError(t, err, "Runner.Stop should not return an error")
+
+	// Check that Ingest was not called since no hosts should have been found
+	mockClient.AssertNotCalled(t, "Ingest", mock.Anything, mock.Anything)
 }
 
 func boolPtr(b bool) *bool {

--- a/network-discovery/server/server.go
+++ b/network-discovery/server/server.go
@@ -10,12 +10,11 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
-
 	"github.com/netboxlabs/orb-discovery/network-discovery/config"
 	"github.com/netboxlabs/orb-discovery/network-discovery/metrics"
 	"github.com/netboxlabs/orb-discovery/network-discovery/policy"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // Response represents the server response

--- a/network-discovery/server/server_test.go
+++ b/network-discovery/server/server_test.go
@@ -12,12 +12,11 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/network-discovery/metrics"
 	"github.com/netboxlabs/orb-discovery/network-discovery/policy"
 	"github.com/netboxlabs/orb-discovery/network-discovery/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type MockClient struct {

--- a/network-discovery/version/version_test.go
+++ b/network-discovery/version/version_test.go
@@ -3,9 +3,8 @@ package version_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/netboxlabs/orb-discovery/network-discovery/version"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVersion(t *testing.T) {


### PR DESCRIPTION
This pull request adds enhanced logging to the `run` method in the `Runner` class to improve visibility into the network discovery process. The changes include logging when no hosts are found, providing a summary of the discovery process, and adding detailed debug logs for each processed host.

### Logging improvements:

* Added a warning log to indicate when the discovery process completes without finding any hosts. This log includes the discovery `targets` and `policy` name for context. (`network-discovery/policy/runner.go`, [network-discovery/policy/runner.goR226-R235](diffhunk://#diff-cd137d22aa443fd1284d18bdc5bae57a78e9a4352e5fc306c1efd5b09681da4cR226-R235))
* Added an informational log summarizing the discovery process, including the number of hosts found and the `policy` name. (`network-discovery/policy/runner.go`, [network-discovery/policy/runner.goR226-R235](diffhunk://#diff-cd137d22aa443fd1284d18bdc5bae57a78e9a4352e5fc306c1efd5b09681da4cR226-R235))
* Added a debug log for each host being processed, detailing its `addresses`, `ports`, and `hostnames`, along with the `policy` name. (`network-discovery/policy/runner.go`, [network-discovery/policy/runner.goR226-R235](diffhunk://#diff-cd137d22aa443fd1284d18bdc5bae57a78e9a4352e5fc306c1efd5b09681da4cR226-R235))