### PR TITLE
fix: remove assigned object entities from list to ingest

### DIFF
--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -288,14 +288,40 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 	}
 
 	currentDevice := m.registry.GetOrCreateEntity(DeviceEntityType, CurrentDeviceIndex).(*diode.Device)
+
+	assignedInterfaceIndices := *m.getAssignedInterfaces(uniqueEntities)
+
+	// Build final entity list, excluding assigned interfaces to sending duplciates for ingestion
 	entities := make([]diode.Entity, 0, len(uniqueEntities))
 	for entity := range uniqueEntities {
 		if diodeInterface, ok := entity.(*diode.Interface); ok {
+			isAssigned := false
+			if assignedInterfaceIndices[diodeInterface] {
+				isAssigned = true
+			}
 			diodeInterface.Device = currentDevice
+			if !isAssigned {
+				entities = append(entities, entity)
+			}
+		} else {
+			entities = append(entities, entity)
 		}
-		entities = append(entities, entity)
 	}
 	return entities
+}
+
+func (*ObjectIDMapper) getAssignedInterfaces(uniqueEntities map[diode.Entity]bool) *map[diode.Entity]bool {
+	assignedInterfaceIndices := make(map[diode.Entity]bool)
+	for entity := range uniqueEntities {
+		if ipAddress, ok := entity.(*diode.IPAddress); ok {
+			if ipAddress.AssignedObject != nil {
+				if assignedInterface, ok := ipAddress.AssignedObject.(*diode.Interface); ok {
+					assignedInterfaceIndices[assignedInterface] = true
+				}
+			}
+		}
+	}
+	return &assignedInterfaceIndices
 }
 
 func (m *ObjectIDMapper) groupByObjectIDIndex(objectIDs ObjectIDValueMap) map[ObjectIDIndex]*ObjectIDIndexDetails {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -289,9 +289,9 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 
 	currentDevice := m.registry.GetOrCreateEntity(DeviceEntityType, CurrentDeviceIndex).(*diode.Device)
 
-	assignedInterfaceIndices := *m.getAssignedInterfaces(uniqueEntities)
+	assignedInterfaceIndices := m.getAssignedInterfaces(uniqueEntities)
 
-	// Build final entity list, excluding assigned interfaces to sending duplciates for ingestion
+	// Build final entity list, excluding assigned interfaces to sending duplcates for ingestion
 	entities := make([]diode.Entity, 0, len(uniqueEntities))
 	for entity := range uniqueEntities {
 		if diodeInterface, ok := entity.(*diode.Interface); ok {
@@ -310,7 +310,7 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 	return entities
 }
 
-func (*ObjectIDMapper) getAssignedInterfaces(uniqueEntities map[diode.Entity]bool) *map[diode.Entity]bool {
+func (*ObjectIDMapper) getAssignedInterfaces(uniqueEntities map[diode.Entity]bool) map[diode.Entity]bool {
 	assignedInterfaceIndices := make(map[diode.Entity]bool)
 	for entity := range uniqueEntities {
 		if ipAddress, ok := entity.(*diode.IPAddress); ok {
@@ -321,7 +321,7 @@ func (*ObjectIDMapper) getAssignedInterfaces(uniqueEntities map[diode.Entity]boo
 			}
 		}
 	}
-	return &assignedInterfaceIndices
+	return assignedInterfaceIndices
 }
 
 func (m *ObjectIDMapper) groupByObjectIDIndex(objectIDs ObjectIDValueMap) map[ObjectIDIndex]*ObjectIDIndexDetails {

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -267,11 +267,6 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 				".1.3.6.1.2.1.4.20.1.2.192.168.1.2": mapping.Value{Value: "999", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 4},
 			},
 			expected: []diode.Entity{
-				&diode.Interface{
-					Name:   diode.String("GigabitEthernet1/0/1"),
-					Type:   diode.String("other"),
-					Device: &diode.Device{},
-				},
 				&diode.IPAddress{
 					Address: diode.String("192.168.1.2/32"),
 					AssignedObject: &diode.Interface{


### PR DESCRIPTION
This pull request introduces changes to the `ObjectIDMapper` class in `snmp-discovery/mapping/mapping.go` to improve how entities are mapped and filtered, specifically by excluding assigned interfaces to prevent duplicates during ingestion. Additionally, it modifies the corresponding test cases in `mapping_test.go` to align with the updated logic.

### Entity Mapping Enhancements:
* [`snmp-discovery/mapping/mapping.go`](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40R291-R326): Added logic in `MapObjectIDsToEntity` to exclude assigned interfaces from the final entity list, ensuring no duplicates are sent for ingestion. Introduced a helper method `getAssignedInterfaces` to identify assigned interfaces from the `uniqueEntities` map.

### Test Case Updates:
* [`snmp-discovery/mapping/mapping_test.go`](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L270-L274): Updated the `TestMapObjectIDsToEntity` test to remove an `Interface` entity from the expected results, reflecting the new behavior of excluding assigned interfaces.