### PR TITLE
feat: query using more specific object IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 *.egg-info/
 .coverage/
 .coverage
+
+.cursor/
+.cursor.md

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -356,7 +356,8 @@ func (m *ObjectIDMapper) ObjectIDs() map[string]int {
 				if childEntry.IdentifierSize == 0 {
 					objectIDs[childEntry.OID] = 1
 				} else {
-					objectIDs[childEntry.OID] = entry.IdentifierSize
+					// Use the child's IdentifierSize if it is non-zero; otherwise, use the parent's IdentifierSize.
+					objectIDs[childEntry.OID] = childEntry.IdentifierSize
 				}
 			}
 		} else {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -349,11 +349,23 @@ func (m *ObjectIDMapper) getMappingEntry(objectID string) (*Entry, error) {
 // ObjectIDs returns the ObjectIDs that the ObjectIDMapper can map
 func (m *ObjectIDMapper) ObjectIDs() map[string]int {
 	objectIDs := make(map[string]int)
-	for objectID := range m.mapping {
-		if m.mapping[objectID].IdentifierSize == 0 {
-			objectIDs[objectID] = 1
+	for _, entry := range m.mapping {
+		// If the entry has child mapping entries, add the child OIDs
+		if len(entry.MappingEntries) > 0 {
+			for _, childEntry := range entry.MappingEntries {
+				if childEntry.IdentifierSize == 0 {
+					objectIDs[childEntry.OID] = 1
+				} else {
+					objectIDs[childEntry.OID] = entry.IdentifierSize
+				}
+			}
 		} else {
-			objectIDs[objectID] = m.mapping[objectID].IdentifierSize
+			// If no child entries, add the parent OID itself
+			if entry.IdentifierSize == 0 {
+				objectIDs[entry.OID] = 1
+			} else {
+				objectIDs[entry.OID] = entry.IdentifierSize
+			}
 		}
 	}
 	return objectIDs

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -385,7 +385,7 @@ func TestObjectIDs(t *testing.T) {
 			},
 		},
 		{
-			name: "Duplicate OID",
+			name: "Child OIDs from parent mapping",
 			mapping: []config.MappingEntry{
 				{
 					OID:    ".1.3.6.1.2.1.2.2.1",
@@ -406,7 +406,8 @@ func TestObjectIDs(t *testing.T) {
 				},
 			},
 			expectedOIDs: map[string]int{
-				".1.3.6.1.2.1.2.2.1": 1,
+				".1.3.6.1.2.1.2.2.1.2": 1,
+				".1.3.6.1.2.1.2.2.1.5": 1,
 			},
 		},
 	}

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -28,11 +28,25 @@ func (n *FakeSNMPWalker) Walk(oid string, _ int) (map[string]PDU, error) {
 		}, nil
 	}
 
-	if oid == "iso.3.6.1.2.1.2.2.1" {
+	if oid == "1.3.6.1.2.1.2.2.1.2" {
+		return map[string]PDU{
+			"1.3.6.1.2.1.2.2.1.2.999": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString},
+		}, nil
+	}
+
+	if oid == "1.3.6.1.2.1.2.2.1.5" {
+		return map[string]PDU{
+			"1.3.6.1.2.1.2.2.1.5.999": {Value: 1000000, Type: gosnmp.Integer},
+		}, nil
+	}
+
+	// Handle the new child OID format for policy tests
+	if oid == "iso.3.6.1.2.1.2.2.1.2" {
 		return map[string]PDU{
 			"iso.3.6.1.2.1.2.2.1.2.999": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString},
 		}, nil
 	}
+
 	return make(map[string]PDU), nil
 }
 

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -69,10 +69,12 @@ func (m *MockClient) Ingest(context.Context, []diode.Entity) (*diodepb.IngestRes
 func TestSNMPHost(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	const ipAddressObjectID = "1.3.6.1.2.1.4.20.1.1"
-	const interfaceObjectID = "1.3.6.1.2.1.2.2.1"
+	const interfaceNameOID = "1.3.6.1.2.1.2.2.1.2"
+	const interfaceSpeedOID = "1.3.6.1.2.1.2.2.1.5"
 	objectIDsToQuery := make(map[string]int)
 	objectIDsToQuery[ipAddressObjectID] = 4
-	objectIDsToQuery[interfaceObjectID] = 1
+	objectIDsToQuery[interfaceNameOID] = 1
+	objectIDsToQuery[interfaceSpeedOID] = 1
 
 	t.Run("Successfully walks a host", func(t *testing.T) {
 		// Setup
@@ -101,9 +103,11 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Walk", ipAddressObjectID, 4).Return(map[string]snmp.PDU{
 			ipAddressObjectID: {Value: "192.168.1.1", Type: gosnmp.IPAddress, IdentifierSize: 4},
 		}, nil)
-		mockWalker.On("Walk", interfaceObjectID, 1).Return(map[string]snmp.PDU{
-			interfaceObjectID + ".1": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString, IdentifierSize: 1},
-			interfaceObjectID + ".2": {Value: 1000000, Type: gosnmp.Integer, IdentifierSize: 1},
+		mockWalker.On("Walk", interfaceNameOID, 1).Return(map[string]snmp.PDU{
+			interfaceNameOID + ".1": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString, IdentifierSize: 1},
+		}, nil)
+		mockWalker.On("Walk", interfaceSpeedOID, 1).Return(map[string]snmp.PDU{
+			interfaceSpeedOID + ".1": {Value: 1000000, Type: gosnmp.Integer, IdentifierSize: 1},
 		}, nil)
 
 		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
@@ -118,8 +122,8 @@ func TestSNMPHost(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 3, len(oids))
 		assert.Equal(t, mapping.Value{Value: "192.168.1.1", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4}, oids[ipAddressObjectID])
-		assert.Equal(t, mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1}, oids[interfaceObjectID+".1"])
-		assert.Equal(t, mapping.Value{Value: "1000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1}, oids[interfaceObjectID+".2"])
+		assert.Equal(t, mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1}, oids[interfaceNameOID+".1"])
+		assert.Equal(t, mapping.Value{Value: "1000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1}, oids[interfaceSpeedOID+".1"])
 		mockWalker.AssertExpectations(t)
 	})
 
@@ -196,9 +200,11 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Walk", ipAddressObjectID, 4).Return(map[string]snmp.PDU{
 			ipAddressObjectID: {Value: "192.168.1.1", Type: gosnmp.IPAddress, IdentifierSize: 4},
 		}, nil)
-		mockWalker.On("Walk", interfaceObjectID, 1).Return(map[string]snmp.PDU{
-			interfaceObjectID + ".1": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString, IdentifierSize: 1},
-			interfaceObjectID + ".2": {Value: "invalid", Type: gosnmp.Asn1BER(255), IdentifierSize: 1}, // Invalid type
+		mockWalker.On("Walk", interfaceNameOID, 1).Return(map[string]snmp.PDU{
+			interfaceNameOID + ".1": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString, IdentifierSize: 1},
+		}, nil)
+		mockWalker.On("Walk", interfaceSpeedOID, 1).Return(map[string]snmp.PDU{
+			interfaceSpeedOID + ".1": {Value: "invalid", Type: gosnmp.Asn1BER(255), IdentifierSize: 1}, // Invalid type
 		}, nil)
 
 		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
@@ -213,9 +219,9 @@ func TestSNMPHost(t *testing.T) {
 		assert.NoError(t, err)        // Walk should continue despite PDU mapping error
 		assert.Equal(t, 2, len(oids)) // Should have 2 valid PDUs
 		assert.Equal(t, mapping.Value{Value: "192.168.1.1", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4}, oids[ipAddressObjectID])
-		assert.Equal(t, mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1}, oids[interfaceObjectID+".1"])
+		assert.Equal(t, mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1}, oids[interfaceNameOID+".1"])
 		// The invalid PDU should be skipped
