### PR TITLE
feat: improvements from testing

### DIFF
--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -171,6 +171,10 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					interfaceEntity.Name = &value.Value
 					fieldFound = true
 				case "speed":
+					if value.Value == "" {
+						logger.Debug("Speed is empty", "value", value.Value)
+						continue
+					}
 					speed, err := strconv.Atoi(value.Value)
 					if err != nil {
 						logger.Warn("Error converting speed to int", "error", err, "value", value.Value)
@@ -180,8 +184,13 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					interfaceEntity.Speed = &speed64
 					fieldFound = true
 				case "macAddress":
+					macAddress, err := formatMACAddress(value.Value)
+					if err != nil {
+						logger.Warn("Error formatting mac address", "error", err, "value", value.Value)
+						continue
+					}
 					interfaceEntity.PrimaryMacAddress = &diode.MACAddress{
-						MacAddress: &value.Value,
+						MacAddress: &macAddress,
 					}
 					fieldFound = true
 				case "adminStatus":
@@ -201,6 +210,20 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	}
 
 	return interfaceEntity
+}
+
+func formatMACAddress(rawStr string) (string, error) {
+	// Decode escaped characters into actual bytes
+	unquoted, err := strconv.Unquote(`"` + rawStr + `"`)
+	if err != nil {
+		return "", fmt.Errorf("failed to unquote string: %v", err)
+	}
+
+	macParts := make([]string, len(unquoted))
+	for i := 0; i < len(unquoted); i++ {
+		macParts[i] = fmt.Sprintf("%02x", unquoted[i])
+	}
+	return strings.Join(macParts, ":"), nil
 }
 
 // DeviceMapper is a struct that maps devices to entities

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -372,7 +372,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 					OID:    "1.3.6.1.2.1.2.2.1.6.1",
 					Index:  "1",
 					Parent: "1.3.6.1.2.1.2.2.1.6",
