### PR TITLE
fix: add a leading dot to OIDs to match other lookups

### DIFF
--- a/snmp-discovery/scripts/create-cisco-device-list.sh
+++ b/snmp-discovery/scripts/create-cisco-device-list.sh
@@ -14,9 +14,9 @@ echo "devices:"
 
 # Parse each matching line and append to YAML
 grep "1\.3\.6\.1\.4\.1\.9\.1\." "$TMPFILE" | while read -r line; do
-  OID=$(echo $line | awk '{print $2}')
+  OID=$(echo $line | awk '{print $2}' | sed 's/^"//' | sed 's/"$//')
   NAME=$(echo "$line" | awk '{print $1}')
-  echo "  $OID: $NAME"
+  echo "  .$OID: $NAME"
 done
 
 # Clean up


### PR DESCRIPTION
This pull request modifies the `create-cisco-device-list.sh` script to improve the formatting of OIDs and ensure proper handling of quotation marks. 

Formatting and handling improvements:

* [`snmp-discovery/scripts/create-cisco-device-list.sh`](diffhunk://#diff-ba3e2aeb54171eb66267330902e1c08d4e69dcf4f6d1fcc13d6c5593bf53b643L17-R19): Updated the `OID` extraction to strip surrounding quotation marks using `sed` and added a leading period (`.`) to the OID in the YAML output for better compatibility.