### PR TITLE
Release SNMP Discovery

### DIFF
--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -64,7 +64,8 @@ jobs:
                     { "message": "*", "release": "patch"},
                     { "message": "fix*", "release": "patch" },
                     { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
+                    { "message": "perf*",  "release": "major" },
+                    { "message": "major*",  "release": "major" }
                   ]
                 }],
                 "@semantic-release/release-notes-generator",
@@ -204,7 +205,8 @@ jobs:
                     { "message": "*", "release": "patch"},
                     { "message": "fix*", "release": "patch" },
                     { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
+                    { "message": "perf*",  "release": "major" },
+                    { "message": "major*",  "release": "major" }
                   ]
                 }],
                 "@semantic-release/release-notes-generator",

--- a/.github/workflows/snmp-discovery-lint.yaml
+++ b/.github/workflows/snmp-discovery-lint.yaml
@@ -23,11 +23,11 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
           check-latest: true
       - name: Lint
-        uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 #v6.1.1
+        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0
         with:
-          version: v1.62
+          version: v2.1.6
           working-directory: snmp-discovery
           args: --config ../.github/golangci.yaml

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -1,11 +1,11 @@
-name: Device Discovery - release
+name: SNMP Discovery - release
 on:
   workflow_dispatch:
   push:
-    branches:
-        - "release"
+    branches: [ release ]
     paths:
-        - "device-discovery/**"
+      - "snmp-discovery/**"
+      - "!snmp-discovery/docker/**"
 
 concurrency:
   group: ${{ github.workflow }}
@@ -14,9 +14,8 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  PYTHON_RUNTIME_VERSION: "3.11"
-  APP_NAME: device-discovery
-  PYTHON_PACKAGE_NAME: netboxlabs_device_discovery
+  GO_VERSION: '1.24'
+  APP_NAME: snmp-discovery
 
 permissions:
   contents: write
@@ -24,18 +23,6 @@ permissions:
   pull-requests: write
 
 jobs:
-  get-python-package-name:
-    name: Get Python package name
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v4
-      - name: Python package name
-        id: python-package-name
-        run: echo "python-package-name=${{ env.PYTHON_PACKAGE_NAME }}" >> "$GITHUB_OUTPUT"
-    outputs:
-        python-package-name: ${{ steps.python-package-name.outputs.python-package-name }}
-
   get-next-version:
     name: Semantic release get next version
     runs-on: ubuntu-latest
@@ -132,54 +119,53 @@ jobs:
 
   build:
     name: Build
-    needs: [ get-python-package-name, get-next-version ]
+    needs: get-next-version
     runs-on: ubuntu-latest
-    timeout-minutes: 5
-    defaults:
-      run:
-        working-directory: ${{ env.APP_NAME  }}
-    permissions:
-      id-token: write
-      contents: read
+    strategy:
+      fail-fast: false
+    if: needs.get-next-version.outputs.new-release-published == 'true'
     env:
       BUILD_VERSION: ${{ needs.get-next-version.outputs.new-release-version }}
-      BUILD_TRACK: release
       BUILD_COMMIT: ${{ needs.get-next-version.outputs.short-sha }}
-      OUTPUT_FILENAME: ${{ needs.get-python-package-name.outputs.python-package-name }}-${{ needs.get-next-version.outputs.new-release-version }}.tar.gz
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v5
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 #v3.8.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
         with:
-          python-version: ${{ env.PYTHON_RUNTIME_VERSION }}
-      - name: Insert version variables into Python
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set build info
         run: |
-          sed -i "s/__commit_hash__ = .*/__commit_hash__ = \"${BUILD_COMMIT}\"/" device_discovery/version.py
-          sed -i "s/__track__ = .*/__track__ = \"${BUILD_TRACK}\"/" device_discovery/version.py
-          sed -i "s/__version__ = .*/__version__ = \"${BUILD_VERSION}\"/" device_discovery/version.py
-      - name: Display contents of version.py
-        run: cat device_discovery/version.py
-      - name: Build sdist 
-        run: |
-          pip install toml-cli
-          toml set --toml-path pyproject.toml project.version ${{ env.BUILD_VERSION }}
-          cat pyproject.toml | grep version
-          python3 -m pip install --upgrade build
-          python3 -m build --sdist --outdir dist/
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
+          echo $BUILD_COMMIT > ./snmp-discovery/version/BUILD_COMMIT.txt
+          echo $BUILD_VERSION > ./snmp-discovery/version/BUILD_VERSION.txt
+
+      - name: Build image and push
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 #v6.10.0
         with:
-          name: ${{ env.OUTPUT_FILENAME }}
-          path: ${{env.APP_NAME}}/dist/${{ env.OUTPUT_FILENAME }}
-          retention-days: 30
-          if-no-files-found: error
-      - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@67339c736fd9354cd4f8cb0b744f2b82a74b5c70 #v1.12.3
-        with:
-          packages-dir: ${{env.APP_NAME}}/dist
+          context: snmp-discovery
+          file: snmp-discovery/docker/Dockerfile
+          platforms: linux/amd64, linux/arm64
+          push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          tags: |
+            netboxlabs/snmp-discovery:latest
+            netboxlabs/snmp-discovery:${{ env.BUILD_VERSION }}
+          build-args: |
+            GO_VERSION=${{ env.GO_VERSION }}
 
   semantic-release:
     name: Semantic release
-    needs: [ build ]
+    needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/snmp-discovery-tests.yaml
+++ b/.github/workflows/snmp-discovery-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.23.x'
+          go-version: '1.24.x'
           check-latest: true
       - name: Run go build
         run: go build ./...

--- a/.github/workflows/worker-release.yaml
+++ b/.github/workflows/worker-release.yaml
@@ -77,7 +77,8 @@ jobs:
                     { "message": "*", "release": "patch"},
                     { "message": "fix*", "release": "patch" },
                     { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
+                    { "message": "perf*",  "release": "major" },
+                    { "message": "major*",  "release": "major" }
                   ]
                 }],
                 "@semantic-release/release-notes-generator",
@@ -218,7 +219,8 @@ jobs:
                     { "message": "*", "release": "patch"},
                     { "message": "fix*", "release": "patch" },
                     { "message": "feat*", "release": "minor" },
-                    { "message": "perf*",  "release": "major" }
+                    { "message": "perf*",  "release": "major" },
+                    { "message": "major*",  "release": "major" }
                   ]
                 }],
                 "@semantic-release/release-notes-generator",

--- a/snmp-discovery/Makefile
+++ b/snmp-discovery/Makefile
@@ -9,7 +9,7 @@ COMMIT_SHA := $(shell git rev-parse --short HEAD)
 .PHONY: install-dev-tools
 install-dev-tools:
 	@go install github.com/mfridman/tparse@latest
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
 	@go install github.com/jandelgado/gcov2lcov@latest
 	
 .PHONY: build

