### PR TITLE
feat: additional defaults and upgrade to go1.24

### DIFF
--- a/.github/workflows/snmp-discovery-lint.yaml
+++ b/.github/workflows/snmp-discovery-lint.yaml
@@ -23,11 +23,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
           check-latest: true
       - name: Lint
-        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 #v6.1.1
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0
         with:
-          version: v1.62
+          version: v2.1.6
           working-directory: snmp-discovery
           args: --config ../.github/golangci.yaml

--- a/.github/workflows/snmp-discovery-tests.yaml
+++ b/.github/workflows/snmp-discovery-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
           check-latest: true
       - name: Run go build
         run: go build ./...

--- a/snmp-discovery/Makefile
+++ b/snmp-discovery/Makefile
@@ -9,7 +9,7 @@ COMMIT_SHA := $(shell git rev-parse --short HEAD)
 .PHONY: install-dev-tools
 install-dev-tools:
 	@go install github.com/mfridman/tparse@latest
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	@go install github.com/jandelgado/gcov2lcov@latest
 	
 .PHONY: build

--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/server"

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -42,7 +42,7 @@ type IPAddressDefaults struct {
 	Comments    string   `yaml:"comments,omitempty"`
 	Role        string   `yaml:"role,omitempty"`
 	Tenant      string   `yaml:"tenant,omitempty"`
-	VRF         string   `yaml:"vrf,omitempty"`
+	Vrf         string   `yaml:"vrf,omitempty"`
 }
 
 type InterfaceDefaults struct {

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -35,7 +35,7 @@ type Authentication struct {
 	PrivPassphrase  string `yaml:"priv_passphrase"`
 }
 
-// EntityDefaults represents default values for a specific entity type
+// IPAddressDefaults represents default values for a specific entity type
 type IPAddressDefaults struct {
 	Description string   `yaml:"description,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
@@ -45,12 +45,14 @@ type IPAddressDefaults struct {
 	Vrf         string   `yaml:"vrf,omitempty"`
 }
 
+// InterfaceDefaults represents default values for a specific entity type
 type InterfaceDefaults struct {
 	Description string   `yaml:"description,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
 	Type        string   `yaml:"if_type,omitempty"`
 }
 
+// DeviceDefaults represents default values for a specific entity type
 type DeviceDefaults struct {
 	Description string   `yaml:"description,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -36,21 +36,36 @@ type Authentication struct {
 }
 
 // EntityDefaults represents default values for a specific entity type
-type EntityDefaults struct {
+type IPAddressDefaults struct {
 	Description string   `yaml:"description,omitempty"`
-	Comments    string   `yaml:"comments,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
+	Comments    string   `yaml:"comments,omitempty"`
+	Role        string   `yaml:"role,omitempty"`
+	Tenant      string   `yaml:"tenant,omitempty"`
+	VRF         string   `yaml:"vrf,omitempty"`
+}
+
+type InterfaceDefaults struct {
+	Description string   `yaml:"description,omitempty"`
+	Tags        []string `yaml:"tags,omitempty"`
+	Type        string   `yaml:"if_type,omitempty"`
+}
+
+type DeviceDefaults struct {
+	Description string   `yaml:"description,omitempty"`
+	Tags        []string `yaml:"tags,omitempty"`
+	Comments    string   `yaml:"comments,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy
 type Defaults struct {
-	Description string         `yaml:"description,omitempty"`
-	Comments    string         `yaml:"comments,omitempty"`
-	Tags        []string       `yaml:"tags,omitempty"`
-	Tenant      string         `yaml:"tenant,omitempty"`
-	IPAddress   EntityDefaults `yaml:"ip_address,omitempty"`
-	Interface   EntityDefaults `yaml:"interface,omitempty"`
-	Device      EntityDefaults `yaml:"device,omitempty"`
+	Tags      []string          `yaml:"tags,omitempty"`
+	Site      string            `yaml:"site,omitempty"`
+	Location  string            `yaml:"location,omitempty"`
+	Role      string            `yaml:"role,omitempty"`
+	IPAddress IPAddressDefaults `yaml:"ip_address,omitempty"`
+	Interface InterfaceDefaults `yaml:"interface,omitempty"`
+	Device    DeviceDefaults    `yaml:"device,omitempty"`
 }
 
 // PolicyConfig represents the configuration of a policy

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -47,6 +47,7 @@ type Defaults struct {
 	Description string         `yaml:"description,omitempty"`
 	Comments    string         `yaml:"comments,omitempty"`
 	Tags        []string       `yaml:"tags,omitempty"`
+	Tenant      string         `yaml:"tenant,omitempty"`
 	IPAddress   EntityDefaults `yaml:"ip_address,omitempty"`
 	Interface   EntityDefaults `yaml:"interface,omitempty"`
 	Device      EntityDefaults `yaml:"device,omitempty"`

--- a/snmp-discovery/config/logger_test.go
+++ b/snmp-discovery/config/logger_test.go
@@ -4,10 +4,9 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 )
 
 func TestNewLogger(t *testing.T) {

--- a/snmp-discovery/docker/Dockerfile
+++ b/snmp-discovery/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.23
+ARG GO_VERSION=1.24
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 

--- a/snmp-discovery/go.mod
+++ b/snmp-discovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/orb-discovery/snmp-discovery
 
-go 1.23.8
+go 1.24.2
 
 require (
 	github.com/gin-gonic/gin v1.10.0

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -64,7 +64,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 type InterfaceMapper struct{}
 
 // applyEntityDefaults applies default values to an entity based on the provided defaults
-func applyEntityDefaults(entity interface{}, defaults *config.Defaults, getEntityDefaults func(defaults config.Defaults) config.EntityDefaults) {
+func applyEntityDefaults(entity diode.Entity, defaults *config.Defaults, getEntityDefaults func(defaults config.Defaults) config.EntityDefaults) {
 	if defaults == nil {
 		return
 	}
@@ -134,6 +134,11 @@ func applyEntityDefaults(entity interface{}, defaults *config.Defaults, getEntit
 		}
 		if e.Comments == nil && defaults.Comments != "" {
 			e.Comments = &defaults.Comments
+		}
+		if e.Tenant == nil && defaults.Tenant != "" {
+			e.Tenant = &diode.Tenant{
+				Name: &defaults.Tenant,
+			}
 		}
 	}
 }

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -51,39 +51,10 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 		}
 	}
 
-	// Apply defaults if available
-	if defaults := entityRegistry.GetDefaults(); defaults != nil && fieldFound {
-		// Apply IP address specific defaults
-		if defaults.IPAddress.Description != "" {
-			ipAddress.Description = &defaults.IPAddress.Description
-		}
-		if defaults.IPAddress.Comments != "" {
-			ipAddress.Comments = &defaults.IPAddress.Comments
-		}
-		var tags []*diode.Tag
-		// Add entity-specific tags
-		if len(defaults.IPAddress.Tags) > 0 {
-			for _, tag := range defaults.IPAddress.Tags {
-				tags = append(tags, &diode.Tag{Name: &tag})
-			}
-		}
-		// Add global tags
-		if len(defaults.Tags) > 0 {
-			for _, tag := range defaults.Tags {
-				tags = append(tags, &diode.Tag{Name: &tag})
-			}
-		}
-		if len(tags) > 0 {
-			ipAddress.Tags = tags
-		}
-
-		// Apply global defaults if not overridden by entity-specific defaults
-		if ipAddress.Description == nil && defaults.Description != "" {
-			ipAddress.Description = &defaults.Description
-		}
-		if ipAddress.Comments == nil && defaults.Comments != "" {
-			ipAddress.Comments = &defaults.Comments
-		}
+	if fieldFound {
+		applyEntityDefaults(&ipAddress, entityRegistry.GetDefaults(), func(defaults config.Defaults) config.EntityDefaults {
+			return defaults.IPAddress
+		})
 	}
 
 	return &ipAddress
@@ -91,6 +62,70 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 
 // InterfaceMapper is a struct that maps interfaces to entities
 type InterfaceMapper struct{}
+
+// applyEntityDefaults applies default values to an entity based on the provided defaults
+func applyEntityDefaults(entity interface{}, defaults *config.Defaults, getEntityDefaults func(defaults config.Defaults) config.EntityDefaults) {
+	if defaults == nil {
+		return
+	}
+	entityDefaults := getEntityDefaults(*defaults)
+
+	// Apply entity-specific defaults
+	if entityDefaults.Description != "" {
+		switch e := entity.(type) {
+		case *diode.Interface:
+			e.Description = &entityDefaults.Description
+		case *diode.Device:
+			e.Description = &entityDefaults.Description
+		case *diode.IPAddress:
+			e.Description = &entityDefaults.Description
+		}
+	}
+
+	// Collect tags from both entity-specific and global defaults
+	var tags []*diode.Tag
+	if len(entityDefaults.Tags) > 0 {
+		for _, tag := range entityDefaults.Tags {
+			tags = append(tags, &diode.Tag{Name: &tag})
+		}
+	}
+	if len(defaults.Tags) > 0 {
+		for _, tag := range defaults.Tags {
+			tags = append(tags, &diode.Tag{Name: &tag})
+		}
+	}
+
+	// Apply tags if any exist
+	if len(tags) > 0 {
+		switch e := entity.(type) {
+		case *diode.Interface:
+			e.Tags = tags
+		case *diode.Device:
+			e.Tags = tags
+		case *diode.IPAddress:
+			e.Tags = tags
+		}
+	}
+
+	// Apply global defaults if not overridden by entity-specific defaults
+	switch e := entity.(type) {
+	case *diode.Interface:
+		if e.Description == nil && defaults.Description != "" {
+			e.Description = &defaults.Description
+		}
+	case *diode.Device:
+		if e.Description == nil && defaults.Description != "" {
+			e.Description = &defaults.Description
+		}
+	case *diode.IPAddress:
+		if e.Description == nil && defaults.Description != "" {
+			e.Description = &defaults.Description
+		}
+		if e.Comments == nil && defaults.Comments != "" {
+			e.Comments = &defaults.Comments
+		}
+	}
+}
 
 // Map maps interfaces to entities
 func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
@@ -132,32 +167,10 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	}
 
 	// Apply defaults if available
-	if defaults := entityRegistry.GetDefaults(); defaults != nil && fieldFound {
-		// Apply interface specific defaults
-		if defaults.Interface.Description != "" {
-			interfaceEntity.Description = &defaults.Interface.Description
-		}
-		var tags []*diode.Tag
-		// Add entity-specific tags
-		if len(defaults.Interface.Tags) > 0 {
-			for _, tag := range defaults.Interface.Tags {
-				tags = append(tags, &diode.Tag{Name: &tag})
-			}
-		}
-		// Add global tags
-		if len(defaults.Tags) > 0 {
-			for _, tag := range defaults.Tags {
-				tags = append(tags, &diode.Tag{Name: &tag})
-			}
-		}
-		if len(tags) > 0 {
-			interfaceEntity.Tags = tags
-		}
-
-		// Apply global defaults if not overridden by entity-specific defaults
-		if interfaceEntity.Description == nil && defaults.Description != "" {
-			interfaceEntity.Description = &defaults.Description
-		}
+	if fieldFound {
+		applyEntityDefaults(interfaceEntity, entityRegistry.GetDefaults(), func(defaults config.Defaults) config.EntityDefaults {
+			return defaults.Interface
+		})
 	}
 
 	return interfaceEntity
@@ -227,32 +240,10 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 	}
 
 	// Apply defaults if available
-	if defaults := entityRegistry.GetDefaults(); fieldFound && defaults != nil {
-		// Apply device specific defaults
-		if defaults.Device.Description != "" {
-			deviceEntity.Description = &defaults.Device.Description
-		}
-		var tags []*diode.Tag
-		// Add entity-specific tags
-		if len(defaults.Device.Tags) > 0 {
-			for _, tag := range defaults.Device.Tags {
-				tags = append(tags, &diode.Tag{Name: &tag})
-			}
-		}
-		// Add global tags
-		if len(defaults.Tags) > 0 {
-			for _, tag := range defaults.Tags {
-				tags = append(tags, &diode.Tag{Name: &tag})
-			}
-		}
-		if len(tags) > 0 {
-			deviceEntity.Tags = tags
-		}
-
-		// Apply global defaults if not overridden by entity-specific defaults
-		if deviceEntity.Description == nil && defaults.Description != "" {
-			deviceEntity.Description = &defaults.Description
-		}
+	if fieldFound {
+		applyEntityDefaults(deviceEntity, entityRegistry.GetDefaults(), func(defaults config.Defaults) config.EntityDefaults {
+			return defaults.Device
+		})
 	}
 
 	return deviceEntity

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -15,6 +15,53 @@ import (
 // IPAddressMapper is a struct that maps IP addresses to entities
 type IPAddressMapper struct{}
 
+// applyDefaults applies default values to an IP address entity
+func (m *IPAddressMapper) applyDefaults(entity *diode.IPAddress, defaults *config.Defaults) {
+	if defaults == nil {
+		return
+	}
+	entityDefaults := defaults.IPAddress
+
+	// Apply entity-specific defaults
+	if entityDefaults.Description != "" {
+		entity.Description = &entityDefaults.Description
+	}
+	if entityDefaults.Comments != "" {
+		entity.Comments = &entityDefaults.Comments
+	}
+
+	// Collect tags from both entity-specific and global defaults
+	var tags []*diode.Tag
+	if len(entityDefaults.Tags) > 0 {
+		for _, tag := range entityDefaults.Tags {
+			tags = append(tags, &diode.Tag{Name: &tag})
+		}
+	}
+	if len(defaults.Tags) > 0 {
+		for _, tag := range defaults.Tags {
+			tags = append(tags, &diode.Tag{Name: &tag})
+		}
+	}
+
+	// Apply tags if any exist
+	if len(tags) > 0 {
+		entity.Tags = tags
+	}
+
+	// Apply global defaults if not overridden by entity-specific defaults
+	if entity.Description == nil && entityDefaults.Description != "" {
+		entity.Description = &entityDefaults.Description
+	}
+	if entity.Comments == nil && entityDefaults.Comments != "" {
+		entity.Comments = &entityDefaults.Comments
+	}
+	if entity.Tenant == nil && entityDefaults.Tenant != "" {
+		entity.Tenant = &diode.Tenant{
+			Name: &entityDefaults.Tenant,
+		}
+	}
+}
+
 // Map maps IP addresses to entities
 func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
 	logger.Debug("Mapping values to ipAddress entity", "values", values, "mappingEntry", mappingEntry)
@@ -52,9 +99,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	}
 
 	if fieldFound {
-		applyEntityDefaults(&ipAddress, entityRegistry.GetDefaults(), func(defaults config.Defaults) config.EntityDefaults {
-			return defaults.IPAddress
-		})
+		m.applyDefaults(&ipAddress, entityRegistry.GetDefaults())
 	}
 
 	return &ipAddress
@@ -63,31 +108,16 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 // InterfaceMapper is a struct that maps interfaces to entities
 type InterfaceMapper struct{}
 
-// applyEntityDefaults applies default values to an entity based on the provided defaults
-func applyEntityDefaults(entity diode.Entity, defaults *config.Defaults, getEntityDefaults func(defaults config.Defaults) config.EntityDefaults) {
+// applyDefaults applies default values to an interface entity
+func (m *InterfaceMapper) applyDefaults(entity *diode.Interface, defaults *config.Defaults) {
 	if defaults == nil {
 		return
 	}
-	entityDefaults := getEntityDefaults(*defaults)
+	entityDefaults := defaults.Interface
 
 	// Apply entity-specific defaults
 	if entityDefaults.Description != "" {
-		switch e := entity.(type) {
-		case *diode.Interface:
-			e.Description = &entityDefaults.Description
-		case *diode.Device:
-			e.Description = &entityDefaults.Description
-		case *diode.IPAddress:
-			e.Description = &entityDefaults.Description
-		}
-	}
-	if entityDefaults.Comments != "" {
-		switch e := entity.(type) {
-		case *diode.Device:
-			e.Comments = &entityDefaults.Comments
-		case *diode.IPAddress:
-			e.Comments = &entityDefaults.Comments
-		}
+		entity.Description = &entityDefaults.Description
 	}
 
 	// Collect tags from both entity-specific and global defaults
@@ -105,41 +135,12 @@ func applyEntityDefaults(entity diode.Entity, defaults *config.Defaults, getEnti
 
 	// Apply tags if any exist
 	if len(tags) > 0 {
-		switch e := entity.(type) {
-		case *diode.Interface:
-			e.Tags = tags
-		case *diode.Device:
-			e.Tags = tags
-		case *diode.IPAddress:
-			e.Tags = tags
-		}
+		entity.Tags = tags
 	}
 
 	// Apply global defaults if not overridden by entity-specific defaults
-	switch e := entity.(type) {
-	case *diode.Interface:
-		if e.Description == nil && defaults.Description != "" {
-			e.Description = &defaults.Description
-		}
-	case *diode.Device:
-		if e.Description == nil && defaults.Description != "" {
-			e.Description = &defaults.Description
-		}
-		if e.Comments == nil && defaults.Comments != "" {
-			e.Comments = &defaults.Comments
-		}
-	case *diode.IPAddress:
-		if e.Description == nil && defaults.Description != "" {
-			e.Description = &defaults.Description
-		}
-		if e.Comments == nil && defaults.Comments != "" {
-			e.Comments = &defaults.Comments
-		}
-		if e.Tenant == nil && defaults.Tenant != "" {
-			e.Tenant = &diode.Tenant{
-				Name: &defaults.Tenant,
-			}
-		}
+	if entity.Description == nil && entityDefaults.Description != "" {
+		entity.Description = &entityDefaults.Description
 	}
 }
 
@@ -184,9 +185,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 
 	// Apply defaults if available
 	if fieldFound {
-		applyEntityDefaults(interfaceEntity, entityRegistry.GetDefaults(), func(defaults config.Defaults) config.EntityDefaults {
-			return defaults.Interface
-		})
+		m.applyDefaults(interfaceEntity, entityRegistry.GetDefaults())
 	}
 
 	return interfaceEntity
@@ -195,6 +194,48 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 // DeviceMapper is a struct that maps devices to entities
 type DeviceMapper struct {
 	devices data.DeviceDataRetreiver
+}
+
+// applyDefaults applies default values to a device entity
+func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defaults) {
+	if defaults == nil {
+		return
+	}
+	entityDefaults := defaults.Device
+
+	// Apply entity-specific defaults
+	if entityDefaults.Description != "" {
+		entity.Description = &entityDefaults.Description
+	}
+	if entityDefaults.Comments != "" {
+		entity.Comments = &entityDefaults.Comments
+	}
+
+	// Collect tags from both entity-specific and global defaults
+	var tags []*diode.Tag
+	if len(entityDefaults.Tags) > 0 {
+		for _, tag := range entityDefaults.Tags {
+			tags = append(tags, &diode.Tag{Name: &tag})
+		}
+	}
+	if len(defaults.Tags) > 0 {
+		for _, tag := range defaults.Tags {
+			tags = append(tags, &diode.Tag{Name: &tag})
+		}
+	}
+
+	// Apply tags if any exist
+	if len(tags) > 0 {
+		entity.Tags = tags
+	}
+
+	// Apply global defaults if not overridden by entity-specific defaults
+	if entity.Description == nil && entityDefaults.Description != "" {
+		entity.Description = &entityDefaults.Description
+	}
+	if entity.Comments == nil && entityDefaults.Comments != "" {
+		entity.Comments = &entityDefaults.Comments
+	}
 }
 
 // NewDeviceMapper creates a new DeviceMapper
@@ -257,9 +298,7 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 
 	// Apply defaults if available
 	if fieldFound {
-		applyEntityDefaults(deviceEntity, entityRegistry.GetDefaults(), func(defaults config.Defaults) config.EntityDefaults {
-			return defaults.Device
-		})
+		m.applyDefaults(deviceEntity, entityRegistry.GetDefaults())
 	}
 
 	return deviceEntity

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -246,6 +246,24 @@ func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defa
 			Name: &defaults.Role,
 		}
 	}
+
+	if entity.Site == nil && defaults.Site != "" {
+		entity.Site = &diode.Site{
+			Name: &defaults.Site,
+		}
+	}
+
+	if entity.Location == nil && defaults.Location != "" {
+		entity.Location = &diode.Location{
+			Name: &defaults.Location,
+		}
+		if entity.Location.Site == nil && defaults.Site != "" {
+			entity.Location.Site = &diode.Site{
+				Name: &defaults.Site,
+			}
+		}
+	}
+
 }
 
 // NewDeviceMapper creates a new DeviceMapper

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/data"
 )

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -240,6 +240,12 @@ func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defa
 	if entity.Comments == nil && entityDefaults.Comments != "" {
 		entity.Comments = &entityDefaults.Comments
 	}
+
+	if entity.Role == nil && defaults.Role != "" {
+		entity.Role = &diode.DeviceRole{
+			Name: &defaults.Role,
+		}
+	}
 }
 
 // NewDeviceMapper creates a new DeviceMapper

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -60,6 +60,15 @@ func (m *IPAddressMapper) applyDefaults(entity *diode.IPAddress, defaults *confi
 			Name: &entityDefaults.Tenant,
 		}
 	}
+	if entity.Role == nil && entityDefaults.Role != "" {
+		entity.Role = &entityDefaults.Role
+	}
+	if entity.Vrf == nil && entityDefaults.Vrf != "" {
+		entity.Vrf = &diode.VRF{
+			Name: &entityDefaults.Vrf,
+			Rd:   &entityDefaults.Vrf,
+		}
+	}
 }
 
 // Map maps IP addresses to entities
@@ -263,7 +272,6 @@ func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defa
 			}
 		}
 	}
-
 }
 
 // NewDeviceMapper creates a new DeviceMapper

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -142,6 +142,10 @@ func (m *InterfaceMapper) applyDefaults(entity *diode.Interface, defaults *confi
 	if entity.Description == nil && entityDefaults.Description != "" {
 		entity.Description = &entityDefaults.Description
 	}
+
+	if entity.Type == nil && entityDefaults.Type != "" {
+		entity.Type = &entityDefaults.Type
+	}
 }
 
 // Map maps interfaces to entities

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -81,6 +81,14 @@ func applyEntityDefaults(entity interface{}, defaults *config.Defaults, getEntit
 			e.Description = &entityDefaults.Description
 		}
 	}
+	if entityDefaults.Comments != "" {
+		switch e := entity.(type) {
+		case *diode.Device:
+			e.Comments = &entityDefaults.Comments
+		case *diode.IPAddress:
+			e.Comments = &entityDefaults.Comments
+		}
+	}
 
 	// Collect tags from both entity-specific and global defaults
 	var tags []*diode.Tag
@@ -116,6 +124,9 @@ func applyEntityDefaults(entity interface{}, defaults *config.Defaults, getEntit
 	case *diode.Device:
 		if e.Description == nil && defaults.Description != "" {
 			e.Description = &defaults.Description
+		}
+		if e.Comments == nil && defaults.Comments != "" {
+			e.Comments = &defaults.Comments
 		}
 	case *diode.IPAddress:
 		if e.Description == nil && defaults.Description != "" {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -319,6 +319,78 @@ func TestIPAddressMapper_Map(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "mapping with tenant default",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   mapping.IPAddress,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Tenant: "test-tenant",
+			},
+			expectedEntity: &diode.IPAddress{
+				Address: stringPtr("192.168.1.1/32"),
+				Tenant: &diode.Tenant{
+					Name: stringPtr("test-tenant"),
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with tenant default and entity-specific defaults",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   mapping.IPAddress,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Tenant: "global-tenant",
+				IPAddress: config.EntityDefaults{
+					Description: "IP Address specific description",
+				},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address:     stringPtr("192.168.1.1/32"),
+				Description: stringPtr("IP Address specific description"),
+				Tenant: &diode.Tenant{
+					Name: stringPtr("global-tenant"),
+				},
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -343,6 +415,10 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				for i, tag := range tt.expectedEntity.Tags {
 					assert.Equal(t, tag.Name, ipAddress.Tags[i].Name)
 				}
+			}
+			if tt.expectedEntity.Tenant != nil {
+				assert.NotNil(t, ipAddress.Tenant)
+				assert.Equal(t, tt.expectedEntity.Tenant.Name, ipAddress.Tenant.Name)
 			}
 		})
 	}

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -6,11 +6,10 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestIPAddressMapper_Map(t *testing.T) {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -723,8 +723,10 @@ func TestDeviceMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Tags: []string{"global-tag1", "global-tag2"},
-				Role: "test-role",
+				Tags:     []string{"global-tag1", "global-tag2"},
+				Role:     "test-role",
+				Site:     "test-site",
+				Location: "test-location",
 				Device: config.DeviceDefaults{
 					Description: "Device specific description",
 					Tags:        []string{"device-tag1", "device-tag2"},
@@ -743,6 +745,15 @@ func TestDeviceMapper_Map(t *testing.T) {
 				},
 				Role: &diode.DeviceRole{
 					Name: stringPtr("test-role"),
+				},
+				Site: &diode.Site{
+					Name: stringPtr("test-site"),
+				},
+				Location: &diode.Location{
+					Name: stringPtr("test-location"),
+					Site: &diode.Site{
+						Name: stringPtr("test-site"),
+					},
 				},
 			},
 			expectError: false,
@@ -824,6 +835,13 @@ func TestDeviceMapper_Map(t *testing.T) {
 				assert.Equal(t, tt.expectedEntity.Platform.Manufacturer.Name, device.Platform.Manufacturer.Name)
 			}
 			assert.Equal(t, tt.expectedEntity.Description, device.Description)
+			if tt.expectedEntity.Location != nil {
+				assert.Equal(t, tt.expectedEntity.Location.Name, device.Location.Name)
+				assert.Equal(t, tt.expectedEntity.Location.Site.Name, device.Location.Site.Name)
+			}
+			if tt.expectedEntity.Site != nil {
+				assert.Equal(t, tt.expectedEntity.Site.Name, device.Site.Name)
+			}
 			if tt.expectedEntity.Tags != nil {
 				assert.Equal(t, len(tt.expectedEntity.Tags), len(device.Tags))
 				for i, tag := range tt.expectedEntity.Tags {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -484,58 +484,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "mapping with global defaults",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.2.2.1.1.1": {
-					OID:    "1.3.6.1.2.1.2.2.1.1.1",
-					Index:  "1",
-					Parent: "1.3.6.1.2.1.2.2.1.1",
-					Value:  "1",
-					Type:   mapping.Integer,
-				},
-				"1.3.6.1.2.1.2.2.1.2.1": {
-					OID:    "1.3.6.1.2.1.2.2.1.2.1",
-					Index:  "1",
-					Parent: "1.3.6.1.2.1.2.2.1.2",
-					Value:  "eth0",
-					Type:   mapping.OctetString,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.2.2.1.1",
-				Entity: "interface",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.2.2.1.1",
-						Entity: "interface",
-						Field:  "_id",
-					},
-					{
-						OID:    "1.3.6.1.2.1.2.2.1.2",
-						Entity: "interface",
-						Field:  "name",
-					},
-				},
-			},
-			defaults: &config.Defaults{
-				Interface: config.InterfaceDefaults{
-					Description: "Global description",
-				},
-				Tags: []string{"global-tag1", "global-tag2"},
-			},
-			expectedEntity: &diode.Interface{
-				Name:        stringPtr("eth0"),
-				Description: stringPtr("Global description"),
-				Tags: []*diode.Tag{
-					{Name: stringPtr("global-tag1")},
-					{Name: stringPtr("global-tag2")},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "mapping with entity-specific defaults",
+			name: "mapping with defaults",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.2.2.1.1.1": {
 					OID:    "1.3.6.1.2.1.2.2.1.1.1",
@@ -573,59 +522,9 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				Interface: config.InterfaceDefaults{
 					Description: "Interface specific description",
 					Tags:        []string{"interface-tag1", "interface-tag2"},
+					Type:        "ethernet",
 				},
-			},
-			expectedEntity: &diode.Interface{
-				Name:        stringPtr("eth0"),
-				Description: stringPtr("Interface specific description"),
-				Tags: []*diode.Tag{
-					{Name: stringPtr("interface-tag1")},
-					{Name: stringPtr("interface-tag2")},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "mapping with both global and entity-specific defaults",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.2.2.1.1.1": {
-					OID:    "1.3.6.1.2.1.2.2.1.1.1",
-					Index:  "1",
-					Parent: "1.3.6.1.2.1.2.2.1.1",
-					Value:  "1",
-					Type:   mapping.Integer,
-				},
-				"1.3.6.1.2.1.2.2.1.2.1": {
-					OID:    "1.3.6.1.2.1.2.2.1.2.1",
-					Index:  "1",
-					Parent: "1.3.6.1.2.1.2.2.1.2",
-					Value:  "eth0",
-					Type:   mapping.OctetString,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.2.2.1.1",
-				Entity: "interface",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.2.2.1.1",
-						Entity: "interface",
-						Field:  "_id",
-					},
-					{
-						OID:    "1.3.6.1.2.1.2.2.1.2",
-						Entity: "interface",
-						Field:  "name",
-					},
-				},
-			},
-			defaults: &config.Defaults{
 				Tags: []string{"global-tag1", "global-tag2"},
-				Interface: config.InterfaceDefaults{
-					Description: "Interface specific description",
-					Tags:        []string{"interface-tag1", "interface-tag2"},
-				},
 			},
 			expectedEntity: &diode.Interface{
 				Name:        stringPtr("eth0"),
@@ -636,6 +535,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 					{Name: stringPtr("global-tag1")},
 					{Name: stringPtr("global-tag2")},
 				},
+				Type: stringPtr("ethernet"),
 			},
 			expectError: false,
 		},
@@ -713,6 +613,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			if tt.expectedEntity.PrimaryMacAddress != nil {
 				assert.Equal(t, tt.expectedEntity.PrimaryMacAddress.MacAddress, iface.PrimaryMacAddress.MacAddress)
 			}
+			assert.Equal(t, tt.expectedEntity.Type, iface.Type)
 			assert.Equal(t, tt.expectedEntity.Enabled, iface.Enabled)
 			assert.Equal(t, tt.expectedEntity.Description, iface.Description)
 			if tt.expectedEntity.Tags != nil {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -700,84 +700,6 @@ func TestDeviceMapper_Map(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "mapping with global defaults",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.1.5.0": {
-					OID:    "1.3.6.1.2.1.1.5.0",
-					Index:  "0",
-					Parent: "1.3.6.1.2.1.1.5",
-					Value:  "router1",
-					Type:   mapping.OctetString,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.1",
-				Entity: "device",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.1.5",
-						Entity: "device",
-						Field:  "name",
-					},
-				},
-			},
-			defaults: &config.Defaults{
-				Tags: []string{"global-tag1", "global-tag2"},
-				Device: config.DeviceDefaults{
-					Description: "Device description",
-				},
-			},
-			expectedEntity: &diode.Device{
-				Name:        stringPtr("router1"),
-				Description: stringPtr("Device description"),
-				Tags: []*diode.Tag{
-					{Name: stringPtr("global-tag1")},
-					{Name: stringPtr("global-tag2")},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "mapping with entity-specific defaults",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.1.5.0": {
-					OID:    "1.3.6.1.2.1.1.5.0",
-					Index:  "0",
-					Parent: "1.3.6.1.2.1.1.5",
-					Value:  "router1",
-					Type:   mapping.OctetString,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.1",
-				Entity: "device",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.1.5",
-						Entity: "device",
-						Field:  "name",
-					},
-				},
-			},
-			defaults: &config.Defaults{
-				Device: config.DeviceDefaults{
-					Description: "Device specific description",
-					Tags:        []string{"device-tag1", "device-tag2"},
-				},
-			},
-			expectedEntity: &diode.Device{
-				Name:        stringPtr("router1"),
-				Description: stringPtr("Device specific description"),
-				Tags: []*diode.Tag{
-					{Name: stringPtr("device-tag1")},
-					{Name: stringPtr("device-tag2")},
-				},
-			},
-			expectError: false,
-		},
-		{
 			name: "mapping with both global and entity-specific defaults",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.1.5.0": {
@@ -802,6 +724,7 @@ func TestDeviceMapper_Map(t *testing.T) {
 			},
 			defaults: &config.Defaults{
 				Tags: []string{"global-tag1", "global-tag2"},
+				Role: "test-role",
 				Device: config.DeviceDefaults{
 					Description: "Device specific description",
 					Tags:        []string{"device-tag1", "device-tag2"},
@@ -817,6 +740,9 @@ func TestDeviceMapper_Map(t *testing.T) {
 					{Name: stringPtr("device-tag2")},
 					{Name: stringPtr("global-tag1")},
 					{Name: stringPtr("global-tag2")},
+				},
+				Role: &diode.DeviceRole{
+					Name: stringPtr("test-role"),
 				},
 			},
 			expectError: false,

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -252,6 +252,73 @@ func TestIPAddressMapper_Map(t *testing.T) {
 			expectedEntity: &diode.IPAddress{},
 			expectError:    false,
 		},
+		{
+			name: "mapping with global comments",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   mapping.IPAddress,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Comments: "Global comments",
+			},
+			expectedEntity: &diode.IPAddress{
+				Address:  stringPtr("192.168.1.1/32"),
+				Comments: stringPtr("Global comments"),
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with entity-specific comments",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   mapping.IPAddress,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Comments: "Global comments",
+				IPAddress: config.EntityDefaults{
+					Comments: "IP Address specific comments",
+				},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address:  stringPtr("192.168.1.1/32"),
+				Comments: stringPtr("IP Address specific comments"),
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -854,6 +921,73 @@ func TestDeviceMapper_Map(t *testing.T) {
 			},
 			expectedEntity: &diode.Device{},
 			expectError:    false,
+		},
+		{
+			name: "mapping with global comments",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.1.5.0": {
+					OID:    "1.3.6.1.2.1.1.5.0",
+					Index:  "0",
+					Parent: "1.3.6.1.2.1.1.5",
+					Value:  "router1",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.1",
+				Entity: "device",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.1.5",
+						Entity: "device",
+						Field:  "name",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Comments: "Global comments",
+			},
+			expectedEntity: &diode.Device{
+				Name:     stringPtr("router1"),
+				Comments: stringPtr("Global comments"),
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with entity-specific comments",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.1.5.0": {
+					OID:    "1.3.6.1.2.1.1.5.0",
+					Index:  "0",
+					Parent: "1.3.6.1.2.1.1.5",
+					Value:  "router1",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.1",
+				Entity: "device",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.1.5",
+						Entity: "device",
+						Field:  "name",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Comments: "Global comments",
+				Device: config.EntityDefaults{
+					Comments: "Device specific comments",
+				},
+			},
+			expectedEntity: &diode.Device{
+				Name:     stringPtr("router1"),
+				Comments: stringPtr("Device specific comments"),
+			},
+			expectError: false,
 		},
 	}
 

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -87,12 +87,14 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Description: "Global description",
-				Tags:        []string{"global-tag1", "global-tag2"},
+				IPAddress: config.IPAddressDefaults{
+					Description: "IP Address Description",
+					Tags:        []string{"global-tag1", "global-tag2"},
+				},
 			},
 			expectedEntity: &diode.IPAddress{
 				Address:     stringPtr("192.168.1.1/32"),
-				Description: stringPtr("Global description"),
+				Description: stringPtr("IP Address Description"),
 				Tags: []*diode.Tag{
 					{Name: stringPtr("global-tag1")},
 					{Name: stringPtr("global-tag2")},
@@ -129,7 +131,7 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				IPAddress: config.EntityDefaults{
+				IPAddress: config.IPAddressDefaults{
 					Description: "IP Address specific description",
 					Tags:        []string{"ip-tag1", "ip-tag2"},
 				},
@@ -173,9 +175,8 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Description: "Global description",
-				Tags:        []string{"global-tag1", "global-tag2"},
-				IPAddress: config.EntityDefaults{
+				Tags: []string{"global-tag1", "global-tag2"},
+				IPAddress: config.IPAddressDefaults{
 					Description: "IP Address specific description",
 					Tags:        []string{"ip-tag1", "ip-tag2"},
 				},
@@ -253,38 +254,6 @@ func TestIPAddressMapper_Map(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name: "mapping with global comments",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
-					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
-					Index:  "192.168.1.1",
-					Parent: "1.3.6.1.2.1.4.20.1.1",
-					Value:  "192.168.1.1",
-					Type:   mapping.IPAddress,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.4.20.1.1",
-				Entity: "ipAddress",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.4.20.1.1",
-						Entity: "ipAddress",
-						Field:  "address",
-					},
-				},
-			},
-			defaults: &config.Defaults{
-				Comments: "Global comments",
-			},
-			expectedEntity: &diode.IPAddress{
-				Address:  stringPtr("192.168.1.1/32"),
-				Comments: stringPtr("Global comments"),
-			},
-			expectError: false,
-		},
-		{
 			name: "mapping with entity-specific comments",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
@@ -308,8 +277,7 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Comments: "Global comments",
-				IPAddress: config.EntityDefaults{
+				IPAddress: config.IPAddressDefaults{
 					Comments: "IP Address specific comments",
 				},
 			},
@@ -343,7 +311,9 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Tenant: "test-tenant",
+				IPAddress: config.IPAddressDefaults{
+					Tenant: "test-tenant",
+				},
 			},
 			expectedEntity: &diode.IPAddress{
 				Address: stringPtr("192.168.1.1/32"),
@@ -377,16 +347,16 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Tenant: "global-tenant",
-				IPAddress: config.EntityDefaults{
+				IPAddress: config.IPAddressDefaults{
 					Description: "IP Address specific description",
+					Tenant:      "ip-address-tenant",
 				},
 			},
 			expectedEntity: &diode.IPAddress{
 				Address:     stringPtr("192.168.1.1/32"),
 				Description: stringPtr("IP Address specific description"),
 				Tenant: &diode.Tenant{
-					Name: stringPtr("global-tenant"),
+					Name: stringPtr("ip-address-tenant"),
 				},
 			},
 			expectError: false,
@@ -549,8 +519,10 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Description: "Global description",
-				Tags:        []string{"global-tag1", "global-tag2"},
+				Interface: config.InterfaceDefaults{
+					Description: "Global description",
+				},
+				Tags: []string{"global-tag1", "global-tag2"},
 			},
 			expectedEntity: &diode.Interface{
 				Name:        stringPtr("eth0"),
@@ -598,7 +570,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Interface: config.EntityDefaults{
+				Interface: config.InterfaceDefaults{
 					Description: "Interface specific description",
 					Tags:        []string{"interface-tag1", "interface-tag2"},
 				},
@@ -649,9 +621,8 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Description: "Global description",
-				Tags:        []string{"global-tag1", "global-tag2"},
-				Interface: config.EntityDefaults{
+				Tags: []string{"global-tag1", "global-tag2"},
+				Interface: config.InterfaceDefaults{
 					Description: "Interface specific description",
 					Tags:        []string{"interface-tag1", "interface-tag2"},
 				},
@@ -851,12 +822,14 @@ func TestDeviceMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Description: "Global description",
-				Tags:        []string{"global-tag1", "global-tag2"},
+				Tags: []string{"global-tag1", "global-tag2"},
+				Device: config.DeviceDefaults{
+					Description: "Device description",
+				},
 			},
 			expectedEntity: &diode.Device{
 				Name:        stringPtr("router1"),
-				Description: stringPtr("Global description"),
+				Description: stringPtr("Device description"),
 				Tags: []*diode.Tag{
 					{Name: stringPtr("global-tag1")},
 					{Name: stringPtr("global-tag2")},
@@ -888,7 +861,7 @@ func TestDeviceMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Device: config.EntityDefaults{
+				Device: config.DeviceDefaults{
 					Description: "Device specific description",
 					Tags:        []string{"device-tag1", "device-tag2"},
 				},
@@ -927,16 +900,17 @@ func TestDeviceMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Description: "Global description",
-				Tags:        []string{"global-tag1", "global-tag2"},
-				Device: config.EntityDefaults{
+				Tags: []string{"global-tag1", "global-tag2"},
+				Device: config.DeviceDefaults{
 					Description: "Device specific description",
 					Tags:        []string{"device-tag1", "device-tag2"},
+					Comments:    "Device specific comments",
 				},
 			},
 			expectedEntity: &diode.Device{
 				Name:        stringPtr("router1"),
 				Description: stringPtr("Device specific description"),
+				Comments:    stringPtr("Device specific comments"),
 				Tags: []*diode.Tag{
 					{Name: stringPtr("device-tag1")},
 					{Name: stringPtr("device-tag2")},
@@ -997,73 +971,6 @@ func TestDeviceMapper_Map(t *testing.T) {
 			},
 			expectedEntity: &diode.Device{},
 			expectError:    false,
-		},
-		{
-			name: "mapping with global comments",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.1.5.0": {
-					OID:    "1.3.6.1.2.1.1.5.0",
-					Index:  "0",
-					Parent: "1.3.6.1.2.1.1.5",
-					Value:  "router1",
-					Type:   mapping.OctetString,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.1",
-				Entity: "device",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.1.5",
-						Entity: "device",
-						Field:  "name",
-					},
-				},
-			},
-			defaults: &config.Defaults{
-				Comments: "Global comments",
-			},
-			expectedEntity: &diode.Device{
-				Name:     stringPtr("router1"),
-				Comments: stringPtr("Global comments"),
-			},
-			expectError: false,
-		},
-		{
-			name: "mapping with entity-specific comments",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.1.5.0": {
-					OID:    "1.3.6.1.2.1.1.5.0",
-					Index:  "0",
-					Parent: "1.3.6.1.2.1.1.5",
-					Value:  "router1",
-					Type:   mapping.OctetString,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.1",
-				Entity: "device",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.1.5",
-						Entity: "device",
-						Field:  "name",
-					},
-				},
-			},
-			defaults: &config.Defaults{
-				Comments: "Global comments",
-				Device: config.EntityDefaults{
-					Comments: "Device specific comments",
-				},
-			},
-			expectedEntity: &diode.Device{
-				Name:     stringPtr("router1"),
-				Comments: stringPtr("Device specific comments"),
-			},
-			expectError: false,
 		},
 	}
 

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -254,76 +254,6 @@ func TestIPAddressMapper_Map(t *testing.T) {
 			expectError:    false,
 		},
 		{
-			name: "mapping with entity-specific comments",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
-					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
-					Index:  "192.168.1.1",
-					Parent: "1.3.6.1.2.1.4.20.1.1",
-					Value:  "192.168.1.1",
-					Type:   mapping.IPAddress,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.4.20.1.1",
-				Entity: "ipAddress",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.4.20.1.1",
-						Entity: "ipAddress",
-						Field:  "address",
-					},
-				},
-			},
-			defaults: &config.Defaults{
-				IPAddress: config.IPAddressDefaults{
-					Comments: "IP Address specific comments",
-				},
-			},
-			expectedEntity: &diode.IPAddress{
-				Address:  stringPtr("192.168.1.1/32"),
-				Comments: stringPtr("IP Address specific comments"),
-			},
-			expectError: false,
-		},
-		{
-			name: "mapping with tenant default",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
-					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
-					Index:  "192.168.1.1",
-					Parent: "1.3.6.1.2.1.4.20.1.1",
-					Value:  "192.168.1.1",
-					Type:   mapping.IPAddress,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.4.20.1.1",
-				Entity: "ipAddress",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.4.20.1.1",
-						Entity: "ipAddress",
-						Field:  "address",
-					},
-				},
-			},
-			defaults: &config.Defaults{
-				IPAddress: config.IPAddressDefaults{
-					Tenant: "test-tenant",
-				},
-			},
-			expectedEntity: &diode.IPAddress{
-				Address: stringPtr("192.168.1.1/32"),
-				Tenant: &diode.Tenant{
-					Name: stringPtr("test-tenant"),
-				},
-			},
-			expectError: false,
-		},
-		{
 			name: "mapping with tenant default and entity-specific defaults",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
@@ -350,6 +280,8 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				IPAddress: config.IPAddressDefaults{
 					Description: "IP Address specific description",
 					Tenant:      "ip-address-tenant",
+					Role:        "ip-address-role",
+					Vrf:         "ip-address-vrf",
 				},
 			},
 			expectedEntity: &diode.IPAddress{
@@ -357,6 +289,11 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				Description: stringPtr("IP Address specific description"),
 				Tenant: &diode.Tenant{
 					Name: stringPtr("ip-address-tenant"),
+				},
+				Role: stringPtr("ip-address-role"),
+				Vrf: &diode.VRF{
+					Name: stringPtr("ip-address-vrf"),
+					Rd:   stringPtr("ip-address-vrf"),
 				},
 			},
 			expectError: false,
@@ -380,6 +317,11 @@ func TestIPAddressMapper_Map(t *testing.T) {
 			assert.True(t, ok)
 			assert.Equal(t, tt.expectedEntity.Address, ipAddress.Address)
 			assert.Equal(t, tt.expectedEntity.Description, ipAddress.Description)
+			assert.Equal(t, tt.expectedEntity.Role, ipAddress.Role)
+			if tt.expectedEntity.Vrf != nil {
+				assert.Equal(t, tt.expectedEntity.Vrf.Name, ipAddress.Vrf.Name)
+				assert.Equal(t, tt.expectedEntity.Vrf.Rd, ipAddress.Vrf.Rd)
+			}
 			if tt.expectedEntity.Tags != nil {
 				assert.Equal(t, len(tt.expectedEntity.Tags), len(ipAddress.Tags))
 				for i, tag := range tt.expectedEntity.Tags {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/data"
 )

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
+	"github.com/stretchr/testify/assert"
 )
 
 type FakeManufacturers struct{}

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -8,10 +8,9 @@ import (
 	"os"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"gopkg.in/yaml.v3"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
+	"gopkg.in/yaml.v3"
 )
 
 // Manager represents the policy manager

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -7,12 +7,11 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // MockRunner mocks the Runner

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-co-op/gocron/v2"
 	"github.com/netboxlabs/diode-sdk-go/diode"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/data"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -119,19 +119,17 @@ func TestRunnerRun(t *testing.T) {
 				Config: config.PolicyConfig{
 					Schedule: nil,
 					Defaults: config.Defaults{
-						Description: "Test",
-						Comments:    "This is a test",
-						Tags:        []string{"test", "snmp"},
-						IPAddress: config.EntityDefaults{
+						Tags: []string{"test", "snmp"},
+						IPAddress: config.IPAddressDefaults{
 							Description: "IP Address Default",
 							Comments:    "IP Address Comment",
 							Tags:        []string{"ip", "default"},
 						},
-						Interface: config.EntityDefaults{
+						Interface: config.InterfaceDefaults{
 							Description: "Interface Default",
 							Tags:        []string{"interface", "default"},
 						},
-						Device: config.EntityDefaults{
+						Device: config.DeviceDefaults{
 							Description: "Device Default",
 							Tags:        []string{"device", "default"},
 						},
@@ -203,19 +201,17 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	policyConfig := config.Policy{
 		Config: config.PolicyConfig{
 			Defaults: config.Defaults{
-				Description: "Test",
-				Comments:    "This is a test",
-				Tags:        []string{"test", "snmp"},
-				IPAddress: config.EntityDefaults{
+				Tags: []string{"test", "snmp"},
+				IPAddress: config.IPAddressDefaults{
 					Description: "IP Address Default",
 					Comments:    "IP Address Comment",
 					Tags:        []string{"ip", "default"},
 				},
-				Interface: config.EntityDefaults{
+				Interface: config.InterfaceDefaults{
 					Description: "Interface Default",
 					Tags:        []string{"interface", "default"},
 				},
-				Device: config.EntityDefaults{
+				Device: config.DeviceDefaults{
 					Description: "Device Default",
 					Tags:        []string{"device", "default"},
 				},

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -10,12 +10,11 @@ import (
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type MockDiodeClient struct {

--- a/snmp-discovery/server/server.go
+++ b/snmp-discovery/server/server.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
 )

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -12,11 +12,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type MockClient struct {

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -2,7 +2,6 @@ package snmp
 
 import (
 	"github.com/gosnmp/gosnmp"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 )
 

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/gosnmp/gosnmp"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
 )

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -10,12 +10,11 @@ import (
 	"github.com/gosnmp/gosnmp"
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // MockSNMP is a mock for Walker

--- a/snmp-discovery/version/version_test.go
+++ b/snmp-discovery/version/version_test.go
@@ -3,9 +3,8 @@ package version_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/version"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVersion(t *testing.T) {


### PR DESCRIPTION
This pull request introduces several updates and improvements across the `snmp-discovery` project, focusing on enhancing configuration flexibility, updating dependencies, and improving code maintainability. The most significant changes include the restructuring of default configurations, the addition of new mapping logic for entities, and dependency updates for compatibility with Go 1.24.

### Configuration Enhancements:
* Renamed `EntityDefaults` to more specific types (`IPAddressDefaults`, `InterfaceDefaults`, `DeviceDefaults`) and added new fields like `Role`, `Tenant`, and `Vrf` for `IPAddressDefaults`. This change improves clarity and expands the configurability of default values for different entity types (`snmp-discovery/config/config.go`).
* Updated the configuration example in `README.md` to reflect the new naming convention (`ipAddress` instead of `ip_address`) for better consistency with YAML standards (`snmp-discovery/README.md`).

### Mapping Logic Improvements:
* Refactored `IPAddressMapper`, `InterfaceMapper`, and `DeviceMapper` to use new `applyDefaults` methods for applying default values to entities. This reduces code duplication and ensures consistent handling of defaults across different entity types (`snmp-discovery/mapping/mappers.go`). [[1]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL54-L93) [[2]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL135-R273) [[3]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL230-R336)
* Extended test cases for mappers to validate the application of new default fields (`Role`, `Tenant`, `Vrf`, etc.) and ensure proper handling of both global and entity-specific defaults (`snmp-discovery/mapping/mappers_test.go`). [[1]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R255-R299) [[2]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R319-R333) [[3]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L409-L514)

### Dependency Updates:
* Updated the Go version in `Dockerfile` and `go.mod` to 1.24 for compatibility with the latest features and improvements (`snmp-discovery/docker/Dockerfile`, `snmp-discovery/go.mod`). [[1]](diffhunk://#diff-f843a06d81f89848c1fd359f129a47d9ae7e1a13f300fc6641222e3786767906L1-R1) [[2]](diffhunk://#diff-b317fe0c907478d97c235e904821194309658448be78cf050d9ada1dd275ec8fL3-R3)
* Updated the `golangci-lint` dependency to version 2 in the `Makefile` to ensure compatibility with the latest linter features (`snmp-discovery/Makefile`).

### Code Cleanup:
* Removed unnecessary blank lines in import sections across multiple files to improve readability (`snmp-discovery/cmd/main.go`, `snmp-discovery/config/logger_test.go`, `snmp-discovery/mapping/mappers.go`, `snmp-discovery/mapping/mappers_test.go`). [[1]](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L13) [[2]](diffhunk://#diff-2b83d6ab9dd330737bee368cbe0c80e5f22d2a8648729076659a9c2e2f7017e1R7-L10) [[3]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL10-R72) [[4]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L9-R12)

These changes collectively improve the maintainability, configurability, and compatibility of the `snmp-discovery` project.