### PR TITLE
fix: make only one device entity is created per device

### DIFF
--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -332,6 +332,7 @@ func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defa
 	}
 }
 
+// CurrentDeviceIndex is the index of the current device
 const CurrentDeviceIndex = "CURRENT"
 
 // NewDeviceMapper creates a new DeviceMapper

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -181,7 +181,7 @@ func (m *InterfaceMapper) applyDefaults(entity *diode.Interface, defaults *confi
 // Map maps interfaces to entities
 func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults) diode.Entity {
 	m.logger.Debug("Mapping values to interface entity", "values", values, "mappingEntry", mappingEntry)
-	interfaceEntity := entityRegistry.GetOrCreateEntity(IPAddressEntityType, getIndex(values)).(*diode.Interface)
+	interfaceEntity := entityRegistry.GetOrCreateEntity(InterfaceEntityType, getIndex(values)).(*diode.Interface)
 
 	fieldFound := false
 	for objectID, value := range values {

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -181,7 +181,7 @@ func (m *InterfaceMapper) applyDefaults(entity *diode.Interface, defaults *confi
 // Map maps interfaces to entities
 func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults) diode.Entity {
 	m.logger.Debug("Mapping values to interface entity", "values", values, "mappingEntry", mappingEntry)
-	interfaceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values)).(*diode.Interface)
+	interfaceEntity := entityRegistry.GetOrCreateEntity(IPAddressEntityType, getIndex(values)).(*diode.Interface)
 
 	fieldFound := false
 	for objectID, value := range values {
@@ -332,6 +332,8 @@ func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defa
 	}
 }
 
+const CurrentDeviceIndex = "CURRENT"
+
 // NewDeviceMapper creates a new DeviceMapper
 func NewDeviceMapper(manufacturers data.ManufacturerRetriever, deviceLookup data.DeviceRetriever, logger *slog.Logger) *DeviceMapper {
 	return &DeviceMapper{
@@ -344,8 +346,7 @@ func NewDeviceMapper(manufacturers data.ManufacturerRetriever, deviceLookup data
 // Map maps devices to entities
 func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults) diode.Entity {
 	m.logger.Debug("Mapping values to device entity", "values", values, "mappingEntry", mappingEntry)
-	index := "CURRENT" // There's only one device per crawl
-	deviceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), ObjectIDIndex(index)).(*diode.Device)
+	deviceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), CurrentDeviceIndex).(*diode.Device)
 
 	fieldFound := false
 	for objectID, value := range values {

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -344,7 +344,8 @@ func NewDeviceMapper(manufacturers data.ManufacturerRetriever, deviceLookup data
 // Map maps devices to entities
 func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults) diode.Entity {
 	m.logger.Debug("Mapping values to device entity", "values", values, "mappingEntry", mappingEntry)
-	deviceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), getIndex(values)).(*diode.Device)
+	index := "CURRENT" // There's only one device per crawl
+	deviceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), ObjectIDIndex(index)).(*diode.Device)
 
 	fieldFound := false
 	for objectID, value := range values {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -104,8 +104,11 @@ type ObjectIDValueMap map[string]Value
 type EntityType string
 
 const (
-	DeviceEntityType    EntityType = "device"
+	// DeviceEntityType is the type of the device entity
+	DeviceEntityType EntityType = "device"
+	// InterfaceEntityType is the type of the interface entity
 	InterfaceEntityType EntityType = "interface"
+	// IPAddressEntityType is the type of the IP address entity
 	IPAddressEntityType EntityType = "ipAddress"
 )
 
@@ -259,12 +262,12 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 	uniqueEntities := make(map[diode.Entity]bool)
 	for index, value := range objectIDIndexMap {
 		m.logger.Debug("Mapping objectIDIndex", "objectIDIndex", index, "values", value.Values)
-		Entry, err := m.getMappingEntry(value.Index)
+		entry, err := m.getMappingEntry(value.Index)
 		if err != nil {
 			m.logger.Warn("Error finding mapping entry", "error", err, "objectID", value.Index)
 			continue
 		}
-		newEntity := Entry.MapToEntity(value.Values, m.registry, m.defaults, m.logger)
+		newEntity := entry.MapToEntity(value.Values, m.registry, m.defaults, m.logger)
 		uniqueEntities[newEntity] = true
 	}
 

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -103,6 +103,12 @@ type ObjectIDValueMap map[string]Value
 // EntityType is a type that represents an entity type
 type EntityType string
 
+const (
+	DeviceEntityType    EntityType = "device"
+	InterfaceEntityType EntityType = "interface"
+	IPAddressEntityType EntityType = "ipAddress"
+)
+
 // ObjectIDMapper is a struct that maps ObjectIDs to entities
 type ObjectIDMapper struct {
 	mapping  map[string]*Entry
@@ -262,7 +268,7 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 		uniqueEntities[newEntity] = true
 	}
 
-	currentDevice := m.registry.GetOrCreateEntity(EntityType("device"), ObjectIDIndex("CURRENT")).(*diode.Device)
+	currentDevice := m.registry.GetOrCreateEntity(DeviceEntityType, CurrentDeviceIndex).(*diode.Device)
 	entities := make([]diode.Entity, 0, len(uniqueEntities))
 	for entity := range uniqueEntities {
 		if diodeInterface, ok := entity.(*diode.Interface); ok {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -123,7 +123,7 @@ type Entry struct {
 }
 
 // MapToEntity maps a value to an entity
-func (m *Entry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistry *EntityRegistry, defaults *config.Defaults, logger *slog.Logger) []diode.Entity {
+func (m *Entry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistry *EntityRegistry, defaults *config.Defaults, logger *slog.Logger) diode.Entity {
 	logger.Debug("Mapping value to entity", "entity", m.Entity, "value", pdus)
 
 	if m.Mapper == nil {
@@ -136,7 +136,7 @@ func (m *Entry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistr
 		logger.Warn("No entity returned from mapper. Ignoring.", "entity", m.Entity)
 		return nil
 	}
-	return []diode.Entity{entity}
+	return entity
 }
 
 // NewObjectIDMapper creates a new ObjectIDMapper
@@ -250,7 +250,7 @@ func NewObjectIDIndexDetails(index string) *ObjectIDIndexDetails {
 // MapObjectIDsToEntity maps ObjectIDs to entities
 func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diode.Entity {
 	objectIDIndexMap := m.groupByObjectIDIndex(objectIDs)
-	entities := make([]diode.Entity, 0, len(objectIDIndexMap))
+	uniqueEntities := make(map[diode.Entity]bool)
 	for index, value := range objectIDIndexMap {
 		m.logger.Debug("Mapping objectIDIndex", "objectIDIndex", index, "values", value.Values)
 		Entry, err := m.getMappingEntry(value.Index)
@@ -258,28 +258,17 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 			m.logger.Warn("Error finding mapping entry", "error", err, "objectID", value.Index)
 			continue
 		}
-		newEntities := Entry.MapToEntity(value.Values, m.registry, m.defaults, m.logger)
-		entities = append(entities, newEntities...)
+		newEntity := Entry.MapToEntity(value.Values, m.registry, m.defaults, m.logger)
+		uniqueEntities[newEntity] = true
 	}
 
-	var currentDevice *diode.Device
-	for _, entity := range entities {
-		// check if it's a diode.Device
-		if device, ok := entity.(*diode.Device); ok {
-			if currentDevice != nil {
-				m.logger.Warn("Multiple devices found. Ignoring.", "device", device)
-			}
-			// check if the device has a name
-			currentDevice = device
-		}
-	}
-	if currentDevice == nil {
-		m.logger.Warn("No device found.")
-	}
-	for _, entity := range entities {
+	currentDevice := m.registry.GetOrCreateEntity(EntityType("device"), ObjectIDIndex("CURRENT")).(*diode.Device)
+	entities := make([]diode.Entity, 0, len(uniqueEntities))
+	for entity := range uniqueEntities {
 		if diodeInterface, ok := entity.(*diode.Interface); ok {
 			diodeInterface.Device = currentDevice
 		}
+		entities = append(entities, entity)
 	}
 	return entities
 }

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -81,6 +81,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 					},
 					Enabled: &[]bool{true}[0],
 					Type:    diode.String("virtual"),
+					Device:  &diode.Device{},
 				},
 				&diode.Interface{
 					Speed: &[]int64{1000000000}[0],
@@ -90,6 +91,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 					},
 					Enabled: &[]bool{false}[0],
 					Type:    diode.String("virtual"),
+					Device:  &diode.Device{},
 				},
 			},
 		},
@@ -158,6 +160,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 					},
 					Enabled: &[]bool{true}[0],
 					Type:    diode.String("virtual"),
