### PR TITLE
fix: set default interface names

### DIFF
--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -118,6 +118,11 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 
 	if fieldFound {
 		m.applyDefaults(&ipAddress, defaults)
+		if ipAddress.Address != nil {
+			m.logger.Debug("Successfully mapped IP address", "address", *ipAddress.Address)
+		} else {
+			m.logger.Debug("Successfully mapped IP address (address field empty)")
+		}
 	}
 
 	return &ipAddress
@@ -224,6 +229,11 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	// Apply defaults if available
 	if fieldFound {
 		m.applyDefaults(interfaceEntity, defaults)
+		if interfaceEntity.Name != nil {
+			m.logger.Debug("Successfully mapped interface", "name", *interfaceEntity.Name)
+		} else {
+			m.logger.Debug("Successfully mapped interface (name field empty)")
+		}
 	}
 
 	return interfaceEntity
@@ -385,6 +395,11 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 	// Apply defaults if available
 	if fieldFound {
 		m.applyDefaults(deviceEntity, defaults)
+		if deviceEntity.Name != nil {
+			m.logger.Debug("Successfully mapped device", "name", *deviceEntity.Name)
+		} else {
+			m.logger.Debug("Successfully mapped device (name field empty)")
+		}
 	}
 
 	return deviceEntity

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -53,7 +53,7 @@ func TestIPAddressMapper_Map(t *testing.T) {
 			},
 			defaults: nil,
 			expectedEntity: &diode.IPAddress{
-				Address: stringPtr("192.168.1.1/32"),
+				Address: mapping.StringPtr("192.168.1.1/32"),
 			},
 			expectError: false,
 		},
@@ -92,11 +92,11 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			expectedEntity: &diode.IPAddress{
-				Address:     stringPtr("192.168.1.1/32"),
-				Description: stringPtr("IP Address Description"),
+				Address:     mapping.StringPtr("192.168.1.1/32"),
+				Description: mapping.StringPtr("IP Address Description"),
 				Tags: []*diode.Tag{
-					{Name: stringPtr("global-tag1")},
-					{Name: stringPtr("global-tag2")},
+					{Name: mapping.StringPtr("global-tag1")},
+					{Name: mapping.StringPtr("global-tag2")},
 				},
 			},
 			expectError: false,
@@ -136,11 +136,11 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			expectedEntity: &diode.IPAddress{
-				Address:     stringPtr("192.168.1.1/32"),
-				Description: stringPtr("IP Address specific description"),
+				Address:     mapping.StringPtr("192.168.1.1/32"),
+				Description: mapping.StringPtr("IP Address specific description"),
 				Tags: []*diode.Tag{
-					{Name: stringPtr("ip-tag1")},
-					{Name: stringPtr("ip-tag2")},
+					{Name: mapping.StringPtr("ip-tag1")},
+					{Name: mapping.StringPtr("ip-tag2")},
 				},
 			},
 			expectError: false,
@@ -181,13 +181,13 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			expectedEntity: &diode.IPAddress{
-				Address:     stringPtr("192.168.1.1/32"),
-				Description: stringPtr("IP Address specific description"),
+				Address:     mapping.StringPtr("192.168.1.1/32"),
+				Description: mapping.StringPtr("IP Address specific description"),
 				Tags: []*diode.Tag{
-					{Name: stringPtr("ip-tag1")},
-					{Name: stringPtr("ip-tag2")},
-					{Name: stringPtr("global-tag1")},
-					{Name: stringPtr("global-tag2")},
+					{Name: mapping.StringPtr("ip-tag1")},
+					{Name: mapping.StringPtr("ip-tag2")},
+					{Name: mapping.StringPtr("global-tag1")},
+					{Name: mapping.StringPtr("global-tag2")},
 				},
 			},
 			expectError: false,
@@ -237,7 +237,7 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			expectedEntity: &diode.IPAddress{
-				Address: stringPtr("192.168.1.1/32"),
+				Address: mapping.StringPtr("192.168.1.1/32"),
 			},
 			expectError: false,
 		},
