### PR TITLE
feat: support dry-run mode in snmp discovery

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -4,18 +4,18 @@ Orb snmp discovery backend, which is a wrapper over [NMAP](https://nmap.org/) sc
 ### Usage
 ```sh
 Usage of snmp-discovery:
- -diode-app-name-prefix string
+  -diode-app-name-prefix string
     	diode producer_app_name prefix
   -diode-client-id string
-    	diode client ID (REQUIRED). Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_CLIENT_ID})
+    	diode client ID. Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_CLIENT_ID})
   -diode-client-secret string
-    	diode client secret (REQUIRED). Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_CLIENT_SECRET})
+    	diode client secret. Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_CLIENT_SECRET})
   -diode-target string
-    	diode target (REQUIRED)
-  --otel-endpoint string
-    	OpenTelemetry exporter endpoint
-  --otel-export-period int
-    	Period in seconds between OpenTelemetry exports (default: 60)
+    	diode target. Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_TARGET})
+  -dry-run
+    	run in dry-run mode, do not ingest data
+  -dry-run-output-dir string
+    	output dir for dry-run mode.  Environment variable can be used by wrapping it in ${} (e.g. ${DRY_RUN_OUTPUT_DIR})
   -help
     	show this help
   -host string
@@ -24,6 +24,10 @@ Usage of snmp-discovery:
     	log format (default "TEXT")
   -log-level string
     	log level (default "INFO")
+  -otel-endpoint string
+    	OpenTelemetry exporter endpoint (e.g. localhost:4317). Environment variables can be used by wrapping them in ${} (e.g. ${OTEL_ENDPOINT})
+  -otel-export-period int
+    	Period in seconds between OpenTelemetry exports (default 10)
   -port int
     	server port (default 8070)
 ```

--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -25,7 +25,7 @@ Usage of snmp-discovery:
   -log-level string
     	log level (default "INFO")
   -otel-endpoint string
-    	OpenTelemetry exporter endpoint (e.g. localhost:4317). Environment variables can be used by wrapping them in ${} (e.g. ${OTEL_ENDPOINT})
+    	OpenTelemetry exporter endpoint (e.g. localhost:4317). Environment variable can be used by wrapping it in ${} (e.g. ${OTEL_ENDPOINT})
   -otel-export-period int
     	Period in seconds between OpenTelemetry exports (default 10)
   -port int

--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -57,7 +57,7 @@ func main() {
 	help := flag.Bool("help", false, "show this help")
 	// Add new flags for metrics
 	otelEndpoint := flag.String("otel-endpoint", "", "OpenTelemetry exporter endpoint (e.g. localhost:4317)."+
-		" Environment variables can be used by wrapping them in ${} (e.g. ${OTEL_ENDPOINT})")
+		" Environment variable can be used by wrapping it in ${} (e.g. ${OTEL_ENDPOINT})")
 	otelExportPeriod := flag.Int("otel-export-period", 10, "Period in seconds between OpenTelemetry exports")
 
 	flag.Parse()

--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -42,12 +42,16 @@ func resolveEnv(value string) string {
 func main() {
 	host := flag.String("host", "0.0.0.0", "server host")
 	port := flag.Int("port", 8070, "server port")
-	diodeTarget := flag.String("diode-target", "", "diode target (REQUIRED)")
-	diodeClientID := flag.String("diode-client-id", "", "diode client ID (REQUIRED)."+
-		" Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_CLIENT_ID})")
-	diodeClientSecret := flag.String("diode-client-secret", "", "diode client secret (REQUIRED)."+
-		" Environment variables can be used by wrapping them in ${} (e.g. ${MY_DIODE_CLIENT_SECRET})")
+	diodeTarget := flag.String("diode-target", "", "diode target."+
+		" Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_TARGET})")
+	diodeClientID := flag.String("diode-client-id", "", "diode client ID."+
+		" Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_CLIENT_ID})")
+	diodeClientSecret := flag.String("diode-client-secret", "", "diode client secret."+
+		" Environment variable can be used by wrapping it in ${} (e.g. ${DIODE_CLIENT_SECRET})")
 	diodeAppNamePrefix := flag.String("diode-app-name-prefix", "", "diode producer_app_name prefix")
+	dryRun := flag.Bool("dry-run", false, "run in dry-run mode, do not ingest data")
+	dryRunOutputDir := flag.String("dry-run-output-dir", "", "output dir for dry-run mode. "+
+		" Environment variable can be used by wrapping it in ${} (e.g. ${DRY_RUN_OUTPUT_DIR})")
 	logLevel := flag.String("log-level", "INFO", "log level")
 	logFormat := flag.String("log-format", "TEXT", "log format")
 	help := flag.Bool("help", false, "show this help")
@@ -58,12 +62,15 @@ func main() {
 
 	flag.Parse()
 
-	if *help || *diodeTarget == "" || *diodeClientID == "" || *diodeClientSecret == "" {
+	if *help {
 		fmt.Fprintf(os.Stderr, "Usage of snmp-discovery:\n")
 		flag.PrintDefaults()
-		if *help {
-			os.Exit(0)
-		}
+		os.Exit(0)
+	}
+
+	if !*dryRun && (*diodeTarget == "" || *diodeClientID == "" || *diodeClientSecret == "") {
+		fmt.Fprintf(os.Stderr, "Usage of snmp-discovery:\n")
+		flag.PrintDefaults()
 		os.Exit(1)
 	}
 
@@ -72,15 +79,24 @@ func main() {
 		producerName = fmt.Sprintf("%s/%s", *diodeAppNamePrefix, AppName)
 	}
 
-	client, err := diode.NewClient(
-		resolveEnv(*diodeTarget),
-		producerName,
-		version.GetBuildVersion(),
-		diode.WithClientID(resolveEnv(*diodeClientID)),
-		diode.WithClientSecret(resolveEnv(*diodeClientSecret)),
-	)
+	var client diode.Client
+	var err error
+	if *dryRun {
+		client, err = diode.NewDryRunClient(
+			producerName,
+			resolveEnv(*dryRunOutputDir),
+		)
+	} else {
+		client, err = diode.NewClient(
+			resolveEnv(*diodeTarget),
+			producerName,
+			version.GetBuildVersion(),
+			diode.WithClientID(resolveEnv(*diodeClientID)),
+			diode.WithClientSecret(resolveEnv(*diodeClientSecret)),
+		)
+	}
 	if err != nil {
-		fmt.Printf("error creating diode client: %v\n", err)
+		fmt.Fprintf(os.Stderr, "error creating diode client: %v\n", err)
 		os.Exit(1)
 	}
 

--- a/snmp-discovery/go.mod
+++ b/snmp-discovery/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-co-op/gocron/v2 v2.14.0
 	github.com/gosnmp/gosnmp v1.39.0
-	github.com/netboxlabs/diode-sdk-go v1.0.0
+	github.com/netboxlabs/diode-sdk-go v1.1.0
 	github.com/stretchr/testify v1.10.0
 	go.opentelemetry.io/otel v1.35.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.35.0

--- a/snmp-discovery/go.sum
+++ b/snmp-discovery/go.sum
@@ -70,8 +70,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/netboxlabs/diode-sdk-go v1.0.0 h1:xHMOp5SFnkJkwqSziWfF5u6h1VWWa1FTnmKCEe7CVvc=
-github.com/netboxlabs/diode-sdk-go v1.0.0/go.mod h1:UNUmF3TJrvPVUutjKqMPpcRPm29myBjgc5c3CjHduis=
+github.com/netboxlabs/diode-sdk-go v1.1.0 h1:+W2VwTFoofgG8CZcwQ1x0EcmDo9yFbyPwAH4gaKbswc=
+github.com/netboxlabs/diode-sdk-go v1.1.0/go.mod h1:UNUmF3TJrvPVUutjKqMPpcRPm29myBjgc5c3CjHduis=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -28,6 +28,11 @@ func (m *MockDiodeClient) Ingest(ctx context.Context, entities []diode.Entity) (
 	return args.Get(0).(*diodepb.IngestResponse), args.Error(1)
 }
 
+func (m *MockDiodeClient) IngestProto(ctx context.Context, entities []*diodepb.Entity) (*diodepb.IngestResponse, error) {
+	args := m.Called(ctx, entities)
+	return args.Get(0).(*diodepb.IngestResponse), args.Error(1)
+}
+
 func (m *MockDiodeClient) Close() error {
 	args := m.Called()
 	return args.Error(0)

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -29,6 +29,11 @@ func (m *MockClient) Ingest(ctx context.Context, entities []diode.Entity) (*diod
 	return args.Get(0).(*diodepb.IngestResponse), args.Error(1)
 }
 
+func (m *MockClient) IngestProto(ctx context.Context, entities []*diodepb.Entity) (*diodepb.IngestResponse, error) {
+	args := m.Called(ctx, entities)
+	return args.Get(0).(*diodepb.IngestResponse), args.Error(1)
+}
+
 func (m *MockClient) Close() error {
 	args := m.Called()
 	return args.Error(0)


### PR DESCRIPTION
This pull request introduces several enhancements and updates to the `snmp-discovery` project, including support for a dry-run mode, improvements to environment variable handling, updates to dependencies, and additions to mock client functionality for testing. The most important changes are grouped below by theme.

### Feature Enhancements:
* Added support for a dry-run mode (`-dry-run` flag) in `snmp-discovery`, which allows data to be processed without ingestion, along with a `-dry-run-output-dir` option for specifying output directories. [[1]](diffhunk://#diff-fbffef8cc46e9659ab7585122a69d863e94f180f7fe48ea221791f0320e58779L10-R18) [[2]](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L45-R54) [[3]](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L75-R99)
* Updated the logic in `main.go` to handle dry-run mode, ensuring required flags (`diode-target`, `diode-client-id`, `diode-client-secret`) are validated only when dry-run mode is disabled.

### Environment Variable Handling:
* Improved descriptions for environment variable usage in the `README.md` and `main.go`, simplifying examples and removing references to custom prefixes like `MY_`. [[1]](diffhunk://#diff-fbffef8cc46e9659ab7585122a69d863e94f180f7fe48ea221791f0320e58779L10-R18) [[2]](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L45-R54)

### Dependency Updates:
* Upgraded the `diode-sdk-go` dependency from version `v1.0.0` to `v1.1.0` in `go.mod` to support new features such as dry-run mode.

### Testing Improvements:
* Added `IngestProto` method to mock clients (`MockDiodeClient` and `MockClient`) in `runner_test.go` and `server_test.go`, enhancing test coverage for proto-based ingestion functionality. [[1]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fR31-R35) [[2]](diffhunk://#diff-dd2e681eb687c29c248a79d49e7ff2634765985bdba868594effaf8b485bf614R32-R36)