### PR TITLE
Release

### DIFF
--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -420,6 +420,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				Speed:             int64Ptr(1000000),
 				PrimaryMacAddress: &diode.MACAddress{MacAddress: mapping.StringPtr("00:11:22:33:44:55")},
 				Enabled:           boolPtr(true),
+				Type:              mapping.StringPtr("other"),
 			},
 			expectError: false,
 		},
@@ -515,7 +516,8 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				},
 			},
 			expectedEntity: &diode.Interface{
-				Name: mapping.StringPtr("Unknown"),
+				Name: mapping.StringPtr("unknown"),
+				Type: mapping.StringPtr("other"),
 			},
 			expectError: false,
 		},
@@ -528,7 +530,8 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				Field:  "_id",
 			},
 			expectedEntity: &diode.Interface{
-				Name: mapping.StringPtr("Unknown"),
+				Name: mapping.StringPtr("unknown"),
+				Type: mapping.StringPtr("other"),
 			},
 			expectError: false,
 		},

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -84,7 +84,8 @@ func createEntity(entityType EntityType) (diode.Entity, error) {
 		return &diode.IPAddress{}, nil
 	case "interface":
 		return &diode.Interface{
-			Name: StringPtr("Unknown"),
+			Name: StringPtr("unknown"),
+			Type: StringPtr("other"),
 		}, nil
 	case "device":
 		return &diode.Device{}, nil

--- a/snmp-discovery/scripts/create-cisco-device-list.sh
+++ b/snmp-discovery/scripts/create-cisco-device-list.sh
@@ -14,9 +14,9 @@ echo "devices:"
 
 # Parse each matching line and append to YAML
 grep "1\.3\.6\.1\.4\.1\.9\.1\." "$TMPFILE" | while read -r line; do
-  OID=$(echo $line | awk '{print $2}')
+  OID=$(echo $line | awk '{print $2}' | sed 's/^"//' | sed 's/"$//')
   NAME=$(echo "$line" | awk '{print $1}')
-  echo "  $OID: $NAME"
+  echo "  .$OID: $NAME"
 done
 
 # Clean up


### PR DESCRIPTION
This pull request includes changes to enhance the handling of interface entities and improve the parsing of device lists in the SNMP discovery module. The most important updates include standardizing the default interface name, adding a `Type` field to interface entities, and refining the parsing logic in the Cisco device list script.

### Interface entity updates:

* [`snmp-discovery/mapping/mappers_test.go`](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R423): Updated test cases to include the `Type` field (`"other"`) and standardized the default interface name to `"unknown"` instead of `"Unknown"`. [[1]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R423) [[2]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L518-R520) [[3]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L531-R534)
* [`snmp-discovery/mapping/mapping.go`](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L87-R88): Modified the `createEntity` function to set the default interface name to `"unknown"` and added a `Type` field with the value `"other"` for interface entities.

### Cisco device list parsing improvements:

* [`snmp-discovery/scripts/create-cisco-device-list.sh`](diffhunk://#diff-ba3e2aeb54171eb66267330902e1c08d4e69dcf4f6d1fcc13d6c5593bf53b643L17-R19): Updated the script to strip surrounding quotes from OID values and prepend a dot (`"."`) to the OID in the output for better formatting.