### PR TITLE
updates snmp readme with correct usage

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -3,22 +3,25 @@ Orb snmp discovery backend
 
 ### Usage
 ```bash
-usage: snmp-discovery [-h] [-V] [-s HOST] [-p PORT] -t DIODE_TARGET -k DIODE_API_KEY
-
-Orb SNMP Discovery Backend
-
-options:
-  -h, --help            show this help message and exit
-  -V, --version         Display SNMP Discover version
-  -s HOST, --host HOST  Server host
-  -p PORT, --port PORT  Server port
-  -t DIODE_TARGET, --diode-target DIODE_TARGET
-                        Diode target
-  -k DIODE_API_KEY, --diode-api-key DIODE_API_KEY
-                        Diode API key. Environment variables can be used by wrapping them in ${} (e.g.
-                        ${MY_API_KEY})
-  -a DIODE_APP_NAME_PREFIX, --diode-app-name-prefix DIODE_APP_NAME_PREFIX
-                        Diode producer_app_name prefix
+Usage of snmp-discovery:
+ -diode-app-name-prefix string
+    	diode producer_app_name prefix
+  -diode-client-id string
+    	diode client ID (REQUIRED). Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_CLIENT_ID})
+  -diode-client-secret string
+    	diode client secret (REQUIRED). Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_CLIENT_SECRET})
+  -diode-target string
+    	diode target (REQUIRED). Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_TARGET})
+  -help
+    	show this help
+  -host string
+    	server host (default "0.0.0.0")
+  -log-format string
+    	log format (default "TEXT")
+  -log-level string
+    	log level (default "INFO")
+  -port int
+    	server port (default 8070)
 ```
 
 ## Configuration


### PR DESCRIPTION
This pull request updates the usage instructions for the `Orb SNMP Discovery Backend` in the `snmp-discovery/README.md` file. The changes revise the command-line options to reflect a new structure and additional parameters.

### Updates to usage instructions:

* Replaced the old command-line options with a new format that includes additional parameters such as `-diode-client-id`, `-diode-client-secret`, and logging options (`-log-format` and `-log-level`). Environment variable support for certain parameters is retained.
* Updated default values for `-host` (`"0.0.0.0"`) and `-port` (`8070`) to enhance usability.