--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -3,22 +3,25 @@ Orb snmp discovery backend
 
 ### Usage
 ```bash
-usage: snmp-discovery [-h] [-V] [-s HOST] [-p PORT] -t DIODE_TARGET -k DIODE_API_KEY
-
-Orb SNMP Discovery Backend
-
-options:
-  -h, --help            show this help message and exit
-  -V, --version         Display SNMP Discover version
-  -s HOST, --host HOST  Server host
-  -p PORT, --port PORT  Server port
-  -t DIODE_TARGET, --diode-target DIODE_TARGET
-                        Diode target
-  -k DIODE_API_KEY, --diode-api-key DIODE_API_KEY
-                        Diode API key. Environment variables can be used by wrapping them in ${} (e.g.
-                        ${MY_API_KEY})
-  -a DIODE_APP_NAME_PREFIX, --diode-app-name-prefix DIODE_APP_NAME_PREFIX
-                        Diode producer_app_name prefix
+Usage of snmp-discovery:
+ -diode-app-name-prefix string
+    	diode producer_app_name prefix
+  -diode-client-id string
+    	diode client ID (REQUIRED). Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_CLIENT_ID})
+  -diode-client-secret string
+    	diode client secret (REQUIRED). Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_CLIENT_SECRET})
+  -diode-target string
+    	diode target (REQUIRED). Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_TARGET})
+  -help
+    	show this help
+  -host string
+    	server host (default "0.0.0.0")
+  -log-format string
+    	log format (default "TEXT")
+  -log-level string
+    	log level (default "INFO")
+  -port int
+    	server port (default 8070)
 ```
 
 ## Configuration

--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -54,6 +54,9 @@ scope:
   targets:  # List of SNMP targets to discover
     - host: "192.168.1.1"  # Required: Hostname or IP address
       port: 161  # Optional: SNMP port (default: 161)
+    - host: "10.10.10.0/24"  # CIDR range: expands to all IPs in the subnet
+    - host: "10.10.10.10-20" # Dash range: expands to 10.10.10.10, 10.10.10.11, ..., 10.10.10.20
+    - host: "mydevice.local" # Hostname
   authentication:  # SNMP authentication settings
     protocol_version: "SNMPv2c"  # Required: SNMP protocol version ("SNMPv1", "SNMPv2c", or "SNMPv3")
     community: "public"  # Required for v1/v2c: SNMP community string
@@ -65,7 +68,21 @@ scope:
     # priv_protocol: "AES"
     # priv_passphrase: "privkey"
   retries: 3  # Optional: Number of SNMP retries (default: 0)
-```
+
+#### Target Range Formats
+
+The `host` field in `targets` supports the following formats:
+
+- **Single IP address:**
+  - `192.168.1.1`
+- **Hostname:**
+  - `mydevice.local`
+- **CIDR range:**
+  - `10.10.10.0/24` (expands to all IPs in the subnet)
+- **Dash range:**
+  - `10.10.10.10-20` (expands to 10.10.10.10, 10.10.10.11, ..., 10.10.10.20)
+
+Invalid or out-of-bounds ranges will be skipped and logged.
 
 ### Defaults
 

--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/server"

--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -66,7 +66,7 @@ func main() {
 	}
 
 	client, err := diode.NewClient(
-		*diodeTarget,
+		resolveEnv(*diodeTarget),
 		producerName,
 		version.GetBuildVersion(),
 		diode.WithClientID(resolveEnv(*diodeClientID)),

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -35,21 +35,39 @@ type Authentication struct {
 	PrivPassphrase  string `yaml:"priv_passphrase"`
 }
 
-// EntityDefaults represents default values for a specific entity type
-type EntityDefaults struct {
+// IPAddressDefaults represents default values for a specific entity type
+type IPAddressDefaults struct {
 	Description string   `yaml:"description,omitempty"`
-	Comments    string   `yaml:"comments,omitempty"`
 	Tags        []string `yaml:"tags,omitempty"`
+	Comments    string   `yaml:"comments,omitempty"`
+	Role        string   `yaml:"role,omitempty"`
+	Tenant      string   `yaml:"tenant,omitempty"`
+	Vrf         string   `yaml:"vrf,omitempty"`
+}
+
+// InterfaceDefaults represents default values for a specific entity type
+type InterfaceDefaults struct {
+	Description string   `yaml:"description,omitempty"`
+	Tags        []string `yaml:"tags,omitempty"`
+	Type        string   `yaml:"if_type,omitempty"`
+}
+
+// DeviceDefaults represents default values for a specific entity type
+type DeviceDefaults struct {
+	Description string   `yaml:"description,omitempty"`
+	Tags        []string `yaml:"tags,omitempty"`
+	Comments    string   `yaml:"comments,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy
 type Defaults struct {
-	Description string         `yaml:"description,omitempty"`
-	Comments    string         `yaml:"comments,omitempty"`
-	Tags        []string       `yaml:"tags,omitempty"`
-	IPAddress   EntityDefaults `yaml:"ip_address,omitempty"`
-	Interface   EntityDefaults `yaml:"interface,omitempty"`
-	Device      EntityDefaults `yaml:"device,omitempty"`
+	Tags      []string          `yaml:"tags,omitempty"`
+	Site      string            `yaml:"site,omitempty"`
+	Location  string            `yaml:"location,omitempty"`
+	Role      string            `yaml:"role,omitempty"`
+	IPAddress IPAddressDefaults `yaml:"ip_address,omitempty"`
+	Interface InterfaceDefaults `yaml:"interface,omitempty"`
+	Device    DeviceDefaults    `yaml:"device,omitempty"`
 }
 
 // PolicyConfig represents the configuration of a policy

--- a/snmp-discovery/config/logger_test.go
+++ b/snmp-discovery/config/logger_test.go
@@ -4,10 +4,9 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 )
 
 func TestNewLogger(t *testing.T) {

--- a/snmp-discovery/docker/Dockerfile
+++ b/snmp-discovery/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.23
+ARG GO_VERSION=1.24
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 

--- a/snmp-discovery/go.mod
+++ b/snmp-discovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/orb-discovery/snmp-discovery
 
-go 1.23.8
+go 1.24.2
 
 require (
 	github.com/gin-gonic/gin v1.10.0

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -7,13 +7,68 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/data"
 )
 
 // IPAddressMapper is a struct that maps IP addresses to entities
 type IPAddressMapper struct{}
+
+// applyDefaults applies default values to an IP address entity
+func (m *IPAddressMapper) applyDefaults(entity *diode.IPAddress, defaults *config.Defaults) {
+	if defaults == nil {
+		return
+	}
+	entityDefaults := defaults.IPAddress
+
+	// Apply entity-specific defaults
+	if entityDefaults.Description != "" {
+		entity.Description = &entityDefaults.Description
+	}
+	if entityDefaults.Comments != "" {
+		entity.Comments = &entityDefaults.Comments
+	}
+
+	// Collect tags from both entity-specific and global defaults
+	var tags []*diode.Tag
+	if len(entityDefaults.Tags) > 0 {
+		for _, tag := range entityDefaults.Tags {
+			tags = append(tags, &diode.Tag{Name: &tag})
+		}
+	}
+	if len(defaults.Tags) > 0 {
+		for _, tag := range defaults.Tags {
+			tags = append(tags, &diode.Tag{Name: &tag})
+		}
+	}
+
+	// Apply tags if any exist
+	if len(tags) > 0 {
+		entity.Tags = tags
+	}
+
+	// Apply global defaults if not overridden by entity-specific defaults
+	if entity.Description == nil && entityDefaults.Description != "" {
+		entity.Description = &entityDefaults.Description
+	}
+	if entity.Comments == nil && entityDefaults.Comments != "" {
+		entity.Comments = &entityDefaults.Comments
+	}
+	if entity.Tenant == nil && entityDefaults.Tenant != "" {
+		entity.Tenant = &diode.Tenant{
+			Name: &entityDefaults.Tenant,
+		}
+	}
+	if entity.Role == nil && entityDefaults.Role != "" {
+		entity.Role = &entityDefaults.Role
+	}
+	if entity.Vrf == nil && entityDefaults.Vrf != "" {
+		entity.Vrf = &diode.VRF{
+			Name: &entityDefaults.Vrf,
+			Rd:   &entityDefaults.Vrf,
+		}
+	}
+}
 
 // Map maps IP addresses to entities
 func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
@@ -51,39 +106,8 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 		}
 	}
 
