### PR TITLE
feat: embed mappings

### DIFF
--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -94,7 +94,11 @@ func main() {
 		logger.Info("Metrics export configured", slog.String("endpoint", *otelEndpoint), slog.Int("period_seconds", *otelExportPeriod))
 	}
 
-	policyManager := policy.NewManager(ctx, logger, client)
+	policyManager, err := policy.NewManager(ctx, logger, client)
+	if err != nil {
+		logger.Error("failed to create policy manager", "error", err)
+		os.Exit(1)
+	}
 	server := server.NewServer(*host, *port, logger, policyManager, version.GetBuildVersion())
 
 	// handle signals

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -13,8 +13,6 @@ type Status struct {
 type Scope struct {
 	Targets        []Target       `yaml:"targets"`
 	Authentication Authentication `yaml:"authentication"`
-	MappingConfig  string         `yaml:"mapping_config,omitempty"`
-	Mappings       []MappingEntry `yaml:"mappings,omitempty"`
 }
 
 // Target represents a target host to crawl

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -23,19 +23,25 @@ const (
 
 // Manager represents the policy manager
 type Manager struct {
-	policies map[string]*Runner
-	client   diode.Client
-	logger   *slog.Logger
-	ctx      context.Context
+	policies      map[string]*Runner
+	client        diode.Client
+	logger        *slog.Logger
+	ctx           context.Context
+	mappingConfig config.Mapping
 }
 
 // NewManager returns a new policy manager
 func NewManager(ctx context.Context, logger *slog.Logger, client diode.Client) *Manager {
+	mappingConfig, err := loadMappingConfig()
+	if err != nil {
+		logger.Error("Failed to load mapping config", "error", err)
+	}
 	return &Manager{
-		ctx:      ctx,
-		client:   client,
-		logger:   logger,
-		policies: make(map[string]*Runner),
+		ctx:           ctx,
+		client:        client,
+		logger:        logger,
+		mappingConfig: mappingConfig,
+		policies:      make(map[string]*Runner),
 	}
 }
 
@@ -57,16 +63,10 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 	}
 
 	for name := range payload.Policies {
-		// Load the mapping config
-		mappingConfig, err := m.loadMappingConfig()
-		if err != nil {
-			return nil, fmt.Errorf("invalid mapping config : %w", err)
-		}
 
 		// Create a new policy with updated mappings
 		updatedPolicy := payload.Policies[name]
 		m.applyDefaults(&updatedPolicy)
-		updatedPolicy.Scope.Mappings = mappingConfig.Entries
 		payload.Policies[name] = updatedPolicy
 	}
 
@@ -74,8 +74,7 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 }
 
 // loadMappingConfig loads the mapping config from the embedded file
