### PR TITLE
feat: add dry run mode support for network-discovery

### DIFF
--- a/network-discovery/README.md
+++ b/network-discovery/README.md
@@ -13,31 +13,31 @@ sudo setcap cap_net_raw,cap_net_admin=eip $(which nmap)
 ```sh
 Usage of network-discovery:
   -diode-app-name-prefix string
-       diode producer_app_name prefix
+        diode producer_app_name prefix
   -diode-client-id string
-       diode client ID. Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_CLIENT_ID})
+        diode client ID. Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_CLIENT_ID})
   -diode-client-secret string
-       diode client secret. Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_CLIENT_SECRET})
+        diode client secret. Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_CLIENT_SECRET})
   -diode-target string
-       diode target. Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_TARGET})
+        diode target. Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_TARGET})
   -dry-run
-       run in dry-run mode, do not ingest data
+        run in dry-run mode, do not ingest data
   -dry-run-output-dir string
-       output dir for dry-run mode.  Environment variable can be used by wrapping it in ${} (e.g. ${DRY_RUN_OUTPUT_DIR})
+        output dir for dry-run mode.  Environment variable can be used by wrapping it in ${} (e.g. ${DRY_RUN_OUTPUT_DIR})
   -help
-       show this help
+        show this help
   -host string
-       server host (default "0.0.0.0")
+        server host (default "0.0.0.0")
   -log-format string
-       log format (default "TEXT")
+        log format (default "TEXT")
   -log-level string
-       log level (default "INFO")
+        log level (default "INFO")
   -otel-endpoint string
-       OpenTelemetry exporter endpoint
+        OpenTelemetry exporter endpoint
   -otel-export-period int
-       Period in seconds between OpenTelemetry exports (default 60)
+        Period in seconds between OpenTelemetry exports (default 60)
   -port int
-       server port (default 8073)
+        server port (default 8073)
 ```
 
 ### Policy RFC

--- a/network-discovery/README.md
+++ b/network-discovery/README.md
@@ -12,28 +12,32 @@ sudo setcap cap_net_raw,cap_net_admin=eip $(which nmap)
 ### Usage
 ```sh
 Usage of network-discovery:
- -diode-app-name-prefix string
-    	diode producer_app_name prefix
+  -diode-app-name-prefix string
+       diode producer_app_name prefix
   -diode-client-id string
-    	diode client ID (REQUIRED). Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_CLIENT_ID})
+       diode client ID. Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_CLIENT_ID})
   -diode-client-secret string
-    	diode client secret (REQUIRED). Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_CLIENT_SECRET})
+       diode client secret. Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_CLIENT_SECRET})
   -diode-target string
-    	diode target (REQUIRED)
-  --otel-endpoint string
-    	OpenTelemetry exporter endpoint
-  --otel-export-period int
-    	Period in seconds between OpenTelemetry exports (default: 60)
+       diode target. Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_TARGET})
+  -dry-run
+       run in dry-run mode, do not ingest data
+  -dry-run-output-dir string
+       output dir for dry-run mode.  Environment variable can be used by wrapping it in ${} (e.g. ${DRY_RUN_OUTPUT_DIR})
   -help
-    	show this help
+       show this help
   -host string
-    	server host (default "0.0.0.0")
+       server host (default "0.0.0.0")
   -log-format string
-    	log format (default "TEXT")
+       log format (default "TEXT")
   -log-level string
-    	log level (default "INFO")
+       log level (default "INFO")
+  -otel-endpoint string
+       OpenTelemetry exporter endpoint
+  -otel-export-period int
+       Period in seconds between OpenTelemetry exports (default 60)
   -port int
-    	server port (default 8073)
+       server port (default 8073)
 ```
 
 ### Policy RFC

