### PR TITLE
adds snmp release pipeline

### DIFF
--- a/.github/workflows/device-discovery-release.yaml
+++ b/.github/workflows/device-discovery-release.yaml
@@ -77,7 +77,8 @@ jobs:
                     { "message": "*", "release": "patch"},
                     { "message": "fix*", "release": "patch" },
                     { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
+                    { "message": "perf*",  "release": "major" },
+                    { "message": "major*",  "release": "major" }
                   ]
                 }],
                 "@semantic-release/release-notes-generator",
@@ -218,7 +219,8 @@ jobs:
                     { "message": "*", "release": "patch"},
                     { "message": "fix*", "release": "patch" },
                     { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
+                    { "message": "perf*",  "release": "major" },
+                    { "message": "major*",  "release": "major" }
                   ]
                 }],
                 "@semantic-release/release-notes-generator",

--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -64,7 +64,8 @@ jobs:
                     { "message": "*", "release": "patch"},
                     { "message": "fix*", "release": "patch" },
                     { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
+                    { "message": "perf*",  "release": "major" },
+                    { "message": "major*",  "release": "major" }
                   ]
                 }],
                 "@semantic-release/release-notes-generator",
@@ -204,7 +205,8 @@ jobs:
                     { "message": "*", "release": "patch"},
                     { "message": "fix*", "release": "patch" },
                     { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
+                    { "message": "perf*",  "release": "major" },
+                    { "message": "major*",  "release": "major" }
                   ]
                 }],
                 "@semantic-release/release-notes-generator",

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -1,0 +1,237 @@
+name: SNMP Discovery - release
+on:
+  workflow_dispatch:
+  push:
+    branches: [ release ]
+    paths:
+      - "snmp-discovery/**"
+      - "!snmp-discovery/docker/**"
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
+  GO_VERSION: '1.24'
+  APP_NAME: snmp-discovery
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  get-next-version:
+    name: Semantic release get next version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - name: Write package.json
+        uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 #v1.3
+        with:
+          path: ./package.json
+          write-mode: overwrite
+          contents: |
+            {
+              "name": "${{ env.APP_NAME }}",
+              "version": "1.0.0",
+              "devDependencies": {
+                "semantic-release-export-data": "^1.0.1",
+                "@semantic-release/changelog": "^6.0.3"
+              }
+            }
+      - name: Write .releaserc.json
+        uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 #v1.3
+        with:
+          path: ./.releaserc.json
+          write-mode: overwrite
+          contents: |
+            {
+              "branches": "release",
+              "repositoryUrl": "https://github.com/netboxlabs/orb-discovery",
+              "debug": "true",
+              "tagFormat": "${{ env.APP_NAME }}/v${version}",
+              "plugins": [
+                ["semantic-release-export-data"],
+                ["@semantic-release/commit-analyzer", {
+                  "releaseRules": [
+                    { "message": "*", "release": "patch"},
+                    { "message": "fix*", "release": "patch" },
+                    { "message": "feat*", "release": "minor" },
+                    { "message": "perf*",  "release": "major" },
+                    { "message": "major*",  "release": "major" }
+                  ]
+                }],
+                "@semantic-release/release-notes-generator",
+                [
+                  "@semantic-release/changelog",
+                  {
+                    "changelogFile": "CHANGELOG.md",
+                    "changelogTitle": "# Semantic Versioning Changelog"
+                  }
+                ],
+                [
+                  "@semantic-release/github",
+                  {
+                    "assets": [
+                      {
+                        "path": "release/**"
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+      - name: setup semantic-release
+        run: npm i
+      - name: release dry-run
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_SEMANTIC_RELEASE_WEBHOOK }}
+        run: npx semantic-release --debug --dry-run
+        id: get-next-version
+      - name: Set short sha output
+        id: short-sha
+        run: echo "::set-output name=short-sha::${GITHUB_SHA::7}"
+      - name: Set release version
+        id: release-version
+        run: |
+          echo "::set-output name=release-version::`echo ${{ steps.get-next-version.outputs.new-release-version }} | sed 's/v//g'`"
+    outputs:
+      new-release-published: ${{ steps.get-next-version.outputs.new-release-published }}
+      new-release-version: ${{ steps.release-version.outputs.release-version }}
+      short-sha: ${{ steps.short-sha.outputs.short-sha }}
+
+  confirm-version:
+    name: Next version ${{ needs.get-next-version.outputs.new-release-version }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: get-next-version
+    if: needs.get-next-version.outputs.new-release-published == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "The new release version is ${{ needs.get-next-version.outputs.new-release-version }} commit ${{ needs.get-next-version.outputs.short-sha }}"
+
+  build:
+    name: Build
+    needs: get-next-version
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    if: needs.get-next-version.outputs.new-release-published == 'true'
+    env:
+      BUILD_VERSION: ${{ needs.get-next-version.outputs.new-release-version }}
+      BUILD_COMMIT: ${{ needs.get-next-version.outputs.short-sha }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 #v3.8.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set build info
+        run: |
+          echo $BUILD_COMMIT > ./snmp-discovery/version/BUILD_COMMIT.txt
+          echo $BUILD_VERSION > ./snmp-discovery/version/BUILD_VERSION.txt
+
+      - name: Build image and push
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 #v6.10.0
+        with:
+          context: snmp-discovery
+          file: snmp-discovery/docker/Dockerfile
+          platforms: linux/amd64, linux/arm64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            netboxlabs/snmp-discovery:latest
+            netboxlabs/snmp-discovery:${{ env.BUILD_VERSION }}
+          build-args: |
+            GO_VERSION=${{ env.GO_VERSION }}
+
+  semantic-release:
+    name: Semantic release
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - name: Write package.json
+        uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 #v1.3
+        with:
+          path: ./package.json
+          write-mode: overwrite
+          contents: |
+            {
+              "name": "${{ env.APP_NAME }}",
+              "version": "1.0.0",
+              "devDependencies": {
+                "semantic-release-export-data": "^1.0.1",
+                "@semantic-release/changelog": "^6.0.3"
+              }
+            }
+      - name: Write .releaserc.json
+        uses: DamianReeves/write-file-action@6929a9a6d1807689191dcc8bbe62b54d70a32b42 #v1.3
+        with:
+          path: ./.releaserc.json
+          write-mode: overwrite
+          contents: |
+            {
+              "branches": "release",
+              "repositoryUrl": "https://github.com/netboxlabs/orb-discovery",
+              "debug": "true",
+              "tagFormat": "${{ env.APP_NAME }}/v${version}",
+              "plugins": [
+                ["semantic-release-export-data"],
+                ["@semantic-release/commit-analyzer", {
+                  "releaseRules": [
+                    { "message": "*", "release": "patch"},
+                    { "message": "fix*", "release": "patch" },
+                    { "message": "feat*", "release": "minor" },
+                    { "message": "perf*",  "release": "major" },
+                    { "message": "major*",  "release": "major" }
+                  ]
+                }],
+                "@semantic-release/release-notes-generator",
+                [
+                  "@semantic-release/changelog",
+                  {
+                    "changelogFile": "CHANGELOG.md",
+                    "changelogTitle": "# Semantic Versioning Changelog"
+                  }
+                ],
+                [
+                  "@semantic-release/github",
+                  {
+                    "assets": [
+                      {
+                        "path": "release/**"
+                      }
+                    ]
+                  }
+                ]
+              ]
+            }
+      - name: setup semantic-release
+        run: npm i
+      - name: Release
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}
+        run: npx semantic-release --debug

--- a/.github/workflows/worker-release.yaml
+++ b/.github/workflows/worker-release.yaml
@@ -77,7 +77,8 @@ jobs:
                     { "message": "*", "release": "patch"},
                     { "message": "fix*", "release": "patch" },
                     { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
+                    { "message": "perf*",  "release": "major" },
+                    { "message": "major*",  "release": "major" }
                   ]
                 }],
                 "@semantic-release/release-notes-generator",
@@ -218,7 +219,8 @@ jobs:
                     { "message": "*", "release": "patch"},
                     { "message": "fix*", "release": "patch" },
                     { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
+                    { "message": "perf*",  "release": "major" },
+                    { "message": "major*",  "release": "major" }
                   ]
                 }],
                 "@semantic-release/release-notes-generator",


### PR DESCRIPTION
This pull request introduces updates to the semantic release rules across multiple workflows and adds a new workflow for SNMP Discovery releases. The changes aim to enhance release automation and improve versioning consistency.

### Updates to semantic release rules:
* [`.github/workflows/device-discovery-release.yaml`](diffhunk://#diff-950ab6e4df215649e66efacd9a47040b86a7fd9494c32660cde2aea0f58a02d0L80-R81): Added a new rule to treat commit messages starting with "major*" as triggering a major release. This change ensures proper handling of explicit major version bumps. [[1]](diffhunk://#diff-950ab6e4df215649e66efacd9a47040b86a7fd9494c32660cde2aea0f58a02d0L80-R81) [[2]](diffhunk://#diff-950ab6e4df215649e66efacd9a47040b86a7fd9494c32660cde2aea0f58a02d0L221-R223)
* [`.github/workflows/network-discovery-release.yaml`](diffhunk://#diff-9e83be94be4c5a084d3b8bd5b054f1fd774314525af718e3a1a03b1f2fa09421L67-R68): Applied the same update to semantic release rules, adding support for "major*" commit messages to trigger major releases. [[1]](diffhunk://#diff-9e83be94be4c5a084d3b8bd5b054f1fd774314525af718e3a1a03b1f2fa09421L67-R68) [[2]](diffhunk://#diff-9e83be94be4c5a084d3b8bd5b054f1fd774314525af718e3a1a03b1f2fa09421L207-R209)
* [`.github/workflows/worker-release.yaml`](diffhunk://#diff-b7662b3976a0fc851e80c2ccc9ed4fcef2683df1ceeac5f1bea89c2d249956f2L80-R81): Updated semantic release rules to include "major*" for major version bumps, aligning with changes in other workflows. [[1]](diffhunk://#diff-b7662b3976a0fc851e80c2ccc9ed4fcef2683df1ceeac5f1bea89c2d249956f2L80-R81) [[2]](diffhunk://#diff-b7662b3976a0fc851e80c2ccc9ed4fcef2683df1ceeac5f1bea89c2d249956f2L221-R223)

### Addition of SNMP Discovery release workflow:
* [`.github/workflows/snmp-discovery-release.yaml`](diffhunk://#diff-97f7673ffb778603a67a9739dfc61695ae28aa5d9fa8d1c8c4014c6a0feca04eR1-R237): Introduced a new workflow for SNMP Discovery releases. This workflow includes steps for semantic versioning, Docker image builds, and publishing to Docker Hub. It uses semantic-release plugins for automated release notes, changelog generation, and GitHub asset management.