-	// Apply defaults if available
-	if defaults := entityRegistry.GetDefaults(); defaults != nil && fieldFound {
-		// Apply IP address specific defaults
-		if defaults.IPAddress.Description != "" {
-			ipAddress.Description = &defaults.IPAddress.Description
-		}
-		if defaults.IPAddress.Comments != "" {
-			ipAddress.Comments = &defaults.IPAddress.Comments
-		}
-		var tags []*diode.Tag
-		// Add entity-specific tags
-		if len(defaults.IPAddress.Tags) > 0 {
-			for _, tag := range defaults.IPAddress.Tags {
-				tags = append(tags, &diode.Tag{Name: &tag})
-			}
-		}
-		// Add global tags
-		if len(defaults.Tags) > 0 {
-			for _, tag := range defaults.Tags {
-				tags = append(tags, &diode.Tag{Name: &tag})
-			}
-		}
-		if len(tags) > 0 {
-			ipAddress.Tags = tags
-		}
-
-		// Apply global defaults if not overridden by entity-specific defaults
-		if ipAddress.Description == nil && defaults.Description != "" {
-			ipAddress.Description = &defaults.Description
-		}
-		if ipAddress.Comments == nil && defaults.Comments != "" {
-			ipAddress.Comments = &defaults.Comments
-		}
+	if fieldFound {
+		m.applyDefaults(&ipAddress, entityRegistry.GetDefaults())
 	}
 
 	return &ipAddress
@@ -91,6 +115,46 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 
 // InterfaceMapper is a struct that maps interfaces to entities
 type InterfaceMapper struct{}
+
+// applyDefaults applies default values to an interface entity
+func (m *InterfaceMapper) applyDefaults(entity *diode.Interface, defaults *config.Defaults) {
+	if defaults == nil {
+		return
+	}
+	entityDefaults := defaults.Interface
+
+	// Apply entity-specific defaults
+	if entityDefaults.Description != "" {
+		entity.Description = &entityDefaults.Description
+	}
+
+	// Collect tags from both entity-specific and global defaults
+	var tags []*diode.Tag
+	if len(entityDefaults.Tags) > 0 {
+		for _, tag := range entityDefaults.Tags {
+			tags = append(tags, &diode.Tag{Name: &tag})
+		}
+	}
+	if len(defaults.Tags) > 0 {
+		for _, tag := range defaults.Tags {
+			tags = append(tags, &diode.Tag{Name: &tag})
+		}
+	}
+
+	// Apply tags if any exist
+	if len(tags) > 0 {
+		entity.Tags = tags
+	}
+
+	// Apply global defaults if not overridden by entity-specific defaults
+	if entity.Description == nil && entityDefaults.Description != "" {
+		entity.Description = &entityDefaults.Description
+	}
+
+	if entity.Type == nil && entityDefaults.Type != "" {
+		entity.Type = &entityDefaults.Type
+	}
+}
 
 // Map maps interfaces to entities
 func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, logger *slog.Logger) diode.Entity {
@@ -132,32 +196,8 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	}
 
 	// Apply defaults if available
-	if defaults := entityRegistry.GetDefaults(); defaults != nil && fieldFound {
-		// Apply interface specific defaults
-		if defaults.Interface.Description != "" {
-			interfaceEntity.Description = &defaults.Interface.Description
-		}
-		var tags []*diode.Tag
-		// Add entity-specific tags
-		if len(defaults.Interface.Tags) > 0 {
-			for _, tag := range defaults.Interface.Tags {
-				tags = append(tags, &diode.Tag{Name: &tag})
-			}
-		}
-		// Add global tags
-		if len(defaults.Tags) > 0 {
-			for _, tag := range defaults.Tags {
-				tags = append(tags, &diode.Tag{Name: &tag})
-			}
-		}
-		if len(tags) > 0 {
-			interfaceEntity.Tags = tags
-		}
-
-		// Apply global defaults if not overridden by entity-specific defaults
-		if interfaceEntity.Description == nil && defaults.Description != "" {
-			interfaceEntity.Description = &defaults.Description
-		}
+	if fieldFound {
+		m.applyDefaults(interfaceEntity, entityRegistry.GetDefaults())
 	}
 
 	return interfaceEntity
@@ -166,6 +206,71 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 // DeviceMapper is a struct that maps devices to entities
 type DeviceMapper struct {
 	devices data.DeviceDataRetreiver
+}
+
+// applyDefaults applies default values to a device entity
+func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defaults) {
+	if defaults == nil {
+		return
+	}
+	entityDefaults := defaults.Device
+
+	// Apply entity-specific defaults
+	if entityDefaults.Description != "" {
+		entity.Description = &entityDefaults.Description
+	}
+	if entityDefaults.Comments != "" {
+		entity.Comments = &entityDefaults.Comments
+	}
+
+	// Collect tags from both entity-specific and global defaults
+	var tags []*diode.Tag
+	if len(entityDefaults.Tags) > 0 {
+		for _, tag := range entityDefaults.Tags {
+			tags = append(tags, &diode.Tag{Name: &tag})
+		}
+	}
+	if len(defaults.Tags) > 0 {
+		for _, tag := range defaults.Tags {
+			tags = append(tags, &diode.Tag{Name: &tag})
+		}
+	}
+
+	// Apply tags if any exist
+	if len(tags) > 0 {
+		entity.Tags = tags
+	}
+
+	// Apply global defaults if not overridden by entity-specific defaults
+	if entity.Description == nil && entityDefaults.Description != "" {
+		entity.Description = &entityDefaults.Description
+	}
+	if entity.Comments == nil && entityDefaults.Comments != "" {
+		entity.Comments = &entityDefaults.Comments
+	}
+
+	if entity.Role == nil && defaults.Role != "" {
+		entity.Role = &diode.DeviceRole{
+			Name: &defaults.Role,
+		}
+	}
+
+	if entity.Site == nil && defaults.Site != "" {
+		entity.Site = &diode.Site{
+			Name: &defaults.Site,
+		}
+	}
+
+	if entity.Location == nil && defaults.Location != "" {
+		entity.Location = &diode.Location{
+			Name: &defaults.Location,
+		}
+		if entity.Location.Site == nil && defaults.Site != "" {
+			entity.Location.Site = &diode.Site{
+				Name: &defaults.Site,
+			}
+		}
+	}
 }
 
 // NewDeviceMapper creates a new DeviceMapper
@@ -227,32 +332,8 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 	}
 
 	// Apply defaults if available
