### PR TITLE
fix: blank device location

### DIFF
--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -55,11 +55,15 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
     tags = list(defaults.tags) if defaults.tags else []
     description = None
     comments = None
+    location = None
 
     if defaults.device:
         tags.extend(defaults.device.tags or [])
         description = defaults.device.description
         comments = defaults.device.comments
+
+    if defaults.location:
+        location = Location(name=defaults.location, site=defaults.site)
 
     device = Device(
         name=device_info.get("hostname"),
@@ -74,7 +78,7 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
         status="active",
         site=defaults.site,
         tags=tags,
-        location=Location(name=defaults.location, site=defaults.site),
+        location=location,
         tenant=defaults.tenant,
         description=description,
         comments=comments,
@@ -252,7 +256,6 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
 
     vlan = VLAN(
         vid=int(vid),
-        site=defaults.site,
         name=vlan_name,
         group=group,
         tenant=tenant,

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -213,7 +213,6 @@ def test_translate_vlan(sample_defaults):
     assert vlan.vid == 1
     assert vlan.name == "Test VLAN"
     assert len(vlan.tags) == 2
-    assert vlan.site.name == "New York"
     assert vlan.comments == "test"
 
 
@@ -238,5 +237,4 @@ def test_translate_vlan_with_defaults(sample_defaults):
     assert vlan.group.name == "Default Group"
     assert vlan.tenant.name == "Default Tenant"
     assert vlan.role.name == "Default Role"
-    assert vlan.site.name == "New York"
     assert len(vlan.tags) == 3


### PR DESCRIPTION
This pull request introduces updates to the `translate.py` file in the `device-discovery` module, focusing on enhancing flexibility in handling `location` and simplifying VLAN translation. The changes primarily affect the `translate_device` and `translate_vlan` functions.

### Changes to `translate_device` function:

* Added a conditional check to initialize `location` only if `defaults.location` is provided. This ensures `location` is not unnecessarily instantiated when no location data is available. (`[device-discovery/device_discovery/translate.pyR58-R67](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R58-R67)`)
* Updated the `Device` instantiation to use the newly defined `location` variable, improving clarity and consistency in how location data is handled. (`[device-discovery/device_discovery/translate.pyL77-R81](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L77-R81)`)

### Changes to `translate_vlan` function:

* Removed the `site` attribute from the `VLAN` instantiation, simplifying the function and potentially decoupling VLANs from a specific site. (`[device-discovery/device_discovery/translate.pyL255](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L255)`)