### PR TITLE
fix: diff creation fixes

### DIFF
--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/signal"
 	"strings"
@@ -85,10 +86,12 @@ func main() {
 	ctx := context.Background()
 	logger := config.NewLogger(*logLevel, *logFormat)
 
-	// Initialize metrics
-	if err := metrics.SetupMetricsExport(ctx, logger, resolveEnv(*otelEndpoint), *otelExportPeriod); err != nil {
-		logger.Error("failed to setup metrics export", "error", err)
-		os.Exit(1)
+	if otelEndpoint != nil && *otelEndpoint != "" {
+		if err := metrics.SetupMetricsExport(ctx, logger, *otelEndpoint, *otelExportPeriod); err != nil {
+			logger.Error("failed to setup metrics export", "error", err)
+			os.Exit(1)
+		}
+		logger.Info("Metrics export configured", slog.String("endpoint", *otelEndpoint), slog.Int("period_seconds", *otelExportPeriod))
 	}
 
 	policyManager := policy.NewManager(ctx, logger, client)

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -248,7 +248,7 @@ func (m *InterfaceMapper) FormatMACAddress(input string) (string, error) {
 	}
 
 	output := strings.Join(parts, ":")
-	m.logger.Info("Formatting mac address", "rawStr", input, "output", output)
+	m.logger.Debug("Formatted mac address", "input", input, "output", output)
 	return output, nil
 }
 

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -201,7 +201,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					interfaceEntity.Speed = &speed64
 					fieldFound = true
 				case "macAddress":
-					macAddress, err := formatMACAddress(value.Value)
+					macAddress, err := m.FormatMACAddress(value.Value)
 					if err != nil {
 						m.logger.Warn("Error formatting mac address", "error", err, "value", value.Value)
 						continue
@@ -231,18 +231,35 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	return interfaceEntity
 }
 
-func formatMACAddress(rawStr string) (string, error) {
-	// Decode escaped characters into actual bytes
-	unquoted, err := strconv.Unquote(`"` + rawStr + `"`)
-	if err != nil {
-		return "", fmt.Errorf("failed to unquote string: %v", err)
+// FormatMACAddress formats a MAC address from a string to a colon-separated hex string
+func (m *InterfaceMapper) FormatMACAddress(input string) (string, error) {
+	// var party
+	// for _, c := range []byte(input) {
+	// 	hexValue := fmt.Sprintf("%02x", c)
+
+	// 	m.logger.Info("Character", "character", c, "hex", fmt.Sprintf("%02x", c))
+	// }
+
+	// // Remove double backslashes (\\x) and replace with actual hex marker
+	// cleaned := strings.ReplaceAll(input, `\x`, "\\x")
+
+	// Decode the hex string to bytes
+	bytes := []byte(input)
+
+	// Check for correct MAC address length
+	// if len(bytes) != 6 {
+	// 	return "", fmt.Errorf("invalid MAC address length: got %d bytes", len(bytes))
+	// }
+
+	// Format to colon-separated hex string
+	var parts []string
+	for _, b := range bytes {
+		parts = append(parts, fmt.Sprintf("%02x", b))
 	}
 
-	macParts := make([]string, len(unquoted))
-	for i := 0; i < len(unquoted); i++ {
-		macParts[i] = fmt.Sprintf("%02x", unquoted[i])
-	}
-	return strings.Join(macParts, ":"), nil
+	output := strings.Join(parts, ":")
+	m.logger.Info("Formatting mac address", "rawStr", input, "output", output)
+	return output, nil
 }
 
 // DeviceMapper is a struct that maps devices to entities

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -182,7 +182,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	for objectID, value := range values {
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(propertyMappingEntry.OID) {
-				m.logger.Debug("Mapping value to interface entity with mapper", "objectID", objectID, "value", value, "mappingEntry", propertyMappingEntry)
+				m.logger.Debug("Mapping value to interface entity with mapper", "objectID", objectID, "value", value)
 				switch propertyMappingEntry.Field {
 				case "name":
 					interfaceEntity.Name = &value.Value
@@ -214,8 +214,6 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					enabled := value.Value == "1"
 					interfaceEntity.Enabled = &enabled
 					fieldFound = true
-				case "device":
-					// TODO: This should be the current device
 				default:
 					m.logger.Warn("Unknown field", "field", propertyMappingEntry.Field)
 				}

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -13,7 +13,16 @@ import (
 )
 
 // IPAddressMapper is a struct that maps IP addresses to entities
-type IPAddressMapper struct{}
+type IPAddressMapper struct {
+	logger *slog.Logger
+}
+
+// NewIPAddressMapper creates a new IPAddressMapper
+func NewIPAddressMapper(logger *slog.Logger) *IPAddressMapper {
+	return &IPAddressMapper{
+		logger: logger,
+	}
+}
 
 // applyDefaults applies default values to an IP address entity
 func (m *IPAddressMapper) applyDefaults(entity *diode.IPAddress, defaults *config.Defaults) {
@@ -72,14 +81,14 @@ func (m *IPAddressMapper) applyDefaults(entity *diode.IPAddress, defaults *confi
 }
 
 // Map maps IP addresses to entities
-func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults, logger *slog.Logger) diode.Entity {
-	logger.Debug("Mapping values to ipAddress entity", "values", values, "mappingEntry", mappingEntry)
+func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults) diode.Entity {
+	m.logger.Debug("Mapping values to ipAddress entity", "values", values, "mappingEntry", mappingEntry)
 	ipAddress := diode.IPAddress{}
 
 	fieldFound := false
 	// for each value in the map, map it to the ip address entity
 	for objectID, value := range values {
-		logger.Debug("Mapping value to ipAddress entity", "objectID", objectID, "value", value)
+		m.logger.Debug("Mapping value to ipAddress entity", "objectID", objectID, "value", value)
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(propertyMappingEntry.OID) {
 				switch propertyMappingEntry.Field {
@@ -91,7 +100,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					if propertyMappingEntry.Relationship != (config.Relationship{}) {
 						linkedEntity := entityRegistry.GetOrCreateEntity(EntityType(propertyMappingEntry.Relationship.Type), ObjectIDIndex(value.Value))
 						if linkedEntity == nil {
-							logger.Warn("No linked entity found while mapping assigned object", "relationship", propertyMappingEntry.Relationship)
+							m.logger.Warn("No linked entity found while mapping assigned object", "relationship", propertyMappingEntry.Relationship)
 							continue
 						}
 						// Handle relationship mapping
@@ -101,7 +110,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 						}
 					}
 				default:
-					logger.Warn("Unknown field", "field", mappingEntry.Field)
+					m.logger.Warn("Unknown field", "field", mappingEntry.Field)
 				}
 			}
 		}
@@ -115,7 +124,16 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 }
 
 // InterfaceMapper is a struct that maps interfaces to entities
-type InterfaceMapper struct{}
+type InterfaceMapper struct {
+	logger *slog.Logger
+}
+
+// NewInterfaceMapper creates a new InterfaceMapper
+func NewInterfaceMapper(logger *slog.Logger) *InterfaceMapper {
+	return &InterfaceMapper{
+		logger: logger,
+	}
+}
 
 // applyDefaults applies default values to an interface entity
 func (m *InterfaceMapper) applyDefaults(entity *diode.Interface, defaults *config.Defaults) {
@@ -156,27 +174,27 @@ func (m *InterfaceMapper) applyDefaults(entity *diode.Interface, defaults *confi
 }
 
 // Map maps interfaces to entities
-func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults, logger *slog.Logger) diode.Entity {
-	logger.Debug("Mapping values to interface entity", "values", values, "mappingEntry", mappingEntry)
+func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults) diode.Entity {
+	m.logger.Debug("Mapping values to interface entity", "values", values, "mappingEntry", mappingEntry)
 	interfaceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values)).(*diode.Interface)
 
 	fieldFound := false
 	for objectID, value := range values {
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(propertyMappingEntry.OID) {
-				logger.Debug("Mapping value to interface entity with mapper", "objectID", objectID, "value", value, "mappingEntry", propertyMappingEntry)
+				m.logger.Debug("Mapping value to interface entity with mapper", "objectID", objectID, "value", value, "mappingEntry", propertyMappingEntry)
 				switch propertyMappingEntry.Field {
 				case "name":
 					interfaceEntity.Name = &value.Value
 					fieldFound = true
 				case "speed":
 					if value.Value == "" {
-						logger.Debug("Speed is empty", "value", value.Value)
+						m.logger.Debug("Speed is empty", "value", value.Value)
 						continue
 					}
 					speed, err := strconv.Atoi(value.Value)
 					if err != nil {
-						logger.Warn("Error converting speed to int", "error", err, "value", value.Value)
+						m.logger.Warn("Error converting speed to int", "error", err, "value", value.Value)
 						continue
 					}
 					speed64 := int64(speed)
@@ -185,7 +203,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				case "macAddress":
 					macAddress, err := formatMACAddress(value.Value)
 					if err != nil {
-						logger.Warn("Error formatting mac address", "error", err, "value", value.Value)
+						m.logger.Warn("Error formatting mac address", "error", err, "value", value.Value)
 						continue
 					}
 					interfaceEntity.PrimaryMacAddress = &diode.MACAddress{
@@ -199,7 +217,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				case "device":
 					// TODO: This should be the current device
 				default:
-					logger.Warn("Unknown field", "field", propertyMappingEntry.Field)
+					m.logger.Warn("Unknown field", "field", propertyMappingEntry.Field)
 				}
 			}
 		}
@@ -230,6 +248,7 @@ func formatMACAddress(rawStr string) (string, error) {
 // DeviceMapper is a struct that maps devices to entities
 type DeviceMapper struct {
 	devices data.DeviceDataRetreiver
+	logger  *slog.Logger
 }
 
 // applyDefaults applies default values to a device entity
@@ -298,22 +317,23 @@ func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defa
 }
 
 // NewDeviceMapper creates a new DeviceMapper
-func NewDeviceMapper(devices data.DeviceDataRetreiver) *DeviceMapper {
+func NewDeviceMapper(devices data.DeviceDataRetreiver, logger *slog.Logger) *DeviceMapper {
 	return &DeviceMapper{
 		devices: devices,
+		logger:  logger,
 	}
 }
 
 // Map maps devices to entities
-func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults, logger *slog.Logger) diode.Entity {
-	logger.Debug("Mapping values to device entity", "values", values, "mappingEntry", mappingEntry)
+func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults) diode.Entity {
+	m.logger.Debug("Mapping values to device entity", "values", values, "mappingEntry", mappingEntry)
 	deviceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values)).(*diode.Device)
 
 	fieldFound := false
 	for objectID, value := range values {
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(propertyMappingEntry.OID) {
-				logger.Debug("Mapping value to device entity with mapper", "objectID", objectID, "value", value, "mappingEntry", propertyMappingEntry)
+				m.logger.Debug("Mapping value to device entity with mapper", "objectID", objectID, "value", value, "mappingEntry", propertyMappingEntry)
 				switch propertyMappingEntry.Field {
 				case "name":
 					deviceEntity.Name = &value.Value
@@ -322,12 +342,12 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 					// Use getDeviceIDs to get the manufacturer and model
 					manufacturerID, modelID, err := m.getDeviceIDs(value.Value)
 					if err != nil {
-						logger.Warn("Error getting device IDs", "error", err, "value", value.Value)
+						m.logger.Warn("Error getting device IDs", "error", err, "value", value.Value)
 						continue
 					}
 					manufacturer, err := m.devices.GetManufacturer(manufacturerID)
 					if err != nil {
-						logger.Warn("Error getting manufacturer", "error", err, "manufacturerID", manufacturerID)
+						m.logger.Warn("Error getting manufacturer", "error", err, "manufacturerID", manufacturerID)
 						continue
 					}
 
@@ -343,7 +363,7 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 
 					deviceModel, err := m.devices.GetDeviceModel(modelID)
 					if err != nil {
-						logger.Warn("Error getting device model", "error", err, "modelID", modelID)
+						m.logger.Warn("Error getting device model", "error", err, "modelID", modelID)
 					}
 					deviceEntity.DeviceType = &diode.DeviceType{
 						Model:        &deviceModel,
@@ -351,7 +371,7 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 					}
 					fieldFound = true
 				default:
-					logger.Warn("Unknown field", "field", propertyMappingEntry.Field)
+					m.logger.Warn("Unknown field", "field", propertyMappingEntry.Field)
 				}
 			}
 		}

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -3,6 +3,7 @@ package mapping
 import (
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -151,9 +152,7 @@ func (m *InterfaceMapper) applyDefaults(entity *diode.Interface, defaults *confi
 		entity.Description = &entityDefaults.Description
 	}
 
-	if entity.Type == nil && entityDefaults.Type != "" {
-		entity.Type = &entityDefaults.Type
-	}
+	entity.Type = &entityDefaults.Type
 }
 
 // Map maps interfaces to entities
@@ -190,13 +189,15 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 						continue
 					}
 					interfaceEntity.PrimaryMacAddress = &diode.MACAddress{
-						MacAddress: &macAddress,
+						MacAddress: &macAddress, // TODO: This format is not correct - being rejected by netbox
 					}
 					fieldFound = true
 				case "adminStatus":
 					enabled := value.Value == "1"
 					interfaceEntity.Enabled = &enabled
 					fieldFound = true
+				case "device":
+					// TODO: This should be the current device
 				default:
 					logger.Warn("Unknown field", "field", propertyMappingEntry.Field)
 				}
@@ -335,6 +336,8 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 					}
 
 					deviceEntity.Platform = &diode.Platform{
+						Name:         &manufacturer,
+						Slug:         toSlug(&manufacturer),
 						Manufacturer: &manufacturerEntity,
 					}
 