-	if defaults := entityRegistry.GetDefaults(); fieldFound && defaults != nil {
-		// Apply device specific defaults
-		if defaults.Device.Description != "" {
-			deviceEntity.Description = &defaults.Device.Description
-		}
-		var tags []*diode.Tag
-		// Add entity-specific tags
-		if len(defaults.Device.Tags) > 0 {
-			for _, tag := range defaults.Device.Tags {
-				tags = append(tags, &diode.Tag{Name: &tag})
-			}
-		}
-		// Add global tags
-		if len(defaults.Tags) > 0 {
-			for _, tag := range defaults.Tags {
-				tags = append(tags, &diode.Tag{Name: &tag})
-			}
-		}
-		if len(tags) > 0 {
-			deviceEntity.Tags = tags
-		}
-
-		// Apply global defaults if not overridden by entity-specific defaults
-		if deviceEntity.Description == nil && defaults.Description != "" {
-			deviceEntity.Description = &defaults.Description
-		}
+	if fieldFound {
+		m.applyDefaults(deviceEntity, entityRegistry.GetDefaults())
 	}
 
 	return deviceEntity

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -171,6 +171,10 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					interfaceEntity.Name = &value.Value
 					fieldFound = true
 				case "speed":
+					if value.Value == "" {
+						logger.Debug("Speed is empty", "value", value.Value)
+						continue
+					}
 					speed, err := strconv.Atoi(value.Value)
 					if err != nil {
 						logger.Warn("Error converting speed to int", "error", err, "value", value.Value)
@@ -180,8 +184,13 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					interfaceEntity.Speed = &speed64
 					fieldFound = true
 				case "macAddress":
+					macAddress, err := formatMACAddress(value.Value)
+					if err != nil {
+						logger.Warn("Error formatting mac address", "error", err, "value", value.Value)
+						continue
+					}
 					interfaceEntity.PrimaryMacAddress = &diode.MACAddress{
-						MacAddress: &value.Value,
+						MacAddress: &macAddress,
 					}
 					fieldFound = true
 				case "adminStatus":
@@ -201,6 +210,20 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	}
 
 	return interfaceEntity
+}
+
+func formatMACAddress(rawStr string) (string, error) {
+	// Decode escaped characters into actual bytes
+	unquoted, err := strconv.Unquote(`"` + rawStr + `"`)
+	if err != nil {
+		return "", fmt.Errorf("failed to unquote string: %v", err)
+	}
+
+	macParts := make([]string, len(unquoted))
+	for i := 0; i < len(unquoted); i++ {
+		macParts[i] = fmt.Sprintf("%02x", unquoted[i])
+	}
+	return strings.Join(macParts, ":"), nil
 }
 
 // DeviceMapper is a struct that maps devices to entities

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -6,11 +6,10 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 func TestIPAddressMapper_Map(t *testing.T) {
@@ -87,12 +86,14 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Description: "Global description",
-				Tags:        []string{"global-tag1", "global-tag2"},
+				IPAddress: config.IPAddressDefaults{
+					Description: "IP Address Description",
+					Tags:        []string{"global-tag1", "global-tag2"},
+				},
 			},
 			expectedEntity: &diode.IPAddress{
 				Address:     stringPtr("192.168.1.1/32"),
-				Description: stringPtr("Global description"),
+				Description: stringPtr("IP Address Description"),
 				Tags: []*diode.Tag{
 					{Name: stringPtr("global-tag1")},
 					{Name: stringPtr("global-tag2")},
@@ -129,7 +130,7 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				IPAddress: config.EntityDefaults{
+				IPAddress: config.IPAddressDefaults{
 					Description: "IP Address specific description",
 					Tags:        []string{"ip-tag1", "ip-tag2"},
 				},
@@ -173,9 +174,8 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Description: "Global description",
-				Tags:        []string{"global-tag1", "global-tag2"},
-				IPAddress: config.EntityDefaults{
+				Tags: []string{"global-tag1", "global-tag2"},
+				IPAddress: config.IPAddressDefaults{
 					Description: "IP Address specific description",
 					Tags:        []string{"ip-tag1", "ip-tag2"},
 				},
@@ -252,6 +252,51 @@ func TestIPAddressMapper_Map(t *testing.T) {
 			expectedEntity: &diode.IPAddress{},
 			expectError:    false,
 		},
+		{
+			name: "mapping with tenant default and entity-specific defaults",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   mapping.IPAddress,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				IPAddress: config.IPAddressDefaults{
+					Description: "IP Address specific description",
+					Tenant:      "ip-address-tenant",
+					Role:        "ip-address-role",
+					Vrf:         "ip-address-vrf",
+				},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address:     stringPtr("192.168.1.1/32"),
+				Description: stringPtr("IP Address specific description"),
+				Tenant: &diode.Tenant{
+					Name: stringPtr("ip-address-tenant"),
+				},
+				Role: stringPtr("ip-address-role"),
+				Vrf: &diode.VRF{
+					Name: stringPtr("ip-address-vrf"),
+					Rd:   stringPtr("ip-address-vrf"),
+				},
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -271,11 +316,20 @@ func TestIPAddressMapper_Map(t *testing.T) {
 			assert.True(t, ok)
 			assert.Equal(t, tt.expectedEntity.Address, ipAddress.Address)
 			assert.Equal(t, tt.expectedEntity.Description, ipAddress.Description)
+			assert.Equal(t, tt.expectedEntity.Role, ipAddress.Role)
+			if tt.expectedEntity.Vrf != nil {
+				assert.Equal(t, tt.expectedEntity.Vrf.Name, ipAddress.Vrf.Name)
+				assert.Equal(t, tt.expectedEntity.Vrf.Rd, ipAddress.Vrf.Rd)
+			}
 			if tt.expectedEntity.Tags != nil {
 				assert.Equal(t, len(tt.expectedEntity.Tags), len(ipAddress.Tags))
 				for i, tag := range tt.expectedEntity.Tags {
 					assert.Equal(t, tag.Name, ipAddress.Tags[i].Name)
 				}
+			}
+			if tt.expectedEntity.Tenant != nil {
+				assert.NotNil(t, ipAddress.Tenant)
+				assert.Equal(t, tt.expectedEntity.Tenant.Name, ipAddress.Tenant.Name)
 			}
 		})
 	}
@@ -371,7 +425,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "mapping with global defaults",
+			name: "mapping with defaults",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.2.2.1.1.1": {
 					OID:    "1.3.6.1.2.1.2.2.1.1.1",
@@ -406,112 +460,12 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Description: "Global description",
-				Tags:        []string{"global-tag1", "global-tag2"},
-			},
-			expectedEntity: &diode.Interface{
-				Name:        stringPtr("eth0"),
-				Description: stringPtr("Global description"),
-				Tags: []*diode.Tag{
-					{Name: stringPtr("global-tag1")},
-					{Name: stringPtr("global-tag2")},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "mapping with entity-specific defaults",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.2.2.1.1.1": {
-					OID:    "1.3.6.1.2.1.2.2.1.1.1",
-					Index:  "1",
-					Parent: "1.3.6.1.2.1.2.2.1.1",
-					Value:  "1",
-					Type:   mapping.Integer,
-				},
-				"1.3.6.1.2.1.2.2.1.2.1": {
-					OID:    "1.3.6.1.2.1.2.2.1.2.1",
-					Index:  "1",
-					Parent: "1.3.6.1.2.1.2.2.1.2",
-					Value:  "eth0",
-					Type:   mapping.OctetString,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.2.2.1.1",
-				Entity: "interface",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.2.2.1.1",
-						Entity: "interface",
-						Field:  "_id",
-					},
-					{
-						OID:    "1.3.6.1.2.1.2.2.1.2",
-						Entity: "interface",
-						Field:  "name",
-					},
-				},
-			},
-			defaults: &config.Defaults{
-				Interface: config.EntityDefaults{
+				Interface: config.InterfaceDefaults{
 					Description: "Interface specific description",
 					Tags:        []string{"interface-tag1", "interface-tag2"},
+					Type:        "ethernet",
 				},
-			},
-			expectedEntity: &diode.Interface{
-				Name:        stringPtr("eth0"),
-				Description: stringPtr("Interface specific description"),
-				Tags: []*diode.Tag{
-					{Name: stringPtr("interface-tag1")},
-					{Name: stringPtr("interface-tag2")},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "mapping with both global and entity-specific defaults",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.2.2.1.1.1": {
-					OID:    "1.3.6.1.2.1.2.2.1.1.1",
-					Index:  "1",
-					Parent: "1.3.6.1.2.1.2.2.1.1",
-					Value:  "1",
-					Type:   mapping.Integer,
-				},
-				"1.3.6.1.2.1.2.2.1.2.1": {
-					OID:    "1.3.6.1.2.1.2.2.1.2.1",
-					Index:  "1",
-					Parent: "1.3.6.1.2.1.2.2.1.2",
-					Value:  "eth0",
-					Type:   mapping.OctetString,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.2.2.1.1",
-				Entity: "interface",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.2.2.1.1",
-						Entity: "interface",
-						Field:  "_id",
-					},
-					{
-						OID:    "1.3.6.1.2.1.2.2.1.2",
-						Entity: "interface",
-						Field:  "name",
-					},
-				},
-			},
-			defaults: &config.Defaults{
-				Description: "Global description",
-				Tags:        []string{"global-tag1", "global-tag2"},
-				Interface: config.EntityDefaults{
-					Description: "Interface specific description",
-					Tags:        []string{"interface-tag1", "interface-tag2"},
-				},
+				Tags: []string{"global-tag1", "global-tag2"},
 			},
 			expectedEntity: &diode.Interface{
 				Name:        stringPtr("eth0"),
@@ -522,6 +476,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 					{Name: stringPtr("global-tag1")},
 					{Name: stringPtr("global-tag2")},
 				},
+				Type: stringPtr("ethernet"),
 			},
 			expectError: false,
 		},
