### PR TITLE
fix: fix guage and counter parsing

### DIFF
--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -3,7 +3,7 @@ package snmp
 import (
 	"fmt"
 	"log/slog"
-	"strconv"
+	"reflect"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -61,7 +61,7 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 			return nil, err
 		}
 		for k, value := range pdu {
-			s.logger.Debug("Mapping PDU", "objectID", k, "value", value)
+			s.logger.Debug("Mapping PDU", "objectID", k, "value", value, "ValueType", reflect.TypeOf(value.Value))
 			value, err := MapPDU(value)
 			if err != nil {
 				s.logger.Warn("Error mapping PDU", "objectID", k, "error", err)
@@ -101,20 +101,8 @@ func MapPDU(pdu PDU) (mapping.Value, error) {
 		if ticks, ok := pdu.Value.(uint32); ok {
 			value = fmt.Sprintf("%d", ticks)
 		}
-	case gosnmp.Counter32, gosnmp.Gauge32:
-		if str, ok := pdu.Value.(string); ok {
-			if val, err := strconv.ParseUint(str, 10, 32); err == nil {
-				value = fmt.Sprintf("%d", uint32(val))
-			}
-		} else if val, ok := pdu.Value.(uint32); ok {
-			value = fmt.Sprintf("%d", val)
-		}
-	case gosnmp.Counter64:
-		if str, ok := pdu.Value.(string); ok {
-			if val, err := strconv.ParseUint(str, 10, 64); err == nil {
-				value = fmt.Sprintf("%d", val)
-			}
-		} else if val, ok := pdu.Value.(uint64); ok {
+	case gosnmp.Counter32, gosnmp.Gauge32, gosnmp.Counter64:
+		if val, ok := pdu.Value.(uint); ok {
 			value = fmt.Sprintf("%d", val)
 		}
 	default:
@@ -187,6 +175,7 @@ func NewClient(host string, port uint16, retries int, authentication *config.Aut
 				Community: authentication.Community,
 				Version:   gosnmp.Version1,
 				Timeout:   time.Duration(2) * time.Second,
+				Retries:   retries,
 			},
 		}, nil
 	case ProtocolVersion2c:
@@ -197,6 +186,7 @@ func NewClient(host string, port uint16, retries int, authentication *config.Aut
 				Community: authentication.Community,
 				Version:   gosnmp.Version2c,
 				Timeout:   time.Duration(2) * time.Second,
+				Retries:   retries,
 			},
 		}, nil
 	case ProtocolVersion3:

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -3,6 +3,7 @@ package snmp
 import (
 	"fmt"
 	"log/slog"
+	"strconv"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -67,7 +68,7 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 				continue
 			}
 			output[k] = value
-			output[k] = value
+			s.logger.Debug("Mapped PDU", "objectID", k, "value", value)
 		}
 	}
 
@@ -101,11 +102,19 @@ func MapPDU(pdu PDU) (mapping.Value, error) {
 			value = fmt.Sprintf("%d", ticks)
 		}
 	case gosnmp.Counter32, gosnmp.Gauge32:
-		if val, ok := pdu.Value.(uint32); ok {
+		if str, ok := pdu.Value.(string); ok {
+			if val, err := strconv.ParseUint(str, 10, 32); err == nil {
+				value = fmt.Sprintf("%d", uint32(val))
+			}
+		} else if val, ok := pdu.Value.(uint32); ok {
 			value = fmt.Sprintf("%d", val)
 		}
 	case gosnmp.Counter64:
-		if val, ok := pdu.Value.(uint64); ok {
+		if str, ok := pdu.Value.(string); ok {
+			if val, err := strconv.ParseUint(str, 10, 64); err == nil {
+				value = fmt.Sprintf("%d", val)
+			}
+		} else if val, ok := pdu.Value.(uint64); ok {
 			value = fmt.Sprintf("%d", val)
 		}
 	default:

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -432,7 +432,7 @@ func TestMapPDU(t *testing.T) {
 			pdu: snmp.PDU{
 				Name:  "test.7",
 				Type:  gosnmp.Counter32,
-				Value: uint32(4294967295),
+				Value: uint(4294967295),
 			},
 			expectedValue: mapping.Value{
 				Type:  mapping.Asn1BER(gosnmp.Counter32),
@@ -445,7 +445,7 @@ func TestMapPDU(t *testing.T) {
 			pdu: snmp.PDU{
 				Name:  "test.8",
 				Type:  gosnmp.Gauge32,
-				Value: "4294967295",
+				Value: uint(4294967295),
 			},
 			expectedValue: mapping.Value{
 				Type:  mapping.Asn1BER(gosnmp.Gauge32),
@@ -458,7 +458,7 @@ func TestMapPDU(t *testing.T) {
 			pdu: snmp.PDU{
 				Name:  "test.9",
 				Type:  gosnmp.Counter64,
-				Value: uint64(18446744073709551615),
+				Value: uint(18446744073709551615),
 			},
 			expectedValue: mapping.Value{
 				Type:  mapping.Asn1BER(gosnmp.Counter64),

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -445,11 +445,11 @@ func TestMapPDU(t *testing.T) {
 			pdu: snmp.PDU{
 				Name:  "test.8",
 				Type:  gosnmp.Gauge32,
-				Value: uint32(65535),
+				Value: "4294967295",
 			},
 			expectedValue: mapping.Value{
 				Type:  mapping.Asn1BER(gosnmp.Gauge32),
-				Value: "65535",
+				Value: "4294967295",
 			},
 			expectError: false,
 		},


### PR DESCRIPTION
This pull request introduces changes to the SNMP package to improve logging and handle string-based numeric values in SNMP PDUs. The most important updates include adding debug logs for mapped PDUs, extending `MapPDU` to parse numeric strings, and updating corresponding tests to validate these changes.

### Logging Improvements:
* [`snmp-discovery/snmp/snmp.go`](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L70-R71): Added a debug log in the `Walk` method to log mapped PDU details, including `objectID` and `value`.

### Enhanced Numeric Parsing:
* [`snmp-discovery/snmp/snmp.go`](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L104-R117): Updated the `MapPDU` function to handle cases where numeric values in PDUs are provided as strings. This includes parsing string values into appropriate numeric types (`uint32` and `uint64`) using `strconv.ParseUint`.

### Test Updates:
* [`snmp-discovery/snmp/snmp_test.go`](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L448-R452): Modified the `TestMapPDU` test to include scenarios where numeric values are represented as strings, ensuring the updated `MapPDU` function behaves as expected.