+					Device:  &diode.Device{},
 				},
 				&diode.IPAddress{
 					Address: diode.String("192.168.1.2/32"),
@@ -265,14 +268,16 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 			},
 			expected: []diode.Entity{
 				&diode.Interface{
-					Name: diode.String("GigabitEthernet1/0/1"),
-					Type: diode.String("virtual"),
+					Name:   diode.String("GigabitEthernet1/0/1"),
+					Type:   diode.String("virtual"),
+					Device: &diode.Device{},
 				},
 				&diode.IPAddress{
 					Address: diode.String("192.168.1.2/32"),
 					AssignedObject: &diode.Interface{
-						Name: diode.String("GigabitEthernet1/0/1"),
-						Type: diode.String("virtual"),
+						Name:   diode.String("GigabitEthernet1/0/1"),
+						Type:   diode.String("virtual"),
+						Device: &diode.Device{},
 					},
 				},
 			},

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -286,6 +286,7 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 
 	expectedEntities := []diode.Entity{
 		&diode.Interface{
+			Device:      &diode.Device{},
 			Name:        diode.String("GigabitEthernet1/0/1"),
 			Description: diode.String("Interface Default"),
 			Tags: []*diode.Tag{


### PR DESCRIPTION
This pull request introduces several changes to the `snmp-discovery` module, focusing on improving entity mapping logic, ensuring unique entity handling, and updating tests to reflect these changes. The most significant updates include modifying the device mapping logic to enforce uniqueness, simplifying the `MapToEntity` method, and adding a `Device` field to test entities for better consistency.

### Entity Mapping Improvements:
* [`snmp-discovery/mapping/mappers.go`](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL347-R348): Updated the `Map` method in `DeviceMapper` to use a fixed index ("CURRENT") for device entities, ensuring there's only one device per crawl.
* [`snmp-discovery/mapping/mapping.go`](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L126-R126): Changed `MapToEntity` in `Entry` to return a single `diode.Entity` instead of a slice, simplifying entity mapping logic. [[1]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L126-R126) [[2]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L139-R139)
* [`snmp-discovery/mapping/mapping.go`](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L253-R271): Modified `MapObjectIDsToEntity` in `ObjectIDMapper` to ensure entities are unique using a map and added logic to associate interfaces with the current device.

### Test Updates:
* `snmp-discovery/mapping/mapping_test.go` and `snmp-discovery/policy/runner_test.go`: Added the `Device` field to test entities to align with the updated mapping logic and ensure consistency in test cases. [[1]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519R84) [[2]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519R94) [[3]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519R163) [[4]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519R273-R280) [[5]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fR289)