### PR TITLE
Release

### DIFF
--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -225,7 +225,9 @@ func (m *InterfaceMapper) applyDefaults(entity *diode.Interface, defaults *confi
 		entity.Description = &entityDefaults.Description
 	}
 
-	entity.Type = &entityDefaults.Type
+	if entity.Type == nil || *entity.Type == "" {
+		entity.Type = &entityDefaults.Type
+	}
 }
 
 // Map maps interfaces to entities

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -433,7 +433,6 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				Mtu:               int64Ptr(1500),
 				PrimaryMacAddress: &diode.MACAddress{MacAddress: mapping.StringPtr("00:11:22:33:44:55")},
 				Enabled:           boolPtr(true),
-				Type:              mapping.StringPtr("other"),
 			},
 			expectError: false,
 		},
@@ -530,7 +529,6 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			},
 			expectedEntity: &diode.Interface{
 				Name: mapping.StringPtr("unknown"),
-				Type: mapping.StringPtr("other"),
 			},
 			expectError: false,
 		},
@@ -544,7 +542,6 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			},
 			expectedEntity: &diode.Interface{
 				Name: mapping.StringPtr("unknown"),
-				Type: mapping.StringPtr("other"),
 			},
 			expectError: false,
 		},

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -87,7 +87,6 @@ func createEntity(entityType EntityType) (diode.Entity, error) {
 	case "interface":
 		return &diode.Interface{
 			Name: StringPtr("unknown"),
-			// Type: StringPtr("other"),
 		}, nil
 	case "device":
 		return &diode.Device{}, nil

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -87,7 +87,7 @@ func createEntity(entityType EntityType) (diode.Entity, error) {
 	case "interface":
 		return &diode.Interface{
 			Name: StringPtr("unknown"),
-			Type: StringPtr("other"),
+			// Type: StringPtr("other"),
 		}, nil
 	case "device":
 		return &diode.Device{}, nil

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -80,7 +80,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 						MacAddress: &[]string{"00:00:00:00:00:00"}[0],
 					},
 					Enabled: &[]bool{true}[0],
-					Type:    diode.String("virtual"),
+					Type:    diode.String("other"),
 					Device:  &diode.Device{},
 				},
 				&diode.Interface{
@@ -90,7 +90,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 						MacAddress: &[]string{"00:00:00:00:00:11"}[0],
 					},
 					Enabled: &[]bool{false}[0],
-					Type:    diode.String("virtual"),
+					Type:    diode.String("other"),
 					Device:  &diode.Device{},
 				},
 			},
@@ -159,7 +159,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 						MacAddress: diode.String("00:00:00:00:00:00"),
 					},
 					Enabled: &[]bool{true}[0],
-					Type:    diode.String("virtual"),
+					Type:    diode.String("other"),
 					Device:  &diode.Device{},
 				},
 				&diode.IPAddress{
@@ -269,14 +269,14 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 			expected: []diode.Entity{
 				&diode.Interface{
 					Name:   diode.String("GigabitEthernet1/0/1"),
-					Type:   diode.String("virtual"),
+					Type:   diode.String("other"),
 					Device: &diode.Device{},
 				},
 				&diode.IPAddress{
 					Address: diode.String("192.168.1.2/32"),
 					AssignedObject: &diode.Interface{
 						Name:   diode.String("GigabitEthernet1/0/1"),
-						Type:   diode.String("virtual"),
+						Type:   diode.String("other"),
 						Device: &diode.Device{},
 					},
 				},
@@ -353,7 +353,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 				&FakeDeviceLookup{},
 				&config.Defaults{
 					Interface: config.InterfaceDefaults{
-						Type: "virtual",
+						Type: "other",
 					},
 				},
 			)

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -105,6 +105,10 @@ func (m *Manager) applyDefaults(policy *config.Policy) {
 	if policy.Config.LookupExtensionsDir == "" {
 		policy.Config.LookupExtensionsDir = config.DefaultLookupExtensionsDir
 	}
+
+	if policy.Config.Defaults.Interface.Type == "" {
+		policy.Config.Defaults.Interface.Type = "other"
+	}
 }
 
 // validatePolicy validates the policy

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -146,7 +146,7 @@ func TestRunnerRun(t *testing.T) {
 						Interface: config.InterfaceDefaults{
 							Description: "Interface Default",
 							Tags:        []string{"interface", "default"},
-							Type:        "unknown",
+							Type:        "other",
 						},
 						Device: config.DeviceDefaults{
 							Description: "Device Default",


### PR DESCRIPTION
This pull request introduces changes to ensure default values for the `Type` field in various entities and updates related tests to reflect these defaults. The most critical updates involve introducing logic to apply defaults when the `Type` field is missing or empty and modifying test cases to align with these changes.

### Default value handling:

* [`snmp-discovery/mapping/mappers.go`](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR228-R231): Added logic in `applyDefaults` to set the `Type` field to the default value if it is `nil` or an empty string.
* [`snmp-discovery/policy/manager.go`](diffhunk://#diff-97d32253107e3c811caf8c6de6078b90fc18fbfecca66691424c657d8b77651cR108-R111): Added logic in `applyDefaults` to ensure the `Type` field in `InterfaceDefaults` is set to `"other"` if it is empty.

### Test case updates:

* [`snmp-discovery/mapping/mappers_test.go`](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L436): Removed explicit `Type` assignments in test cases to allow the default value logic to take effect. [[1]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L436) [[2]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L533) [[3]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L547)
* [`snmp-discovery/mapping/mapping_test.go`](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L83-R83): Updated multiple test cases to replace `"virtual"` with `"other"` for the `Type` field to reflect the new default value. [[1]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L83-R83) [[2]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L93-R93) [[3]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L162-R162) [[4]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L272-R279) [[5]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L356-R356)
* [`snmp-discovery/policy/runner_test.go`](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL149-R149): Updated the default `Type` value in test configurations from `"unknown"` to `"other"`.