### PR TITLE
feat: allow diode target to be set as env var

### DIFF
--- a/device-discovery/device_discovery/main.py
+++ b/device-discovery/device_discovery/main.py
@@ -96,6 +96,10 @@ def main():
 
     try:
         args = parser.parse_args()
+        target = args.diode_target
+        if target.startswith("${") and target.endswith("}"):
+            env_var = target[2:-1]
+            target = os.getenv(env_var, target)
         client_id = args.diode_client_id
         if client_id.startswith("${") and client_id.endswith("}"):
             env_var = client_id[2:-1]
@@ -111,7 +115,7 @@ def main():
         client = Client()
         client.init_client(
             prefix=args.diode_app_name_prefix,
-            target=args.diode_target,
+            target=target,
             client_id=client_id,
             client_secret=client_secret,
         )

--- a/network-discovery/cmd/main.go
+++ b/network-discovery/cmd/main.go
@@ -70,7 +70,7 @@ func main() {
 	}
 
 	client, err := diode.NewClient(
-		*diodeTarget,
+		resolveEnv(*diodeTarget),
 		producerName,
 		version.GetBuildVersion(),
 		diode.WithClientID(resolveEnv(*diodeClientID)),

--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -67,7 +67,7 @@ func main() {
 	}
 
 	client, err := diode.NewClient(
-		resolveEnv(*diodeTarget),
+		*diodeTarget,
 		producerName,
 		version.GetBuildVersion(),
 		diode.WithClientID(resolveEnv(*diodeClientID)),

--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -67,7 +67,7 @@ func main() {
 	}
 
 	client, err := diode.NewClient(
-		*diodeTarget,
+		resolveEnv(*diodeTarget),
 		producerName,
 		version.GetBuildVersion(),
 		diode.WithClientID(resolveEnv(*diodeClientID)),

--- a/worker/worker/main.py
+++ b/worker/worker/main.py
@@ -96,6 +96,10 @@ def main():
 
     try:
         args = parser.parse_args()
+        target = args.diode_target
+        if target.startswith("${") and target.endswith("}"):
+            env_var = target[2:-1]
+            target = os.getenv(env_var, target)
         client_id = args.diode_client_id
         if client_id.startswith("${") and client_id.endswith("}"):
             env_var = client_id[2:-1]
@@ -109,7 +113,7 @@ def main():
             setup_metrics_export(args.otel_endpoint, args.otel_export_period)
 
         config = DiodeConfig(
-            target=args.diode_target,
+            target=target,
             prefix=args.diode_app_name_prefix,
             client_id=client_id,
             client_secret=client_secret,


### PR DESCRIPTION
This pull request introduces changes to improve environment variable resolution for `diode_target` and `diode_client_id` across multiple components. The updates ensure that these values can dynamically reference environment variables when specified in the format `${ENV_VAR}`. The changes also refactor code to use the resolved values consistently.

### Improvements to environment variable resolution:

* **Python components (`device-discovery` and `worker`)**:
  - In `device-discovery/device_discovery/main.py` and `worker/worker/main.py`, added logic to resolve `diode_target` from environment variables if specified in the `${ENV_VAR}` format. Updated references to use the resolved `target` variable instead of `args.diode_target`. [[1]](diffhunk://#diff-1999bab46324c3ee0f3648305dd694f66fea0998ed4e291ba704b6d4b9598faaR99-R102) [[2]](diffhunk://#diff-1999bab46324c3ee0f3648305dd694f66fea0998ed4e291ba704b6d4b9598faaL114-R118) [[3]](diffhunk://#diff-c9e84020610222e9db70eaeb5f034ea9d7371c5f3451ae914ff9ae3679cb540cR99-R102) [[4]](diffhunk://#diff-c9e84020610222e9db70eaeb5f034ea9d7371c5f3451ae914ff9ae3679cb540cL112-R116)

* **Go components (`network-discovery` and `snmp-discovery`)**:
  - Updated `network-discovery/cmd/main.go` and `snmp-discovery/cmd/main.go` to use a `resolveEnv` function for resolving `diodeTarget` and `diodeClientID` from environment variables. This ensures consistent handling of environment variable substitution in Go-based components. [[1]](diffhunk://#diff-d72917593858580ada0014ddab78df86e3d1dcecd37ef0e1caf2258ad7ad9fb6L73-R73) [[2]](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L70-R70)