### PR TITLE
feat: add network_mask and proper hostname to network discovery

### DIFF
--- a/network-discovery/config/config.go
+++ b/network-discovery/config/config.go
@@ -47,16 +47,18 @@ type Scope struct {
 	TopPorts     *int     `yaml:"top_ports,omitempty"`
 	ScanTypes    []string `yaml:"scan_types,omitempty"`
 	MaxRetries   *int     `yaml:"max_retries,omitempty"`
+	DNSServers   []string `yaml:"dns_servers,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy
 type Defaults struct {
-	Vrf         string   `yaml:"vrf,omitempty"`
-	Tenant      string   `yaml:"tenant,omitempty"`
-	Role        string   `yaml:"role,omitempty"`
-	Description string   `yaml:"description,omitempty"`
-	Comments    string   `yaml:"comments,omitempty"`
-	Tags        []string `yaml:"tags,omitempty"`
+	Vrf           string   `yaml:"vrf,omitempty"`
+	Tenant        string   `yaml:"tenant,omitempty"`
+	Role          string   `yaml:"role,omitempty"`
+	Description   string   `yaml:"description,omitempty"`
+	Comments      string   `yaml:"comments,omitempty"`
+	Tags          []string `yaml:"tags,omitempty"`
+	NetworkPrefix *int     `yaml:"network_prefix,omitempty"`
 }
 
 // PolicyConfig represents the configuration of a policy

--- a/network-discovery/config/config.go
+++ b/network-discovery/config/config.go
@@ -52,13 +52,13 @@ type Scope struct {
 
 // Defaults represents the supported default values for a policy
 type Defaults struct {
-	Vrf           string   `yaml:"vrf,omitempty"`
-	Tenant        string   `yaml:"tenant,omitempty"`
-	Role          string   `yaml:"role,omitempty"`
-	Description   string   `yaml:"description,omitempty"`
-	Comments      string   `yaml:"comments,omitempty"`
-	Tags          []string `yaml:"tags,omitempty"`
-	NetworkPrefix *int     `yaml:"network_prefix,omitempty"`
+	Vrf         string   `yaml:"vrf,omitempty"`
+	Tenant      string   `yaml:"tenant,omitempty"`
+	Role        string   `yaml:"role,omitempty"`
+	Description string   `yaml:"description,omitempty"`
+	Comments    string   `yaml:"comments,omitempty"`
+	Tags        []string `yaml:"tags,omitempty"`
+	NetworkMask *int     `yaml:"network_mask,omitempty"`
 }
 
 // PolicyConfig represents the configuration of a policy

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -120,9 +120,9 @@ func (r *Runner) run() {
 		options = append(options, nmap.WithMostCommonPorts(*r.scope.TopPorts))
 	}
 
-	NetPrefix := "/32"
-	if r.config.Defaults.NetworkPrefix != nil && *r.config.Defaults.NetworkPrefix > 0 {
-		NetPrefix = fmt.Sprintf("/%d", *r.config.Defaults.NetworkPrefix)
+	NetMask := "/32"
+	if r.config.Defaults.NetworkMask != nil && *r.config.Defaults.NetworkMask > 0 {
+		NetMask = fmt.Sprintf("/%d", *r.config.Defaults.NetworkMask)
 	}
 
 	hasOtherScans := false
@@ -243,7 +243,7 @@ func (r *Runner) run() {
 		r.logger.Debug("processing host", slog.Any("host_address", host.Addresses), slog.Any("host_ports", host.Ports),
 			slog.Any("host_hostnames", host.Hostnames), slog.String("policy", policyName))
 		ip := &diode.IPAddress{
-			Address: diode.String(host.Addresses[0].Addr + NetPrefix),
+			Address: diode.String(host.Addresses[0].Addr + NetMask),
 		}
 		if r.config.Defaults.Description != "" {
 			ip.Description = diode.String(r.config.Defaults.Description)

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -104,6 +104,10 @@ func (r *Runner) run() {
 		nmap.WithPortExclusions(r.scope.ExcludePorts...)
 	}
 
+	if len(r.scope.DNSServers) > 0 {
+		options = append(options, nmap.WithCustomDNSServers(r.scope.DNSServers...))
+	}
+
 	if r.scope.FastMode != nil && *r.scope.FastMode {
 		options = append(options, nmap.WithFastMode())
 	}
@@ -114,6 +118,11 @@ func (r *Runner) run() {
 
 	if r.scope.TopPorts != nil {
 		options = append(options, nmap.WithMostCommonPorts(*r.scope.TopPorts))
+	}
+
+	NetPrefix := "/32"
+	if r.config.Defaults.NetworkPrefix != nil && *r.config.Defaults.NetworkPrefix > 0 {
+		NetPrefix = fmt.Sprintf("/%d", *r.config.Defaults.NetworkPrefix)
 	}
 
 	hasOtherScans := false
@@ -175,6 +184,7 @@ func (r *Runner) run() {
 
 	options = append(options, nmap.WithNonInteractive())
 	options = append(options, nmap.WithTargets(r.scope.Targets...))
+	options = append(options, nmap.WithForcedDNSResolution())
 
 	scanner, err := nmap.NewScanner(ctx, options...)
 	if err != nil {
@@ -233,7 +243,7 @@ func (r *Runner) run() {
 		r.logger.Debug("processing host", slog.Any("host_address", host.Addresses), slog.Any("host_ports", host.Ports),
 			slog.Any("host_hostnames", host.Hostnames), slog.String("policy", policyName))
 		ip := &diode.IPAddress{
-			Address: diode.String(host.Addresses[0].Addr + "/32"),
+			Address: diode.String(host.Addresses[0].Addr + NetPrefix),
 		}
 		if r.config.Defaults.Description != "" {
 			ip.Description = diode.String(r.config.Defaults.Description)
@@ -265,6 +275,20 @@ func (r *Runner) run() {
 			ip.Tags = tags
 		}
 
+		if host.Hostnames != nil {
+			var fallbackHostname string
+			for _, hostname := range host.Hostnames {
+				fallbackHostname = hostname.Name
+				if hostname.Type == "PTR" {
+					ip.DnsName = diode.String(hostname.Name)
+					break
+				}
+			}
+			if ip.DnsName == nil && fallbackHostname != "" {
+				ip.DnsName = diode.String(fallbackHostname)
+			}
+		}
+
 		if !hasComments {
 			var metadata config.HostMetadata
 
@@ -274,15 +298,6 @@ func (r *Runner) run() {
 					metadata.ExtraPorts[i] = config.ExtraPort{
 						State: extraPort.State,
 						Count: extraPort.Count,
-					}
-				}
-			}
-			if host.Hostnames != nil {
-				metadata.Hostnames = make([]config.Hostname, len(host.Hostnames))
-				for i, hostname := range host.Hostnames {
-					metadata.Hostnames[i] = config.Hostname{
-						Name: hostname.Name,
-						Type: hostname.Type,
 					}
 				}
 			}

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -134,8 +134,8 @@ func TestRunnerWithOptions(t *testing.T) {
 			policy: config.Policy{
 				Config: config.PolicyConfig{
 					Defaults: config.Defaults{
-						Description:   "Test with ports",
-						NetworkPrefix: intPtr(24),
+						Description: "Test with ports",
+						NetworkMask: intPtr(24),
 					},
 				},
 				Scope: config.Scope{

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -132,11 +132,17 @@ func TestRunnerWithOptions(t *testing.T) {
 		{
 			name: "with ports and exclude ports",
 			policy: config.Policy{
-				Config: config.PolicyConfig{},
+				Config: config.PolicyConfig{
+					Defaults: config.Defaults{
+						Description:   "Test with ports",
+						NetworkPrefix: intPtr(24),
+					},
+				},
 				Scope: config.Scope{
 					Targets:      []string{"localhost"},
 					Ports:        []string{"80", "443"},
 					ExcludePorts: []string{"22"},
+					DNSServers:   []string{"8.8.8.8"},
 				},
 			},
 		},


### PR DESCRIPTION
This pull request introduces enhancements to the network discovery tool, focusing on DNS configuration, network prefix customization, and improved hostname handling. These changes add flexibility and robustness to the tool's configuration and execution.

### Enhancements to configuration options:
* Added `DNSServers` field to the `Scope` struct to allow specifying custom DNS servers for network scans (`network-discovery/config/config.go`).
* Added `NetworkPrefix` field to the `Defaults` struct to support customizable network prefixes for IP address processing (`network-discovery/config/config.go`).

### Updates to the scanning logic:
* Integrated the `DNSServers` field into the runner logic to enable custom DNS server usage during scans (`network-discovery/policy/runner.go`).
* Added logic to apply the `NetworkPrefix` field when formatting IP addresses, defaulting to `/32` if not specified (`network-discovery/policy/runner.go`). [[1]](diffhunk://#diff-cd137d22aa443fd1284d18bdc5bae57a78e9a4352e5fc306c1efd5b09681da4cR123-R127) [[2]](diffhunk://#diff-cd137d22aa443fd1284d18bdc5bae57a78e9a4352e5fc306c1efd5b09681da4cL236-R246)
* Enforced DNS resolution by adding `nmap.WithForcedDNSResolution()` to the scanning options (`network-discovery/policy/runner.go`).

### Improvements to hostname processing:
* Enhanced hostname handling to prioritize PTR records for DNS names while falling back to the first available hostname if no PTR is found (`network-discovery/policy/runner.go`).
* Removed redundant hostname metadata processing to streamline the code (`network-discovery/policy/runner.go`).

### Test coverage updates:
* Updated the `TestRunnerWithOptions` test to include scenarios for `NetworkPrefix` and `DNSServers`, ensuring the new fields are validated (`network-discovery/policy/runner_test.go`).



## Results
for a simple policy like this
```
policies:
    discovery_1:
        config:
          defaults:
            network_prefix: 26
        scope:
          targets:
            - 192.168.31.110/26
          fast_mode: true
```

![image](https://github.com/user-attachments/assets/4ff99f29-f1a6-4149-9edc-4a3cf3d98f9b)

