### PR TITLE
fix: adds upper and lower limits to interface speed

### DIFF
--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -14,6 +14,12 @@ import (
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/data"
 )
 
+// Interface speed constants
+const (
+	minInterfaceSpeed = 1
+	maxInterfaceSpeed = 2147483647
+)
+
 // IPAddressMapper is a struct that maps IP addresses to entities
 type IPAddressMapper struct {
 	logger *slog.Logger
@@ -270,6 +276,11 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					speed, err := strconv.Atoi(value.Value)
 					if err != nil {
 						m.logger.Warn("Error converting speed to int", "error", err, "value", value.Value)
+						continue
+					}
+					// Check if speed is within valid range (1 to 2147483647 inclusive)
+					if speed < minInterfaceSpeed || speed > maxInterfaceSpeed {
+						m.logger.Warn("Interface speed is outside valid range (1-2147483647)", "speed", speed, "value", value.Value)
 						continue
 					}
 					bitsPerSecond := int64(speed)

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -278,13 +278,13 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 						m.logger.Warn("Error converting speed to int", "error", err, "value", value.Value)
 						continue
 					}
+					bitsPerSecond := int64(speed)
+					kiloBitsPerSecond := bitsPerSecond / 1000
 					// Check if speed is within valid range (1 to 2147483647 inclusive)
-					if speed < minInterfaceSpeed || speed > maxInterfaceSpeed {
+					if kiloBitsPerSecond < minInterfaceSpeed || kiloBitsPerSecond > maxInterfaceSpeed {
 						m.logger.Warn("Interface speed is outside valid range (1-2147483647)", "speed", speed, "value", value.Value, "mappingID", propertyMappingEntry.OID, "interfaceIndex", objectID)
 						continue
 					}
-					bitsPerSecond := int64(speed)
-					kiloBitsPerSecond := bitsPerSecond / 1000
 					interfaceEntity.Speed = &kiloBitsPerSecond
 					fieldFound = true
 				case "mtu":

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -280,7 +280,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					}
 					// Check if speed is within valid range (1 to 2147483647 inclusive)
 					if speed < minInterfaceSpeed || speed > maxInterfaceSpeed {
-						m.logger.Warn("Interface speed is outside valid range (1-2147483647)", "speed", speed, "value", value.Value)
+						m.logger.Warn("Interface speed is outside valid range (1-2147483647)", "speed", speed, "value", value.Value, "mappingID", propertyMappingEntry.OID, "interfaceIndex", objectID)
 						continue
 					}
 					bitsPerSecond := int64(speed)

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -759,6 +759,114 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "mapping with speed below minimum should result in nil speed",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.5.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.5.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.5",
+					Value:  "0",
+					Type:   mapping.Integer,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.5",
+						Entity: "interface",
+						Field:  "speed",
+					},
+				},
+			},
+			defaults: nil,
+			expectedEntity: &diode.Interface{
+				Name:  mapping.StringPtr("eth0"),
+				Speed: nil, // Speed should be nil when value is below minimum
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with speed above maximum should result in nil speed",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.5.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.5.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.5",
+					Value:  "2147483648",
+					Type:   mapping.Integer,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.5",
+						Entity: "interface",
+						Field:  "speed",
+					},
+				},
+			},
+			defaults: nil,
+			expectedEntity: &diode.Interface{
+				Name:  mapping.StringPtr("eth0"),
+				Speed: nil, // Speed should be nil when value is above maximum
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -834,7 +834,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 					OID:    "1.3.6.1.2.1.2.2.1.5.1",
 					Index:  "1",
 					Parent: "1.3.6.1.2.1.2.2.1.5",
-					Value:  "2147483648",
+					Value:  "2147483648000",
 					Type:   mapping.Integer,
 				},
 			},


### PR DESCRIPTION
This pull request introduces validation for interface speed values in the SNMP discovery module, ensuring they fall within a defined range, and updates the corresponding unit tests to cover these cases. The changes improve data integrity and robustness in handling interface speed mappings.

### Validation of interface speed values:

* [`snmp-discovery/mapping/mappers.go`](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR17-R22): Added constants `minInterfaceSpeed` and `maxInterfaceSpeed` to define valid speed range (1 to 2147483647 inclusive) and implemented validation logic in the `InterfaceMapper.Map` method to discard values outside this range. [[1]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR17-R22) [[2]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR281-R285)

### Unit test enhancements:

* [`snmp-discovery/mapping/mappers_test.go`](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R762-R869): Added test cases to verify the behavior of `InterfaceMapper.Map` when interface speed values are below the minimum or above the maximum range, ensuring `Speed` is set to `nil` in these scenarios.