### PR TITLE
fix: uppercases the mac address

### DIFF
--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -252,10 +252,10 @@ func (m *InterfaceMapper) FormatMACAddress(input string) (string, error) {
 	// Format to colon-separated hex string
 	var parts []string
 	for _, b := range bytes {
-		parts = append(parts, fmt.Sprintf("%02x", b))
+		parts = append(parts, fmt.Sprintf("%02X", b))
 	}
 
-	output := strings.ToUpper(strings.Join(parts, ":"))
+	output := strings.Join(parts, ":")
 	m.logger.Debug("Formatted mac address", "input", input, "output", output)
 	return output, nil
 }

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -255,7 +255,7 @@ func (m *InterfaceMapper) FormatMACAddress(input string) (string, error) {
 		parts = append(parts, fmt.Sprintf("%02x", b))
 	}
 
-	output := strings.Join(parts, ":")
+	output := strings.ToUpper(strings.Join(parts, ":"))
 	m.logger.Debug("Formatted mac address", "input", input, "output", output)
 	return output, nil
 }

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -587,6 +587,12 @@ func TestInterfaceMapper_FormatMACAddress(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name:        "valid hex string with lowercase letters",
+			input:       "\x00\x11\x22\x33\x44\xab",
+			expected:    "00:11:22:33:44:AB",
+			expectError: false,
+		},
+		{
 			name:        "invalid (too short) hex string with backslashes",
 			input:       "\x00\x11\x22\x33\x44",
 			expected:    "",


### PR DESCRIPTION
This pull request updates the `FormatMACAddress` method in `InterfaceMapper` to ensure MAC addresses are consistently formatted in uppercase and adds a corresponding test case to verify this behavior.

Changes to `FormatMACAddress` method:

* [`snmp-discovery/mapping/mappers.go`](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL258-R258): Modified the `FormatMACAddress` function to convert MAC address strings to uppercase after joining the parts with colons.

Updates to test cases:

* [`snmp-discovery/mapping/mappers_test.go`](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R589-R594): Added a new test case to validate the behavior of `FormatMACAddress` when the input contains lowercase hexadecimal characters, ensuring the output is correctly converted to uppercase.