### PR TITLE
feat: add override_defaults support for device_discovery

### DIFF
--- a/device-discovery/device_discovery/policy/models.py
+++ b/device-discovery/device_discovery/policy/models.py
@@ -18,24 +18,24 @@ class Status(Enum):
     FAILED = "failed"
 
 
-class Napalm(BaseModel):
-    """Model for NAPALM configuration."""
-
-    driver: str | None = Field(default=None, description="Driver name, optional")
-    hostname: str
-    username: str
-    password: str
-    timeout: int = 60
-    optional_args: dict[str, Any] | None = Field(
-        default=None, description="Optional arguments"
-    )
-
 class ObjectParameters(BaseModel):
     """Model for object parameters."""
 
     comments: str | None = Field(default=None, description="Comments, optional")
     description: str | None = Field(default=None, description="Description, optional")
     tags: list[str] | None = Field(default=None, description="Tags, optional")
+
+
+class DeviceParameters(ObjectParameters):
+    """Model for device specific parameters."""
+
+    model: str | None = Field(
+        default=None, description="Device model override, optional"
+    )
+    manufacturer: str | None = Field(
+        default=None, description="Device manufacturer override, optional"
+    )
+
 
 class VlanParameters(ObjectParameters):
     """Model for VLAN parameters."""
@@ -44,6 +44,7 @@ class VlanParameters(ObjectParameters):
     tenant: str | None = Field(default=None, description="VLAN tenant, optional")
     role: str | None = Field(default=None, description="VLAN role, optional")
 
+
 class IpamParameters(ObjectParameters):
     """Model for IPAM parameters."""
 
@@ -51,26 +52,42 @@ class IpamParameters(ObjectParameters):
     tenant: str | None = Field(default=None, description="IPAM tenant, optional")
     vrf: str | None = Field(default=None, description="IPAM VRF, optional")
 
+
 class Defaults(BaseModel):
     """Model for default configuration."""
 
     site: str | None = Field(default="undefined", description="Site name, optional")
-    role: str | None = Field(default="undefined", description="Device Role name, optional")
+    role: str | None = Field(
+        default="undefined", description="Device Role name, optional"
+    )
     if_type: str | None = Field(default="other", description="Interface type, optional")
     location: str | None = Field(default=None, description="Location name, optional")
     tenant: str | None = Field(default=None, description="Tenant name, optional")
     tags: list[str] | None = Field(default=None, description="Tags, optional")
-    device: ObjectParameters | None = Field(default=None, description="Device parameters, optional")
-    interface: ObjectParameters | None = Field(default=None, description="Interface parameters, optional")
-    ipaddress: IpamParameters | None = Field(default=None, description="IP Address parameters, optional")
-    prefix: IpamParameters | None = Field(default=None, description="Prefix parameters, optional")
-    vlan: VlanParameters | None = Field(default=None, description="VLAN parameters, optional")
+    device: DeviceParameters | None = Field(
+        default=None, description="Device parameters, optional"
+    )
+    interface: ObjectParameters | None = Field(
+        default=None, description="Interface parameters, optional"
+    )
+    ipaddress: IpamParameters | None = Field(
+        default=None, description="IP Address parameters, optional"
+    )
+    prefix: IpamParameters | None = Field(
+        default=None, description="Prefix parameters, optional"
+    )
+    vlan: VlanParameters | None = Field(
+        default=None, description="VLAN parameters, optional"
+    )
+
 
 class Config(BaseModel):
     """Model for discovery configuration."""
 
     schedule: str | None = Field(default=None, description="cron interval, optional")
-    defaults: Defaults | None = Field(default=None, description="Default configuration, optional")
+    defaults: Defaults | None = Field(
+        default=None, description="Default configuration, optional"
+    )
 
     @field_validator("schedule")
     @classmethod
@@ -92,6 +109,23 @@ class Config(BaseModel):
         except CroniterBadCronError:
             raise ValueError("Invalid cron schedule format.")
         return value
+
+
+class Napalm(BaseModel):
+    """Model for NAPALM configuration."""
+
+    driver: str | None = Field(default=None, description="Driver name, optional")
+    hostname: str
+    username: str
+    password: str
+    timeout: int = 60
+    optional_args: dict[str, Any] | None = Field(
+        default=None, description="Optional arguments"
+    )
+    override_defaults: Defaults | None = Field(
+        default=None,
+        description="Override default configuration for this host, optional",
+    )
 
 
 class Policy(BaseModel):

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -77,7 +77,7 @@ class PolicyRunner:
             id = str(uuid.uuid4())
             self.scopes[id] = scope
 
