### PR TITLE
fix: remove force DNS resolution in network-discovery

### DIFF
--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -239,7 +239,6 @@ func (r *Runner) run() {
 
 	options = append(options, nmap.WithNonInteractive())
 	options = append(options, nmap.WithTargets(r.scope.Targets...))
-	options = append(options, nmap.WithForcedDNSResolution())
 
 	scanner, err := nmap.NewScanner(ctx, options...)
 	if err != nil {


### PR DESCRIPTION
This pull request makes a small change to the `run` method in `network-discovery/policy/runner.go`. The change removes the `nmap.WithForcedDNSResolution()` option from the list of Nmap scanner options, likely to modify the behavior of DNS resolution during network scans.