### PR TITLE
fix: PolicyManager stop cleanup

### DIFF
--- a/device-discovery/device_discovery/policy/manager.py
+++ b/device-discovery/device_discovery/policy/manager.py
@@ -112,4 +112,4 @@ class PolicyManager:
         for name, runner in self.runners.items():
             logger.info(f"Stopping policy '{name}'")
             runner.stop()
-        self.runners = []
+        self.runners = {}

--- a/device-discovery/tests/policy/test_manager.py
+++ b/device-discovery/tests/policy/test_manager.py
@@ -138,4 +138,4 @@ def test_stop_all_policies(policy_manager):
     mock_runner2.stop.assert_called_once()
 
     # Ensure runners dictionary is emptied
-    assert policy_manager.runners == []
+    assert policy_manager.runners == {}

--- a/worker/tests/policy/test_manager.py
+++ b/worker/tests/policy/test_manager.py
@@ -130,4 +130,4 @@ def test_stop_all_policies(policy_manager):
     mock_runner2.stop.assert_called_once()
 
     # Ensure runners dictionary is emptied
-    assert policy_manager.runners == []
+    assert policy_manager.runners == {}

--- a/worker/worker/policy/manager.py
+++ b/worker/worker/policy/manager.py
@@ -131,4 +131,4 @@ class PolicyManager:
         for name, runner in self.runners.items():
             logger.info(f"Stopping policy '{name}'")
             runner.stop()
-        self.runners = []
+        self.runners = {}


### PR DESCRIPTION
## Summary
- fix cleanup in PolicyManager.stop() to reset runners to an empty dict
- update tests for expected dict type after stop

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_b_684040dc5dd8832c9178f287334f0dd0