### PR TITLE
feat: allow diode target to be specified as an env var

### DIFF
--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -66,7 +66,7 @@ func main() {
 	}
 
 	client, err := diode.NewClient(
-		*diodeTarget,
+		resolveEnv(*diodeTarget),
 		producerName,
 		version.GetBuildVersion(),
 		diode.WithClientID(resolveEnv(*diodeClientID)),


### PR DESCRIPTION
This pull request introduces a small but important change to the `snmp-discovery/cmd/main.go` file. The change replaces the direct use of `*diodeTarget` and `*diodeClientID` with the `resolveEnv` function to ensure environment variable resolution for these parameters.

* [`snmp-discovery/cmd/main.go`](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L69-R69): Updated `diode.NewClient` to use `resolveEnv` for `*diodeTarget` and `*diodeClientID` to improve flexibility and support for environment variable overrides.