@@ -385,4 +388,26 @@ func (m *DeviceMapper) getDeviceIDs(objectID string) (int, int, error) {
 	}
 
 	return 0, 0, fmt.Errorf("invalid objectID: %s", objectID)
+}
+
+func toSlug(input *string) *string {
+	// Convert to lowercase
+	slug := strings.ToLower(*input)
+
+	// Remove all non-word characters (except spaces and dashes)
+	re := regexp.MustCompile(`[^\w\s-]`)
+	slug = re.ReplaceAllString(slug, "")
+
+	// Replace spaces and underscores with dashes
+	slug = strings.ReplaceAll(slug, " ", "-")
+	slug = strings.ReplaceAll(slug, "_", "-")
+
+	// Collapse multiple dashes into one
+	re = regexp.MustCompile(`-+`)
+	slug = re.ReplaceAllString(slug, "-")
+
+	// Trim leading/trailing dashes
+	slug = strings.Trim(slug, "-")
+
+	return &slug
 }

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -233,23 +233,13 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 
 // FormatMACAddress formats a MAC address from a string to a colon-separated hex string
 func (m *InterfaceMapper) FormatMACAddress(input string) (string, error) {
-	// var party
-	// for _, c := range []byte(input) {
-	// 	hexValue := fmt.Sprintf("%02x", c)
-
-	// 	m.logger.Info("Character", "character", c, "hex", fmt.Sprintf("%02x", c))
-	// }
-
-	// // Remove double backslashes (\\x) and replace with actual hex marker
-	// cleaned := strings.ReplaceAll(input, `\x`, "\\x")
-
 	// Decode the hex string to bytes
 	bytes := []byte(input)
 
 	// Check for correct MAC address length
-	// if len(bytes) != 6 {
-	// 	return "", fmt.Errorf("invalid MAC address length: got %d bytes", len(bytes))
-	// }
+	if len(bytes) != 6 {
+		return "", fmt.Errorf("invalid MAC address length: got %d bytes", len(bytes))
+	}
 
 	// Format to colon-separated hex string
 	var parts []string

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -579,6 +579,18 @@ func TestInterfaceMapper_FormatMACAddress(t *testing.T) {
 			expected:    "00:11:22:33:44:55",
 			expectError: false,
 		},
+		{
+			name:        "invalid (too short) hex string with backslashes",
+			input:       "\x00\x11\x22\x33\x44",
+			expected:    "",
+			expectError: true,
+		},
+		{
+			name:        "invalid (too long) hex string with backslashes",
+			input:       "\x00\x11\x22\x33\x44\x55\x66",
+			expected:    "",
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -371,7 +371,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 					OID:    "1.3.6.1.2.1.2.2.1.6.1",
 					Index:  "1",
 					Parent: "1.3.6.1.2.1.2.2.1.6",
-					Value:  "\\x00\\x11\\x22\\x33\\x44\\x55",
+					Value:  "\x00\x11\x22\x33\x44\x55",
 					Type:   mapping.OctetString,
 				},
 				"1.3.6.1.2.1.2.2.1.7.1": {
@@ -558,6 +558,38 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				for i, tag := range tt.expectedEntity.Tags {
 					assert.Equal(t, tag.Name, iface.Tags[i].Name)
 				}
+			}
+		})
+	}
+}
+
+func TestInterfaceMapper_FormatMACAddress(t *testing.T) {
+	logger := slog.Default()
+	mapper := mapping.NewInterfaceMapper(logger)
+
+	tests := []struct {
+		name        string
+		input       string
+		expected    string
+		expectError bool
+	}{
+		{
+			name:        "valid hex string with backslashes",
+			input:       "\x00\x11\x22\x33\x44\x55",
+			expected:    "00:11:22:33:44:55",
+			expectError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := mapper.FormatMACAddress(tt.input)
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Empty(t, result)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expected, result)
 			}
 		})
 	}

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -302,8 +302,8 @@ func TestIPAddressMapper_Map(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			registry := mapping.NewEntityRegistry(logger)
-			mapper := &mapping.IPAddressMapper{}
-			entity := mapper.Map(tt.values, tt.mappingEntry, registry, tt.defaults, logger)
+			mapper := mapping.NewIPAddressMapper(logger)
+			entity := mapper.Map(tt.values, tt.mappingEntry, registry, tt.defaults)
 
 			if tt.expectError {
 				assert.Nil(t, entity)
@@ -534,8 +534,8 @@ func TestInterfaceMapper_Map(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := slog.Default()
 			registry := mapping.NewEntityRegistry(logger)
-			mapper := &mapping.InterfaceMapper{}
-			entity := mapper.Map(tt.values, tt.mappingEntry, registry, tt.defaults, logger)
+			mapper := mapping.NewInterfaceMapper(logger)
+			entity := mapper.Map(tt.values, tt.mappingEntry, registry, tt.defaults)
 
 			if tt.expectError {
 				assert.Nil(t, entity)
@@ -574,7 +574,7 @@ func TestDeviceMapper_Map(t *testing.T) {
 	mockManufacturers.On("GetDeviceModel", 1234).Return("cisco4000", nil)
 	mockManufacturers.On("GetDeviceModel", 999).Return("", fmt.Errorf("device model not found"))
 
-	mapper := mapping.NewDeviceMapper(mockManufacturers)
+	mapper := mapping.NewDeviceMapper(mockManufacturers, logger)
 
 	tests := []struct {
 		name           string
@@ -752,7 +752,7 @@ func TestDeviceMapper_Map(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			registry := mapping.NewEntityRegistry(logger)
-			entity := mapper.Map(tt.values, tt.mappingEntry, registry, tt.defaults, logger)
+			entity := mapper.Map(tt.values, tt.mappingEntry, registry, tt.defaults)
 
 			if tt.expectError {
 				assert.Nil(t, entity)

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -250,7 +250,28 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 			m.logger.Warn("Error finding mapping entry", "error", err, "objectID", value.Index)
 			continue
 		}
-		entities = append(entities, Entry.MapToEntity(value.Values, m.registry, m.defaults, m.logger)...)
+		newEntities := Entry.MapToEntity(value.Values, m.registry, m.defaults, m.logger)
+		entities = append(entities, newEntities...)
+	}
+
+	var currentDevice *diode.Device
+	for _, entity := range entities {
+		// check if it's a diode.Device
+		if device, ok := entity.(*diode.Device); ok {
+			if currentDevice != nil {
+				m.logger.Warn("Multiple devices found. Ignoring.", "device", device)
+			}
+			// check if the device has a name
+			currentDevice = device
+		}
+	}
+	if currentDevice == nil {
+		m.logger.Warn("No device found.")
+	}
+	for _, entity := range entities {
+		if diodeInterface, ok := entity.(*diode.Interface); ok {
+			diodeInterface.Device = currentDevice
+		}
 	}
 	return entities
 }

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -123,7 +123,7 @@ func (m *Entry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistr
 		logger.Warn("No mapper found for entity. Ignoring.", "entity", m.Entity)
 		return nil
 	}
-	entity := m.Mapper.Map(pdus, m, entityRegistry, defaults, logger)
+	entity := m.Mapper.Map(pdus, m, entityRegistry, defaults)
 	logger.Debug("Entity returned from mapper", "entity", entity)
 	if entity == nil {
 		logger.Warn("No entity returned from mapper. Ignoring.", "entity", m.Entity)
@@ -135,9 +135,14 @@ func (m *Entry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistr
 // NewObjectIDMapper creates a new ObjectIDMapper
 func NewObjectIDMapper(mappings []config.MappingEntry, logger *slog.Logger, devices data.DeviceDataRetreiver, defaults *config.Defaults) *ObjectIDMapper {
 	entityMappers := map[string]orbToEntityMapper{
-		"ipAddress": &IPAddressMapper{},
-		"interface": &InterfaceMapper{},
+		"ipAddress": &IPAddressMapper{
+			logger: logger,
+		},
+		"interface": &InterfaceMapper{
+			logger: logger,
+		},
 		"device": &DeviceMapper{
+			logger:  logger,
 			devices: devices,
 		},
 	}
@@ -160,7 +165,7 @@ func NewObjectIDMapper(mappings []config.MappingEntry, logger *slog.Logger, devi
 }
 
 type orbToEntityMapper interface {
-	Map(pdus map[ObjectIDIndex]*ObjectIDValue, Entry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults, logger *slog.Logger) diode.Entity
+	Map(pdus map[ObjectIDIndex]*ObjectIDValue, Entry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults) diode.Entity
 }
 
 func getIndex(values map[ObjectIDIndex]*ObjectIDValue) ObjectIDIndex {

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -78,6 +78,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 						MacAddress: &[]string{"00:00:00:00:00:00"}[0],
 					},
 					Enabled: &[]bool{true}[0],
+					Type:    diode.String("virtual"),
 				},
 				&diode.Interface{
 					Speed: &[]int64{1000000000}[0],
@@ -86,6 +87,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 						MacAddress: &[]string{"00:00:00:00:00:11"}[0],
 					},
 					Enabled: &[]bool{false}[0],
+					Type:    diode.String("virtual"),
 				},
 			},
 		},
@@ -153,6 +155,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 						MacAddress: &[]string{"00:00:00:00:00:00"}[0],
 					},
 					Enabled: &[]bool{true}[0],
+					Type:    diode.String("virtual"),
 				},
 				&diode.IPAddress{
 					Address: diode.String("192.168.1.2/32"),
@@ -261,11 +264,13 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 			expected: []diode.Entity{
 				&diode.Interface{
 					Name: diode.String("GigabitEthernet1/0/1"),
+					Type: diode.String("virtual"),
 				},
 				&diode.IPAddress{
 					Address: diode.String("192.168.1.2/32"),
 					AssignedObject: &diode.Interface{
 						Name: diode.String("GigabitEthernet1/0/1"),
+						Type: diode.String("virtual"),
 					},
 				},
 			},
@@ -321,6 +326,8 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 						Model: &[]string{"cisco4000"}[0],
 					},
 					Platform: &diode.Platform{
+						Name: diode.String("Cisco"),
+						Slug: diode.String("cisco"),
 						Manufacturer: &diode.Manufacturer{
 							Name: diode.String("Cisco"),
 						},
@@ -336,7 +343,11 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 				tt.mapping,
 				slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})),
 				&FakeManufacturers{},