-					Value:  "00:11:22:33:44:55",
+					Value:  "\\x00\\x11\\x22\\x33\\x44\\x55",
 					Type:   mapping.OctetString,
 				},
 				"1.3.6.1.2.1.2.2.1.7.1": {

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -63,11 +63,11 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 			objectIDs: mapping.ObjectIDValueMap{
 				".1.3.6.1.2.1.2.2.1.2.999": mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.5.999": mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
-				".1.3.6.1.2.1.2.2.1.6.999": mapping.Value{Value: "00:00:00:00:00:00", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.6.999": mapping.Value{Value: "\x00\x00\x00\x00\x00\x00", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.7.999": mapping.Value{Value: "1", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.2.555": mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.5.555": mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
-				".1.3.6.1.2.1.2.2.1.6.555": mapping.Value{Value: "00:00:00:00:00:11", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.6.555": mapping.Value{Value: "\x00\x00\x00\x00\x00\x11", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.7.555": mapping.Value{Value: "0", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
 			},
 			expected: []diode.Entity{
@@ -141,7 +141,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 			objectIDs: mapping.ObjectIDValueMap{
 				".1.3.6.1.2.1.2.2.1.2.999":          mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.5.999":          mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
-				".1.3.6.1.2.1.2.2.1.6.999":          mapping.Value{Value: "00:00:00:00:00:00", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.6.999":          mapping.Value{Value: "\x00\x00\x00\x00\x00\x00", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.7.999":          mapping.Value{Value: "1", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
 				".1.3.6.1.2.1.4.20.1.1.192.168.1.2": mapping.Value{Value: "192.168.1.2", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4},
 			},

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -160,7 +160,6 @@ func (m *Manager) HasPolicy(name string) bool {
 // StartPolicy starts the policy
 func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 	m.logger.Debug("Starting policy", "policy", policy)
-	m.logger.Debug("Starting policy", "policy", policy)
 	if len(policy.Scope.Targets) == 0 {
 		return fmt.Errorf("%s : no targets found in the policy", name)
 	}

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -95,7 +95,7 @@ func (r *Runner) run() {
 	expandedTargets := r.expandTargetRanges(r.scope.Targets)
 
 	entities = r.queryTargets(expandedTargets, objectIDs, mapper, entities)
-	r.logger.Info("SNMP crawl complete.")
+	r.logger.Info("SNMP crawl complete", slog.Any("policy", r.ctx.Value(policyKey)), slog.Any("entityCount", len(entities)))
 
 	if len(entities) == 0 {
 		r.logger.Info("No entities to ingest", slog.Any("policy", r.ctx.Value(policyKey)))

--- a/snmp-discovery/scripts/create-cisco-device-list.sh
+++ b/snmp-discovery/scripts/create-cisco-device-list.sh
@@ -21,7 +21,7 @@ grep "1\.3\.6\.1\.4\.1\.9\.1\." "$TMPFILE" | while read -r line; do
   ID=$(echo "$OID" | awk -F. '{print $NF}')
   echo "  - id: $ID"
   echo "    oid: $OID"
-  echo "    name: $NAME"
+  echo "    name: \"$NAME\""
 done
 
 # Clean up

--- a/snmp-discovery/scripts/create-device-data.sh
+++ b/snmp-discovery/scripts/create-device-data.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 if [ -z "$1" ]; then
     echo "Usage: $0 <output_file>"
     exit 1
@@ -12,13 +15,13 @@ TMP_MANUFACTURERS=$(mktemp)
 TMP_DEVICES=$(mktemp)
 
 echo "Saving manufacturers to $TMP_MANUFACTURERS"
-./scripts/create-manufacturer-list.py > "$TMP_MANUFACTURERS"
+"$SCRIPT_DIR/create-manufacturer-list.py" > "$TMP_MANUFACTURERS"
 
 echo "Saving cisco devices to $TMP_DEVICES"
-./scripts/create-cisco-device-list.sh > "$TMP_DEVICES"
+"$SCRIPT_DIR/create-cisco-device-list.sh" > "$TMP_DEVICES"
 
 echo "Merging manufacturers and devices to $OUTPUT"
-./scripts/merge_yaml.py "$TMP_MANUFACTURERS" "$TMP_DEVICES" > "$OUTPUT"
+"$SCRIPT_DIR/merge_yaml.py" "$TMP_MANUFACTURERS" "$TMP_DEVICES" > "$OUTPUT"
 
 echo "Cleaning up"
 rm "$TMP_MANUFACTURERS" "$TMP_DEVICES"

--- a/snmp-discovery/scripts/merge_yaml.py
+++ b/snmp-discovery/scripts/merge_yaml.py
@@ -50,7 +50,7 @@ def parse_value(val):
     # Try to convert to int if possible
     if re.match(r'^\d+$', val):
         return int(val)
-    return val
+    return re.sub(r'[^a-zA-Z0-9\s]', '', val)
 
 def merge_dicts(dicts):
     merged = {}

--- a/snmp-discovery/server/server.go
+++ b/snmp-discovery/server/server.go
@@ -105,7 +105,7 @@ func (s *Server) createPolicy(c *gin.Context) {
 		return
 	}
 
-	s.logger.Info("Found %d policies", "policyCount", len(policies))
+	s.logger.Info("Received policies", "policyCount", len(policies))
 
 	rPolicies := []string{}
 	for name, policy := range policies {


### PR DESCRIPTION
This pull request introduces improvements to SNMP discovery functionality, including enhanced handling of MAC addresses, better logging, and updates to scripts for device data creation and merging. The changes aim to improve data processing accuracy, debugging capabilities, and script reliability.

### Enhancements to SNMP mapping and parsing:

* Added a `formatMACAddress` function to properly decode and format raw MAC address strings, replacing direct assignment with formatted values in the `PrimaryMacAddress` field. [[1]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR187-R193) [[2]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR215-R228)
* Improved handling of empty speed values by adding a debug log and skipping processing for such cases.

### Updates to test cases:

* Updated test cases in `mappers_test.go` and `mapping_test.go` to use escaped characters for MAC address values, ensuring compatibility with new formatting logic. [[1]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L375-R375) [[2]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L66-R70) [[3]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L144-R144)

### Logging improvements:

* Enhanced logging in `runner.go` to include policy context and entity count after SNMP crawl completion.
* Adjusted log messages in `server.go` to clarify the context of received policies.

### Script reliability improvements:

* Modified `create-device-data.sh` to use absolute paths for script dependencies, improving portability and reducing errors in execution. [[1]](diffhunk://#diff-b3360ff2aa9f66f695525fee9e23b3332e310eab1bf675a5bd63f3069ff642dfR5-R7) [[2]](diffhunk://#diff-b3360ff2aa9f66f695525fee9e23b3332e310eab1bf675a5bd63f3069ff642dfL15-R24)
* Updated `create-cisco-device-list.sh` to quote device names in YAML output for consistency.

### Data sanitization:

* Enhanced `merge_yaml.py` to sanitize input values by removing non-alphanumeric characters, ensuring clean data merging.