### PR TITLE
feat: bundle the lookup extensions in snmp-discovery image

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -52,7 +52,7 @@ policies:
         device:
           description: "SNMP discovered device"
           comments: "Automatically discovered via SNMP"
-      lookup_extensions_dir: "/opt/orb/snmp-extensions" # Specifies a directory containing device data yaml files (see below)
+      lookup_extensions_dir: "/opt/orb/snmp-extensions" # (Optional) Specifies an override for the directory containing device data yaml files (see below). Defaults to `/etc/snmp-discovery/lookup-extensions
     scope:
       targets:
         - host: "192.168.1.1"
@@ -87,7 +87,7 @@ policies:
 ```
 
 ### Device Model Lookup
-The `lookup_extensions_dir` specifies a directory containing device data YAML files that map SNMP device OIDs to human-readable device names. This allows snmp-discovery to provide meaningful device identification instead of raw OID values.
+The `lookup_extensions_dir` specifies a directory containing device data YAML files that map SNMP device OIDs to human-readable device names. This allows snmp-discovery to provide meaningful device identification instead of raw OID values. This only needs to be set if additional or modified files are being provided instead of the ones that are included with orb-discovery and orb-agent.
 
 #### File Format
 Device lookup files must be in YAML format with a `.yaml` or `.yml` extension. Each file should contain a `devices` section that maps SNMP device OIDs to device names:
@@ -102,13 +102,15 @@ devices:
 ```
 
 #### Example Device Lookup Files
-The repository includes several pre-built device lookup files for popular vendors:
+The repository includes several pre-built device lookup files for popular vendors. These are included in the orb-discovery and orb-agent images.
 
 - **Cisco devices**: `cisco.yaml` - Contains mappings for Cisco routers, switches, and other networking equipment
 - **TP-Link devices**: `tplink.yaml` - Contains mappings for TP-Link switches and routers
 - **Dell Networking**: `dell-networking.yaml` - Contains mappings for Dell networking equipment
 - **Lenovo devices**: `lenovo.yaml` - Contains mappings for Lenovo networking equipment
 - **Ruckus devices**: `ruckus.yaml` - Contains mappings for Ruckus wireless equipment
+
+The full list of vendor device files is available [here](https://github.com/netboxlabs/orb-discovery/tree/release/snmp-discovery/lookup_extension).
 
 #### Creating Custom Device Lookup Files
 You can create custom device lookup files for your specific hardware by:

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -2,6 +2,11 @@ package config
 
 import "time"
 
+const (
+	// DefaultLookupExtensionsDir is the default directory for lookup extensions
+	DefaultLookupExtensionsDir = "/etc/snmp-discovery/lookup-extensions"
+)
+
 // Status represents the status of the snmp-discovery service
 type Status struct {
 	StartTime     time.Time `json:"start_time"`

--- a/snmp-discovery/docker/Dockerfile
+++ b/snmp-discovery/docker/Dockerfile
@@ -10,14 +10,21 @@ ARG TARGETOS TARGETARCH
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/snmp-discovery ./cmd/main.go
 
-FROM alpine:3.20
+FROM alpine:3.22
 
+# Copy the binary
 COPY --from=builder /build/snmp-discovery /usr/local/bin/snmp-discovery
 
+# Create application directories
+RUN mkdir -p /etc/snmp-discovery/lookup-extensions
+
+# Copy lookup extensions to proper location
+COPY --from=builder /src/snmp-discovery/lookup_extensions /etc/snmp-discovery/lookup-extensions
+
 LABEL maintainer="techops@netboxlabs.com"
-LABEL org.opencontainers.image.title="Orb snmp Discovery"
-LABEL org.opencontainers.image.url="https://github.com/netboxlabs/orb-discovery/tree/develop/snmp-discovery"
-LABEL org.opencontainers.image.documentation="https://github.com/netboxlabs/orb-discovery/tree/develop/snmp-discovery"
+LABEL org.opencontainers.image.title="Orb SNMP Discovery"
+LABEL org.opencontainers.image.url="https://github.com/netboxlabs/orb-discovery/tree/release/snmp-discovery"
+LABEL org.opencontainers.image.documentation="https://github.com/netboxlabs/orb-discovery/tree/release/snmp-discovery"
 LABEL org.opencontainers.image.description="NetBox Labs snmp-discovery image"
 LABEL org.opencontainers.image.vendor="NetBox Labs, Inc"
 LABEL org.opencontainers.image.authors="techops@netboxlabs.com"

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -100,6 +100,11 @@ func (m *Manager) applyDefaults(policy *config.Policy) {
 			policy.Scope.Targets[i].Port = SNMPDefaultPort
 		}
 	}
+
+	// Set default lookup extensions directory if not specified
+	if policy.Config.LookupExtensionsDir == "" {
+		policy.Config.LookupExtensionsDir = config.DefaultLookupExtensionsDir
+	}
 }
 
 // validatePolicy validates the policy
@@ -146,10 +151,6 @@ func (m *Manager) validatePolicy(policy config.Policy) error {
 				return fmt.Errorf("missing priv protocol")
 			}
 		}
-	}
-
-	if policy.Config.LookupExtensionsDir == "" {
-		return fmt.Errorf("missing lookup extensions directory")
 	}
 
 	return nil

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -109,7 +109,7 @@ func TestManagerParsePolicies(t *testing.T) {
 		assert.Contains(t, err.Error(), "policy1 : invalid policy : missing protocol version")
 	})
 