-				&config.Defaults{},
+				&config.Defaults{
+					Interface: config.InterfaceDefaults{
+						Type: "virtual",
+					},
+				},
 			)
 			entities := mapper.MapObjectIDsToEntity(tt.objectIDs)
 

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -57,7 +57,7 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 		// Load the mapping config
 		mappingConfig, err := m.loadMappingConfig(policy)
 		if err != nil {
-			return nil, fmt.Errorf("%s : invalid policy : %w", name, err)
+			return nil, fmt.Errorf("%s : invalid mapping config : %w", name, err)
 		}
 
 		// Create a new policy with updated mappings

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -13,6 +13,8 @@ import (
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/metrics"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/targets"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // Define a custom type for the context key
@@ -83,8 +85,25 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 
 // run runs the policy
 func (r *Runner) run() {
+	policyName := r.ctx.Value(policyKey).(string)
 	// Track policy execution
-	metrics.GetPolicyExecutions().Add(r.ctx, 1)
+	if rMetric := metrics.GetPolicyExecutions(); rMetric != nil {
+		rMetric.Add(r.ctx, 1,
+			metric.WithAttributes(
+				attribute.String("policy", r.ctx.Value(policyKey).(string)),
+			))
+	}
+	startTime := time.Now()
+
+	defer func() {
+		if rMetric := metrics.GetDiscoveryLatency(); rMetric != nil {
+			// Calculate duration in milliseconds
+			duration := float64(time.Since(startTime).Milliseconds())
+			rMetric.Record(r.ctx, duration, metric.WithAttributes(
+				attribute.String("policy", policyName),
+			))
+		}
+	}()
 
 	ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 	defer cancel()
@@ -118,8 +137,13 @@ func (r *Runner) run() {
 
 func (r *Runner) queryTargets(expandedTargets []config.Target, objectIDs map[string]int, mapper *mapping.ObjectIDMapper, entities []diode.Entity) []diode.Entity {
 	for _, target := range expandedTargets {
+		policyName := r.ctx.Value(policyKey).(string)
 		// Track discovery attempt
-		metrics.GetDiscoveryAttempts().Add(r.ctx, 1)
+		if rMetric := metrics.GetDiscoveryAttempts(); rMetric != nil {
+			rMetric.Add(r.ctx, 1,
+				metric.WithAttributes(
+					attribute.String("policy", policyName)))
+		}
 
 		// Start timing the discovery
 		startTime := time.Now()
@@ -129,21 +153,40 @@ func (r *Runner) queryTargets(expandedTargets []config.Target, objectIDs map[str
 		if err != nil {
 			r.logger.Warn("Error crawling host", "host", target.Host, "error", err)
 			// Track failed discovery
-			metrics.GetDiscoveryFailure().Add(r.ctx, 1)
+			if rMetric := metrics.GetDiscoveryFailure(); rMetric != nil {
+				policyName := r.ctx.Value(policyKey).(string)
+				rMetric.Add(r.ctx, 1,
+					metric.WithAttributes(
+						attribute.String("policy", policyName),
+						attribute.String("error", err.Error()),
+					))
+			}
 			continue
 		}
 
 		// Track successful discovery
-		metrics.GetDiscoverySuccess().Add(r.ctx, 1)
+		if rMetric := metrics.GetDiscoverySuccess(); rMetric != nil {
+			rMetric.Add(r.ctx, 1,
+				metric.WithAttributes(
+					attribute.String("policy", policyName)))
+		}
 
 		// Record discovery latency
-		metrics.GetDiscoveryLatency().Record(r.ctx, time.Since(startTime).Seconds())
+		if rMetric := metrics.GetDiscoveryLatency(); rMetric != nil {
+			rMetric.Record(r.ctx, time.Since(startTime).Seconds(),
+				metric.WithAttributes(
+					attribute.String("policy", policyName)))
+		}
 
 		entitiesForTarget := mapper.MapObjectIDsToEntity(oids)
 		entities = append(entities, entitiesForTarget...)
 
 		// Update discovered hosts gauge
-		metrics.GetDiscoveredHosts().Record(r.ctx, int64(len(entitiesForTarget)))
+		if rMetric := metrics.GetDiscoveredHosts(); rMetric != nil {
+			rMetric.Record(r.ctx, int64(len(entitiesForTarget)),
+				metric.WithAttributes(
+					attribute.String("policy", policyName)))
+		}
 	}
 	return entities
 }

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -144,6 +144,7 @@ func TestRunnerRun(t *testing.T) {
 						Interface: config.InterfaceDefaults{
 							Description: "Interface Default",
 							Tags:        []string{"interface", "default"},
+							Type:        "unknown",
 						},
 						Device: config.DeviceDefaults{
 							Description: "Device Default",
@@ -237,6 +238,7 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 				Interface: config.InterfaceDefaults{
 					Description: "Interface Default",
 					Tags:        []string{"interface", "default"},
+					Type:        "unknown",
 				},
 				Device: config.DeviceDefaults{
 					Description: "Device Default",
@@ -284,6 +286,7 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 				{Name: diode.String("test")},
 				{Name: diode.String("snmp")},
 			},
+			Type: diode.String("unknown"),
 		},
 	}
 

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -238,7 +238,7 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 				Interface: config.InterfaceDefaults{
 					Description: "Interface Default",
 					Tags:        []string{"interface", "default"},
-					Type:        "unknown",
+					Type:        "virtual",
 				},
 				Device: config.DeviceDefaults{
 					Description: "Device Default",
@@ -286,7 +286,7 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 				{Name: diode.String("test")},
 				{Name: diode.String("snmp")},
 			},
-			Type: diode.String("unknown"),
+			Type: diode.String("virtual"),
 		},
 	}
 

--- a/snmp-discovery/server/server.go
+++ b/snmp-discovery/server/server.go
@@ -13,6 +13,8 @@ import (
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/metrics"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // Response represents the server response
@@ -42,8 +44,15 @@ func init() {
 // metricsMiddleware is a middleware that records API metrics
 func metricsMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// Record API request
-		metrics.GetAPIRequests().Add(c.Request.Context(), 1)
+		if apiMetric := metrics.GetAPIRequests(); apiMetric != nil {
+			apiMetric.Add(c.Request.Context(), 1,
+				metric.WithAttributes(
+					attribute.String("endpoint", c.Request.URL.Path),
+					attribute.String("method", c.Request.Method),
+					attribute.Int("status", c.Writer.Status()),
+				),
+			)
+		}
 
 		// Start timing the request
 		startTime := time.Now()
@@ -52,7 +61,18 @@ func metricsMiddleware() gin.HandlerFunc {
 		c.Next()
 
 		// Record API response latency
-		metrics.GetAPIResponseLatency().Record(c.Request.Context(), time.Since(startTime).Seconds())
+
+		if apiMetric := metrics.GetAPIResponseLatency(); apiMetric != nil {
+			// Calculate duration in milliseconds
+			duration := float64(time.Since(startTime).Milliseconds())
+			apiMetric.Record(c.Request.Context(), duration,
+				metric.WithAttributes(
+					attribute.String("endpoint", c.Request.URL.Path),
+					attribute.String("method", c.Request.Method),
+					attribute.Int("status", c.Writer.Status()),
+				),
+			)
+		}
 	}
 }
 

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -367,11 +367,11 @@ func TestMapPDU(t *testing.T) {
 			pdu: snmp.PDU{
 				Name:  "test.2",
 				Type:  gosnmp.OctetString,
-				Value: []byte("test bytes"),
+				Value: []byte("\xF4\x7F\x35\x93\xAF\xC0"),
 			},
 			expectedValue: mapping.Value{
 				Type:  mapping.Asn1BER(gosnmp.OctetString),
-				Value: "test bytes",
+				Value: string([]byte("\xF4\x7F\x35\x93\xAF\xC0")),
 			},
 			expectError: false,
 		},


### PR DESCRIPTION
Some improvements based on testing.
- Stops the otel metrics causing crashes when not initialised
- fixing mapping of interface type
- fixes mappign of platform (name and slug are required fields)
- fixes mac address mapping
- some minor refactoring and error handling improvements

Still to investigate:
- IP Addresses are being mapped but not sent to diode
- Not all interface names are being sent to diode