-		_, exists := oids[interfaceObjectID+".2"]
+		_, exists := oids[interfaceSpeedOID+".1"]
 		assert.False(t, exists)
 		mockWalker.AssertExpectations(t)
 	})


### PR DESCRIPTION
This pull request refactors the SNMP discovery functionality to better handle child OIDs and improve test coverage. The changes primarily focus on updating the `ObjectIDMapper` logic, enhancing test cases, and modifying mock implementations to support the new child OID format.

### Refactoring ObjectIDMapper Logic:
* Updated `ObjectIDs` method in `snmp-discovery/mapping/mapping.go` to include child OIDs from parent mapping entries, ensuring both parent and child OIDs are properly handled.

### Enhancements to Test Cases:
* Modified `TestObjectIDs` in `snmp-discovery/mapping/mapping_test.go` to validate child OIDs are correctly extracted from parent mappings. [[1]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L388-R388) [[2]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L409-R410)
* Updated `TestSNMPHost` in `snmp-discovery/snmp/snmp_test.go` to test the new child OID format, replacing the previous single interface OID with `interfaceNameOID` and `interfaceSpeedOID`. This ensures better granularity and validation of SNMP data retrieval. [[1]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L72-R77) [[2]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L104-R110) [[3]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L121-R126) [[4]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L199-R207) [[5]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L216-R224)

### Mock Implementation Updates:
* Enhanced `FakeSNMPWalker` in `snmp-discovery/snmp/mocks.go` to support child OID format and provide mock data for `interfaceNameOID` and `interfaceSpeedOID`.