-	t.Run("Invalid Policy - Missing LookupExtensionsDir", func(t *testing.T) {
+	t.Run("Valid Policy - Missing LookupExtensionsDir (Uses Default)", func(t *testing.T) {
 		yamlData := []byte(`
         policies:
           policy1:
@@ -125,9 +125,35 @@ func TestManagerParsePolicies(t *testing.T) {
                 community: public
     `)
 
-		_, err := manager.ParsePolicies(yamlData)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "policy1 : invalid policy : missing lookup extensions directory")
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		// Verify default value is applied
+		assert.Equal(t, config.DefaultLookupExtensionsDir, policies["policy1"].Config.LookupExtensionsDir)
+	})
+
+	t.Run("Valid Policy - Explicit LookupExtensionsDir", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              defaults:
+                comments: test
+              lookup_extensions_dir: /custom/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  port: 162
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+    `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		// Verify explicit value is preserved
+		assert.Equal(t, "/custom/extensions", policies["policy1"].Config.LookupExtensionsDir)
 	})
 
 	t.Run("No Policies", func(t *testing.T) {
@@ -170,15 +196,29 @@ func TestManagerPolicyLifecycle(t *testing.T) {
               authentication:
                 protocol_version: SNMPv2c
                 community: public
+          policy4:
+            config:
+              # No lookup_extensions_dir specified - should use default
+            scope:
+              targets:
+                - host: 192.168.3.1
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
        `)
 
 	policies, err := manager.ParsePolicies(yamlData)
 	assert.NoError(t, err)
 
+	// Verify default value is applied to policy4
+	assert.Equal(t, config.DefaultLookupExtensionsDir, policies["policy4"].Config.LookupExtensionsDir)
+
 	// Start policies
 	err = manager.StartPolicy("policy1", policies["policy1"])
 	assert.NoError(t, err)
 	err = manager.StartPolicy("policy2", policies["policy2"])
+	assert.NoError(t, err)
+	err = manager.StartPolicy("policy4", policies["policy4"])
 	assert.NoError(t, err)
 
 	// Try to start policy 3
@@ -188,6 +228,7 @@ func TestManagerPolicyLifecycle(t *testing.T) {
 	// Check if the policies exist
 	assert.True(t, manager.HasPolicy("policy1"))
 	assert.True(t, manager.HasPolicy("policy2"))
+	assert.True(t, manager.HasPolicy("policy4"))
 	assert.False(t, manager.HasPolicy("policy3"))
 
 	// Stop policy 1
@@ -197,6 +238,7 @@ func TestManagerPolicyLifecycle(t *testing.T) {
 	// Check if the policy exists
 	assert.False(t, manager.HasPolicy("policy1"))
 	assert.True(t, manager.HasPolicy("policy2"))
+	assert.True(t, manager.HasPolicy("policy4"))
 	assert.False(t, manager.HasPolicy("policy3"))
 
 	// Stop Manager
@@ -206,6 +248,7 @@ func TestManagerPolicyLifecycle(t *testing.T) {
 	// Check if the policies exist
 	assert.False(t, manager.HasPolicy("policy1"))
 	assert.False(t, manager.HasPolicy("policy2"))
+	assert.False(t, manager.HasPolicy("policy4"))
 	assert.False(t, manager.HasPolicy("policy3"))
 }
 


### PR DESCRIPTION
This pull request introduces enhancements to the `snmp-discovery` project, focusing on improving the handling of the `lookup_extensions_dir` configuration by providing a default value, updating documentation, and refining associated tests. Additionally, it includes minor updates to the Dockerfile and configuration files.

### Default Configuration Enhancements:
* Added a constant `DefaultLookupExtensionsDir` (`/etc/snmp-discovery/lookup-extensions`) in `snmp-discovery/config/config.go` to serve as the default directory for lookup extensions.
* Updated `applyDefaults` in `snmp-discovery/policy/manager.go` to automatically set the default directory if `lookup_extensions_dir` is not specified.
* Removed validation for missing `lookup_extensions_dir` in `validatePolicy`, as it now defaults to a predefined value.

### Documentation Updates:
* Clarified the optional nature of `lookup_extensions_dir` in `snmp-discovery/README.md` and added details about the default behavior. [[1]](diffhunk://#diff-fbffef8cc46e9659ab7585122a69d863e94f180f7fe48ea221791f0320e58779L55-R55) [[2]](diffhunk://#diff-fbffef8cc46e9659ab7585122a69d863e94f180f7fe48ea221791f0320e58779L90-R90)
* Provided a link to the full list of pre-built vendor device files in the README.

### Testing Improvements:
* Modified `TestManagerParsePolicies` in `snmp-discovery/policy/manager_test.go` to verify default and explicit values for `lookup_extensions_dir`. (F4dc5cd6L109R125)
* Enhanced `TestManagerPolicyLifecycle` to validate the default directory behavior across policy lifecycle scenarios. (F4dc5cd6L170R248)

### Dockerfile Updates:
* Updated the base image to Alpine 3.22 in `snmp-discovery/docker/Dockerfile`.
* Added steps to create the default lookup extensions directory and copy relevant files during the build process.

These changes improve usability by reducing configuration overhead, ensuring consistent behavior, and providing clearer documentation for users.