-func (m *Manager) loadMappingConfig() (config.Mapping, error) {
-	m.logger.Debug("Loading embedded mapping config")
+func loadMappingConfig() (config.Mapping, error) {
 	mappingConfigFileContents, err := embeddedMapping.ReadFile("mapping.yaml")
 	if err != nil {
 		return config.Mapping{}, fmt.Errorf("failed to read embedded mapping config file: %w", err)
@@ -161,16 +160,8 @@ func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 		return fmt.Errorf("%s : no targets found in the policy", name)
 	}
 
-	if len(policy.Scope.Mappings) == 0 {
-		return fmt.Errorf("%s : no mappings found in the policy", name)
-	}
-
-	if len(policy.Scope.Mappings) == 0 {
-		return fmt.Errorf("%s : no mappings found in the policy", name)
-	}
-
 	if !m.HasPolicy(name) {
-		r, err := NewRunner(m.ctx, m.logger, name, policy, m.client, snmp.NewClient)
+		r, err := NewRunner(m.ctx, m.logger, name, policy, m.client, snmp.NewClient, m.mappingConfig)
 		if err != nil {
 			return err
 		}

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -161,7 +161,7 @@ func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 	}
 
 	if !m.HasPolicy(name) {
-		r, err := NewRunner(m.ctx, m.logger, name, policy, m.client, snmp.NewClient, m.mappingConfig)
+		r, err := NewRunner(m.ctx, m.logger, name, policy, m.client, snmp.NewClient, &m.mappingConfig)
 		if err != nil {
 			return err
 		}

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -31,10 +31,11 @@ type Manager struct {
 }
 
 // NewManager returns a new policy manager
-func NewManager(ctx context.Context, logger *slog.Logger, client diode.Client) *Manager {
+func NewManager(ctx context.Context, logger *slog.Logger, client diode.Client) (*Manager, error) {
 	mappingConfig, err := loadMappingConfig()
 	if err != nil {
 		logger.Error("Failed to load mapping config", "error", err)
+		return nil, err
 	}
 	return &Manager{
 		ctx:           ctx,
@@ -42,7 +43,7 @@ func NewManager(ctx context.Context, logger *slog.Logger, client diode.Client) *
 		logger:        logger,
 		mappingConfig: mappingConfig,
 		policies:      make(map[string]*Runner),
-	}
+	}, nil
 }
 
 // ParsePolicies parses the policies from the request

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -2,16 +2,19 @@ package policy
 
 import (
 	"context"
+	"embed"
 	"errors"
 	"fmt"
 	"log/slog"
-	"os"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
 	"gopkg.in/yaml.v3"
 )
+
+//go:embed mapping.yaml
+var embeddedMapping embed.FS
 
 const (
 	// SNMPDefaultPort is the default SNMP port
@@ -53,11 +56,11 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 		}
 	}
 
-	for name, policy := range payload.Policies {
+	for name := range payload.Policies {
 		// Load the mapping config
-		mappingConfig, err := m.loadMappingConfig(policy)
+		mappingConfig, err := m.loadMappingConfig()
 		if err != nil {
-			return nil, fmt.Errorf("%s : invalid mapping config : %w", name, err)
+			return nil, fmt.Errorf("invalid mapping config : %w", err)
 		}
 
 		// Create a new policy with updated mappings
@@ -70,17 +73,17 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 	return payload.Policies, nil
 }
 
-// loadMappingConfig loads the mapping config from the file
-func (m *Manager) loadMappingConfig(policy config.Policy) (config.Mapping, error) {
-	m.logger.Debug("Loading mapping config", "mappingConfig", policy.Scope.MappingConfig)
-	mappingConfigFileContents, err := os.ReadFile(policy.Scope.MappingConfig)
+// loadMappingConfig loads the mapping config from the embedded file
+func (m *Manager) loadMappingConfig() (config.Mapping, error) {
+	m.logger.Debug("Loading embedded mapping config")
+	mappingConfigFileContents, err := embeddedMapping.ReadFile("mapping.yaml")
 	if err != nil {
-		return config.Mapping{}, fmt.Errorf("failed to read mapping config file: %w", err)
+		return config.Mapping{}, fmt.Errorf("failed to read embedded mapping config file: %w", err)
 	}
 
 	var mappingConfig config.Mapping
 	if err := yaml.Unmarshal(mappingConfigFileContents, &mappingConfig); err != nil {
-		return config.Mapping{}, err
+		return config.Mapping{}, fmt.Errorf("failed to unmarshal embedded mapping config: %w", err)
 	}
 
 	return mappingConfig, nil
@@ -140,15 +143,6 @@ func (m *Manager) validatePolicy(policy config.Policy) error {
 				return fmt.Errorf("missing priv protocol")
 			}
 		}
-	}
-
-	// Validate MappingConfig
-	if policy.Scope.MappingConfig == "" {
-		return fmt.Errorf("missing mapping configuration file")
-	}
-
-	if _, err := os.Stat(policy.Scope.MappingConfig); os.IsNotExist(err) {
-		return fmt.Errorf("mapping configuration file does not exist")
 	}
 
 	return nil

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -103,8 +103,6 @@ func TestManagerParsePolicies(t *testing.T) {
 		policies, err := manager.ParsePolicies(yamlData)
 		assert.NoError(t, err)
 		assert.Contains(t, policies, "policy1")
-		// Verify that the embedded mapping was loaded
-		assert.NotEmpty(t, policies["policy1"].Scope.Mappings)
 	})
 
 	t.Run("Invalid Policy", func(t *testing.T) {

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -33,19 +33,10 @@ func (m *MockRunner) Stop() error {
 	return args.Error(0)
 }
 
-func writeMappingConfigFile(filename string) {
-	_ = os.WriteFile(filename, []byte(`
-    entries:
-      - oid: 1.3.6.1.2.1.1.1.0
-        entity: device
-        field: description
-        description: "Device description string (sysDescr)"
-    `), 0o644)
-}
-
 func TestManagerParsePolicies(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
-	manager := policy.NewManager(context.Background(), logger, nil)
+	manager, err := policy.NewManager(context.Background(), logger, nil)
+	assert.NoError(t, err)
 
 	t.Run("Valid Policy", func(t *testing.T) {
 		yamlData := []byte(`
@@ -62,14 +53,7 @@ func TestManagerParsePolicies(t *testing.T) {
               authentication:
                 protocol_version: SNMPv2c
                 community: public
-              mapping_config: "valid_mapping.yaml"
        `)
-
-		// Create a dummy valid mapping file
-		writeMappingConfigFile("valid_mapping.yaml")
-		defer func() {
-			_ = os.Remove("valid_mapping.yaml")
-		}()
 
 		policies, err := manager.ParsePolicies(yamlData)
 		assert.NoError(t, err)
@@ -82,7 +66,7 @@ func TestManagerParsePolicies(t *testing.T) {
 		assert.Equal(t, uint16(161), policies["policy1"].Scope.Targets[1].Port)
 	})
 
-	t.Run("Policy with mapping config (now ignored)", func(t *testing.T) {
+	t.Run("Valid Policy with Embedded Mapping", func(t *testing.T) {
 		yamlData := []byte(`
         policies:
           policy1:
@@ -96,10 +80,9 @@ func TestManagerParsePolicies(t *testing.T) {
               authentication:
                 protocol_version: SNMPv2c
                 community: public
-              mapping_config: "invalid_mapping.yaml"
        `)
 
-		// Since we now use embedded mapping, this should succeed even with invalid mapping file path
+		// With embedded mapping, policies should parse successfully
 		policies, err := manager.ParsePolicies(yamlData)
 		assert.NoError(t, err)
 		assert.Contains(t, policies, "policy1")
@@ -130,7 +113,8 @@ func TestManagerParsePolicies(t *testing.T) {
 
 func TestManagerPolicyLifecycle(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
-	manager := policy.NewManager(context.Background(), logger, nil)
+	manager, err := policy.NewManager(context.Background(), logger, nil)
+	assert.NoError(t, err)
 	yamlData := []byte(`
         policies:
           policy1:
@@ -140,7 +124,6 @@ func TestManagerPolicyLifecycle(t *testing.T) {
               authentication:
                 protocol_version: SNMPv2c
                 community: public
-              mapping_config: "valid_mapping.yaml"
           policy2:
             scope:
               targets:
@@ -148,21 +131,13 @@ func TestManagerPolicyLifecycle(t *testing.T) {
               authentication:
                 protocol_version: SNMPv2c
                 community: public
-              mapping_config: "valid_mapping.yaml"
           policy3:
             scope:
               targets: []
               authentication:
                 protocol_version: SNMPv2c
                 community: public
-              mapping_config: "valid_mapping.yaml"
        `)
-
-	// Create a dummy valid mapping file
-	writeMappingConfigFile("valid_mapping.yaml")
-	defer func() {
-		_ = os.Remove("valid_mapping.yaml")
-	}()
 
 	policies, err := manager.ParsePolicies(yamlData)
 	assert.NoError(t, err)

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -82,7 +82,7 @@ func TestManagerParsePolicies(t *testing.T) {
 		assert.Equal(t, uint16(161), policies["policy1"].Scope.Targets[1].Port)
 	})
 
-	t.Run("Invalid MappingConfig", func(t *testing.T) {
+	t.Run("Policy with mapping config (now ignored)", func(t *testing.T) {
 		yamlData := []byte(`
         policies:
           policy1:
@@ -99,9 +99,12 @@ func TestManagerParsePolicies(t *testing.T) {
               mapping_config: "invalid_mapping.yaml"
        `)
 
-		_, err := manager.ParsePolicies(yamlData)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "policy1 : invalid policy : mapping configuration file does not exist")
+		// Since we now use embedded mapping, this should succeed even with invalid mapping file path
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		// Verify that the embedded mapping was loaded
+		assert.NotEmpty(t, policies["policy1"].Scope.Mappings)
 	})
 
 	t.Run("Invalid Policy", func(t *testing.T) {

--- a/snmp-discovery/policy/mapping.yaml
+++ b/snmp-discovery/policy/mapping.yaml
@@ -1,0 +1,47 @@
+entries:
+  # Interface mappings
+  - oid: ".1.3.6.1.2.1.2.2.1"
+    entity: "interface"
+    field: "_id"
+    identifier_size: 1
+    mapping_entries:
+      - oid: ".1.3.6.1.2.1.2.2.1.2"
+        entity: "interface"
+        field: "name"
+      - oid: ".1.3.6.1.2.1.2.2.1.5"
+        entity: "interface"
+        field: "speed"
+      - oid: ".1.3.6.1.2.1.2.2.1.6"
+        entity: "interface"
+        field: "macAddress"
+      - oid: ".1.3.6.1.2.1.2.2.1.7"
+        entity: "interface"
+        field: "adminStatus"
+
+  # IP Address mappings
+  - oid: ".1.3.6.1.2.1.4.20.1"
+    entity: "ipAddress"
+    field: "_id"
+    identifier_size: 4
+    mapping_entries:
+      - oid: ".1.3.6.1.2.1.4.20.1.1"
+        entity: "ipAddress"
+        field: "address"
+      - oid: ".1.3.6.1.2.1.4.20.1.2"
+        entity: "ipAddress"
+        field: "assigned_object"
+        relationship:
+          type: "interface"
+          field: "_id"
+
+  # Device mappings
+  - oid: ".1.3.6.1.2.1.1"
+    entity: "device"
+    field: "_id"
+    mapping_entries:
+      - oid: ".1.3.6.1.2.1.1.5.0"
+        entity: "device"
+        field: "name"
+      - oid: ".1.3.6.1.2.1.1.2.0"
+        entity: "device"
+        field: "platform"

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -38,11 +38,11 @@ type Runner struct {
 	config        config.PolicyConfig
 	ClientFactory snmp.ClientFactory
 	manufacturers data.DeviceDataRetreiver
-	mappingConfig config.Mapping
+	mappingConfig *config.Mapping
 }
 
 // NewRunner returns a new policy runner
-func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, client diode.Client, ClientFactory snmp.ClientFactory, mappingConfig config.Mapping) (*Runner, error) {
+func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, client diode.Client, ClientFactory snmp.ClientFactory, mappingConfig *config.Mapping) (*Runner, error) {
 	s, err := gocron.NewScheduler()
 	if err != nil {
 		return nil, err

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -38,10 +38,11 @@ type Runner struct {
 	config        config.PolicyConfig
 	ClientFactory snmp.ClientFactory
 	manufacturers data.DeviceDataRetreiver
+	mappingConfig config.Mapping
 }
 
 // NewRunner returns a new policy runner
-func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, client diode.Client, ClientFactory snmp.ClientFactory) (*Runner, error) {
+func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, client diode.Client, ClientFactory snmp.ClientFactory, mappingConfig config.Mapping) (*Runner, error) {
 	s, err := gocron.NewScheduler()
 	if err != nil {
 		return nil, err
@@ -61,6 +62,7 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 		logger:        logger,
 		ClientFactory: ClientFactory,
 		manufacturers: manufacturers,
+		mappingConfig: mappingConfig,
 	}
 
 	runner.task = gocron.NewTask(runner.run)
@@ -108,7 +110,7 @@ func (r *Runner) run() {
 	ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 	defer cancel()
 
-	mapper := mapping.NewObjectIDMapper(r.scope.Mappings, r.logger, r.manufacturers, &r.config.Defaults)
+	mapper := mapping.NewObjectIDMapper(r.mappingConfig.Entries, r.logger, r.manufacturers, &r.config.Defaults)
 	objectIDs := mapper.ObjectIDs()
 
 	r.logger.Info("Starting SNMP crawl of targets", slog.Any("targetCount", len(r.scope.Targets)), slog.Any("objectCount", len(objectIDs)))

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -94,7 +94,7 @@ func TestNewRunner(t *testing.T) {
 	ctx := context.Background()
 
 	// Create new runner
-	_, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, mappingConfig)
+	_, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, &mappingConfig)
 	assert.NoError(t, err, "policy.NewRunner should not return an error")
 }
 
@@ -187,7 +187,7 @@ func TestRunnerRun(t *testing.T) {
 			}
 
 			// Create runner
-			runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, mappingConfig)
+			runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, &mappingConfig)
 			assert.NoError(t, err, "policy.NewRunner should not return an error")
 
 			// Use a channel to signal that Ingest was called
@@ -278,7 +278,7 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	}
 
 	// Create runner
-	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, mappingConfig)
+	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, &mappingConfig)
 	assert.NoError(t, err)
 
 	// Use a channel to signal that Ingest was called
@@ -356,7 +356,7 @@ func TestRunnerWalkError(t *testing.T) {
 	}
 
 	// Create runner with the mock client factory
-	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, mockClientFactory, mappingConfig)
+	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, mockClientFactory, &mappingConfig)
 	assert.NoError(t, err)
 
 	// Set up a channel to detect if Ingest is called (it shouldn't be)

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -73,17 +73,19 @@ func TestNewRunner(t *testing.T) {
 					Port: 161,
 				},
 			},
-			Mappings: []config.MappingEntry{
-				{
-					OID:    "iso.3.6.1.2.1.2.2.1",
-					Entity: "interface",
-					Field:  "_id",
-					MappingEntries: []config.MappingEntry{
-						{
-							OID:    "iso.3.6.1.2.1.2.2.1.2",
-							Entity: "interface",
-							Field:  "name",
-						},
+		},
+	}
+	mappingConfig := config.Mapping{
+		Entries: []config.MappingEntry{
+			{
+				OID:    "iso.3.6.1.2.1.2.2.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []config.MappingEntry{
+					{
+						OID:    "iso.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
 					},
 				},
 			},
@@ -92,7 +94,7 @@ func TestNewRunner(t *testing.T) {
 	ctx := context.Background()
 
 	// Create new runner
-	_, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker)
+	_, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, mappingConfig)
 	assert.NoError(t, err, "policy.NewRunner should not return an error")
 }
 
@@ -163,26 +165,29 @@ func TestRunnerRun(t *testing.T) {
 						ProtocolVersion: snmp.ProtocolVersion2c,
 						Community:       "public",
 					},
-					Mappings: []config.MappingEntry{
-						{
-							OID:    "iso.3.6.1.2.1.2.2.1",
-							Entity: "interface",
-							Field:  "_id",
-							MappingEntries: []config.MappingEntry{
-								{
-									OID:    "iso.3.6.1.2.1.2.2.1.2",
-									Entity: "interface",
-									Field:  "name",
-								},
+				},
+			}
+			ctx := context.Background()
+
+			mappingConfig := config.Mapping{
+				Entries: []config.MappingEntry{
+					{
+						OID:    "iso.3.6.1.2.1.2.2.1",
+						Entity: "interface",
+						Field:  "_id",
+						MappingEntries: []config.MappingEntry{
+							{
+								OID:    "iso.3.6.1.2.1.2.2.1.2",
+								Entity: "interface",
+								Field:  "name",
 							},
 						},
 					},
 				},
 			}
-			ctx := context.Background()
 
 			// Create runner
-			runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker)
+			runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, mappingConfig)
 			assert.NoError(t, err, "policy.NewRunner should not return an error")
 
 			// Use a channel to signal that Ingest was called
@@ -252,17 +257,20 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 					Host: "192.168.1.1",
 				},
 			},
-			Mappings: []config.MappingEntry{
-				{
-					OID:    "iso.3.6.1.2.1.2.2.1",
-					Entity: "interface",
-					Field:  "_id",
-					MappingEntries: []config.MappingEntry{
-						{
-							OID:    "iso.3.6.1.2.1.2.2.1.2",
-							Entity: "interface",
-							Field:  "name",
-						},
+		},
+	}
+
+	mappingConfig := config.Mapping{
+		Entries: []config.MappingEntry{
+			{
+				OID:    "iso.3.6.1.2.1.2.2.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []config.MappingEntry{
+					{
+						OID:    "iso.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
 					},
 				},
 			},
@@ -270,7 +278,7 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	}
 
 	// Create runner
-	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker)
+	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, mappingConfig)
 	assert.NoError(t, err)
 
 	// Use a channel to signal that Ingest was called
@@ -343,8 +351,12 @@ func TestRunnerWalkError(t *testing.T) {
 		return mockHost, nil
 	}
 
+	mappingConfig := config.Mapping{
+		Entries: []config.MappingEntry{},
+	}
+
 	// Create runner with the mock client factory
-	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, mockClientFactory)
+	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, mockClientFactory, mappingConfig)
 	assert.NoError(t, err)
 
 	// Set up a channel to detect if Ingest is called (it shouldn't be)

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -38,9 +38,10 @@ func TestServerConfigureAndStart(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
 	client := new(MockClient)
-	policyManager := policy.NewManager(ctx, logger, client)
+	policyManager, err := policy.NewManager(ctx, logger, client)
+	require.NoError(t, err)
 
-	err := setupTestMeter(t)
+	err = setupTestMeter(t)
 	require.NoError(t, err)
 
 	srv := server.NewServer("localhost", 8081, logger, policyManager, "1.0.0")
@@ -65,7 +66,8 @@ func TestServerGetCapabilities(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
 	client := new(MockClient)
-	policyManager := policy.NewManager(ctx, logger, client)
+	policyManager, err := policy.NewManager(ctx, logger, client)
+	require.NoError(t, err)
 
 	srv := server.NewServer("localhost", 8081, logger, policyManager, "1.0.0")
 
@@ -84,7 +86,8 @@ func TestServerCreateDeletePolicy(t *testing.T) {
 	ctx := context.Background()
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
 	client := new(MockClient)
-	policyManager := policy.NewManager(ctx, logger, client)
+	policyManager, err := policy.NewManager(ctx, logger, client)
+	require.NoError(t, err)
 
 	srv := server.NewServer("localhost", 8081, logger, policyManager, "1.0.0")
 
@@ -100,16 +103,9 @@ func TestServerCreateDeletePolicy(t *testing.T) {
           authentication:
             protocol_version: SNMPv2c
             community: public
-          mapping_config: valid_mapping.yaml
     `)
 
-	// Create a dummy valid mapping file
-	writeMappingConfigFile("valid_mapping.yaml")
-	defer func() {
-		_ = os.Remove("valid_mapping.yaml")
-	}()
-
-	err := setupTestMeter(t)
+	err = setupTestMeter(t)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()
@@ -132,7 +128,6 @@ func TestServerCreateDeletePolicy(t *testing.T) {
           authentication:
             protocol_version: SNMPv2c
             community: public
-          mapping_config: valid_mapping.yaml
       test-policy:
         scope:
           targets: 
@@ -140,13 +135,7 @@ func TestServerCreateDeletePolicy(t *testing.T) {
           authentication:
             protocol_version: SNMPv2c
             community: public
-          mapping_config: valid_mapping.yaml
     `)
-
-	writeMappingConfigFile("valid_mapping.yaml")
-	defer func() {
-		_ = os.Remove("valid_mapping.yaml")
-	}()
 
 	w = httptest.NewRecorder()
 	request, _ = http.NewRequest(http.MethodPost, "/api/v1/policies", bytes.NewReader(body))
@@ -180,15 +169,6 @@ func setupTestMeter(_ *testing.T) error {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	// Use the no-op meter provider for testing to avoid actual metrics export
 	return metrics.SetupMetricsExport(ctx, logger, "localhost:4317", 10)
-}
-
-func writeMappingConfigFile(filename string) {
-	_ = os.WriteFile(filename, []byte(`
-    entries:
-      - oid: .1.3.6.1.2.1.1.1.0
-        entity: device
-        field: description
-    `), 0o644)
 }
 
 func TestServerCreateInvalidPolicy(t *testing.T) {
@@ -234,7 +214,6 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                   authentication:
                     protocol_version: SNMPv2c
                     community: public
-                  mapping_config: valid_mapping.yaml
               test-policy-invalid:
                 config:
                   defaults:
@@ -244,7 +223,6 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                   authentication:
                     protocol_version: SNMPv2c
                     community: public
-                  mapping_config: valid_mapping.yaml
             `),
 			returnCode:    http.StatusBadRequest,
 			returnMessage: `test-policy-invalid : no targets found in the policy`,
@@ -261,7 +239,6 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                   authentication:
                     protocol_version: SNMPv2c
                     community: public
-                  mapping_config: valid_mapping.yaml
               test-policy-invalid:
                 config:
                   defaults:
@@ -269,7 +246,6 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                 scope:
                   targets:
                     - host: 192.168.31.1
-                  mapping_config: valid_mapping.yaml
             `),
 			returnCode:    http.StatusBadRequest,
 			returnMessage: `test-policy-invalid : invalid policy : missing protocol version`,
@@ -286,7 +262,6 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                   authentication:
                     protocol_version: SNMPv4
                     community: public
-                  mapping_config: valid_mapping.yaml
             `),
 			returnCode:    http.StatusBadRequest,
 			returnMessage: `test-policy : invalid policy : unsupported protocol version`,
@@ -302,7 +277,6 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                     - host: 192.168.31.1
                   authentication:
                     protocol_version: SNMPv2c
-                  mapping_config: valid_mapping.yaml
             `),
 			returnCode:    http.StatusBadRequest,
 			returnMessage: `test-policy : invalid policy : missing community`,
@@ -324,7 +298,6 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                     auth_protocol: MD5
                     priv_passphrase: pass
                     priv_protocol: DES
-                  mapping_config: valid_mapping.yaml
             `),
 			returnCode:    http.StatusBadRequest,
 			returnMessage: `test-policy : invalid policy : invalid security level`,
@@ -345,7 +318,6 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                     auth_protocol: MD5
                     priv_passphrase: pass
                     priv_protocol: DES
-                  mapping_config: valid_mapping.yaml
             `),
 			returnCode:    http.StatusBadRequest,
 			returnMessage: `test-policy : invalid policy : invalid security level`,
@@ -420,7 +392,6 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                     auth_passphrase: pass
                     auth_protocol: MD5
                     priv_protocol: DES
-                  mapping_config: valid_mapping.yaml
             `),
 			returnCode:    http.StatusBadRequest,
 			returnMessage: `test-policy : invalid policy : missing priv passphrase`,
@@ -441,7 +412,6 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                     auth_passphrase: pass
                     priv_passphrase: pass
                     priv_protocol: DES
-                  mapping_config: valid_mapping.yaml
             `),
 			returnCode:    http.StatusBadRequest,
 			returnMessage: `test-policy : invalid policy : missing auth protocol`,