@@ -284,15 +284,15 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				},
 			},
 			expectedEntity: &diode.IPAddress{
-				Address:     stringPtr("192.168.1.1/32"),
-				Description: stringPtr("IP Address specific description"),
+				Address:     mapping.StringPtr("192.168.1.1/32"),
+				Description: mapping.StringPtr("IP Address specific description"),
 				Tenant: &diode.Tenant{
-					Name: stringPtr("ip-address-tenant"),
+					Name: mapping.StringPtr("ip-address-tenant"),
 				},
-				Role: stringPtr("ip-address-role"),
+				Role: mapping.StringPtr("ip-address-role"),
 				Vrf: &diode.VRF{
-					Name: stringPtr("ip-address-vrf"),
-					Rd:   stringPtr("ip-address-vrf"),
+					Name: mapping.StringPtr("ip-address-vrf"),
+					Rd:   mapping.StringPtr("ip-address-vrf"),
 				},
 			},
 			expectError: false,
@@ -416,9 +416,9 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			},
 			defaults: nil,
 			expectedEntity: &diode.Interface{
-				Name:              stringPtr("eth0"),
+				Name:              mapping.StringPtr("eth0"),
 				Speed:             int64Ptr(1000000),
-				PrimaryMacAddress: &diode.MACAddress{MacAddress: stringPtr("00:11:22:33:44:55")},
+				PrimaryMacAddress: &diode.MACAddress{MacAddress: mapping.StringPtr("00:11:22:33:44:55")},
 				Enabled:           boolPtr(true),
 			},
 			expectError: false,
@@ -467,15 +467,15 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				Tags: []string{"global-tag1", "global-tag2"},
 			},
 			expectedEntity: &diode.Interface{
-				Name:        stringPtr("eth0"),
-				Description: stringPtr("Interface specific description"),
+				Name:        mapping.StringPtr("eth0"),
+				Description: mapping.StringPtr("Interface specific description"),
 				Tags: []*diode.Tag{
-					{Name: stringPtr("interface-tag1")},
-					{Name: stringPtr("interface-tag2")},
-					{Name: stringPtr("global-tag1")},
-					{Name: stringPtr("global-tag2")},
+					{Name: mapping.StringPtr("interface-tag1")},
+					{Name: mapping.StringPtr("interface-tag2")},
+					{Name: mapping.StringPtr("global-tag1")},
+					{Name: mapping.StringPtr("global-tag2")},
 				},
-				Type: stringPtr("ethernet"),
+				Type: mapping.StringPtr("ethernet"),
 			},
 			expectError: false,
 		},
@@ -515,7 +515,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				},
 			},
 			expectedEntity: &diode.Interface{
-				Name: stringPtr("Unknown"),
+				Name: mapping.StringPtr("Unknown"),
 			},
 			expectError: false,
 		},
@@ -528,7 +528,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				Field:  "_id",
 			},
 			expectedEntity: &diode.Interface{
-				Name: stringPtr("Unknown"),
+				Name: mapping.StringPtr("Unknown"),
 			},
 			expectError: false,
 		},
@@ -669,16 +669,16 @@ func TestDeviceMapper_Map(t *testing.T) {
 			},
 			defaults: nil,
 			expectedEntity: &diode.Device{
-				Name: stringPtr("router1"),
+				Name: mapping.StringPtr("router1"),
 				DeviceType: &diode.DeviceType{
 					Manufacturer: &diode.Manufacturer{
-						Name: stringPtr("Cisco"),
+						Name: mapping.StringPtr("Cisco"),
 					},
-					Model: stringPtr("cisco4000"),
+					Model: mapping.StringPtr("cisco4000"),
 				},
 				Platform: &diode.Platform{
 					Manufacturer: &diode.Manufacturer{
-						Name: stringPtr("Cisco"),
+						Name: mapping.StringPtr("Cisco"),
 					},
 				},
 			},
