### PR TITLE
fix: removes mapping to type that doesn't exist in netbox

### DIFF
--- a/snmp-discovery/mapping/interface_types.go
+++ b/snmp-discovery/mapping/interface_types.go
@@ -149,9 +149,6 @@ func isEthernetInterfaceType(ifType string) bool {
 }
 
 func getEthernetInterfaceType(speed *int64) string {
-	if *speed <= 10000 {
-		return "10base-t"
-	}
 	if *speed <= 100000 {
 		return "100base-tx"
 	}

--- a/snmp-discovery/mapping/interface_types_test.go
+++ b/snmp-discovery/mapping/interface_types_test.go
@@ -215,8 +215,8 @@ var tests = []struct {
 		name:                 "ethernetCsmacd 10Mbps",
 		ifType:               "6",
 		defaultInterfaceType: "",
-		expectedNetboxType:   "10base-t",
-		description:          "ethernetCsmacd with 10Mbps should map to 10base-t",
+		expectedNetboxType:   "100base-tx",
+		description:          "ethernetCsmacd with 10Mbps should map to 100base-tx",
 		speed:                int64Ptr(10000),
 	},
 	{
@@ -263,8 +263,8 @@ var tests = []struct {
 		name:                 "ethernetCsmacd 1Mbps",
 		ifType:               "6",
 		defaultInterfaceType: "",
-		expectedNetboxType:   "10base-t",
-		description:          "ethernetCsmacd with 1Mbps should map to 10base-t",
+		expectedNetboxType:   "100base-tx",
+		description:          "ethernetCsmacd with 1Mbps should map to 100base-tx",
 		speed:                int64Ptr(1000),
 	},
 	{

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -580,7 +580,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			defaults: nil,
 			expectedEntity: &diode.Interface{
 				Speed: int64Ptr(10000),
-				Type:  mapping.StringPtr("10base-t"),
+				Type:  mapping.StringPtr("100base-tx"),
 			},
 			expectError: false,
 		},


### PR DESCRIPTION
This pull request updates the logic for mapping Ethernet interface types based on speed in the `snmp-discovery` package. The primary change is the removal of the mapping for "10base-t" and its replacement with "100base-tx" for speeds less than or equal to 10 Mbps. Corresponding test cases have been updated to reflect this change.

### Changes to Ethernet interface type mapping:

* [`snmp-discovery/mapping/interface_types.go`](diffhunk://#diff-336574a932e727b8a71ed372b0a2f0723b4f2f3bb3cdf50f9ece13b0c5ab64bfL152-L154): Removed the logic for mapping speeds <= 10 Mbps to "10base-t" and adjusted the mapping to use "100base-tx" for speeds <= 100 Mbps.

### Updates to test cases:

* [`snmp-discovery/mapping/interface_types_test.go`](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acL218-R219): Updated test cases to map speeds of 10 Mbps and 1 Mbps to "100base-tx" instead of "10base-t". [[1]](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acL218-R219) [[2]](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acL266-R267)
* [`snmp-discovery/mapping/mappers_test.go`](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L583-R583): Modified the expected interface type in the `TestInterfaceMapper_Map` test to "100base-tx" for speeds of 10 Mbps.