### PR TITLE
fix: set timeout based on configured value

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -34,7 +34,8 @@ policies:
   snmp_network_1:
     config:
       schedule: "0 */6 * * *" # Cron expression - every 6 hours
-      timeout: 300 # Timeout in seconds (default 2 minutes)
+      timeout: 300 # Timeout for policy in seconds (default 2 minutes)
+      snmp_timeout: 300 # Timeout for SNMP operations in seconds (default 5 seconds)
       retries: 3 # Number of retries
       defaults:
         tags: ["snmp-discovery", "orb"]

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -73,6 +73,7 @@ type PolicyConfig struct {
 	Schedule            *string  `yaml:"schedule,omitempty"`
 	Defaults            Defaults `yaml:"defaults"`
 	Timeout             int      `yaml:"timeout"`
+	SNMPTimeout         int      `yaml:"snmp_timeout"`
 	Retries             int      `yaml:"retries"`
 	LookupExtensionsDir string   `yaml:"lookup_extensions_dir,omitempty"`
 }

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -2,11 +2,6 @@ package config
 
 import "time"
 
-const (
-	// DefaultLookupExtensionsDir is the default directory for lookup extensions
-	DefaultLookupExtensionsDir = "/etc/snmp-discovery/lookup-extensions"
-)
-
 // Status represents the status of the snmp-discovery service
 type Status struct {
 	StartTime     time.Time `json:"start_time"`

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -144,7 +144,7 @@ func (r *Runner) queryTargets(expandedTargets []config.Target, objectIDs map[str
 		// Start timing the discovery
 		startTime := time.Now()
 
-		host := snmp.NewHost(target.Host, target.Port, r.config.Retries, &r.scope.Authentication, r.logger, r.ClientFactory)
+		host := snmp.NewHost(target.Host, target.Port, r.config.Retries, r.timeout, &r.scope.Authentication, r.logger, r.ClientFactory)
 		oids, err := host.Walk(objectIDs)
 		if err != nil {
 			r.logger.Warn("Error crawling host", "host", target.Host, "error", err)

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -69,7 +69,7 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	if err != nil {
 		return nil, err
 	}
-	runner.timeout = time.Duration(policy.Config.Timeout) * time.Minute
+	runner.timeout = time.Duration(policy.Config.Timeout) * time.Second
 	if runner.timeout == 0 {
 		runner.timeout = defaultTimeout
 	}

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -22,8 +22,9 @@ type contextKey string
 
 // Define the policy key
 const (
-	policyKey      contextKey = "policy"
-	defaultTimeout            = 2 * time.Minute
+	policyKey          contextKey = "policy"
+	defaultTimeout                = 2 * time.Minute
+	defaultSNMPTimeout            = 5 * time.Second
 )
 
 // Runner represents the policy runner
@@ -34,6 +35,7 @@ type Runner struct {
 	client        diode.Client
 	logger        *slog.Logger
 	timeout       time.Duration
+	snmpTimeout   time.Duration
 	scope         config.Scope
 	config        config.PolicyConfig
 	ClientFactory snmp.ClientFactory
@@ -72,6 +74,10 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	runner.timeout = time.Duration(policy.Config.Timeout) * time.Second
 	if runner.timeout == 0 {
 		runner.timeout = defaultTimeout
+	}
+	runner.snmpTimeout = time.Duration(policy.Config.SNMPTimeout) * time.Second
+	if runner.snmpTimeout == 0 {
+		runner.snmpTimeout = defaultSNMPTimeout
 	}
 	runner.ctx = context.WithValue(ctx, policyKey, name)
 	runner.scope = policy.Scope
@@ -144,7 +150,7 @@ func (r *Runner) queryTargets(expandedTargets []config.Target, objectIDs map[str
 		// Start timing the discovery
 		startTime := time.Now()
 
-		host := snmp.NewHost(target.Host, target.Port, r.config.Retries, r.timeout, &r.scope.Authentication, r.logger, r.ClientFactory)
+		host := snmp.NewHost(target.Host, target.Port, r.config.Retries, r.snmpTimeout, &r.scope.Authentication, r.logger, r.ClientFactory)
 		oids, err := host.Walk(objectIDs)
 		if err != nil {
 			r.logger.Warn("Error crawling host", "host", target.Host, "error", err)

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -348,7 +348,7 @@ func TestRunnerWalkError(t *testing.T) {
 	mockHost.On("Walk", mock.Anything, mock.Anything).Return(nil, errors.New("walk error"))
 
 	// Create a mock client factory that returns the mock host
-	mockClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
+	mockClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
 		return mockHost, nil
 	}
 

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -1,6 +1,8 @@
 package snmp
 
 import (
+	"time"
+
 	"github.com/gosnmp/gosnmp"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 )
@@ -35,6 +37,6 @@ func (n *FakeSNMPWalker) Walk(oid string, _ int) (map[string]PDU, error) {
 }
 
 // NewFakeSNMPWalker creates a new FakeSNMPWalker
-func NewFakeSNMPWalker(_ string, _ uint16, _ int, _ *config.Authentication) (Walker, error) {
+func NewFakeSNMPWalker(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (Walker, error) {
 	return &FakeSNMPWalker{}, nil
 }

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -16,17 +16,19 @@ type Host struct {
 	address        string
 	port           uint16
 	retries        int
+	timeout        time.Duration
 	authentication *config.Authentication
 	logger         *slog.Logger
 	ClientFactory  ClientFactory
 }
 
 // NewHost creates a new Host
-func NewHost(host string, port uint16, retries int, authentication *config.Authentication, logger *slog.Logger, ClientFactory ClientFactory) *Host {
+func NewHost(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication, logger *slog.Logger, ClientFactory ClientFactory) *Host {
 	return &Host{
 		address:        host,
 		port:           port,
 		retries:        retries,
+		timeout:        timeout,
 		authentication: authentication,
 		logger:         logger,
 		ClientFactory:  ClientFactory,
@@ -37,7 +39,7 @@ func NewHost(host string, port uint16, retries int, authentication *config.Authe
 func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) {
 	s.logger.Info("Scanning", "host", s.address)
 
-	snmpClient, err := s.ClientFactory(s.address, s.port, s.retries, s.authentication)
+	snmpClient, err := s.ClientFactory(s.address, s.port, s.retries, s.timeout, s.authentication)
 	if err != nil {
 		return nil, err
 	}
@@ -162,10 +164,10 @@ const (
 )
 
 // ClientFactory is a function that creates a new SNMPClient
-type ClientFactory func(host string, port uint16, retries int, authentication *config.Authentication) (Walker, error)
+type ClientFactory func(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication) (Walker, error)
 
 // NewClient creates a new SNMPClient for the given target host
-func NewClient(host string, port uint16, retries int, authentication *config.Authentication) (Walker, error) {
+func NewClient(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication) (Walker, error) {
 	switch authentication.ProtocolVersion {
 	case ProtocolVersion1:
 		return &Client{
@@ -174,7 +176,7 @@ func NewClient(host string, port uint16, retries int, authentication *config.Aut
 				Port:      port,
 				Community: authentication.Community,
 				Version:   gosnmp.Version1,
-				Timeout:   time.Duration(2) * time.Second,
+				Timeout:   timeout,
 				Retries:   retries,
 			},
 		}, nil
@@ -185,7 +187,7 @@ func NewClient(host string, port uint16, retries int, authentication *config.Aut
 				Port:      port,
 				Community: authentication.Community,
 				Version:   gosnmp.Version2c,
-				Timeout:   time.Duration(2) * time.Second,
+				Timeout:   timeout,
 				Retries:   retries,
 			},
 		}, nil
@@ -203,7 +205,7 @@ func NewClient(host string, port uint16, retries int, authentication *config.Aut
 				Target:  host,
 				Port:    port,
 				Version: gosnmp.Version3,
-				Timeout: time.Duration(2) * time.Second,
+				Timeout: timeout,
 				Retries: retries,
 				SecurityParameters: &gosnmp.UsmSecurityParameters{
 					UserName:                 authentication.Username,

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/netboxlabs/diode-sdk-go/diode"
@@ -75,11 +76,11 @@ func TestSNMPHost(t *testing.T) {
 
 	t.Run("Successfully walks a host", func(t *testing.T) {
 		// Setup
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
-			fakeWalker, _ := snmp.NewFakeSNMPWalker("192.168.1.1", 161, 3, nil)
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+			fakeWalker, _ := snmp.NewFakeSNMPWalker("192.168.1.1", 161, 3, 1*time.Second, nil)
 			return fakeWalker, nil
 		}
-		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
+		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
 		oids, err := host.Walk(map[string]int{
@@ -105,10 +106,10 @@ func TestSNMPHost(t *testing.T) {
 			interfaceObjectID + ".2": {Value: 1000000, Type: gosnmp.Integer, IdentifierSize: 1},
 		}, nil)
 
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
-		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
+		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
 		oids, err := host.Walk(objectIDsToQuery)
@@ -131,10 +132,10 @@ func TestSNMPHost(t *testing.T) {
 			ipAddressObjectID: {Value: "192.168.1.1", Type: gosnmp.IPAddress, IdentifierSize: 4},
 		}, nil)
 
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
-		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
+		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
 		oids, err := host.Walk(map[string]int{
@@ -153,10 +154,10 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker := &MockSNMP{}
 		mockWalker.On("Connect").Return(assert.AnError)
 		mockWalker.On("Close").Return(nil)
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
-		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
+		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
 		oids, err := host.Walk(objectIDsToQuery)
@@ -173,10 +174,10 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
 		mockWalker.On("Walk", mock.Anything, mock.Anything).Return(make(map[string]snmp.PDU), assert.AnError)
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
-		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
+		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
 		oids, err := host.Walk(objectIDsToQuery)
@@ -200,10 +201,10 @@ func TestSNMPHost(t *testing.T) {
 			interfaceObjectID + ".2": {Value: "invalid", Type: gosnmp.Asn1BER(255), IdentifierSize: 1}, // Invalid type
 		}, nil)
 
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
-		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
+		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
 		oids, err := host.Walk(objectIDsToQuery)
@@ -225,10 +226,10 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
 		mockWalker.On("Walk", mock.Anything, mock.Anything).Return(nil, assert.AnError)
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
 			return nil, fmt.Errorf("error creating client")
 		}
-		host := snmp.NewHost("192.168.1.1", 161, 3, nil, logger, snmpClientFactory)
+		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
 
 		// Execute
 		oids, err := host.Walk(objectIDsToQuery)
@@ -328,7 +329,7 @@ func TestNewClient(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client, err := snmp.NewClient("192.168.1.1", 161, 3, tc.auth)
+			client, err := snmp.NewClient("192.168.1.1", 161, 3, 1*time.Second, tc.auth)
 
 			if tc.expectError {
 				assert.Error(t, err)


### PR DESCRIPTION
This pull request introduces changes to improve timeout handling in the SNMP discovery service, ensuring that timeout values are configurable and consistently passed throughout the codebase. The changes include updates to constructors, method signatures, and tests to support the new timeout parameter.

### Timeout Handling Enhancements:

* Updated `NewHost` constructor in `snmp-discovery/snmp/snmp.go` to include a `timeout` parameter, ensuring timeout values are passed to the `ClientFactory`. [[1]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R19-R31) [[2]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L40-R42)
* Modified `ClientFactory` type definition and `NewClient` function in `snmp-discovery/snmp/snmp.go` to accept a `timeout` parameter, replacing the hardcoded timeout values. [[1]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L165-R170) [[2]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L177-R179) [[3]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L188-R190) [[4]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L206-R208)
* Adjusted the `Runner` logic in `snmp-discovery/policy/runner.go` to convert timeout values from minutes to seconds and pass them to the `snmp.NewHost` function. [[1]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL72-R72) [[2]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL147-R147)

### Mock and Test Updates:

* Updated mock implementations in `snmp-discovery/snmp/mocks.go` and adjusted test cases in `snmp-discovery/snmp/snmp_test.go` to include the `timeout` parameter in `NewFakeSNMPWalker` and `snmp.NewHost` calls. [[1]](diffhunk://#diff-ca04d639e95ac1098548f63ed2dcc476d1fd18379c7a3d4bccadeae762362138L38-R40) [[2]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L78-R83) [[3]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L108-R112) [[4]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L134-R138) [[5]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L156-R160) [[6]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L176-R180) [[7]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L203-R207) [[8]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L228-R232)
* Updated `TestNewClient` in `snmp-discovery/snmp/snmp_test.go` to pass the `timeout` parameter when creating a new SNMP client.

### Code Cleanup:

* Removed unused constant `DefaultLookupExtensionsDir` from `snmp-discovery/config/config.go` for better maintainability.
* Added missing `time` package imports in relevant files to support the new timeout parameter. [[1]](diffhunk://#diff-ca04d639e95ac1098548f63ed2dcc476d1fd18379c7a3d4bccadeae762362138R4-R5) [[2]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58R9)