### PR TITLE
fix: default interface type (other unless specified)

### DIFF
--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -225,7 +225,9 @@ func (m *InterfaceMapper) applyDefaults(entity *diode.Interface, defaults *confi
 		entity.Description = &entityDefaults.Description
 	}
 
-	entity.Type = &entityDefaults.Type
+	if entity.Type == nil || *entity.Type == "" {
+		entity.Type = &entityDefaults.Type
+	}
 }
 
 // Map maps interfaces to entities

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -433,7 +433,6 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				Mtu:               int64Ptr(1500),
 				PrimaryMacAddress: &diode.MACAddress{MacAddress: mapping.StringPtr("00:11:22:33:44:55")},
 				Enabled:           boolPtr(true),
-				Type:              mapping.StringPtr("other"),
 			},
 			expectError: false,
 		},
@@ -530,7 +529,6 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			},
 			expectedEntity: &diode.Interface{
 				Name: mapping.StringPtr("unknown"),
-				Type: mapping.StringPtr("other"),
 			},
 			expectError: false,
 		},
@@ -544,7 +542,6 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			},
 			expectedEntity: &diode.Interface{
 				Name: mapping.StringPtr("unknown"),
-				Type: mapping.StringPtr("other"),
 			},
 			expectError: false,
 		},

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -87,7 +87,6 @@ func createEntity(entityType EntityType) (diode.Entity, error) {
 	case "interface":
 		return &diode.Interface{
 			Name: StringPtr("unknown"),
-			// Type: StringPtr("other"),
 		}, nil
 	case "device":
 		return &diode.Device{}, nil

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -87,7 +87,7 @@ func createEntity(entityType EntityType) (diode.Entity, error) {
 	case "interface":
 		return &diode.Interface{
 			Name: StringPtr("unknown"),
-			Type: StringPtr("other"),
+			// Type: StringPtr("other"),
 		}, nil
 	case "device":
 		return &diode.Device{}, nil

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -80,7 +80,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 						MacAddress: &[]string{"00:00:00:00:00:00"}[0],
 					},
 					Enabled: &[]bool{true}[0],
-					Type:    diode.String("virtual"),
+					Type:    diode.String("other"),
 					Device:  &diode.Device{},
 				},
 				&diode.Interface{
@@ -90,7 +90,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 						MacAddress: &[]string{"00:00:00:00:00:11"}[0],
 					},
 					Enabled: &[]bool{false}[0],
-					Type:    diode.String("virtual"),
+					Type:    diode.String("other"),
 					Device:  &diode.Device{},
 				},
 			},
@@ -159,7 +159,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 						MacAddress: diode.String("00:00:00:00:00:00"),
 					},
 					Enabled: &[]bool{true}[0],
-					Type:    diode.String("virtual"),
+					Type:    diode.String("other"),
 					Device:  &diode.Device{},
 				},
 				&diode.IPAddress{
@@ -269,14 +269,14 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 			expected: []diode.Entity{
 				&diode.Interface{
 					Name:   diode.String("GigabitEthernet1/0/1"),
-					Type:   diode.String("virtual"),
+					Type:   diode.String("other"),
 					Device: &diode.Device{},
 				},
 				&diode.IPAddress{
 					Address: diode.String("192.168.1.2/32"),
 					AssignedObject: &diode.Interface{
 						Name:   diode.String("GigabitEthernet1/0/1"),
-						Type:   diode.String("virtual"),
+						Type:   diode.String("other"),
 						Device: &diode.Device{},
 					},
 				},
@@ -353,7 +353,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 				&FakeDeviceLookup{},
 				&config.Defaults{
 					Interface: config.InterfaceDefaults{
-						Type: "virtual",
+						Type: "other",
 					},
 				},
 			)

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -105,6 +105,10 @@ func (m *Manager) applyDefaults(policy *config.Policy) {
 	if policy.Config.LookupExtensionsDir == "" {
 		policy.Config.LookupExtensionsDir = config.DefaultLookupExtensionsDir
 	}
+
+	if policy.Config.Defaults.Interface.Type == "" {
+		policy.Config.Defaults.Interface.Type = "other"
+	}
 }
 
 // validatePolicy validates the policy

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -146,7 +146,7 @@ func TestRunnerRun(t *testing.T) {
 						Interface: config.InterfaceDefaults{
 							Description: "Interface Default",
 							Tags:        []string{"interface", "default"},
-							Type:        "unknown",
+							Type:        "other",
 						},
 						Device: config.DeviceDefaults{
 							Description: "Device Default",


### PR DESCRIPTION
This pull request introduces changes to improve the handling of default values for `Type` in `diode.Interface` entities and updates related test cases across multiple files in the `snmp-discovery` module. The primary focus is ensuring that `Type` is set to `"other"` when not explicitly defined, enhancing consistency and reliability.

### Enhancements to default handling:

* [`snmp-discovery/mapping/mappers.go`](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR228-R231): Added logic to set `Type` to `"other"` if it is `nil` or an empty string in the `applyDefaults` method.
* [`snmp-discovery/policy/manager.go`](diffhunk://#diff-97d32253107e3c811caf8c6de6078b90fc18fbfecca66691424c657d8b77651cR108-R111): Updated the `applyDefaults` method to ensure `Interface.Type` defaults to `"other"` in policy configurations.

### Updates to test cases:

* [`snmp-discovery/mapping/mappers_test.go`](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L436): Removed hardcoded `"other"` values from test cases to align with the new default handling logic. [[1]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L436) [[2]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L533) [[3]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L547)
* [`snmp-discovery/mapping/mapping_test.go`](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L83-R83): Updated test cases to reflect the default `"other"` value for `Type` in various scenarios. [[1]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L83-R83) [[2]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L93-R93) [[3]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L162-R162) [[4]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L272-R279) [[5]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L356-R356)
* [`snmp-discovery/policy/runner_test.go`](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL149-R149): Adjusted test cases to use `"other"` as the default `Type` for interfaces in policy configurations.

### Code cleanup:

* [`snmp-discovery/mapping/mapping.go`](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L90-R90): Commented out the explicit setting of `"other"` for `Type` in the `createEntity` function, as this is now handled by defaults.