### PR TITLE
release 🚚 

### DIFF
--- a/device-discovery/device_discovery/main.py
+++ b/device-discovery/device_discovery/main.py
@@ -96,6 +96,10 @@ def main():
 
     try:
         args = parser.parse_args()
+        target = args.diode_target
+        if target.startswith("${") and target.endswith("}"):
+            env_var = target[2:-1]
+            target = os.getenv(env_var, target)
         client_id = args.diode_client_id
         if client_id.startswith("${") and client_id.endswith("}"):
             env_var = client_id[2:-1]
@@ -111,7 +115,7 @@ def main():
         client = Client()
         client.init_client(
             prefix=args.diode_app_name_prefix,
-            target=args.diode_target,
+            target=target,
             client_id=client_id,
             client_secret=client_secret,
         )

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -55,11 +55,15 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
     tags = list(defaults.tags) if defaults.tags else []
     description = None
     comments = None
+    location = None
 
     if defaults.device:
         tags.extend(defaults.device.tags or [])
         description = defaults.device.description
         comments = defaults.device.comments
+
+    if defaults.location:
+        location = Location(name=defaults.location, site=defaults.site)
 
     device = Device(
         name=device_info.get("hostname"),
@@ -74,7 +78,7 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
         status="active",
         site=defaults.site,
         tags=tags,
-        location=Location(name=defaults.location, site=defaults.site),
+        location=location,
         tenant=defaults.tenant,
         description=description,
         comments=comments,
@@ -252,7 +256,6 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
 
     vlan = VLAN(
         vid=int(vid),
-        site=defaults.site,
         name=vlan_name,
         group=group,
         tenant=tenant,

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -213,7 +213,6 @@ def test_translate_vlan(sample_defaults):
     assert vlan.vid == 1
     assert vlan.name == "Test VLAN"
     assert len(vlan.tags) == 2
-    assert vlan.site.name == "New York"
     assert vlan.comments == "test"
 
 
@@ -238,5 +237,4 @@ def test_translate_vlan_with_defaults(sample_defaults):
     assert vlan.group.name == "Default Group"
     assert vlan.tenant.name == "Default Tenant"
     assert vlan.role.name == "Default Role"
-    assert vlan.site.name == "New York"
     assert len(vlan.tags) == 3

--- a/network-discovery/cmd/main.go
+++ b/network-discovery/cmd/main.go
@@ -70,7 +70,7 @@ func main() {
 	}
 
 	client, err := diode.NewClient(
-		*diodeTarget,
+		resolveEnv(*diodeTarget),
 		producerName,
 		version.GetBuildVersion(),
 		diode.WithClientID(resolveEnv(*diodeClientID)),

--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -67,7 +67,7 @@ func main() {
 	}
 
 	client, err := diode.NewClient(
-		resolveEnv(*diodeTarget),
+		*diodeTarget,
 		producerName,
 		version.GetBuildVersion(),
 		diode.WithClientID(resolveEnv(*diodeClientID)),

--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -67,7 +67,7 @@ func main() {
 	}
 
 	client, err := diode.NewClient(
-		*diodeTarget,
+		resolveEnv(*diodeTarget),
 		producerName,
 		version.GetBuildVersion(),
 		diode.WithClientID(resolveEnv(*diodeClientID)),

--- a/worker/worker/main.py
+++ b/worker/worker/main.py
@@ -96,6 +96,10 @@ def main():
 
     try:
         args = parser.parse_args()
+        target = args.diode_target
+        if target.startswith("${") and target.endswith("}"):
+            env_var = target[2:-1]
+            target = os.getenv(env_var, target)
         client_id = args.diode_client_id
         if client_id.startswith("${") and client_id.endswith("}"):
             env_var = client_id[2:-1]
@@ -109,7 +113,7 @@ def main():
             setup_metrics_export(args.otel_endpoint, args.otel_export_period)
 
         config = DiodeConfig(
-            target=args.diode_target,
+            target=target,
             prefix=args.diode_app_name_prefix,
             client_id=client_id,
             client_secret=client_secret,


### PR DESCRIPTION
This pull request introduces several changes across multiple modules to enhance environment variable handling, improve device translation logic, and simplify VLAN handling. Key changes include adding support for resolving environment variables in `diode_target` and `diode_client_id`, refining location handling in device translation, and removing the `site` attribute from VLANs.

### Environment Variable Handling:

* Updated `main.py` in `device-discovery` and `worker` modules to resolve `diode_target` and `diode_client_id` from environment variables if specified in the `${VAR_NAME}` format. (`[[1]](diffhunk://#diff-1999bab46324c3ee0f3648305dd694f66fea0998ed4e291ba704b6d4b9598faaR99-R102)`, `[[2]](diffhunk://#diff-1999bab46324c3ee0f3648305dd694f66fea0998ed4e291ba704b6d4b9598faaL114-R118)`, `[[3]](diffhunk://#diff-c9e84020610222e9db70eaeb5f034ea9d7371c5f3451ae914ff9ae3679cb540cR99-R102)`, `[[4]](diffhunk://#diff-c9e84020610222e9db70eaeb5f034ea9d7371c5f3451ae914ff9ae3679cb540cL112-R116)`)
* Modified `main.go` in `network-discovery` to use a helper function `resolveEnv` for resolving environment variables in `diodeTarget` and `diodeClientID`. (`[network-discovery/cmd/main.goL73-R73](diffhunk://#diff-d72917593858580ada0014ddab78df86e3d1dcecd37ef0e1caf2258ad7ad9fb6L73-R73)`)

### Device Translation Improvements:

* Introduced conditional handling for `location` in `translate_device` to ensure it is only set when `defaults.location` is provided. (`[[1]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R58-R67)`, `[[2]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L77-R81)`)

### VLAN Handling Simplification:

* Removed the `site` attribute from the `VLAN` model and updated related test cases to reflect this change. (`[[1]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L255)`, `[[2]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4L216)`, `[[3]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4L241)`)