### PR TITLE
Release

### DIFF
--- a/snmp-discovery/data/lookup_extensions.go
+++ b/snmp-discovery/data/lookup_extensions.go
@@ -80,25 +80,22 @@ func (m *ManufacturerLookup) GetManufacturer(id string) (string, error) {
 	return "", fmt.Errorf("manufacturer not found")
 }
 
-// DeviceRetriever is an interface that provides a method to retrieve device information by vendor and device IDs
+// DeviceRetriever is an interface that provides a method to retrieve device information by device OID
 type DeviceRetriever interface {
-	GetDevice(vendorID, deviceID string) (string, error)
+	GetDevice(deviceOID string) (string, error)
 }
 
 // DeviceLookup represents a device lookup service
 type DeviceLookup struct {
-	devicesByVendor map[string]map[string]string
+	devicesByVendor map[string]string
 }
 
-// GetDevice returns the device name for given vendor ID and device ID
-func (d *DeviceLookup) GetDevice(vendorID, deviceID string) (string, error) {
-	if devices, ok := d.devicesByVendor[vendorID]; ok {
-		if deviceName, ok := devices[deviceID]; ok {
-			return deviceName, nil
-		}
-		return "", fmt.Errorf("device ID %s not found for vendor %s", deviceID, vendorID)
+// GetDevice returns the device name for given device OID
+func (d *DeviceLookup) GetDevice(deviceOID string) (string, error) {
+	if device, ok := d.devicesByVendor[deviceOID]; ok {
+		return device, nil
 	}
-	return "", fmt.Errorf("vendor ID %s not found", vendorID)
+	return "", fmt.Errorf("device ID %s not found", deviceOID)
 }
 
 // LoadDeviceLookupExtensions loads device data from YAML files in the specified directory
@@ -107,11 +104,11 @@ func LoadDeviceLookupExtensions(dir string) (*DeviceLookup, error) {
 	files, err := os.ReadDir(dir)
 	if err != nil {
 		return &DeviceLookup{
-			devicesByVendor: make(map[string]map[string]string),
+			devicesByVendor: make(map[string]string),
 		}, fmt.Errorf("failed to read directory %s: %w", dir, err)
 	}
 
-	devicesByVendor := make(map[string]map[string]string)
+	devicesByVendor := make(map[string]string)
 
 	for _, file := range files {
 		if !isLookupExtensionFile(file) {
@@ -142,14 +139,14 @@ func isLookupExtensionFile(file os.DirEntry) bool {
 }
 
 // loadYAMLFile loads a single YAML file and merges its data into devicesByVendor
-func loadYAMLFile(filePath string, devicesByVendor *map[string]map[string]string) error {
+func loadYAMLFile(filePath string, devicesByVendor *map[string]string) error {
 	data, err := os.ReadFile(filePath)
 	if err != nil {
 		return fmt.Errorf("failed to read file %s: %w", filePath, err)
 	}
 
 	var fileData struct {
-		Devices map[string]map[string]string `yaml:"devices"`
+		Devices map[string]string `yaml:"devices"`
 	}
 
 	if err := yaml.Unmarshal(data, &fileData); err != nil {
@@ -157,14 +154,8 @@ func loadYAMLFile(filePath string, devicesByVendor *map[string]map[string]string
 	}
 
 	// Merge the data into devicesByVendor
-	for vendorID, devices := range fileData.Devices {
-		if (*devicesByVendor)[vendorID] == nil {
-			(*devicesByVendor)[vendorID] = make(map[string]string)
-		}
-
-		for deviceID, deviceName := range devices {
-			(*devicesByVendor)[vendorID][deviceID] = deviceName
-		}
+	for deviceOID, deviceName := range fileData.Devices {
+		(*devicesByVendor)[deviceOID] = deviceName
 	}
 
 	return nil

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -169,84 +169,43 @@ func TestManufacturerLookup_EdgeCases(t *testing.T) {
 func TestDeviceLookup_GetDevice(t *testing.T) {
 	// Create a test DeviceLookup with sample data
 	deviceLookup := &DeviceLookup{
-		devicesByVendor: map[string]map[string]string{
-			"1234": {
-				"5678": "Test Device A",
-				"9ABC": "Test Device B",
-			},
-			"ABCD": {
-				"1111": "Another Device",
-				"2222": "Yet Another Device",
-			},
+		devicesByVendor: map[string]string{
+			"1.3.6.1.4.1.9.1.1234": "Test Device A",
+			"1.3.6.1.4.1.9.1.4321": "Test Device B",
 		},
 	}
 
 	tests := []struct {
-		name     string
-		vendorID string
-		deviceID string
-		want     string
-		wantErr  bool
-		errMsg   string
+		name      string
+		deviceOID string
+		want      string
+		wantErr   bool
+		errMsg    string
 	}{
 		{
-			name:     "successful lookup - existing vendor and device",
-			vendorID: "1234",
-			deviceID: "5678",
-			want:     "Test Device A",
-			wantErr:  false,
+			name:      "successful lookup - existing vendor and device",
+			deviceOID: "1.3.6.1.4.1.9.1.1234",
+			want:      "Test Device A",
+			wantErr:   false,
 		},
 		{
-			name:     "successful lookup - another device",
-			vendorID: "1234",
-			deviceID: "9ABC",
-			want:     "Test Device B",
-			wantErr:  false,
+			name:      "successful lookup - another device",
+			deviceOID: "1.3.6.1.4.1.9.1.4321",
+			want:      "Test Device B",
+			wantErr:   false,
 		},
 		{
-			name:     "successful lookup - different vendor",
-			vendorID: "ABCD",
-			deviceID: "1111",
-			want:     "Another Device",
-			wantErr:  false,
-		},
-		{
-			name:     "non-existing vendor",
-			vendorID: "FFFF",
-			deviceID: "1234",
-			want:     "",
-			wantErr:  true,
-			errMsg:   "vendor ID FFFF not found",
-		},
-		{
-			name:     "existing vendor but non-existing device",
-			vendorID: "1234",
-			deviceID: "FFFF",
-			want:     "",
-			wantErr:  true,
-			errMsg:   "device ID FFFF not found for vendor 1234",
-		},
-		{
-			name:     "empty vendor ID",
-			vendorID: "",
-			deviceID: "1234",
-			want:     "",
-			wantErr:  true,
-			errMsg:   "vendor ID  not found",
-		},
-		{
-			name:     "empty device ID",
-			vendorID: "1234",
-			deviceID: "",
-			want:     "",
-			wantErr:  true,
-			errMsg:   "device ID  not found for vendor 1234",
+			name:      "unsuccessful lookup - non-existing device OID",
+			deviceOID: "1.3.6.1.4.1.9.1.987",
+			want:      "",
+			wantErr:   true,
+			errMsg:    "device ID 1.3.6.1.4.1.9.1.987 not found",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := deviceLookup.GetDevice(tt.vendorID, tt.deviceID)
+			got, err := deviceLookup.GetDevice(tt.deviceOID)
 			if tt.wantErr {
 				assert.Error(t, err)
 				assert.Equal(t, "", got)
@@ -273,72 +232,52 @@ func TestLoadDeviceLookupExtensions(t *testing.T) {
 		name     string
 		files    map[string]string
 		wantErr  bool
-		expected map[string]map[string]string
+		expected map[string]string
 	}{
 		{
 			name: "single valid YAML file",
 			files: map[string]string{
 				"devices.yaml": `devices:
-  "1234":
-    "5678": "Test Device A"
-    "9ABC": "Test Device B"
-  "ABCD":
-    "1111": "Another Device"`,
+  "1.3.6.1.4.1.9.1.1234": "Test Device A"
+  "1.3.6.1.4.1.9.1.4321": "Test Device B"`,
 			},
 			wantErr: false,
-			expected: map[string]map[string]string{
-				"1234": {
-					"5678": "Test Device A",
-					"9ABC": "Test Device B",
-				},
-				"ABCD": {
-					"1111": "Another Device",
-				},
+			expected: map[string]string{
+				"1.3.6.1.4.1.9.1.1234": "Test Device A",
+				"1.3.6.1.4.1.9.1.4321": "Test Device B",
 			},
 		},
 		{
 			name: "multiple YAML files with merge",
 			files: map[string]string{
 				"devices1.yaml": `devices:
-  "1234":
-    "5678": "Device A"`,
+  "1.3.6.1.4.1.9.1.1234": "Device A"`,
 				"devices2.yml": `devices:
-  "1234":
-    "9ABC": "Device B"
-  "ABCD":
-    "1111": "Device C"`,
+  "1.3.6.1.4.1.9.1.4321": "Device B"`,
 			},
 			wantErr: false,
-			expected: map[string]map[string]string{
-				"1234": {
-					"5678": "Device A",
-					"9ABC": "Device B",
-				},
-				"ABCD": {
-					"1111": "Device C",
-				},
+			expected: map[string]string{
+				"1.3.6.1.4.1.9.1.1234": "Device A",
+				"1.3.6.1.4.1.9.1.4321": "Device B",
 			},
 		},
 		{
 			name:     "empty directory",
 			files:    map[string]string{},
 			wantErr:  false,
-			expected: map[string]map[string]string{},
+			expected: map[string]string{},
 		},
 		{
 			name: "non-YAML files ignored",
 			files: map[string]string{
 				"devices.yaml": `devices:
-  "1234":
-    "5678": "Test Device"`,
+  "1.3.6.1.4.1.9.1.1234": "Test Device"`,
 				"readme.txt":  "This should be ignored",
 				"config.json": `{"ignored": true}`,
 			},
 			wantErr: false,
-			expected: map[string]map[string]string{
-				"1234": {
-					"5678": "Test Device",
-				},
+			expected: map[string]string{
+				"1.3.6.1.4.1.9.1.1234": "Test Device",
 			},
 		},
 	}
@@ -414,12 +353,10 @@ func TestLoadDeviceLookupExtensions_InvalidYAML(t *testing.T) {
 
 	// Create a valid YAML file and an invalid one
 	validYAML := `devices:
-  "1234":
-    "5678": "Valid Device"`
+  "1.3.6.1.4.1.9.1.1234": "Valid Device"`
 
 	invalidYAML := `devices:
-  "1234":
-    "5678": "Invalid YAML
+  "1.3.6.1.4.1.9.1.1234": "Invalid YAML
       missing quotes and proper structure`
 
 	err = os.WriteFile(filepath.Join(tempDir, "valid.yaml"), []byte(validYAML), 0o644)
@@ -434,10 +371,8 @@ func TestLoadDeviceLookupExtensions_InvalidYAML(t *testing.T) {
 	assert.NotNil(t, deviceLookup)
 
 	// Should only contain data from valid file
-	expected := map[string]map[string]string{
-		"1234": {
-			"5678": "Valid Device",
-		},
+	expected := map[string]string{
+		"1.3.6.1.4.1.9.1.1234": "Valid Device",
 	}
 	assert.Equal(t, expected, deviceLookup.devicesByVendor)
 }
@@ -551,45 +486,33 @@ func TestLoadYAMLFile(t *testing.T) {
 	tests := []struct {
 		name     string
 		content  string
-		initial  map[string]map[string]string
-		expected map[string]map[string]string
+		initial  map[string]string
+		expected map[string]string
 		wantErr  bool
 	}{
 		{
 			name: "valid YAML file",
 			content: `devices:
-  "1234":
-    "5678": "Device A"
-    "9ABC": "Device B"`,
-			initial: make(map[string]map[string]string),
-			expected: map[string]map[string]string{
-				"1234": {
-					"5678": "Device A",
-					"9ABC": "Device B",
-				},
+    "1.3.6.1.4.1.9.1.1234": "Device A"
+    "1.3.6.1.4.1.9.1.4321": "Device B"`,
+			initial: make(map[string]string),
+			expected: map[string]string{
+				"1.3.6.1.4.1.9.1.1234": "Device A",
+				"1.3.6.1.4.1.9.1.4321": "Device B",
 			},
 			wantErr: false,
 		},
 		{
 			name: "merge with existing data",
 			content: `devices:
-  "1234":
-    "DDDD": "Device D"
-  "ABCD":
-    "1111": "Device C"`,
-			initial: map[string]map[string]string{
-				"1234": {
-					"5678": "Device A",
-				},
+    "1.3.6.1.4.1.9.1.1234": "Device A"
+    "1.3.6.1.4.1.9.1.4321": "Device B"`,
+			initial: map[string]string{
+				"1.3.6.1.4.1.9.1.1234": "Device A",
 			},
-			expected: map[string]map[string]string{
-				"1234": {
-					"5678": "Device A",
-					"DDDD": "Device D",
-				},
-				"ABCD": {
-					"1111": "Device C",
-				},
+			expected: map[string]string{
+				"1.3.6.1.4.1.9.1.1234": "Device A",
+				"1.3.6.1.4.1.9.1.4321": "Device B",
 			},
 			wantErr: false,
 		},
@@ -600,15 +523,15 @@ func TestLoadYAMLFile(t *testing.T) {
     "5678": [unclosed list
       - item1
       - item2`,
-			initial:  make(map[string]map[string]string),
-			expected: make(map[string]map[string]string),
+			initial:  make(map[string]string),
+			expected: make(map[string]string),
 			wantErr:  true,
 		},
 		{
 			name:     "empty file",
 			content:  "",
-			initial:  make(map[string]map[string]string),
-			expected: make(map[string]map[string]string),
+			initial:  make(map[string]string),
+			expected: make(map[string]string),
 			wantErr:  false,
 		},
 	}
@@ -621,12 +544,9 @@ func TestLoadYAMLFile(t *testing.T) {
 			require.NoError(t, err)
 
 			// Create initial devicesByVendor map
-			devicesByVendor := make(map[string]map[string]string)
+			devicesByVendor := make(map[string]string)
 			for k, v := range tt.initial {
-				devicesByVendor[k] = make(map[string]string)
-				for dk, dv := range v {
-					devicesByVendor[k][dk] = dv
-				}
+				devicesByVendor[k] = v
 			}
 
 			// Test loadYAMLFile
@@ -642,7 +562,7 @@ func TestLoadYAMLFile(t *testing.T) {
 }
 
 func TestLoadYAMLFile_FileErrors(t *testing.T) {
-	devicesByVendor := make(map[string]map[string]string)
+	devicesByVendor := make(map[string]string)
 
 	// Test with non-existent file
 	err := loadYAMLFile("/path/that/does/not/exist.yaml", &devicesByVendor)

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -362,8 +362,7 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 					deviceEntity.Description = &value.Value
 					fieldFound = true
 				case "platform":
-					// Use getDeviceIDs to get the manufacturer and model
-					manufacturerID, modelID, err := m.getDeviceIDs(value.Value)
+					manufacturerID, err := m.getManufacturerID(value.Value)
 					if err != nil {
 						m.logger.Warn("Error getting device IDs", "error", err, "value", value.Value)
 						continue
@@ -384,9 +383,9 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 						Manufacturer: &manufacturerEntity,
 					}
 
-					deviceModel, err := m.deviceLookup.GetDevice(manufacturerID, modelID)
+					deviceModel, err := m.deviceLookup.GetDevice(value.Value)
 					if err != nil {
-						m.logger.Warn("Error getting device model falling back to OID", "error", err, "modelID", modelID)
+						m.logger.Warn("Error getting device model falling back to OID", "error", err, "deviceOID", value.Value)
 						deviceModel = value.Value
 					}
 					deviceEntity.DeviceType = &diode.DeviceType{
@@ -414,7 +413,7 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 	return deviceEntity
 }
 
-func (m *DeviceMapper) getDeviceIDs(objectID string) (string, string, error) {
+func (m *DeviceMapper) getManufacturerID(objectID string) (string, error) {
 	parts := strings.Split(objectID, ".")
 	if len(parts) > 0 && parts[0] == "" {
 		parts = parts[1:]
@@ -423,10 +422,10 @@ func (m *DeviceMapper) getDeviceIDs(objectID string) (string, string, error) {
 	const ManufacturerIDIndex = 6
 	// Check if we have enough parts to extract manufacturer and model IDs
 	if len(parts) > ManufacturerIDIndex {
-		return parts[ManufacturerIDIndex], strings.Join(parts[ManufacturerIDIndex+1:], "."), nil
+		return parts[ManufacturerIDIndex], nil
 	}
 
-	return "", "", fmt.Errorf("invalid objectID: %s", objectID)
+	return "", fmt.Errorf("invalid objectID: %s", objectID)
 }
 
 func toSlug(input *string) *string {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -616,9 +616,9 @@ func TestDeviceMapper_Map(t *testing.T) {
 
 	// Create a mock manufacturer data retriever
 	mockDeviceLookup := &MockDeviceLookup{}
-	mockDeviceLookup.On("GetDevice", "9", "1.1234").Return("cisco4000", nil)
-	mockDeviceLookup.On("GetDevice", "9", "1.9999").Return("", fmt.Errorf("device not found"))
-	mockDeviceLookup.On("GetDevice", "123", "1.5678").Return("device-with-unknown-manufacturer", nil)
+	mockDeviceLookup.On("GetDevice", "1.3.6.1.4.1.9.1.1234").Return("cisco4000", nil)
+	mockDeviceLookup.On("GetDevice", "1.3.6.1.4.1.9.1.9999").Return("", fmt.Errorf("device not found"))
+	mockDeviceLookup.On("GetDevice", "1.3.6.1.4.1.123.1.5678").Return("device-with-unknown-manufacturer", nil)
 
 	mockManufacturers := &MockManufacturerDataRetriever{}
 	mockManufacturers.On("GetManufacturer", "9").Return("Cisco", nil)
@@ -1000,8 +1000,8 @@ type MockDeviceLookup struct {
 	mock.Mock
 }
 
-func (m *MockDeviceLookup) GetDevice(vendorID, deviceID string) (string, error) {
-	args := m.Called(vendorID, deviceID)
+func (m *MockDeviceLookup) GetDevice(deviceOID string) (string, error) {
+	args := m.Called(deviceOID)
 	return args.Get(0).(string), args.Error(1)
 }
 

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -230,7 +230,21 @@ type ObjectIDIndex string
 
 // HasParent returns true if the ObjectIDIndex has a parent
 func (o *ObjectIDIndex) HasParent(parent string) bool {
-	return strings.HasPrefix(string(*o), parent)
+	child := string(*o)
+	parentParts := strings.Split(parent, ".")
+	childParts := strings.Split(child, ".")
+
+	if len(parentParts) > len(childParts) {
+		return false
+	}
+
+	for i := 0; i < len(parentParts); i++ {
+		if parentParts[i] != childParts[i] {
+			return false // Mismatch found
+		}
+	}
+
+	return true
 }
 
 // ObjectIDIndexDetails is a struct that contains an index and a map of values

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -456,7 +456,7 @@ func TestObjectIDIndex_HasParent(t *testing.T) {
 			name:     "empty parent",
 			index:    "1.2.3.4",
 			parent:   "",
-			expected: true,
+			expected: false,
 		},
 		{
 			name:     "empty index",

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -19,7 +19,7 @@ func (f *FakeManufacturers) GetManufacturer(_ string) (string, error) {
 
 type FakeDeviceLookup struct{}
 
-func (f *FakeDeviceLookup) GetDevice(_ string, _ string) (string, error) {
+func (f *FakeDeviceLookup) GetDevice(_ string) (string, error) {
 	return "cisco4000", nil
 }
 

--- a/snmp-discovery/scripts/create-cisco-device-list.sh
+++ b/snmp-discovery/scripts/create-cisco-device-list.sh
@@ -12,13 +12,11 @@ curl -sS "$MIB_URL" -o "$TMPFILE"
 # Start YAML
 echo "devices:"
 
-echo "  9: # Cisco PEN" 
-
 # Parse each matching line and append to YAML
 grep "1\.3\.6\.1\.4\.1\.9\.1\." "$TMPFILE" | while read -r line; do
-  ID=$(echo "$line" | awk '{print $2}' | sed 's/1\.3\.6\.1\.4\.1\.9\.//')
+  OID=$(echo $line | awk '{print $2}')
   NAME=$(echo "$line" | awk '{print $1}')
-  echo "    $ID: \"$NAME\""
+  echo "  $OID: $NAME"
 done
 
 # Clean up


### PR DESCRIPTION
This pull request refactors the `snmp-discovery` module to simplify the device lookup process by transitioning from a vendor-and-device ID-based mapping to a single device OID-based mapping. The changes impact core functionality, associated tests, and scripts, ensuring consistency across the codebase.

### Core functionality changes:
* Updated `DeviceRetriever` interface and `DeviceLookup` struct to use device OIDs instead of vendor and device IDs, simplifying the lookup process. (`snmp-discovery/data/lookup_extensions.go`, [[1]](diffhunk://#diff-ae2e522f9cbb28990372f1001533d602c4301bca8df826205644600ca8fcb0c9L83-R98) [[2]](diffhunk://#diff-ae2e522f9cbb28990372f1001533d602c4301bca8df826205644600ca8fcb0c9L110-R111)
* Refactored `loadYAMLFile` function to handle flat device OID mappings instead of nested vendor-device mappings. (`snmp-discovery/data/lookup_extensions.go`, [snmp-discovery/data/lookup_extensions.goL145-R158](diffhunk://#diff-ae2e522f9cbb28990372f1001533d602c4301bca8df826205644600ca8fcb0c9L145-R158))

### Test updates:
* Modified test cases to align with the new device OID-based structure, including updates to mock data and expected results. (`snmp-discovery/data/lookup_extensions_test.go`, [[1]](diffhunk://#diff-58ccfbf44be82c7430183ea30b8086bd15fcb50b136718225b67381e3834c4ffL172-R208) [[2]](diffhunk://#diff-58ccfbf44be82c7430183ea30b8086bd15fcb50b136718225b67381e3834c4ffL276-R280) [[3]](diffhunk://#diff-58ccfbf44be82c7430183ea30b8086bd15fcb50b136718225b67381e3834c4ffL417-R359) [[4]](diffhunk://#diff-58ccfbf44be82c7430183ea30b8086bd15fcb50b136718225b67381e3834c4ffL554-R515)
* Adjusted `MockDeviceLookup` and related tests to reflect the simplified `GetDevice` method. (`snmp-discovery/mapping/mappers_test.go`, [[1]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L619-R621) [[2]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L1003-R1004)

### Mapping logic changes:
* Refactored `DeviceMapper` to use device OIDs directly, removing manufacturer and model ID extraction logic. (`snmp-discovery/mapping/mappers.go`, [[1]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL365-R365) [[2]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL387-R388) [[3]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL417-R416) [[4]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL426-R428)

### Utility updates:
* Enhanced `ObjectIDIndex.HasParent` method for more robust parent-child relationship checks. (`snmp-discovery/mapping/mapping.go`, [snmp-discovery/mapping/mapping.goL233-R247](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L233-R247))

### Script changes:
* Updated `create-cisco-device-list.sh` script to generate YAML mappings directly from device OIDs instead of extracting IDs. (`snmp-discovery/scripts/create-cisco-device-list.sh`, [snmp-discovery/scripts/create-cisco-device-list.shL15-R19](diffhunk://#diff-ba3e2aeb54171eb66267330902e1c08d4e69dcf4f6d1fcc13d6c5593bf53b643L15-R19))