### PR TITLE
fix: select correct mapping entry for PDU

### DIFF
--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -230,7 +230,21 @@ type ObjectIDIndex string
 
 // HasParent returns true if the ObjectIDIndex has a parent
 func (o *ObjectIDIndex) HasParent(parent string) bool {
-	return strings.HasPrefix(string(*o), parent)
+	child := string(*o)
+	parentParts := strings.Split(parent, ".")
+	childParts := strings.Split(child, ".")
+
+	if len(parentParts) > len(childParts) {
+		return false
+	}
+
+	for i := 0; i < len(parentParts); i++ {
+		if parentParts[i] != childParts[i] {
+			return false // Mismatch found
+		}
+	}
+
+	return true
 }
 
 // ObjectIDIndexDetails is a struct that contains an index and a map of values

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -456,7 +456,7 @@ func TestObjectIDIndex_HasParent(t *testing.T) {
 			name:     "empty parent",
 			index:    "1.2.3.4",
 			parent:   "",
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "empty index",


### PR DESCRIPTION
This pull request refines the `HasParent` method in the `ObjectIDIndex` type and updates its corresponding test cases to ensure accurate behavior when comparing parent-child relationships in SNMP object IDs.

### Changes to `HasParent` method logic:
* [`snmp-discovery/mapping/mapping.go`](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L233-R247): The `HasParent` method now performs a more detailed comparison between parent and child object IDs by splitting them into parts and checking each segment for equality. This ensures that the parent-child relationship is correctly validated even when the parent has fewer segments than the child.

### Updates to test cases:
* [`snmp-discovery/mapping/mapping_test.go`](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L459-R459): Modified the test case for an empty parent to expect `false` instead of `true`, aligning with the updated logic in the `HasParent` method.