@@ -599,6 +554,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			if tt.expectedEntity.PrimaryMacAddress != nil {
 				assert.Equal(t, tt.expectedEntity.PrimaryMacAddress.MacAddress, iface.PrimaryMacAddress.MacAddress)
 			}
+			assert.Equal(t, tt.expectedEntity.Type, iface.Type)
 			assert.Equal(t, tt.expectedEntity.Enabled, iface.Enabled)
 			assert.Equal(t, tt.expectedEntity.Description, iface.Description)
 			if tt.expectedEntity.Tags != nil {
@@ -685,82 +641,6 @@ func TestDeviceMapper_Map(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "mapping with global defaults",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.1.5.0": {
-					OID:    "1.3.6.1.2.1.1.5.0",
-					Index:  "0",
-					Parent: "1.3.6.1.2.1.1.5",
-					Value:  "router1",
-					Type:   mapping.OctetString,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.1",
-				Entity: "device",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.1.5",
-						Entity: "device",
-						Field:  "name",
-					},
-				},
-			},
-			defaults: &config.Defaults{
-				Description: "Global description",
-				Tags:        []string{"global-tag1", "global-tag2"},
-			},
-			expectedEntity: &diode.Device{
-				Name:        stringPtr("router1"),
-				Description: stringPtr("Global description"),
-				Tags: []*diode.Tag{
-					{Name: stringPtr("global-tag1")},
-					{Name: stringPtr("global-tag2")},
-				},
-			},
-			expectError: false,
-		},
-		{
-			name: "mapping with entity-specific defaults",
-			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
-				"1.3.6.1.2.1.1.5.0": {
-					OID:    "1.3.6.1.2.1.1.5.0",
-					Index:  "0",
-					Parent: "1.3.6.1.2.1.1.5",
-					Value:  "router1",
-					Type:   mapping.OctetString,
-				},
-			},
-			mappingEntry: &mapping.Entry{
-				OID:    "1.3.6.1.2.1.1",
-				Entity: "device",
-				Field:  "_id",
-				MappingEntries: []mapping.Entry{
-					{
-						OID:    "1.3.6.1.2.1.1.5",
-						Entity: "device",
-						Field:  "name",
-					},
-				},
-			},
-			defaults: &config.Defaults{
-				Device: config.EntityDefaults{
-					Description: "Device specific description",
-					Tags:        []string{"device-tag1", "device-tag2"},
-				},
-			},
-			expectedEntity: &diode.Device{
-				Name:        stringPtr("router1"),
-				Description: stringPtr("Device specific description"),
-				Tags: []*diode.Tag{
-					{Name: stringPtr("device-tag1")},
-					{Name: stringPtr("device-tag2")},
-				},
-			},
-			expectError: false,
-		},
-		{
 			name: "mapping with both global and entity-specific defaults",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.1.5.0": {
@@ -784,21 +664,37 @@ func TestDeviceMapper_Map(t *testing.T) {
 				},
 			},
 			defaults: &config.Defaults{
-				Description: "Global description",
-				Tags:        []string{"global-tag1", "global-tag2"},
-				Device: config.EntityDefaults{
+				Tags:     []string{"global-tag1", "global-tag2"},
+				Role:     "test-role",
+				Site:     "test-site",
+				Location: "test-location",
+				Device: config.DeviceDefaults{
 					Description: "Device specific description",
 					Tags:        []string{"device-tag1", "device-tag2"},
+					Comments:    "Device specific comments",
 				},
 			},
 			expectedEntity: &diode.Device{
 				Name:        stringPtr("router1"),
 				Description: stringPtr("Device specific description"),
+				Comments:    stringPtr("Device specific comments"),
 				Tags: []*diode.Tag{
 					{Name: stringPtr("device-tag1")},
 					{Name: stringPtr("device-tag2")},
 					{Name: stringPtr("global-tag1")},
 					{Name: stringPtr("global-tag2")},
+				},
+				Role: &diode.DeviceRole{
+					Name: stringPtr("test-role"),
+				},
+				Site: &diode.Site{
+					Name: stringPtr("test-site"),
+				},
+				Location: &diode.Location{
+					Name: stringPtr("test-location"),
+					Site: &diode.Site{
+						Name: stringPtr("test-site"),
+					},
 				},
 			},
 			expectError: false,
@@ -880,6 +776,13 @@ func TestDeviceMapper_Map(t *testing.T) {
 				assert.Equal(t, tt.expectedEntity.Platform.Manufacturer.Name, device.Platform.Manufacturer.Name)
 			}
 			assert.Equal(t, tt.expectedEntity.Description, device.Description)
+			if tt.expectedEntity.Location != nil {
+				assert.Equal(t, tt.expectedEntity.Location.Name, device.Location.Name)
+				assert.Equal(t, tt.expectedEntity.Location.Site.Name, device.Location.Site.Name)
+			}
+			if tt.expectedEntity.Site != nil {
+				assert.Equal(t, tt.expectedEntity.Site.Name, device.Site.Name)
+			}
 			if tt.expectedEntity.Tags != nil {
 				assert.Equal(t, len(tt.expectedEntity.Tags), len(device.Tags))
 				for i, tag := range tt.expectedEntity.Tags {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -372,7 +372,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 					OID:    "1.3.6.1.2.1.2.2.1.6.1",
 					Index:  "1",
 					Parent: "1.3.6.1.2.1.2.2.1.6",
-					Value:  "00:11:22:33:44:55",
+					Value:  "\\x00\\x11\\x22\\x33\\x44\\x55",
 					Type:   mapping.OctetString,
 				},
 				"1.3.6.1.2.1.2.2.1.7.1": {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/data"
 )

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -63,11 +63,11 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 			objectIDs: mapping.ObjectIDValueMap{
 				".1.3.6.1.2.1.2.2.1.2.999": mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.5.999": mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
-				".1.3.6.1.2.1.2.2.1.6.999": mapping.Value{Value: "00:00:00:00:00:00", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.6.999": mapping.Value{Value: "\x00\x00\x00\x00\x00\x00", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.7.999": mapping.Value{Value: "1", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.2.555": mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.5.555": mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
-				".1.3.6.1.2.1.2.2.1.6.555": mapping.Value{Value: "00:00:00:00:00:11", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.6.555": mapping.Value{Value: "\x00\x00\x00\x00\x00\x11", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.7.555": mapping.Value{Value: "0", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
 			},
 			expected: []diode.Entity{
@@ -141,7 +141,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 			objectIDs: mapping.ObjectIDValueMap{
 				".1.3.6.1.2.1.2.2.1.2.999":          mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.5.999":          mapping.Value{Value: "1000000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
-				".1.3.6.1.2.1.2.2.1.6.999":          mapping.Value{Value: "00:00:00:00:00:00", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.6.999":          mapping.Value{Value: "\x00\x00\x00\x00\x00\x00", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.2.2.1.7.999":          mapping.Value{Value: "1", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1},
 				".1.3.6.1.2.1.4.20.1.1.192.168.1.2": mapping.Value{Value: "192.168.1.2", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4},
 			},

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/stretchr/testify/assert"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
+	"github.com/stretchr/testify/assert"
 )
 
 type FakeManufacturers struct{}

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -160,7 +160,6 @@ func (m *Manager) HasPolicy(name string) bool {
 // StartPolicy starts the policy
 func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 	m.logger.Debug("Starting policy", "policy", policy)
-	m.logger.Debug("Starting policy", "policy", policy)
 	if len(policy.Scope.Targets) == 0 {
 		return fmt.Errorf("%s : no targets found in the policy", name)
 	}

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -8,10 +8,9 @@ import (
 	"os"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"gopkg.in/yaml.v3"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
+	"gopkg.in/yaml.v3"
 )
 
 // Manager represents the policy manager

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -7,12 +7,11 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // MockRunner mocks the Runner

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -95,7 +95,7 @@ func (r *Runner) run() {
 	expandedTargets := r.expandTargetRanges(r.scope.Targets)
 
 	entities = r.queryTargets(expandedTargets, objectIDs, mapper, entities)
-	r.logger.Info("SNMP crawl complete.")
+	r.logger.Info("SNMP crawl complete", slog.Any("policy", r.ctx.Value(policyKey)), slog.Any("entityCount", len(entities)))
 
 	if len(entities) == 0 {
 		r.logger.Info("No entities to ingest", slog.Any("policy", r.ctx.Value(policyKey)))

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/go-co-op/gocron/v2"
 	"github.com/netboxlabs/diode-sdk-go/diode"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/data"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -11,6 +11,7 @@ import (
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/data"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/targets"
 )
 
 // Define a custom type for the context key
@@ -86,20 +87,14 @@ func (r *Runner) run() {
 
 	mapper := mapping.NewObjectIDMapper(r.scope.Mappings, r.logger, r.manufacturers, &r.config.Defaults)
 	objectIDs := mapper.ObjectIDs()
+
 	r.logger.Info("Starting SNMP crawl of targets", slog.Any("targetCount", len(r.scope.Targets)), slog.Any("objectCount", len(objectIDs)))
 	entities := make([]diode.Entity, 0)
 
-	for _, target := range r.scope.Targets {
-		host := snmp.NewHost(target.Host, target.Port, r.config.Retries, &r.scope.Authentication, r.logger, r.ClientFactory)
-		oids, err := host.Walk(objectIDs)
-		if err != nil {
-			r.logger.Warn("Error crawling host", "host", target.Host, "error", err)
-			continue
-		}
+	// Expand all targets
+	expandedTargets := r.expandTargetRanges(r.scope.Targets)
 
-		entitiesForTarget := mapper.MapObjectIDsToEntity(oids)
-		entities = append(entities, entitiesForTarget...)
-	}
+	entities = r.queryTargets(expandedTargets, objectIDs, mapper, entities)
 	r.logger.Info("SNMP crawl complete.")
 
 	if len(entities) == 0 {
@@ -115,6 +110,39 @@ func (r *Runner) run() {
 	} else {
 		r.logger.Info("entities ingested successfully", slog.Any("policy", r.ctx.Value(policyKey)))
 	}
+}
+
+func (r *Runner) queryTargets(expandedTargets []config.Target, objectIDs map[string]int, mapper *mapping.ObjectIDMapper, entities []diode.Entity) []diode.Entity {
+	for _, target := range expandedTargets {
+		host := snmp.NewHost(target.Host, target.Port, r.config.Retries, &r.scope.Authentication, r.logger, r.ClientFactory)
+		oids, err := host.Walk(objectIDs)
+		if err != nil {
+			r.logger.Warn("Error crawling host", "host", target.Host, "error", err)
+			continue
+		}
+
+		entitiesForTarget := mapper.MapObjectIDsToEntity(oids)
+		entities = append(entities, entitiesForTarget...)
+	}
+	return entities
+}
+
+func (r *Runner) expandTargetRanges(configuredTargets []config.Target) []config.Target {
+	var expandedTargets []config.Target
+	for _, target := range configuredTargets {
+		ips, err := targets.Expand(target.Host)
+		if err != nil {
+			r.logger.Warn("Error expanding target host", "host", target.Host, "error", err)
+			continue
+		}
+		for _, ip := range ips {
+			expandedTargets = append(expandedTargets, config.Target{
+				Host: ip,
+				Port: target.Port,
+			})
+		}
+	}
+	return expandedTargets
 }
 
 // Start starts the policy runner

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -10,12 +10,11 @@ import (
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type MockDiodeClient struct {
@@ -119,19 +118,17 @@ func TestRunnerRun(t *testing.T) {
 				Config: config.PolicyConfig{
 					Schedule: nil,
 					Defaults: config.Defaults{
-						Description: "Test",
-						Comments:    "This is a test",
-						Tags:        []string{"test", "snmp"},
-						IPAddress: config.EntityDefaults{
+						Tags: []string{"test", "snmp"},
+						IPAddress: config.IPAddressDefaults{
 							Description: "IP Address Default",
 							Comments:    "IP Address Comment",
 							Tags:        []string{"ip", "default"},
 						},
-						Interface: config.EntityDefaults{
+						Interface: config.InterfaceDefaults{
 							Description: "Interface Default",
 							Tags:        []string{"interface", "default"},
 						},
-						Device: config.EntityDefaults{
+						Device: config.DeviceDefaults{
 							Description: "Device Default",
 							Tags:        []string{"device", "default"},
 						},
@@ -203,19 +200,17 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	policyConfig := config.Policy{
 		Config: config.PolicyConfig{
 			Defaults: config.Defaults{
-				Description: "Test",
-				Comments:    "This is a test",
-				Tags:        []string{"test", "snmp"},
-				IPAddress: config.EntityDefaults{
+				Tags: []string{"test", "snmp"},
+				IPAddress: config.IPAddressDefaults{
 					Description: "IP Address Default",
 					Comments:    "IP Address Comment",
 					Tags:        []string{"ip", "default"},
 				},
-				Interface: config.EntityDefaults{
+				Interface: config.InterfaceDefaults{
 					Description: "Interface Default",
 					Tags:        []string{"interface", "default"},
 				},
-				Device: config.EntityDefaults{
+				Device: config.DeviceDefaults{
 					Description: "Device Default",
 					Tags:        []string{"device", "default"},
 				},

--- a/snmp-discovery/scripts/create-cisco-device-list.sh
+++ b/snmp-discovery/scripts/create-cisco-device-list.sh
@@ -21,7 +21,7 @@ grep "1\.3\.6\.1\.4\.1\.9\.1\." "$TMPFILE" | while read -r line; do
   ID=$(echo "$OID" | awk -F. '{print $NF}')
   echo "  - id: $ID"
   echo "    oid: $OID"
-  echo "    name: $NAME"
+  echo "    name: \"$NAME\""
 done
 
 # Clean up

--- a/snmp-discovery/scripts/create-device-data.sh
+++ b/snmp-discovery/scripts/create-device-data.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Get the directory where this script is located
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
 if [ -z "$1" ]; then
     echo "Usage: $0 <output_file>"
     exit 1
@@ -12,13 +15,13 @@ TMP_MANUFACTURERS=$(mktemp)
 TMP_DEVICES=$(mktemp)
 
 echo "Saving manufacturers to $TMP_MANUFACTURERS"
-./scripts/create-manufacturer-list.py > "$TMP_MANUFACTURERS"
+"$SCRIPT_DIR/create-manufacturer-list.py" > "$TMP_MANUFACTURERS"
 
 echo "Saving cisco devices to $TMP_DEVICES"
-./scripts/create-cisco-device-list.sh > "$TMP_DEVICES"
+"$SCRIPT_DIR/create-cisco-device-list.sh" > "$TMP_DEVICES"
 
 echo "Merging manufacturers and devices to $OUTPUT"
-./scripts/merge_yaml.py "$TMP_MANUFACTURERS" "$TMP_DEVICES" > "$OUTPUT"
+"$SCRIPT_DIR/merge_yaml.py" "$TMP_MANUFACTURERS" "$TMP_DEVICES" > "$OUTPUT"
 
 echo "Cleaning up"
 rm "$TMP_MANUFACTURERS" "$TMP_DEVICES"

--- a/snmp-discovery/scripts/merge_yaml.py
+++ b/snmp-discovery/scripts/merge_yaml.py
@@ -50,7 +50,7 @@ def parse_value(val):
     # Try to convert to int if possible
     if re.match(r'^\d+$', val):
         return int(val)
-    return val
+    return re.sub(r'[^a-zA-Z0-9\s]', '', val)
 
 def merge_dicts(dicts):
     merged = {}

--- a/snmp-discovery/server/server.go
+++ b/snmp-discovery/server/server.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/gin-gonic/gin"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
 )

--- a/snmp-discovery/server/server.go
+++ b/snmp-discovery/server/server.go
@@ -105,7 +105,7 @@ func (s *Server) createPolicy(c *gin.Context) {
 		return
 	}
 
-	s.logger.Info("Found %d policies", "policyCount", len(policies))
+	s.logger.Info("Received policies", "policyCount", len(policies))
 
 	rPolicies := []string{}
 	for name, policy := range policies {

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -12,11 +12,10 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/server"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 type MockClient struct {

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -2,7 +2,6 @@ package snmp
 
 import (
 	"github.com/gosnmp/gosnmp"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 )
 

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/gosnmp/gosnmp"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
 )

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -10,12 +10,11 @@ import (
 	"github.com/gosnmp/gosnmp"
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/diode-sdk-go/diode/v1/diodepb"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 // MockSNMP is a mock for Walker

--- a/snmp-discovery/targets/targets.go
+++ b/snmp-discovery/targets/targets.go
@@ -1,0 +1,126 @@
+package targets
+
+import (
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+)
+
+// Expand takes a target string and returns a slice of individual IP addresses or hostnames.
+// It supports the following formats:
+// - CIDR notation (e.g., 10.10.10.0/24)
+// - IP range notation (e.g., 10.10.10.0-100)
+// - Single IP address (e.g., 192.168.1.1)
+// - Hostname (e.g., example.com)
+func Expand(target string) ([]string, error) {
+	// Try parsing as CIDR first
+	if strings.Contains(target, "/") {
+		return expandCIDR(target)
+	}
+
+	// Try parsing as IP range
+	if strings.Contains(target, "-") {
+		return expandIPRange(target)
+	}
+
+	// Try parsing as single IP
+	if ip := net.ParseIP(target); ip != nil {
+		return []string{target}, nil
+	}
+
+	// If not an IP, assume it's a hostname
+	return []string{target}, nil
+}
+
+// expandCIDR expands a CIDR notation into individual IP addresses
+func expandCIDR(cidr string) ([]string, error) {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid CIDR notation: %w", err)
+	}
+
+	// Convert IPNet to IP
+	ip := ipnet.IP.To4()
+	if ip == nil {
+		return nil, fmt.Errorf("only IPv4 addresses are supported")
+	}
+
+	// Get network and broadcast addresses
+	mask := ipnet.Mask
+	network := ip.Mask(mask)
+	broadcast := make(net.IP, len(network))
+	for i := range network {
+		broadcast[i] = network[i] | ^mask[i]
+	}
+
+	// Generate all IPs in range
+	var ips []string
+	ip = make(net.IP, len(network))
+	copy(ip, network)
+
+	// Include network address
+	ips = append(ips, ip.String())
+
+	// Generate all IPs including broadcast
+	for inc(ip); ip.To4() != nil && !ip.Equal(broadcast); inc(ip) {
+		ips = append(ips, ip.String())
+	}
+
+	// Include broadcast address
+	ips = append(ips, broadcast.String())
+
+	return ips, nil
+}
+
+// expandIPRange expands an IP range notation (e.g., 10.10.10.0-100) into individual IP addresses
+func expandIPRange(rangeStr string) ([]string, error) {
+	parts := strings.Split(rangeStr, "-")
+	if len(parts) != 2 {
+		return nil, fmt.Errorf("invalid IP range format")
+	}
+
+	baseIP := net.ParseIP(strings.TrimSpace(parts[0]))
+	if baseIP == nil {
+		return nil, fmt.Errorf("invalid base IP address")
+	}
+
+	baseIP = baseIP.To4()
+	if baseIP == nil {
+		return nil, fmt.Errorf("only IPv4 addresses are supported")
+	}
+
+	endNum, err := strconv.Atoi(strings.TrimSpace(parts[1]))
+	if err != nil {
+		return nil, fmt.Errorf("invalid end number in range: %w", err)
+	}
+
+	if endNum < 0 || endNum > 255 {
+		return nil, fmt.Errorf("end number must be between 0 and 255")
+	}
+
+	var ips []string
+	baseNum := int(baseIP[3])
+	if endNum < baseNum {
+		return nil, fmt.Errorf("end number must be greater than or equal to the last octet of the base IP")
+	}
+
+	for i := baseNum; i <= endNum; i++ {
+		ip := make(net.IP, len(baseIP))
+		copy(ip, baseIP)
+		ip[3] = byte(i)
+		ips = append(ips, ip.String())
+	}
+
+	return ips, nil
+}
+
+// inc increments an IP address
+func inc(ip net.IP) {
+	for j := len(ip) - 1; j >= 0; j-- {
+		ip[j]++
+		if ip[j] > 0 {
+			break
+		}
+	}
+}

--- a/snmp-discovery/targets/targets_test.go
+++ b/snmp-discovery/targets/targets_test.go
@@ -1,0 +1,187 @@
+package targets
+
+import (
+	"testing"
+)
+
+func TestExpand(t *testing.T) {
+	tests := []struct {
+		name        string
+		target      string
+		want        []string
+		shouldError bool
+	}{
+		{
+			name:   "Single IP",
+			target: "192.168.1.1",
+			want:   []string{"192.168.1.1"},
+		},
+		{
+			name:   "Hostname",
+			target: "example.com",
+			want:   []string{"example.com"},
+		},
+		{
+			name:        "Invalid CIDR",
+			target:      "192.168.1.1/33",
+			shouldError: true,
+		},
+		{
+			name:        "Invalid IP Range",
+			target:      "192.168.1.1-300",
+			shouldError: true,
+		},
+		{
+			name:        "Invalid IP Range Format",
+			target:      "192.168.1.1-2-3",
+			shouldError: true,
+		},
+		{
+			name:        "Invalid Base IP",
+			target:      "invalid-100",
+			shouldError: true,
+		},
+		{
+			name:        "Range End Less Than Start",
+			target:      "192.168.1.100-50",
+			shouldError: true,
+		},
+		{
+			name:        "IPv6 CIDR",
+			target:      "2001:db8::/32",
+			shouldError: true,
+		},
+		{
+			name:        "IPv6 Range",
+			target:      "2001:db8::1-100",
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Expand(tt.target)
+			if (err != nil) != tt.shouldError {
+				t.Errorf("Expand() error = %v, shouldError %v", err, tt.shouldError)
+				return
+			}
+			if !tt.shouldError && !compareStringSlices(got, tt.want) {
+				t.Errorf("Expand() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandCIDR(t *testing.T) {
+	tests := []struct {
+		name        string
+		cidr        string
+		want        int // expected number of IPs
+		shouldError bool
+	}{
+		{
+			name: "Valid /24 CIDR",
+			cidr: "192.168.1.0/24",
+			want: 256,
+		},
+		{
+			name: "Valid /30 CIDR",
+			cidr: "192.168.1.0/30",
+			want: 4,
+		},
+		{
+			name:        "Invalid CIDR",
+			cidr:        "192.168.1.1/33",
+			shouldError: true,
+		},
+		{
+			name:        "Invalid IP",
+			cidr:        "256.168.1.0/24",
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := expandCIDR(tt.cidr)
+			if (err != nil) != tt.shouldError {
+				t.Errorf("expandCIDR() error = %v, shouldError %v", err, tt.shouldError)
+				return
+			}
+			if !tt.shouldError && len(got) != tt.want {
+				t.Errorf("expandCIDR() returned %d IPs, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandIPRange(t *testing.T) {
+	tests := []struct {
+		name        string
+		rangeStr    string
+		want        int // expected number of IPs
+		shouldError bool
+	}{
+		{
+			name:     "Valid Range",
+			rangeStr: "192.168.1.1-5",
+			want:     5,
+		},
+		{
+			name:     "Single IP Range",
+			rangeStr: "192.168.1.1-1",
+			want:     1,
+		},
+		{
+			name:        "Invalid Range Format",
+			rangeStr:    "192.168.1.1-2-3",
+			shouldError: true,
+		},
+		{
+			name:        "Invalid Base IP",
+			rangeStr:    "invalid-100",
+			shouldError: true,
+		},
+		{
+			name:        "Range End Less Than Start",
+			rangeStr:    "192.168.1.100-50",
+			shouldError: true,
+		},
+		{
+			name:        "Range End Too Large",
+			rangeStr:    "192.168.1.1-300",
+			shouldError: true,
+		},
+		{
+			name:        "Non-numeric Range End",
+			rangeStr:    "192.168.0.0-ten",
+			shouldError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := expandIPRange(tt.rangeStr)
+			if (err != nil) != tt.shouldError {
+				t.Errorf("expandIPRange() error = %v, shouldError %v", err, tt.shouldError)
+				return
+			}
+			if !tt.shouldError && len(got) != tt.want {
+				t.Errorf("expandIPRange() returned %d IPs, want %d", len(got), tt.want)
+			}
+		})
+	}
+}
+
+// Helper function to compare string slices
+func compareStringSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/snmp-discovery/version/version_test.go
+++ b/snmp-discovery/version/version_test.go
@@ -3,9 +3,8 @@ package version_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/version"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestVersion(t *testing.T) {


### PR DESCRIPTION
This pull request introduces multiple updates across various files to enhance functionality, improve compatibility, and refine configurations. Key changes include updates to semantic release rules, Go version upgrades, SNMP discovery feature enhancements, and the addition of default value mappings for entities.

### Semantic Release Rules Updates:
* Added support for `major*` commit messages to trigger major version releases in `.github/workflows/device-discovery-release.yaml`, `.github/workflows/network-discovery-release.yaml`, `.github/workflows/worker-release.yaml`, and `.github/workflows/snmp-discovery-release.yaml`. [[1]](diffhunk://#diff-950ab6e4df215649e66efacd9a47040b86a7fd9494c32660cde2aea0f58a02d0L80-R81) [[2]](diffhunk://#diff-950ab6e4df215649e66efacd9a47040b86a7fd9494c32660cde2aea0f58a02d0L221-R223) [[3]](diffhunk://#diff-9e83be94be4c5a084d3b8bd5b054f1fd774314525af718e3a1a03b1f2fa09421L67-R68) [[4]](diffhunk://#diff-9e83be94be4c5a084d3b8bd5b054f1fd774314525af718e3a1a03b1f2fa09421L207-R209) [[5]](diffhunk://#diff-b7662b3976a0fc851e80c2ccc9ed4fcef2683df1ceeac5f1bea89c2d249956f2L80-R81) [[6]](diffhunk://#diff-b7662b3976a0fc851e80c2ccc9ed4fcef2683df1ceeac5f1bea89c2d249956f2L221-R223)

### Go Version Upgrades:
* Updated Go version from `1.23.x` to `1.24.x` in `.github/workflows/snmp-discovery-lint.yaml`, `.github/workflows/snmp-discovery-tests.yaml`, `snmp-discovery/docker/Dockerfile`, and `snmp-discovery/go.mod`. [[1]](diffhunk://#diff-c39a5aa4a354c7f3183ca64e559aaec2508b8b74c53fc83efc31cb10ac6b8797L26-R31) [[2]](diffhunk://#diff-aaa7dbb08f9c9e15953d3e75405abbf9d28f9d84ce453fb6d8628f82129840aaL35-R35) [[3]](diffhunk://#diff-f843a06d81f89848c1fd359f129a47d9ae7e1a13f300fc6641222e3786767906L1-R1) [[4]](diffhunk://#diff-b317fe0c907478d97c235e904821194309658448be78cf050d9ada1dd275ec8fL3-R3)

### SNMP Discovery Enhancements:
* Expanded `host` field in `targets` to support CIDR ranges, dash ranges, and hostnames in `snmp-discovery/README.md`. [[1]](diffhunk://#diff-fbffef8cc46e9659ab7585122a69d863e94f180f7fe48ea221791f0320e58779R57-R59) [[2]](diffhunk://#diff-fbffef8cc46e9659ab7585122a69d863e94f180f7fe48ea221791f0320e58779L68-R85)
* Added new workflow `.github/workflows/snmp-discovery-release.yaml` to automate SNMP discovery releases.

### Entity Default Value Mapping:
* Introduced detailed default value mappings for `IPAddress`, `Interface`, and `Device` entities in `snmp-discovery/config/config.go` and implemented `applyDefaults` method in `snmp-discovery/mapping/mappers.go`. [[1]](diffhunk://#diff-6ca23964054f973f61443ee3c52410a7bdcc1215394ef455d5d7d62a56676cd2L38-R70) [[2]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL10-R72)

### Miscellaneous Improvements:
* Fixed import order in `snmp-discovery/cmd/main.go` and `snmp-discovery/config/logger_test.go`. [[1]](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L13) [[2]](diffhunk://#diff-2b83d6ab9dd330737bee368cbe0c80e5f22d2a8648729076659a9c2e2f7017e1R7-L10)
* Updated `Makefile` to use the latest version of `golangci-lint` from v2.