--- a/network-discovery/cmd/main.go
+++ b/network-discovery/cmd/main.go
@@ -41,12 +41,16 @@ func resolveEnv(value string) string {
 func main() {
 	host := flag.String("host", "0.0.0.0", "server host")
 	port := flag.Int("port", 8073, "server port")
-	diodeTarget := flag.String("diode-target", "", "diode target (REQUIRED)")
-	diodeClientID := flag.String("diode-client-id", "", "diode client ID (REQUIRED)."+
-		" Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_CLIENT_ID})")
-	diodeClientSecret := flag.String("diode-client-secret", "", "diode client secret (REQUIRED)."+
-		" Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_CLIENT_SECRET})")
+	diodeTarget := flag.String("diode-target", "", "diode target."+
+		" Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_TARGET})")
+	diodeClientID := flag.String("diode-client-id", "", "diode client ID."+
+		" Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_CLIENT_ID})")
+	diodeClientSecret := flag.String("diode-client-secret", "", "diode client secret."+
+		" Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_CLIENT_SECRET})")
 	diodeAppNamePrefix := flag.String("diode-app-name-prefix", "", "diode producer_app_name prefix")
+	dryRun := flag.Bool("dry-run", false, "run in dry-run mode, do not ingest data")
+	dryRunOutputDir := flag.String("dry-run-output-dir", "", "output dir for dry-run mode. "+
+		" Environment variable can be used by wrapping it in ${} (e.g. ${DRY_RUN_OUTPUT_DIR})")
 	logLevel := flag.String("log-level", "INFO", "log level")
 	logFormat := flag.String("log-format", "TEXT", "log format")
 	help := flag.Bool("help", false, "show this help")
@@ -55,12 +59,15 @@ func main() {
 
 	flag.Parse()
 
-	if *help || *diodeTarget == "" || *diodeClientID == "" || *diodeClientSecret == "" {
+	if *help {
 		fmt.Fprintf(os.Stderr, "Usage of network-discovery:\n")
 		flag.PrintDefaults()
-		if *help {
-			os.Exit(0)
-		}
+		os.Exit(0)
+	}
+
+	if !*dryRun && (*diodeTarget == "" || *diodeClientID == "" || *diodeClientSecret == "") {
+		fmt.Fprintf(os.Stderr, "Usage of network-discovery:\n")
+		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
@@ -69,13 +76,22 @@ func main() {
 		producerName = fmt.Sprintf("%s/%s", *diodeAppNamePrefix, AppName)
 	}
 
-	client, err := diode.NewClient(
-		resolveEnv(*diodeTarget),
-		producerName,
-		version.GetBuildVersion(),
-		diode.WithClientID(resolveEnv(*diodeClientID)),
-		diode.WithClientSecret(resolveEnv(*diodeClientSecret)),
-	)
+	var client diode.Client
+	var err error
+	if *dryRun {
+		client, err = diode.NewDryRunClient(
+			producerName,
+			resolveEnv(*dryRunOutputDir),
+		)
+	} else {
+		client, err = diode.NewClient(
+			resolveEnv(*diodeTarget),
+			producerName,
+			version.GetBuildVersion(),
+			diode.WithClientID(resolveEnv(*diodeClientID)),
+			diode.WithClientSecret(resolveEnv(*diodeClientSecret)),
+		)
+	}
 	if err != nil {
 		fmt.Printf("error creating diode client: %v\n", err)
 		os.Exit(1)

--- a/network-discovery/cmd/main.go
+++ b/network-discovery/cmd/main.go
@@ -93,7 +93,7 @@ func main() {
 		)
 	}
 	if err != nil {
-		fmt.Printf("error creating diode client: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error creating diode client: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/network-discovery/go.mod
+++ b/network-discovery/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Ullaakut/nmap/v3 v3.0.4
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-co-op/gocron/v2 v2.14.0
-	github.com/netboxlabs/diode-sdk-go v1.0.0
+	github.com/netboxlabs/diode-sdk-go v1.1.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.35.0

--- a/network-discovery/go.sum
+++ b/network-discovery/go.sum
@@ -69,8 +69,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/netboxlabs/diode-sdk-go v1.0.0 h1:xHMOp5SFnkJkwqSziWfF5u6h1VWWa1FTnmKCEe7CVvc=
-github.com/netboxlabs/diode-sdk-go v1.0.0/go.mod h1:UNUmF3TJrvPVUutjKqMPpcRPm29myBjgc5c3CjHduis=
+github.com/netboxlabs/diode-sdk-go v1.1.0 h1:+W2VwTFoofgG8CZcwQ1x0EcmDo9yFbyPwAH4gaKbswc=
+github.com/netboxlabs/diode-sdk-go v1.1.0/go.mod h1:UNUmF3TJrvPVUutjKqMPpcRPm29myBjgc5c3CjHduis=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -26,6 +26,11 @@ func (m *MockClient) Ingest(ctx context.Context, entities []diode.Entity) (*diod
 	return args.Get(0).(*diodepb.IngestResponse), args.Error(1)
 }
 
+func (m *MockClient) IngestProto(ctx context.Context, entities []*diodepb.Entity) (*diodepb.IngestResponse, error) {
+	args := m.Called(ctx, entities)
+	return args.Get(0).(*diodepb.IngestResponse), args.Error(1)
+}
+
 func (m *MockClient) Close() error {
 	args := m.Called()
 	return args.Error(0)

--- a/network-discovery/server/server_test.go
+++ b/network-discovery/server/server_test.go
@@ -28,6 +28,11 @@ func (m *MockClient) Ingest(ctx context.Context, entities []diode.Entity) (*diod
 	return args.Get(0).(*diodepb.IngestResponse), args.Error(1)
 }
 
+func (m *MockClient) IngestProto(ctx context.Context, entities []*diodepb.Entity) (*diodepb.IngestResponse, error) {
+	args := m.Called(ctx, entities)
+	return args.Get(0).(*diodepb.IngestResponse), args.Error(1)
+}
+
 func (m *MockClient) Close() error {
 	args := m.Called()
 	return args.Error(0)


### PR DESCRIPTION
This pull request introduces several updates to the `network-discovery` project, including support for a dry-run mode, enhancements to the client initialization logic, and upgrades to dependencies. Additionally, new methods have been added to mock client implementations for testing purposes. Below is a categorized summary of the most important changes:

### Feature Enhancements:
* Added support for a dry-run mode in `network-discovery/cmd/main.go`, including new flags `dry-run` and `dry-run-output-dir`. The dry-run mode prevents data ingestion and outputs results to a specified directory. [[1]](diffhunk://#diff-d72917593858580ada0014ddab78df86e3d1dcecd37ef0e1caf2258ad7ad9fb6L44-R53) [[2]](diffhunk://#diff-d72917593858580ada0014ddab78df86e3d1dcecd37ef0e1caf2258ad7ad9fb6L72-R94)
* Updated the client initialization logic to conditionally create either a standard `diode.Client` or a `diode.DryRunClient` based on the `dry-run` flag.

### Dependency Updates:
* Upgraded the `diode-sdk-go` dependency from version `v1.0.0` to `v1.1.0` in `network-discovery/go.mod`.

### Validation Improvements:
* Modified the startup validation logic to ensure required flags (`diode-target`, `diode-client-id`, `diode-client-secret`) are only checked when not in dry-run mode.

### Testing Enhancements:
* Added a new `IngestProto` method to mock client implementations in `network-discovery/policy/runner_test.go` and `network-discovery/server/server_test.go` for testing ingestion of `diodepb.Entity` objects. [[1]](diffhunk://#diff-54d75091996dda1b5aae635a59d4eeb70051f1031594507c1702c48cb379d891R29-R33) [[2]](diffhunk://#diff-05d87c2bf7cc60ec2d4528a650c0fa46d72602807c60d0bcb04b99b1bbd77583R31-R35)