### PR TITLE
Feat/obs 1068 target network mask

### DIFF
--- a/network-discovery/config/config.go
+++ b/network-discovery/config/config.go
@@ -38,17 +38,18 @@ type Status struct {
 
 // Scope represents the scope of a policy
 type Scope struct {
-	Targets      []string `yaml:"targets"`
-	Ports        []string `yaml:"ports,omitempty"`
-	ExcludePorts []string `yaml:"exclude_ports,omitempty"`
-	Timing       *int     `yaml:"timing,omitempty"`
-	FastMode     *bool    `yaml:"fast_mode,omitempty"`
-	PingScan     *bool    `yaml:"ping_scan,omitempty"`
-	TopPorts     *int     `yaml:"top_ports,omitempty"`
-	ScanTypes    []string `yaml:"scan_types,omitempty"`
-	MaxRetries   *int     `yaml:"max_retries,omitempty"`
-	DNSServers   []string `yaml:"dns_servers,omitempty"`
-	OSDetection  *bool    `yaml:"os_detection,omitempty"`
+	Targets        []string `yaml:"targets"`
+	Ports          []string `yaml:"ports,omitempty"`
+	ExcludePorts   []string `yaml:"exclude_ports,omitempty"`
+	Timing         *int     `yaml:"timing,omitempty"`
+	FastMode       *bool    `yaml:"fast_mode,omitempty"`
+	PingScan       *bool    `yaml:"ping_scan,omitempty"`
+	TopPorts       *int     `yaml:"top_ports,omitempty"`
+	ScanTypes      []string `yaml:"scan_types,omitempty"`
+	MaxRetries     *int     `yaml:"max_retries,omitempty"`
+	DNSServers     []string `yaml:"dns_servers,omitempty"`
+	OSDetection    *bool    `yaml:"os_detection,omitempty"`
+	UseTargetMasks *bool    `yaml:"use_target_masks,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy

--- a/network-discovery/config/config.go
+++ b/network-discovery/config/config.go
@@ -48,6 +48,7 @@ type Scope struct {
 	ScanTypes    []string `yaml:"scan_types,omitempty"`
 	MaxRetries   *int     `yaml:"max_retries,omitempty"`
 	DNSServers   []string `yaml:"dns_servers,omitempty"`
+	OSDetection  *bool    `yaml:"os_detection,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -65,23 +65,26 @@ func parseTargets(targets []string) []targetInfo {
 	return result
 }
 
-// getIPWithMask returns the IP address with the appropriate mask based on the target network
-func (r *Runner) getIPWithMask(ipStr string, defaultMask string, processedEntries map[string]bool) string {
+// getIPWithMask returns the IP address with the appropriate mask based on the most specific target network
+func (r *Runner) getIPWithMask(ipStr string, defaultMask string) string {
 	ip := net.ParseIP(ipStr)
 	if ip == nil {
 		return ipStr + defaultMask
 	}
-	var matchingTargets []targetInfo
+
+	var bestTarget *targetInfo
+	var bestMask int
 	for _, target := range r.targets {
 		if target.network.Contains(ip) {
-			matchingTargets = append(matchingTargets, target)
+			maskBits, _ := target.network.Mask.Size()
+			if bestTarget == nil || maskBits > bestMask {
+				bestTarget = &target
+				bestMask = maskBits
+			}
 		}
 	}
-	for _, target := range matchingTargets {
-		if _, exists := processedEntries[ipStr+target.mask]; exists {
-			continue
-		}
-		return ipStr + target.mask
+	if bestTarget != nil {
+		return ipStr + bestTarget.mask
 	}
 	return ipStr + defaultMask
 }
@@ -307,9 +310,20 @@ func (r *Runner) run() {
 		if len(host.Addresses) == 0 {
 			continue
 		}
+		addr := host.Addresses[0].Addr
 
-		ipAddr := r.getIPWithMask(host.Addresses[0].Addr, defaultMask, processedEntries)
-		processedEntries[ipAddr] = true
+		if _, exists := processedEntries[addr]; exists {
+			r.logger.Info("skipping already processed IP address", slog.String("ip_address", addr), slog.String("policy", policyName))
+			continue
+		}
+
+		var ipAddr string
+		if r.scope.UseTargetMasks != nil && *r.scope.UseTargetMasks {
+			ipAddr = r.getIPWithMask(addr, defaultMask)
+		} else {
+			ipAddr = addr + defaultMask
+		}
+		processedEntries[addr] = true
 
 		ip := &diode.IPAddress{
 			Address: diode.String(ipAddr),

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -303,15 +303,13 @@ func (r *Runner) run() {
 	}
 
 	for _, host := range result.Hosts {
-
 		r.logger.Debug("processing host", slog.Any("host_address", host.Addresses), slog.Any("host_ports", host.Ports),
 			slog.Any("host_hostnames", host.Hostnames), slog.String("policy", policyName))
-
 		if len(host.Addresses) == 0 {
 			continue
 		}
-		addr := host.Addresses[0].Addr
 
+		addr := host.Addresses[0].Addr
 		if _, exists := processedEntries[addr]; exists {
 			r.logger.Info("skipping already processed IP address", slog.String("ip_address", addr), slog.String("policy", policyName))
 			continue

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
+	"strings"
 	"time"
 
 	"github.com/Ullaakut/nmap/v3"
@@ -25,6 +27,13 @@ const (
 	defaultTimeout            = 2 * time.Minute
 )
 
+// targetInfo stores information about each target
+type targetInfo struct {
+	original string
+	network  *net.IPNet
+	mask     string
+}
+
 // Runner represents the policy runner
 type Runner struct {
 	scheduler gocron.Scheduler
@@ -35,6 +44,46 @@ type Runner struct {
 	timeout   time.Duration
 	scope     config.Scope
 	config    config.PolicyConfig
+	targets   []targetInfo
+}
+
+// parseTargets parses the target specifications and returns targetInfo slice
+func parseTargets(targets []string) []targetInfo {
+	var result []targetInfo
+	for _, target := range targets {
+		if strings.Contains(target, "/") {
+			info := targetInfo{original: target}
+			_, network, err := net.ParseCIDR(target)
+			if err == nil {
+				info.network = network
+				maskBits, _ := network.Mask.Size()
+				info.mask = fmt.Sprintf("/%d", maskBits)
+				result = append(result, info)
+			}
+		}
+	}
+	return result
+}
+
+// getIPWithMask returns the IP address with the appropriate mask based on the target network
+func (r *Runner) getIPWithMask(ipStr string, defaultMask string, processedEntries map[string]bool) string {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return ipStr + defaultMask
+	}
+	var matchingTargets []targetInfo
+	for _, target := range r.targets {
+		if target.network.Contains(ip) {
+			matchingTargets = append(matchingTargets, target)
+		}
+	}
+	for _, target := range matchingTargets {
+		if _, exists := processedEntries[ipStr+target.mask]; exists {
+			continue
+		}
+		return ipStr + target.mask
+	}
+	return ipStr + defaultMask
 }
 
 // NewRunner returns a new policy runner
@@ -67,6 +116,9 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	runner.ctx = context.WithValue(ctx, policyKey, name)
 	runner.scope = policy.Scope
 	runner.config = policy.Config
+
+	runner.targets = parseTargets(policy.Scope.Targets)
+
 	return runner, nil
 }
 
@@ -97,11 +149,11 @@ func (r *Runner) run() {
 	var options []nmap.Option
 
 	if len(r.scope.Ports) > 0 {
-		nmap.WithPorts(r.scope.Ports...)
+		options = append(options, nmap.WithPorts(r.scope.Ports...))
 	}
 
 	if len(r.scope.ExcludePorts) > 0 {
-		nmap.WithPortExclusions(r.scope.ExcludePorts...)
+		options = append(options, nmap.WithPortExclusions(r.scope.ExcludePorts...))
 	}
 
 	if len(r.scope.DNSServers) > 0 {
@@ -123,11 +175,6 @@ func (r *Runner) run() {
 
 	if r.scope.TopPorts != nil {
 		options = append(options, nmap.WithMostCommonPorts(*r.scope.TopPorts))
-	}
-
-	NetMask := "/32"
-	if r.config.Defaults.NetworkMask != nil && *r.config.Defaults.NetworkMask > 0 {
-		NetMask = fmt.Sprintf("/%d", *r.config.Defaults.NetworkMask)
 	}
 
 	hasOtherScans := false
@@ -244,11 +291,28 @@ func (r *Runner) run() {
 	}
 	r.logger.Info("discovery complete", slog.Int("hosts_found", len(result.Hosts)), slog.String("policy", policyName))
 
+	// Track which IP+mask combinations we've already processed
+	processedEntries := make(map[string]bool)
+
+	defaultMask := "/32"
+	if r.config.Defaults.NetworkMask != nil && *r.config.Defaults.NetworkMask > 0 {
+		defaultMask = fmt.Sprintf("/%d", *r.config.Defaults.NetworkMask)
+	}
+
 	for _, host := range result.Hosts {
+
 		r.logger.Debug("processing host", slog.Any("host_address", host.Addresses), slog.Any("host_ports", host.Ports),
 			slog.Any("host_hostnames", host.Hostnames), slog.String("policy", policyName))
+
+		if len(host.Addresses) == 0 {
+			continue
+		}
+
+		ipAddr := r.getIPWithMask(host.Addresses[0].Addr, defaultMask, processedEntries)
+		processedEntries[ipAddr] = true
+
 		ip := &diode.IPAddress{
-			Address: diode.String(host.Addresses[0].Addr + NetMask),
+			Address: diode.String(ipAddr),
 		}
 		if r.config.Defaults.Description != "" {
 			ip.Description = diode.String(r.config.Defaults.Description)

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -318,10 +318,10 @@ func (r *Runner) run() {
 		}
 
 		var ipAddr string
-		if r.scope.UseTargetMasks != nil && *r.scope.UseTargetMasks {
-			ipAddr = r.getIPWithMask(addr, defaultMask)
-		} else {
+		if r.scope.UseTargetMasks != nil && !*r.scope.UseTargetMasks {
 			ipAddr = addr + defaultMask
+		} else {
+			ipAddr = r.getIPWithMask(addr, defaultMask)
 		}
 		processedEntries[addr] = true
 

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -294,7 +294,7 @@ func (r *Runner) run() {
 	}
 	r.logger.Info("discovery complete", slog.Int("hosts_found", len(result.Hosts)), slog.String("policy", policyName))
 
-	// Track which IP+mask combinations we've already processed
+	// Track discovered hosts
 	processedEntries := make(map[string]bool)
 
 	defaultMask := "/32"

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -108,6 +108,11 @@ func (r *Runner) run() {
 		options = append(options, nmap.WithCustomDNSServers(r.scope.DNSServers...))
 	}
 
+	if r.scope.OSDetection != nil && *r.scope.OSDetection {
+		options = append(options, nmap.WithOSDetection())
+		options = append(options, nmap.WithPrivileged())
+	}
+
 	if r.scope.FastMode != nil && *r.scope.FastMode {
 		options = append(options, nmap.WithFastMode())
 	}

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -344,6 +344,52 @@ func TestRunnerNoHosts(t *testing.T) {
 	mockClient.AssertNotCalled(t, "Ingest", mock.Anything, mock.Anything)
 }
 
+func TestRunnerWithNetworkMask(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	mockClient := new(MockClient)
+	ctx := context.Background()
+
+	policyConfig := config.Policy{
+		Config: config.PolicyConfig{
+			Schedule: nil, // Run immediately
+		},
+		Scope: config.Scope{
+			Targets:    []string{"127.0.0.1/28"},
+			FastMode:   boolPtr(true),
+			MaxRetries: intPtr(0),
+		},
+	}
+
+	// Create runner
+	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient)
+	assert.NoError(t, err)
+
+	// Use a channel to signal that Ingest was called
+	ingestCalled := make(chan bool, 1)
+
+	mockClient.On("Ingest", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		ingestCalled <- true
+		entities := args.Get(1).([]diode.Entity)
+		assert.NotEmpty(t, entities, "Entities should not be empty when scanning a network with a mask")
+		assert.Contains(t, *entities[0].(*diode.IPAddress).Address, "/28", "The scanned entity should reflect the network mask")
+	}).Return(&diodepb.IngestResponse{}, nil)
+
+	// Start the process
+	runner.Start()
+
+	// Wait for Ingest to be called or timeout
+	select {
+	case <-ingestCalled:
+		// Success
+	case <-time.After(10 * time.Second):
+		t.Fatal("Timeout: Ingest was not called")
+	}
+
+	// Stop the process
+	err = runner.Stop()
+	assert.NoError(t, err)
+}
+
 func boolPtr(b bool) *bool {
 	return &b
 }

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -158,12 +158,13 @@ func TestRunnerWithOptions(t *testing.T) {
 			},
 		},
 		{
-			name: "with os detection",
+			name: "with os detection and without target masks",
 			policy: config.Policy{
 				Config: config.PolicyConfig{},
 				Scope: config.Scope{
-					Targets:     []string{"localhost"},
-					OSDetection: boolPtr(true),
+					Targets:        []string{"localhost"},
+					OSDetection:    boolPtr(true),
+					UseTargetMasks: boolPtr(false),
 				},
 			},
 		},
@@ -354,10 +355,9 @@ func TestRunnerWithNetworkMask(t *testing.T) {
 			Schedule: nil, // Run immediately
 		},
 		Scope: config.Scope{
-			Targets:        []string{"127.0.0.1/28"},
-			FastMode:       boolPtr(true),
-			MaxRetries:     intPtr(0),
-			UseTargetMasks: boolPtr(true),
+			Targets:    []string{"127.0.0.1/28"},
+			FastMode:   boolPtr(true),
+			MaxRetries: intPtr(0),
 		},
 	}
 

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -158,6 +158,16 @@ func TestRunnerWithOptions(t *testing.T) {
 			},
 		},
 		{
+			name: "with os detection",
+			policy: config.Policy{
+				Config: config.PolicyConfig{},
+				Scope: config.Scope{
+					Targets:     []string{"localhost"},
+					OSDetection: boolPtr(true),
+				},
+			},
+		},
+		{
 			name: "with top ports and ping scan",
 			policy: config.Policy{
 				Config: config.PolicyConfig{},

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -354,9 +354,10 @@ func TestRunnerWithNetworkMask(t *testing.T) {
 			Schedule: nil, // Run immediately
 		},
 		Scope: config.Scope{
-			Targets:    []string{"127.0.0.1/28"},
-			FastMode:   boolPtr(true),
-			MaxRetries: intPtr(0),
+			Targets:        []string{"127.0.0.1/28"},
+			FastMode:       boolPtr(true),
+			MaxRetries:     intPtr(0),
+			UseTargetMasks: boolPtr(true),
 		},
 	}
 


### PR DESCRIPTION
This pull request enhances the `network-discovery` module by introducing support for OS detection, improving target network handling, and adding corresponding test cases. These changes improve flexibility and accuracy in network scanning while maintaining robust test coverage.

### Enhancements to network scanning capabilities:
* Added an `OSDetection` field to the `Scope` struct in `config.go`, allowing users to enable OS detection during scans.
* Introduced a `targetInfo` struct and `parseTargets` function in `runner.go` to handle network targets more effectively, including parsing CIDR notations and applying network masks. [[1]](diffhunk://#diff-cd137d22aa443fd1284d18bdc5bae57a78e9a4352e5fc306c1efd5b09681da4cR30-R36) [[2]](diffhunk://#diff-cd137d22aa443fd1284d18bdc5bae57a78e9a4352e5fc306c1efd5b09681da4cR47-R86)
* Modified the `run` method in `runner.go` to dynamically determine IP addresses with appropriate network masks, replacing hardcoded defaults.

### Integration of OS detection:
* Updated the `run` method to include `nmap` options for OS detection and privileged mode when `OSDetection` is enabled.

### Expanded test coverage:
* Added a test case for OS detection in `runner_test.go` to validate the new functionality.
* Added a test case to verify proper handling of network masks during scans, ensuring accurate results.