### PR TITLE
fix: ingest interfaces using the correct device

### DIFF
--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -116,7 +116,7 @@ const (
 
 // ObjectIDMapper is a struct that maps ObjectIDs to entities
 type ObjectIDMapper struct {
-	mappingConfig *MappingConfig
+	mappingConfig *Config
 	logger        *slog.Logger
 	registry      *EntityRegistry
 	defaults      *config.Defaults
@@ -150,17 +150,13 @@ func (m *Entry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistr
 	return entity
 }
 
-// NewObjectIDMapper creates a new ObjectIDMapper
-func NewObjectIDMapper(mappingConfig *MappingConfig, logger *slog.Logger, defaults *config.Defaults) *ObjectIDMapper {
-	return &ObjectIDMapper{
-		mappingConfig: mappingConfig,
-		logger:        logger,
-		registry:      NewEntityRegistry(logger),
-		defaults:      defaults,
-	}
+// Config is a struct that contains a mapping of ObjectIDs to Entries
+type Config struct {
+	mapping map[string]*Entry
 }
 
-func NewMappingConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturers data.ManufacturerRetriever, deviceLookup data.DeviceRetriever) *MappingConfig {
+// NewConfig creates a new Config
+func NewConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturers data.ManufacturerRetriever, deviceLookup data.DeviceRetriever) *Config {
 	entityMappers := map[string]orbToEntityMapper{
 		"ipAddress": &IPAddressMapper{
 			logger: logger,
@@ -183,13 +179,19 @@ func NewMappingConfig(mappings []config.MappingEntry, logger *slog.Logger, manuf
 		}
 		mapping[m.OID] = Entry
 	}
-	return &MappingConfig{
+	return &Config{
 		mapping: mapping,
 	}
 }
 
-type MappingConfig struct {
-	mapping map[string]*Entry
+// NewObjectIDMapper creates a new ObjectIDMapper
+func NewObjectIDMapper(mappingConfig *Config, logger *slog.Logger, defaults *config.Defaults) *ObjectIDMapper {
+	return &ObjectIDMapper{
+		mappingConfig: mappingConfig,
+		logger:        logger,
+		registry:      NewEntityRegistry(logger),
+		defaults:      defaults,
+	}
 }
 
 type orbToEntityMapper interface {
@@ -287,7 +289,7 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 	uniqueEntities := make(map[diode.Entity]bool)
 	for index, value := range objectIDIndexMap {
 		m.logger.Debug("Mapping objectIDIndex", "objectIDIndex", index, "values", value.Values)
-		entry, err := m.mappingConfig.GetMappingEntry(value.Index)
+		entry, err := m.mappingConfig.getMappingEntry(value.Index)
 		if err != nil {
 			m.logger.Warn("Error finding mapping entry", "error", err, "objectID", value.Index)
 			continue
@@ -366,7 +368,7 @@ func newObjectIDValue(objectID string, value Value) (*ObjectIDValue, error) {
 }
 
 // Gets the mapper for the closest parent objectID
-func (m *MappingConfig) GetMappingEntry(objectID string) (*Entry, error) {
+func (m *Config) getMappingEntry(objectID string) (*Entry, error) {
 	for {
 		if value, found := m.mapping[objectID]; found {
 			return value, nil
@@ -382,7 +384,7 @@ func (m *MappingConfig) GetMappingEntry(objectID string) (*Entry, error) {
 }
 
 // ObjectIDs returns the ObjectIDs that the ObjectIDMapper can map
-func (m *MappingConfig) ObjectIDs() map[string]int {
+func (m *Config) ObjectIDs() map[string]int {
 	objectIDs := make(map[string]int)
 	for _, entry := range m.mapping {
 		// If the entry has child mapping entries, add the child OIDs

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -116,10 +116,10 @@ const (
 
 // ObjectIDMapper is a struct that maps ObjectIDs to entities
 type ObjectIDMapper struct {
-	mapping  map[string]*Entry
-	logger   *slog.Logger
-	registry *EntityRegistry
-	defaults *config.Defaults
+	mappingConfig *MappingConfig
+	logger        *slog.Logger
+	registry      *EntityRegistry
+	defaults      *config.Defaults
 }
 
 // Entry is a struct that contains a mapping entry
@@ -151,7 +151,16 @@ func (m *Entry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistr
 }
 
 // NewObjectIDMapper creates a new ObjectIDMapper
-func NewObjectIDMapper(mappings []config.MappingEntry, logger *slog.Logger, manufacturers data.ManufacturerRetriever, deviceLookup data.DeviceRetriever, defaults *config.Defaults) *ObjectIDMapper {
+func NewObjectIDMapper(mappingConfig *MappingConfig, logger *slog.Logger, defaults *config.Defaults) *ObjectIDMapper {
+	return &ObjectIDMapper{
+		mappingConfig: mappingConfig,
+		logger:        logger,
+		registry:      NewEntityRegistry(logger),
+		defaults:      defaults,
+	}
+}
+
+func NewMappingConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturers data.ManufacturerRetriever, deviceLookup data.DeviceRetriever) *MappingConfig {
 	entityMappers := map[string]orbToEntityMapper{
 		"ipAddress": &IPAddressMapper{
 			logger: logger,
@@ -174,13 +183,13 @@ func NewObjectIDMapper(mappings []config.MappingEntry, logger *slog.Logger, manu
 		}
 		mapping[m.OID] = Entry
 	}
-
-	return &ObjectIDMapper{
-		mapping:  mapping,
-		logger:   logger,
-		registry: NewEntityRegistry(logger),
-		defaults: defaults,
+	return &MappingConfig{
+		mapping: mapping,
 	}
+}
+
+type MappingConfig struct {
+	mapping map[string]*Entry
 }
 
 type orbToEntityMapper interface {
@@ -278,7 +287,7 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 	uniqueEntities := make(map[diode.Entity]bool)
 	for index, value := range objectIDIndexMap {
 		m.logger.Debug("Mapping objectIDIndex", "objectIDIndex", index, "values", value.Values)
-		entry, err := m.getMappingEntry(value.Index)
+		entry, err := m.mappingConfig.GetMappingEntry(value.Index)
 		if err != nil {
 			m.logger.Warn("Error finding mapping entry", "error", err, "objectID", value.Index)
 			continue
@@ -357,7 +366,7 @@ func newObjectIDValue(objectID string, value Value) (*ObjectIDValue, error) {
 }
 
 // Gets the mapper for the closest parent objectID
-func (m *ObjectIDMapper) getMappingEntry(objectID string) (*Entry, error) {
+func (m *MappingConfig) GetMappingEntry(objectID string) (*Entry, error) {
 	for {
 		if value, found := m.mapping[objectID]; found {
 			return value, nil
@@ -373,7 +382,7 @@ func (m *ObjectIDMapper) getMappingEntry(objectID string) (*Entry, error) {
 }
 
 // ObjectIDs returns the ObjectIDs that the ObjectIDMapper can map
-func (m *ObjectIDMapper) ObjectIDs() map[string]int {
+func (m *MappingConfig) ObjectIDs() map[string]int {
 	objectIDs := make(map[string]int)
 	for _, entry := range m.mapping {
 		// If the entry has child mapping entries, add the child OIDs

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -341,7 +341,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mappingConfig := mapping.NewMappingConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{})
+			mappingConfig := mapping.NewConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{})
 			mapper := mapping.NewObjectIDMapper(mappingConfig, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &config.Defaults{
 				Interface: config.InterfaceDefaults{
 					Type: "other",
@@ -404,7 +404,7 @@ func TestObjectIDs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mappingConfig := mapping.NewMappingConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{})
+			mappingConfig := mapping.NewConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{})
 			objectIDs := mappingConfig.ObjectIDs()
 
 			assert.Equal(t, tt.expectedOIDs, objectIDs)

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -341,17 +341,12 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mapper := mapping.NewObjectIDMapper(
-				tt.mapping,
-				slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})),
-				&FakeManufacturers{},
-				&FakeDeviceLookup{},
-				&config.Defaults{
-					Interface: config.InterfaceDefaults{
-						Type: "other",
-					},
+			mappingConfig := mapping.NewMappingConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{})
+			mapper := mapping.NewObjectIDMapper(mappingConfig, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &config.Defaults{
+				Interface: config.InterfaceDefaults{
+					Type: "other",
 				},
-			)
+			})
 			entities := mapper.MapObjectIDsToEntity(tt.objectIDs)
 
 			assert.ElementsMatch(t, tt.expected, entities)
@@ -409,14 +404,8 @@ func TestObjectIDs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mapper := mapping.NewObjectIDMapper(
-				tt.mapping,
-				slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})),
-				&FakeManufacturers{},
-				&FakeDeviceLookup{},
-				&config.Defaults{},
-			)
-			objectIDs := mapper.ObjectIDs()
+			mappingConfig := mapping.NewMappingConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{})
+			objectIDs := mappingConfig.ObjectIDs()
 
 			assert.Equal(t, tt.expectedOIDs, objectIDs)
 		})

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -142,7 +142,7 @@ func (r *Runner) logEntitiesForIngestion(entities []diode.Entity) {
 }
 
 func (r *Runner) queryTargets(expandedTargets []config.Target) []diode.Entity {
-	mappingConfig := mapping.NewMappingConfig(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup)
+	mappingConfig := mapping.NewConfig(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup)
 	objectIDs := mappingConfig.ObjectIDs()
 	r.logger.Info("Querying targets", slog.Any("targetCount", len(expandedTargets)), slog.Any("objectCount", len(objectIDs)))
 

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -137,7 +137,7 @@ func (r *Runner) run() {
 
 func (r *Runner) logEntitiesForIngestion(entities []diode.Entity) {
 	for _, entity := range entities {
-		r.logger.Info("Entity for ingestion", slog.Any("entity", entity.ConvertToProtoMessage()))
+		r.logger.Debug("Entity for ingestion", slog.Any("entity", entity.ConvertToProtoMessage()))
 	}
 }
 

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -110,22 +110,20 @@ func (r *Runner) run() {
 	ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 	defer cancel()
 
-	mapper := mapping.NewObjectIDMapper(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup, &r.config.Defaults)
-	objectIDs := mapper.ObjectIDs()
-
-	r.logger.Info("Starting SNMP crawl of targets", slog.Any("targetCount", len(r.scope.Targets)), slog.Any("objectCount", len(objectIDs)))
-	entities := make([]diode.Entity, 0)
+	r.logger.Info("Starting SNMP crawl of targets", slog.Any("targetCount", len(r.scope.Targets)))
 
 	// Expand all targets
 	expandedTargets := r.expandTargetRanges(r.scope.Targets)
 
-	entities = r.queryTargets(expandedTargets, objectIDs, mapper, entities)
+	entities := r.queryTargets(expandedTargets)
 	r.logger.Info("SNMP crawl complete", slog.Any("policy", r.ctx.Value(policyKey)), slog.Any("entityCount", len(entities)))
 
 	if len(entities) == 0 {
 		r.logger.Info("No entities to ingest", slog.Any("policy", r.ctx.Value(policyKey)))
 		return
 	}
+
+	r.logEntitiesForIngestion(entities)
 
 	resp, err := r.client.Ingest(ctx, entities)
 	if err != nil {
@@ -137,8 +135,21 @@ func (r *Runner) run() {
 	}
 }
 
-func (r *Runner) queryTargets(expandedTargets []config.Target, objectIDs map[string]int, mapper *mapping.ObjectIDMapper, entities []diode.Entity) []diode.Entity {
+func (r *Runner) logEntitiesForIngestion(entities []diode.Entity) {
+	for _, entity := range entities {
+		r.logger.Info("Entity for ingestion", slog.Any("entity", entity.ConvertToProtoMessage()))
+	}
+}
+
+func (r *Runner) queryTargets(expandedTargets []config.Target) []diode.Entity {
+	mappingConfig := mapping.NewMappingConfig(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup)
+	objectIDs := mappingConfig.ObjectIDs()
+	r.logger.Info("Querying targets", slog.Any("targetCount", len(expandedTargets)), slog.Any("objectCount", len(objectIDs)))
+
+	entities := make([]diode.Entity, 0)
+
 	for _, target := range expandedTargets {
+		mapper := mapping.NewObjectIDMapper(mappingConfig, r.logger, &r.config.Defaults)
 		policyName := r.ctx.Value(policyKey).(string)
 		// Track discovery attempt
 		if rMetric := metrics.GetDiscoveryAttempts(); rMetric != nil {


### PR DESCRIPTION
When there are multiple targets we are using the same device across all of them currently. This PR changes the scope of the mapper to use a device per target.

This pull request refactors the `ObjectIDMapper` implementation in the `snmp-discovery` package to introduce a new `MappingConfig` struct for improved separation of concerns and modularity. The changes also update related test cases and the `Runner` logic to align with the new structure.

### Refactoring of `ObjectIDMapper`:

* Replaced the internal `mapping` field in `ObjectIDMapper` with a new `MappingConfig` struct, which encapsulates mapping-related logic. (`snmp-discovery/mapping/mapping.go`, [snmp-discovery/mapping/mapping.goL119-R119](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L119-R119))
* Added a `NewMappingConfig` constructor to initialize `MappingConfig` with mapping entries, manufacturers, and device lookup dependencies. (`snmp-discovery/mapping/mapping.go`, [snmp-discovery/mapping/mapping.goL154-R163](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L154-R163))
* Migrated mapping-related methods (`getMappingEntry`, `ObjectIDs`) from `ObjectIDMapper` to `MappingConfig`. (`snmp-discovery/mapping/mapping.go`, [[1]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L360-R369) [[2]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L376-R385)

### Updates to `Runner` logic:

* Refactored the `Runner` to use `MappingConfig` for object ID retrieval and mapping, simplifying the `queryTargets` method. (`snmp-discovery/policy/runner.go`, [[1]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL113-R127) [[2]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL140-R152)
* Added a new method `logEntitiesForIngestion` to log entities before ingestion, improving clarity in the ingestion process. (`snmp-discovery/policy/runner.go`, [snmp-discovery/policy/runner.goL140-R152](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL140-R152))

### Test case adjustments:

* Updated test cases to use `MappingConfig` instead of directly initializing `ObjectIDMapper` with mappings and dependencies. (`snmp-discovery/mapping/mapping_test.go`, [[1]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L344-R349) [[2]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L412-R408)