@@ -462,7 +432,6 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
                     auth_passphrase: pass
                     priv_passphrase: pass
                     auth_protocol: MD5
-                  mapping_config: valid_mapping.yaml
             `),
 			returnCode:    http.StatusBadRequest,
 			returnMessage: `test-policy : invalid policy : missing priv protocol`,
@@ -474,12 +443,8 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
 			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
 			client := new(MockClient)
 
-			writeMappingConfigFile("valid_mapping.yaml")
-			defer func() {
-				_ = os.Remove("valid_mapping.yaml")
-			}()
-
-			policyManager := policy.NewManager(ctx, logger, client)
+			policyManager, err := policy.NewManager(ctx, logger, client)
+			require.NoError(t, err)
 
 			srv := server.NewServer("localhost", 8073, logger, policyManager, "1.0.0")
 

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -467,49 +467,6 @@ func TestServerCreateInvalidPolicy(t *testing.T) {
 			returnCode:    http.StatusBadRequest,
 			returnMessage: `test-policy : invalid policy : missing priv protocol`,
 		},
-		{
-			desc:        "missing mapping config",
-			contentType: "application/x-yaml",
-			body: []byte(`
-            policies:
-              test-policy:
-                scope:
-                  targets:
-                    - host: 192.168.31.1
-                  authentication:
-                    protocol_version: SNMPv3
-                    security_level: authPriv
-                    username: user
-                    auth_passphrase: pass
-                    priv_passphrase: pass
-                    auth_protocol: MD5
-                    priv_protocol: DES
-            `),
-			returnCode:    http.StatusBadRequest,
-			returnMessage: `test-policy : invalid policy : missing mapping config`,
-		},
-		{
-			desc:        "missing mapping config file",
-			contentType: "application/x-yaml",
-			body: []byte(`
-            policies:
-              test-policy:
-                scope:
-                  targets:
-                    - host: 192.168.31.1
-                  authentication:
-                    protocol_version: SNMPv3
-                    security_level: authPriv
-                    username: user
-                    auth_passphrase: pass
-                    priv_passphrase: pass
-                    auth_protocol: MD5
-                    priv_protocol: DES
-                  mapping_config: invalid_mapping.yaml
-            `),
-			returnCode:    http.StatusBadRequest,
-			returnMessage: `test-policy : invalid policy : mapping configuration file does not exist`,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
This pull request refactors the SNMP discovery service to use an embedded mapping configuration instead of relying on external mapping files. The changes simplify configuration management, improve reliability, and update tests to reflect the new approach.

### Refactoring to Embedded Mapping Configuration:

* Removed the `MappingConfig` and `Mappings` fields from the `Scope` struct in `config.go`, as mapping configuration is now embedded.
* Introduced an embedded `mapping.yaml` file using the `embed` package, which contains predefined mapping entries. [[1]](diffhunk://#diff-97d32253107e3c811caf8c6de6078b90fc18fbfecca66691424c657d8b77651cR5-R18) [[2]](diffhunk://#diff-b7cede7e8e7568c61abe873dd0ab8f4f7fa2a47b9a3c047c8410b1b0fc971b38R1-R47)
* Updated the `Manager` struct and its `NewManager` constructor to load the embedded mapping configuration during initialization.
* Replaced the `loadMappingConfig` method to read from the embedded `mapping.yaml` file instead of external files.
* Removed validation logic for external mapping configuration files, as it is no longer needed.

### Updates to Policy and Runner Logic:

* Updated the `Runner` struct and its `NewRunner` constructor to accept the embedded mapping configuration as a parameter. [[1]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdR41-R45) [[2]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdR65)
* Modified the `run` method in `Runner` to use the embedded mapping configuration for object ID mapping.
* Simplified the `ParsePolicies` method to ignore mapping configuration in policy definitions, as the embedded mapping is used universally.

### Test Suite Adjustments:

* Updated tests in `manager_test.go` to reflect the new behavior of using embedded mappings, ensuring invalid mapping file paths no longer cause errors. [[1]](diffhunk://#diff-d7a8cc6613db677701db042f45e16e5c7b23bea87c2a21ccfce2a36e66bbd6b7L85-R85) [[2]](diffhunk://#diff-d7a8cc6613db677701db042f45e16e5c7b23bea87c2a21ccfce2a36e66bbd6b7L102-R105)
* Adjusted tests in `runner_test.go` to pass the embedded mapping configuration to `NewRunner` and validate its integration. [[1]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL76-R79) [[2]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL90-R97) [[3]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL166-R173) [[4]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL180-R190) [[5]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL255-R264) [[6]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL269-R281) [[7]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fR354-R359)
* Removed test cases in `server_test.go` that validated the presence or correctness of external mapping configuration files, as they are no longer relevant.