-            config = self.config.model_copy()
+            config = self.config.model_copy(deep=True)
             if scope.override_defaults is not None:
                 config.defaults = config.defaults.model_copy(
                     update=scope.override_defaults.model_dump(exclude_none=True)

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -15,11 +15,30 @@ from napalm import get_network_driver
 from device_discovery.client import Client
 from device_discovery.discovery import discover_device_driver, supported_drivers
 from device_discovery.metrics import get_metric
-from device_discovery.policy.models import Config, Napalm, Status
+from device_discovery.policy.models import Config, Defaults, Napalm, Status
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+
+def merge_defaults(base: Defaults, override: Defaults | None) -> Defaults:
+    """Merge base defaults with override defaults."""
+    if override is None:
+        return base
+
+    def _merge_dict(a: dict, b: dict) -> dict:
+        for k, v in b.items():
+            if isinstance(v, dict) and isinstance(a.get(k), dict):
+                a[k] = _merge_dict(a[k], v)
+            else:
+                a[k] = v
+        return a
+
+    base_dict = base.model_dump()
+    override_dict = override.model_dump(exclude_none=True)
+    merged = _merge_dict(base_dict, override_dict)
+    return Defaults.model_validate(merged)
 
 
 class PolicyRunner:
@@ -76,6 +95,9 @@ class PolicyRunner:
 
             id = str(uuid.uuid4())
             self.scopes[id] = scope
+            self.config.defaults = merge_defaults(
+                self.config.defaults, scope.override_defaults
+            )
             self.scheduler.add_job(
                 self.run, id=id, trigger=trigger, args=[id, scope, self.config]
             )

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -95,11 +95,11 @@ class PolicyRunner:
 
             id = str(uuid.uuid4())
             self.scopes[id] = scope
-            self.config.defaults = merge_defaults(
+            merged_defaults = merge_defaults(
                 self.config.defaults, scope.override_defaults
             )
             self.scheduler.add_job(
-                self.run, id=id, trigger=trigger, args=[id, scope, self.config]
+                self.run, id=id, trigger=trigger, args=[id, scope, merged_defaults, self.config]
             )
             if set_telemetry:
                 set_telemetry = False

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -67,9 +67,9 @@ class PolicyRunner:
         self.config = config
 
         if self.config is None:
-            self.config = Config(defaults={})
+            self.config = Config(defaults=Defaults())
         elif self.config.defaults is None:
-            self.config.defaults = {}
+            self.config.defaults = Defaults()
 
         self.scheduler.start()
         set_telemetry = True

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -22,25 +22,6 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
-def merge_defaults(base: Defaults, override: Defaults | None) -> Defaults:
-    """Merge base defaults with override defaults."""
-    if override is None:
-        return base
-
-    def _merge_dict(a: dict, b: dict) -> dict:
-        for k, v in b.items():
-            if isinstance(v, dict) and isinstance(a.get(k), dict):
-                a[k] = _merge_dict(a[k], v)
-            else:
-                a[k] = v
-        return a
-
-    base_dict = base.model_dump()
-    override_dict = override.model_dump(exclude_none=True)
-    merged = _merge_dict(base_dict, override_dict)
-    return Defaults.model_validate(merged)
-
-
 class PolicyRunner:
     """Policy Runner class."""
 
@@ -95,11 +76,14 @@ class PolicyRunner:
 
             id = str(uuid.uuid4())
             self.scopes[id] = scope
-            merged_defaults = merge_defaults(
-                self.config.defaults, scope.override_defaults
-            )
+
+            config = self.config
+            if scope.override_defaults is not None:
+                config.defaults = config.defaults.model_copy(
+                    update=scope.override_defaults.model_dump(exclude_none=True)
+                )
             self.scheduler.add_job(
-                self.run, id=id, trigger=trigger, args=[id, scope, merged_defaults, self.config]
+                self.run, id=id, trigger=trigger, args=[id, scope, config]
             )
             if set_telemetry:
                 set_telemetry = False

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -77,7 +77,7 @@ class PolicyRunner:
             id = str(uuid.uuid4())
             self.scopes[id] = scope
 
-            config = self.config
+            config = self.config.model_copy()
             if scope.override_defaults is not None:
                 config.defaults = config.defaults.model_copy(
                     update=scope.override_defaults.model_dump(exclude_none=True)

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -53,6 +53,8 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
 
     """
     tags = list(defaults.tags) if defaults.tags else []
+    model = device_info.get("model")
+    manufacturer = device_info.get("vendor")
     description = None
     comments = None
     location = None
@@ -61,18 +63,16 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
         tags.extend(defaults.device.tags or [])
         description = defaults.device.description
         comments = defaults.device.comments
+        model = defaults.device.model or model
+        manufacturer = defaults.device.manufacturer or manufacturer
 
     if defaults.location:
         location = Location(name=defaults.location, site=defaults.site)
 
     device = Device(
         name=device_info.get("hostname"),
-        device_type=DeviceType(
-            model=device_info.get("model"), manufacturer=device_info.get("vendor")
-        ),
-        platform=Platform(
-            name=device_info.get("driver"), manufacturer=device_info.get("vendor")
-        ),
+        device_type=DeviceType(model=model, manufacturer=manufacturer),
+        platform=Platform(name=device_info.get("driver"), manufacturer=manufacturer),
         role=defaults.role,
         serial=device_info.get("serial_number"),
         status="active",

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -53,10 +53,18 @@ def test_setup_policy_runner_with_cron(policy_runner, sample_config, sample_scop
 
         # Ensure scheduler starts and job is added
         mock_start.assert_called_once()
-        mock_add_job.assert_called()
+
+        assert mock_add_job.call_count == 2
+        call_args = mock_add_job.call_args_list[0]  # First call
+        passed_config = call_args[1]["args"][2]
+
+        assert passed_config.defaults.site == "New York/NY"
+        assert passed_config.defaults.role == "Router"
+
+        # default was not modified, only inside the scope
         assert policy_runner.status == Status.RUNNING
-        assert policy_runner.config.defaults.role == "Router"
-        assert policy_runner.config.defaults.site == "New York/NY"
+        assert policy_runner.config.defaults.role == "undefined"
+        assert policy_runner.config.defaults.site == "New York"
 
 
 def test_setup_policy_runner_with_one_time_run(policy_runner, sample_scopes):

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -27,7 +27,13 @@ def sample_config():
 def sample_scopes():
     """Fixture for a sample list of Napalm objects."""
     return [
-        Napalm(driver="ios", hostname="router1", username="admin", password="password")
+        Napalm(
+            driver="ios",
+            hostname="router1",
+            username="admin",
+            password="password",
+            override_defaults=Defaults(role="Router", site="New York/NY"),
+        ),
     ]
 
 
@@ -38,9 +44,10 @@ def test_initial_status(policy_runner):
 
 def test_setup_policy_runner_with_cron(policy_runner, sample_config, sample_scopes):
     """Test setting up the PolicyRunner with a cron schedule."""
-    with patch.object(policy_runner.scheduler, "start") as mock_start, patch.object(
-        policy_runner.scheduler, "add_job"
-    ) as mock_add_job:
+    with (
+        patch.object(policy_runner.scheduler, "start") as mock_start,
+        patch.object(policy_runner.scheduler, "add_job") as mock_add_job,
+    ):
 
         policy_runner.setup("policy1", sample_config, sample_scopes)
 
@@ -48,14 +55,17 @@ def test_setup_policy_runner_with_cron(policy_runner, sample_config, sample_scop
         mock_start.assert_called_once()
         mock_add_job.assert_called()
         assert policy_runner.status == Status.RUNNING
+        assert policy_runner.config.defaults.role == "Router"
+        assert policy_runner.config.defaults.site == "New York/NY"
 
 
 def test_setup_policy_runner_with_one_time_run(policy_runner, sample_scopes):
     """Test setting up the PolicyRunner with a one-time schedule."""
     one_time_config = Config()
-    with patch.object(policy_runner.scheduler, "start") as mock_start, patch.object(
-        policy_runner.scheduler, "add_job"
-    ) as mock_add_job:
+    with (
+        patch.object(policy_runner.scheduler, "start") as mock_start,
+        patch.object(policy_runner.scheduler, "add_job") as mock_add_job,
+    ):
 
         policy_runner.setup("policy1", one_time_config, sample_scopes)
 
@@ -69,10 +79,11 @@ def test_setup_policy_runner_with_one_time_run(policy_runner, sample_scopes):
 def test_setup_with_unsupported_driver_raises_error(policy_runner, sample_scopes):
     """Test setup raises error if driver is unsupported."""
     sample_scopes[0].driver = "unsupported_driver"
-    with patch(
-        "device_discovery.policy.runner.supported_drivers", ["ios"]
-    ), pytest.raises(
-        Exception, match="specified driver 'unsupported_driver' was not found"
+    with (
+        patch("device_discovery.policy.runner.supported_drivers", ["ios"]),
+        pytest.raises(
+            Exception, match="specified driver 'unsupported_driver' was not found"
+        ),
     ):
         policy_runner.setup("policy1", Config(), sample_scopes)
     assert policy_runner.status == Status.NEW
@@ -81,13 +92,13 @@ def test_setup_with_unsupported_driver_raises_error(policy_runner, sample_scopes
 def test_run_device_with_discovered_driver(policy_runner, sample_scopes, sample_config):
     """Test running a device where the driver needs discovery."""
     sample_scopes[0].driver = None  # Force driver discovery
-    with patch(
-        "device_discovery.policy.runner.discover_device_driver", return_value="ios"
-    ) as mock_discover, patch(
-        "device_discovery.policy.runner.get_network_driver"
-    ) as mock_get_driver, patch(
-        "device_discovery.client.Client.ingest"
-    ) as mock_ingest:
+    with (
+        patch(
+            "device_discovery.policy.runner.discover_device_driver", return_value="ios"
+        ) as mock_discover,
+        patch("device_discovery.policy.runner.get_network_driver") as mock_get_driver,
+        patch("device_discovery.client.Client.ingest") as mock_ingest,
+    ):
 
         # Mock the network driver instance
         mock_driver_instance = MagicMock()
@@ -114,11 +125,12 @@ def test_run_device_with_discovered_driver(policy_runner, sample_scopes, sample_
 def test_run_discovered_driver_error(policy_runner, sample_scopes, sample_config):
     """Test running a device where the driver discovery fails."""
     sample_scopes[0].driver = None  # Force driver discovery
-    with patch(
-        "device_discovery.policy.runner.discover_device_driver", return_value=None
-    ) as mock_discover, patch(
-        "device_discovery.policy.runner.logger.error"
-    ) as mock_logger_error:
+    with (
+        patch(
+            "device_discovery.policy.runner.discover_device_driver", return_value=None
+        ) as mock_discover,
+        patch("device_discovery.policy.runner.logger.error") as mock_logger_error,
+    ):
 
         # Run the device with an error to check error handling
         policy_runner.run("test_id", sample_scopes[0], sample_config)
@@ -130,10 +142,13 @@ def test_run_discovered_driver_error(policy_runner, sample_scopes, sample_config
 
 def test_run_device_with_error_in_job(policy_runner, sample_scopes, sample_config):
     """Test run handles an error during device interaction gracefully."""
-    with patch(
-        "device_discovery.policy.runner.get_network_driver",
-        side_effect=Exception("Connection error"),
-    ), patch("device_discovery.policy.runner.logger.error") as mock_logger_error:
+    with (
+        patch(
+            "device_discovery.policy.runner.get_network_driver",
+            side_effect=Exception("Connection error"),
+        ),
+        patch("device_discovery.policy.runner.logger.error") as mock_logger_error,
+    ):
 
         # Run the device with an error to check error handling
         policy_runner.run("test_id", sample_scopes[0], sample_config)
@@ -176,14 +191,12 @@ def test_metrics_during_policy_lifecycle(policy_runner, sample_config, sample_sc
     def mock_get_metric(name):
         return mock_metrics.get(name)
 
-    with patch(
-        "device_discovery.policy.runner.get_metric", side_effect=mock_get_metric
-    ), patch.object(policy_runner.scheduler, "start"), patch.object(
-        policy_runner.scheduler, "add_job"
-    ), patch(
-        "device_discovery.policy.runner.get_network_driver"
-    ), patch(
-        "device_discovery.client.Client.ingest"
+    with (
+        patch("device_discovery.policy.runner.get_metric", side_effect=mock_get_metric),
+        patch.object(policy_runner.scheduler, "start"),
+        patch.object(policy_runner.scheduler, "add_job"),
+        patch("device_discovery.policy.runner.get_network_driver"),
+        patch("device_discovery.client.Client.ingest"),
     ):
 
         # Test setup - should increment active_policies
@@ -238,15 +251,16 @@ def test_metrics_during_failed_discovery(policy_runner, sample_config):
     def mock_get_metric(name):
         return mock_metrics.get(name)
 
-    with patch(
-        "device_discovery.policy.runner.get_metric", side_effect=mock_get_metric
-    ), patch(
-        "device_discovery.policy.runner.discover_device_driver", return_value="ios"
-    ), patch(
-        "device_discovery.policy.runner.get_network_driver",
-        side_effect=Exception("Connection error"),
-    ), patch.object(
-        policy_runner.scheduler, "remove_job"
+    with (
+        patch("device_discovery.policy.runner.get_metric", side_effect=mock_get_metric),
+        patch(
+            "device_discovery.policy.runner.discover_device_driver", return_value="ios"
+        ),
+        patch(
+            "device_discovery.policy.runner.get_network_driver",
+            side_effect=Exception("Connection error"),
+        ),
+        patch.object(policy_runner.scheduler, "remove_job"),
     ):
 
         # Run the device with discovery that will fail

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -3,10 +3,10 @@
 """NetBox Labs - Translate Unit Tests."""
 
 import pytest
-from netboxlabs.diode.sdk.ingester import Tag
 
 from device_discovery.policy.models import (
     Defaults,
+    DeviceParameters,
     IpamParameters,
     ObjectParameters,
     VlanParameters,
@@ -83,12 +83,19 @@ def sample_defaults():
         if_type="other",
         location="local",
         tenant="test",
-        device=ObjectParameters(comments="testing", tags=["devtag"]),
+        device=DeviceParameters(comments="testing", tags=["devtag"]),
         interface=ObjectParameters(description="testing", tags=["inttag"]),
         ipaddress=IpamParameters(description="ip test", tags=["iptag"]),
         prefix=IpamParameters(description="prefix test", tags=["prefixtag"]),
         vlan=VlanParameters(comments="test"),
     )
+
+
+@pytest.fixture
+def sample_override_defaults(sample_defaults):
+    """Sample defaults with device overrides."""
+    sample_defaults.device.model = "Catalyst"
+    return sample_defaults
 
 
 def test_translate_device(sample_device_info, sample_defaults):
@@ -105,6 +112,13 @@ def test_translate_device(sample_device_info, sample_defaults):
     assert device.location.site.name == "New York"
     assert device.tenant.name == "test"
     assert len(device.tags) == 3
+
+
+def test_translate_device_with_overrides(sample_device_info, sample_override_defaults):
+    """Ensure device translation respects model overrides."""
+    device = translate_device(sample_device_info, sample_override_defaults)
+    assert device.device_type.model == "Catalyst"
+    assert device.device_type.manufacturer.name == "Cisco"
 
 
 def test_translate_interface(


### PR DESCRIPTION
This pull request introduces enhancements to the device discovery policy models, configuration handling, and testing framework. The most significant changes include the addition of `DeviceParameters` for more granular device-specific overrides, improved handling of default configurations in `PolicyRunner`, and expanded test coverage for configuration overrides and error handling.

### Enhancements to Policy Models
* Added a new `DeviceParameters` model to allow device-specific overrides for `model` and `manufacturer`. This replaces the generic `ObjectParameters` for devices in `Defaults`. (`device-discovery/device_discovery/policy/models.py`, [device-discovery/device_discovery/policy/models.pyL21-R90](diffhunk://#diff-6a336230783aebcdf213f14e3c6628fe4b4c705e8e65a7367e072ea77836b684L21-R90))
* Updated the `Napalm` model to include an `override_defaults` field for host-specific configuration overrides. (`device-discovery/device_discovery/policy/models.py`, [device-discovery/device_discovery/policy/models.pyR114-R130](diffhunk://#diff-6a336230783aebcdf213f14e3c6628fe4b4c705e8e65a7367e072ea77836b684R114-R130))

### Improvements in Configuration Handling
* Modified `PolicyRunner` to apply `override_defaults` from `Napalm` scopes, ensuring the configuration respects host-specific overrides during job scheduling. (`device-discovery/device_discovery/policy/runner.py`, [device-discovery/device_discovery/policy/runner.pyR79-R86](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fR79-R86))
* Refactored the `Defaults` initialization in `PolicyRunner` to use the `Defaults` model directly instead of empty dictionaries. (`device-discovery/device_discovery/policy/runner.py`, [device-discovery/device_discovery/policy/runner.pyL51-R53](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fL51-R53))

### Updates to Translation Logic
* Enhanced the `translate_device` function to prioritize `model` and `manufacturer` overrides from `DeviceParameters` when translating device information. (`device-discovery/device_discovery/translate.py`, [[1]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R56-R57) [[2]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R66-R75)

### Expanded Test Coverage
* Added tests to validate configuration overrides, ensuring `PolicyRunner` respects `DeviceParameters` during job setup. (`device-discovery/tests/policy/test_runner.py`, [device-discovery/tests/policy/test_runner.pyL41-R76](diffhunk://#diff-b532d3732249713542c40eb5bb38fef6adfbee621e934fa42f4444693b461695L41-R76))
* Introduced tests for `translate_device` to verify that device-specific overrides are correctly applied. (`device-discovery/tests/test_translate.py`, [device-discovery/tests/test_translate.pyR117-R123](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R117-R123))