### PR TITLE
fix: snmpv3 authentication

### DIFF
--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -125,7 +125,10 @@ type Client struct {
 
 // Close implements the Walker interface by closing the SNMP connection
 func (c *Client) Close() error {
-	return c.Conn.Close()
+	if c.Conn != nil {
+		return c.Conn.Close()
+	}
+	return nil
 }
 
 // Walk implements the Walker interface by walking the SNMP tree
@@ -202,11 +205,12 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 		}
 		return &Client{
 			&gosnmp.GoSNMP{
-				Target:  host,
-				Port:    port,
-				Version: gosnmp.Version3,
-				Timeout: timeout,
-				Retries: retries,
+				Target:        host,
+				Port:          port,
+				Version:       gosnmp.Version3,
+				Timeout:       timeout,
+				Retries:       retries,
+				SecurityModel: gosnmp.UserSecurityModel,
 				SecurityParameters: &gosnmp.UsmSecurityParameters{
 					UserName:                 authentication.Username,
 					AuthenticationProtocol:   authProtocol,


### PR DESCRIPTION
This pull request improves the `Client` struct in the `snmp-discovery/snmp/snmp.go` file by enhancing error handling and adding a new security model configuration for SNMP connections.

Enhancements to error handling:

* Updated the `Close` method in the `Client` struct to check if `Conn` is `nil` before attempting to close the connection, ensuring proper error handling and avoiding potential nil pointer dereferences. (`[snmp-discovery/snmp/snmp.goR128-R132](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R128-R132)`)

Improvements to SNMP configuration:

* Added `SecurityModel` configuration (`gosnmp.UserSecurityModel`) in the `NewClient` function to support SNMPv3 user-based security model. (`[snmp-discovery/snmp/snmp.goR213](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R213)`)