@@ -719,25 +719,25 @@ func TestDeviceMapper_Map(t *testing.T) {
 				},
 			},
 			expectedEntity: &diode.Device{
-				Name:        stringPtr("router1"),
-				Description: stringPtr("Device specific description"),
-				Comments:    stringPtr("Device specific comments"),
+				Name:        mapping.StringPtr("router1"),
+				Description: mapping.StringPtr("Device specific description"),
+				Comments:    mapping.StringPtr("Device specific comments"),
 				Tags: []*diode.Tag{
-					{Name: stringPtr("device-tag1")},
-					{Name: stringPtr("device-tag2")},
-					{Name: stringPtr("global-tag1")},
-					{Name: stringPtr("global-tag2")},
+					{Name: mapping.StringPtr("device-tag1")},
+					{Name: mapping.StringPtr("device-tag2")},
+					{Name: mapping.StringPtr("global-tag1")},
+					{Name: mapping.StringPtr("global-tag2")},
 				},
 				Role: &diode.DeviceRole{
-					Name: stringPtr("test-role"),
+					Name: mapping.StringPtr("test-role"),
 				},
 				Site: &diode.Site{
-					Name: stringPtr("test-site"),
+					Name: mapping.StringPtr("test-site"),
 				},
 				Location: &diode.Location{
-					Name: stringPtr("test-location"),
+					Name: mapping.StringPtr("test-location"),
 					Site: &diode.Site{
-						Name: stringPtr("test-site"),
+						Name: mapping.StringPtr("test-site"),
 					},
 				},
 			},
@@ -780,7 +780,7 @@ func TestDeviceMapper_Map(t *testing.T) {
 				},
 			},
 			expectedEntity: &diode.Device{
-				Name: stringPtr("router1"),
+				Name: mapping.StringPtr("router1"),
 			},
 			expectError: false,
 		},
@@ -852,10 +852,6 @@ func (m *MockManufacturerDataRetriever) GetDeviceModel(id int) (string, error) {
 }
 
 // Helper functions to create pointers
-func stringPtr(s string) *string {
-	return &s
-}
-
 func int64Ptr(i int64) *int64 {
 	return &i
 }

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -514,8 +514,10 @@ func TestInterfaceMapper_Map(t *testing.T) {
 					},
 				},
 			},
-			expectedEntity: &diode.Interface{},
-			expectError:    false,
+			expectedEntity: &diode.Interface{
+				Name: stringPtr("Unknown"),
+			},
+			expectError: false,
 		},
 		{
 			name:   "empty values map",
@@ -525,8 +527,10 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				Entity: "interface",
 				Field:  "_id",
 			},
-			expectedEntity: &diode.Interface{},
-			expectError:    false,
+			expectedEntity: &diode.Interface{
+				Name: stringPtr("Unknown"),
+			},
+			expectError: false,
 		},
 	}
 

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -83,7 +83,9 @@ func createEntity(entityType EntityType) (diode.Entity, error) {
 	case "ipAddress":
 		return &diode.IPAddress{}, nil
 	case "interface":
-		return &diode.Interface{}, nil
+		return &diode.Interface{
+			Name: &[]string{"Unknown"}[0],
+		}, nil
 	case "device":
 		return &diode.Device{}, nil
 	}

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -84,12 +84,16 @@ func createEntity(entityType EntityType) (diode.Entity, error) {
 		return &diode.IPAddress{}, nil
 	case "interface":
 		return &diode.Interface{
-			Name: &[]string{"Unknown"}[0],
+			Name: StringPtr("Unknown"),
 		}, nil
 	case "device":
 		return &diode.Device{}, nil
 	}
 	return nil, fmt.Errorf("unimplemented entity type: %s", entityType)
+}
+
+func StringPtr(s string) *string {
+	return &s
 }
 
 // ObjectIDValueMap is a map of ObjectIDs to their values

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -92,6 +92,7 @@ func createEntity(entityType EntityType) (diode.Entity, error) {
 	return nil, fmt.Errorf("unimplemented entity type: %s", entityType)
 }
 
+// StringPtr is a helper function to create a pointer to a string
 func StringPtr(s string) *string {
 	return &s
 }


### PR DESCRIPTION
- Added debug logging to IP address, interface, and device mappers to track successful mapping operations with field values
- Set default "Unknown" name for interface entities when no name is provided during creation