### PR TITLE
Release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ __pycache__/
 *.egg-info/
 .coverage/
 .coverage
+
+.cursor/
+.cursor.md

--- a/snmp-discovery/mapping/interface_types.go
+++ b/snmp-discovery/mapping/interface_types.go
@@ -149,9 +149,6 @@ func isEthernetInterfaceType(ifType string) bool {
 }
 
 func getEthernetInterfaceType(speed *int64) string {
-	if *speed <= 10000 {
-		return "10base-t"
-	}
 	if *speed <= 100000 {
 		return "100base-tx"
 	}

--- a/snmp-discovery/mapping/interface_types_test.go
+++ b/snmp-discovery/mapping/interface_types_test.go
@@ -215,8 +215,8 @@ var tests = []struct {
 		name:                 "ethernetCsmacd 10Mbps",
 		ifType:               "6",
 		defaultInterfaceType: "",
-		expectedNetboxType:   "10base-t",
-		description:          "ethernetCsmacd with 10Mbps should map to 10base-t",
+		expectedNetboxType:   "100base-tx",
+		description:          "ethernetCsmacd with 10Mbps should map to 100base-tx",
 		speed:                int64Ptr(10000),
 	},
 	{
@@ -263,8 +263,8 @@ var tests = []struct {
 		name:                 "ethernetCsmacd 1Mbps",
 		ifType:               "6",
 		defaultInterfaceType: "",
-		expectedNetboxType:   "10base-t",
-		description:          "ethernetCsmacd with 1Mbps should map to 10base-t",
+		expectedNetboxType:   "100base-tx",
+		description:          "ethernetCsmacd with 1Mbps should map to 100base-tx",
 		speed:                int64Ptr(1000),
 	},
 	{

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -20,6 +20,12 @@ const (
 	maxInterfaceSpeed = 2147483647
 )
 
+// MTU constants
+const (
+	minInterfaceMTU = 1
+	maxInterfaceMTU = 2147483647
+)
+
 // IPAddressMapper is a struct that maps IP addresses to entities
 type IPAddressMapper struct {
 	logger *slog.Logger
@@ -297,8 +303,9 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 						m.logger.Warn("Error converting mtu to int64", "error", err, "value", value.Value)
 						continue
 					}
-					if mtu <= 0 {
-						m.logger.Warn("MTU is less than or equal to 0", "value", value.Value)
+					// Check if MTU is within valid range (1 to 2147483647 inclusive) and not overflowing int32
+					if mtu < minInterfaceMTU || mtu > maxInterfaceMTU {
+						m.logger.Warn("Interface MTU is outside valid range (1-2147483647) or overflows int32", "mtu", mtu, "value", value.Value, "mappingID", propertyMappingEntry.OID, "interfaceIndex", objectID)
 						continue
 					}
 					mtu64 := mtu

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -867,6 +867,384 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			name: "mapping with MTU above maximum should result in nil MTU",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.4.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.4.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.4",
+					Value:  "2147483648",
+					Type:   mapping.Integer,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.4",
+						Entity: "interface",
+						Field:  "mtu",
+					},
+				},
+			},
+			defaults: nil,
+			expectedEntity: &diode.Interface{
+				Name: mapping.StringPtr("eth0"),
+				Mtu:  nil, // MTU should be nil when value is above maximum
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with MTU below minimum should result in nil MTU",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.4.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.4.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.4",
+					Value:  "0",
+					Type:   mapping.Integer,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.4",
+						Entity: "interface",
+						Field:  "mtu",
+					},
+				},
+			},
+			defaults: nil,
+			expectedEntity: &diode.Interface{
+				Name: mapping.StringPtr("eth0"),
+				Mtu:  nil, // MTU should be nil when value is below minimum
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with MTU that overflows int32 should result in nil MTU",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.4.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.4.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.4",
+					Value:  "9223372036854775807",
+					Type:   mapping.Integer,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.4",
+						Entity: "interface",
+						Field:  "mtu",
+					},
+				},
+			},
+			defaults: nil,
+			expectedEntity: &diode.Interface{
+				Name: mapping.StringPtr("eth0"),
+				Mtu:  nil, // MTU should be nil when value overflows int32
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with MTU at maximum valid value should succeed",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.4.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.4.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.4",
+					Value:  "2147483647",
+					Type:   mapping.Integer,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.4",
+						Entity: "interface",
+						Field:  "mtu",
+					},
+				},
+			},
+			defaults: nil,
+			expectedEntity: &diode.Interface{
+				Name: mapping.StringPtr("eth0"),
+				Mtu:  int64Ptr(2147483647), // MTU should be set when value is at maximum valid range
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with MTU at minimum valid value should succeed",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.4.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.4.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.4",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.4",
+						Entity: "interface",
+						Field:  "mtu",
+					},
+				},
+			},
+			defaults: nil,
+			expectedEntity: &diode.Interface{
+				Name: mapping.StringPtr("eth0"),
+				Mtu:  int64Ptr(1), // MTU should be set when value is at minimum valid range
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with MTU just above maximum should result in nil MTU",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.4.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.4.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.4",
+					Value:  "2147483648",
+					Type:   mapping.Integer,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.4",
+						Entity: "interface",
+						Field:  "mtu",
+					},
+				},
+			},
+			defaults: nil,
+			expectedEntity: &diode.Interface{
+				Name: mapping.StringPtr("eth0"),
+				Mtu:  nil, // MTU should be nil when value is just above maximum
+			},
+			expectError: false,
+		},
+		{
+			name: "mapping with MTU just below minimum should result in nil MTU",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.4.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.4.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.4",
+					Value:  "0",
+					Type:   mapping.Integer,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.4",
+						Entity: "interface",
+						Field:  "mtu",
+					},
+				},
+			},
+			defaults: nil,
+			expectedEntity: &diode.Interface{
+				Name: mapping.StringPtr("eth0"),
+				Mtu:  nil, // MTU should be nil when value is just below minimum
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -580,7 +580,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			defaults: nil,
 			expectedEntity: &diode.Interface{
 				Speed: int64Ptr(10000),
-				Type:  mapping.StringPtr("10base-t"),
+				Type:  mapping.StringPtr("100base-tx"),
 			},
 			expectError: false,
 		},

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -349,11 +349,24 @@ func (m *ObjectIDMapper) getMappingEntry(objectID string) (*Entry, error) {
 // ObjectIDs returns the ObjectIDs that the ObjectIDMapper can map
 func (m *ObjectIDMapper) ObjectIDs() map[string]int {
 	objectIDs := make(map[string]int)
-	for objectID := range m.mapping {
-		if m.mapping[objectID].IdentifierSize == 0 {
-			objectIDs[objectID] = 1
+	for _, entry := range m.mapping {
+		// If the entry has child mapping entries, add the child OIDs
+		if len(entry.MappingEntries) > 0 {
+			for _, childEntry := range entry.MappingEntries {
+				if childEntry.IdentifierSize == 0 {
+					objectIDs[childEntry.OID] = 1
+				} else {
+					// Use the child's IdentifierSize if it is non-zero; otherwise, use the parent's IdentifierSize.
+					objectIDs[childEntry.OID] = childEntry.IdentifierSize
+				}
+			}
 		} else {
-			objectIDs[objectID] = m.mapping[objectID].IdentifierSize
+			// If no child entries, add the parent OID itself
+			if entry.IdentifierSize == 0 {
+				objectIDs[entry.OID] = 1
+			} else {
+				objectIDs[entry.OID] = entry.IdentifierSize
+			}
 		}
 	}
 	return objectIDs

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -288,14 +288,40 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 	}
 
 	currentDevice := m.registry.GetOrCreateEntity(DeviceEntityType, CurrentDeviceIndex).(*diode.Device)
+
+	assignedInterfaceIndices := m.getAssignedInterfaces(uniqueEntities)
+
+	// Build final entity list, excluding assigned interfaces to sending duplcates for ingestion
 	entities := make([]diode.Entity, 0, len(uniqueEntities))
 	for entity := range uniqueEntities {
 		if diodeInterface, ok := entity.(*diode.Interface); ok {
+			isAssigned := false
+			if assignedInterfaceIndices[diodeInterface] {
+				isAssigned = true
+			}
 			diodeInterface.Device = currentDevice
+			if !isAssigned {
+				entities = append(entities, entity)
+			}
+		} else {
+			entities = append(entities, entity)
 		}
-		entities = append(entities, entity)
 	}
 	return entities
+}
+
+func (*ObjectIDMapper) getAssignedInterfaces(uniqueEntities map[diode.Entity]bool) map[diode.Entity]bool {
+	assignedInterfaceIndices := make(map[diode.Entity]bool)
+	for entity := range uniqueEntities {
+		if ipAddress, ok := entity.(*diode.IPAddress); ok {
+			if ipAddress.AssignedObject != nil {
+				if assignedInterface, ok := ipAddress.AssignedObject.(*diode.Interface); ok {
+					assignedInterfaceIndices[assignedInterface] = true
+				}
+			}
+		}
+	}
+	return assignedInterfaceIndices
 }
 
 func (m *ObjectIDMapper) groupByObjectIDIndex(objectIDs ObjectIDValueMap) map[ObjectIDIndex]*ObjectIDIndexDetails {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -116,10 +116,10 @@ const (
 
 // ObjectIDMapper is a struct that maps ObjectIDs to entities
 type ObjectIDMapper struct {
-	mapping  map[string]*Entry
-	logger   *slog.Logger
-	registry *EntityRegistry
-	defaults *config.Defaults
+	mappingConfig *Config
+	logger        *slog.Logger
+	registry      *EntityRegistry
+	defaults      *config.Defaults
 }
 
 // Entry is a struct that contains a mapping entry
@@ -150,8 +150,13 @@ func (m *Entry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistr
 	return entity
 }
 
-// NewObjectIDMapper creates a new ObjectIDMapper
-func NewObjectIDMapper(mappings []config.MappingEntry, logger *slog.Logger, manufacturers data.ManufacturerRetriever, deviceLookup data.DeviceRetriever, defaults *config.Defaults) *ObjectIDMapper {
+// Config is a struct that contains a mapping of ObjectIDs to Entries
+type Config struct {
+	mapping map[string]*Entry
+}
+
+// NewConfig creates a new Config
+func NewConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturers data.ManufacturerRetriever, deviceLookup data.DeviceRetriever) *Config {
 	entityMappers := map[string]orbToEntityMapper{
 		"ipAddress": &IPAddressMapper{
 			logger: logger,
@@ -174,12 +179,18 @@ func NewObjectIDMapper(mappings []config.MappingEntry, logger *slog.Logger, manu
 		}
 		mapping[m.OID] = Entry
 	}
+	return &Config{
+		mapping: mapping,
+	}
+}
 
+// NewObjectIDMapper creates a new ObjectIDMapper
+func NewObjectIDMapper(mappingConfig *Config, logger *slog.Logger, defaults *config.Defaults) *ObjectIDMapper {
 	return &ObjectIDMapper{
-		mapping:  mapping,
-		logger:   logger,
-		registry: NewEntityRegistry(logger),
-		defaults: defaults,
+		mappingConfig: mappingConfig,
+		logger:        logger,
+		registry:      NewEntityRegistry(logger),
+		defaults:      defaults,
 	}
 }
 
@@ -278,7 +289,7 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 	uniqueEntities := make(map[diode.Entity]bool)
 	for index, value := range objectIDIndexMap {
 		m.logger.Debug("Mapping objectIDIndex", "objectIDIndex", index, "values", value.Values)
-		entry, err := m.getMappingEntry(value.Index)
+		entry, err := m.mappingConfig.getMappingEntry(value.Index)
 		if err != nil {
 			m.logger.Warn("Error finding mapping entry", "error", err, "objectID", value.Index)
 			continue
@@ -357,7 +368,7 @@ func newObjectIDValue(objectID string, value Value) (*ObjectIDValue, error) {
 }
 
 // Gets the mapper for the closest parent objectID
-func (m *ObjectIDMapper) getMappingEntry(objectID string) (*Entry, error) {
+func (m *Config) getMappingEntry(objectID string) (*Entry, error) {
 	for {
 		if value, found := m.mapping[objectID]; found {
 			return value, nil
@@ -373,7 +384,7 @@ func (m *ObjectIDMapper) getMappingEntry(objectID string) (*Entry, error) {
 }
 
 // ObjectIDs returns the ObjectIDs that the ObjectIDMapper can map
-func (m *ObjectIDMapper) ObjectIDs() map[string]int {
+func (m *Config) ObjectIDs() map[string]int {
 	objectIDs := make(map[string]int)
 	for _, entry := range m.mapping {
 		// If the entry has child mapping entries, add the child OIDs

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -341,17 +341,12 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mapper := mapping.NewObjectIDMapper(
-				tt.mapping,
-				slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})),
-				&FakeManufacturers{},
-				&FakeDeviceLookup{},
-				&config.Defaults{
-					Interface: config.InterfaceDefaults{
-						Type: "other",
-					},
+			mappingConfig := mapping.NewConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{})
+			mapper := mapping.NewObjectIDMapper(mappingConfig, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &config.Defaults{
+				Interface: config.InterfaceDefaults{
+					Type: "other",
 				},
-			)
+			})
 			entities := mapper.MapObjectIDsToEntity(tt.objectIDs)
 
 			assert.ElementsMatch(t, tt.expected, entities)
@@ -409,14 +404,8 @@ func TestObjectIDs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mapper := mapping.NewObjectIDMapper(
-				tt.mapping,
-				slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})),
-				&FakeManufacturers{},
-				&FakeDeviceLookup{},
-				&config.Defaults{},
-			)
-			objectIDs := mapper.ObjectIDs()
+			mappingConfig := mapping.NewConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{})
+			objectIDs := mappingConfig.ObjectIDs()
 
 			assert.Equal(t, tt.expectedOIDs, objectIDs)
 		})

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -385,7 +385,7 @@ func TestObjectIDs(t *testing.T) {
 			},
 		},
 		{
-			name: "Duplicate OID",
+			name: "Child OIDs from parent mapping",
 			mapping: []config.MappingEntry{
 				{
 					OID:    ".1.3.6.1.2.1.2.2.1",
@@ -406,7 +406,8 @@ func TestObjectIDs(t *testing.T) {
 				},
 			},
 			expectedOIDs: map[string]int{
-				".1.3.6.1.2.1.2.2.1": 1,
+				".1.3.6.1.2.1.2.2.1.2": 1,
+				".1.3.6.1.2.1.2.2.1.5": 1,
 			},
 		},
 	}

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -267,11 +267,6 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 				".1.3.6.1.2.1.4.20.1.2.192.168.1.2": mapping.Value{Value: "999", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 4},
 			},
 			expected: []diode.Entity{
-				&diode.Interface{
-					Name:   diode.String("GigabitEthernet1/0/1"),
-					Type:   diode.String("other"),
-					Device: &diode.Device{},
-				},
 				&diode.IPAddress{
 					Address: diode.String("192.168.1.2/32"),
 					AssignedObject: &diode.Interface{

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -110,22 +110,20 @@ func (r *Runner) run() {
 	ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 	defer cancel()
 
-	mapper := mapping.NewObjectIDMapper(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup, &r.config.Defaults)
-	objectIDs := mapper.ObjectIDs()
-
-	r.logger.Info("Starting SNMP crawl of targets", slog.Any("targetCount", len(r.scope.Targets)), slog.Any("objectCount", len(objectIDs)))
-	entities := make([]diode.Entity, 0)
+	r.logger.Info("Starting SNMP crawl of targets", slog.Any("targetCount", len(r.scope.Targets)))
 
 	// Expand all targets
 	expandedTargets := r.expandTargetRanges(r.scope.Targets)
 
-	entities = r.queryTargets(expandedTargets, objectIDs, mapper, entities)
+	entities := r.queryTargets(expandedTargets)
 	r.logger.Info("SNMP crawl complete", slog.Any("policy", r.ctx.Value(policyKey)), slog.Any("entityCount", len(entities)))
 
 	if len(entities) == 0 {
 		r.logger.Info("No entities to ingest", slog.Any("policy", r.ctx.Value(policyKey)))
 		return
 	}
+
+	r.logEntitiesForIngestion(entities)
 
 	resp, err := r.client.Ingest(ctx, entities)
 	if err != nil {
@@ -137,8 +135,21 @@ func (r *Runner) run() {
 	}
 }
 
-func (r *Runner) queryTargets(expandedTargets []config.Target, objectIDs map[string]int, mapper *mapping.ObjectIDMapper, entities []diode.Entity) []diode.Entity {
+func (r *Runner) logEntitiesForIngestion(entities []diode.Entity) {
+	for _, entity := range entities {
+		r.logger.Debug("Entity for ingestion", slog.Any("entity", entity.ConvertToProtoMessage()))
+	}
+}
+
+func (r *Runner) queryTargets(expandedTargets []config.Target) []diode.Entity {
+	mappingConfig := mapping.NewConfig(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup)
+	objectIDs := mappingConfig.ObjectIDs()
+	r.logger.Info("Querying targets", slog.Any("targetCount", len(expandedTargets)), slog.Any("objectCount", len(objectIDs)))
+
+	entities := make([]diode.Entity, 0)
+
 	for _, target := range expandedTargets {
+		mapper := mapping.NewObjectIDMapper(mappingConfig, r.logger, &r.config.Defaults)
 		policyName := r.ctx.Value(policyKey).(string)
 		// Track discovery attempt
 		if rMetric := metrics.GetDiscoveryAttempts(); rMetric != nil {

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -28,11 +28,25 @@ func (n *FakeSNMPWalker) Walk(oid string, _ int) (map[string]PDU, error) {
 		}, nil
 	}
 
-	if oid == "iso.3.6.1.2.1.2.2.1" {
+	if oid == "1.3.6.1.2.1.2.2.1.2" {
+		return map[string]PDU{
+			"1.3.6.1.2.1.2.2.1.2.999": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString},
+		}, nil
+	}
+
+	if oid == "1.3.6.1.2.1.2.2.1.5" {
+		return map[string]PDU{
+			"1.3.6.1.2.1.2.2.1.5.999": {Value: 1000000, Type: gosnmp.Integer},
+		}, nil
+	}
+
+	// Handle the new child OID format for policy tests
+	if oid == "iso.3.6.1.2.1.2.2.1.2" {
 		return map[string]PDU{
 			"iso.3.6.1.2.1.2.2.1.2.999": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString},
 		}, nil
 	}
+
 	return make(map[string]PDU), nil
 }
 

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -125,7 +125,10 @@ type Client struct {
 
 // Close implements the Walker interface by closing the SNMP connection
 func (c *Client) Close() error {
-	return c.Conn.Close()
+	if c.Conn != nil {
+		return c.Conn.Close()
+	}
+	return nil
 }
 
 // Walk implements the Walker interface by walking the SNMP tree
@@ -202,11 +205,12 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 		}
 		return &Client{
 			&gosnmp.GoSNMP{
-				Target:  host,
-				Port:    port,
-				Version: gosnmp.Version3,
-				Timeout: timeout,
-				Retries: retries,
+				Target:        host,
+				Port:          port,
+				Version:       gosnmp.Version3,
+				Timeout:       timeout,
+				Retries:       retries,
+				SecurityModel: gosnmp.UserSecurityModel,
 				SecurityParameters: &gosnmp.UsmSecurityParameters{
 					UserName:                 authentication.Username,
 					AuthenticationProtocol:   authProtocol,

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -69,10 +69,12 @@ func (m *MockClient) Ingest(context.Context, []diode.Entity) (*diodepb.IngestRes
 func TestSNMPHost(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	const ipAddressObjectID = "1.3.6.1.2.1.4.20.1.1"
-	const interfaceObjectID = "1.3.6.1.2.1.2.2.1"
+	const interfaceNameOID = "1.3.6.1.2.1.2.2.1.2"
+	const interfaceSpeedOID = "1.3.6.1.2.1.2.2.1.5"
 	objectIDsToQuery := make(map[string]int)
 	objectIDsToQuery[ipAddressObjectID] = 4
-	objectIDsToQuery[interfaceObjectID] = 1
+	objectIDsToQuery[interfaceNameOID] = 1
+	objectIDsToQuery[interfaceSpeedOID] = 1
 
 	t.Run("Successfully walks a host", func(t *testing.T) {
 		// Setup
@@ -101,9 +103,11 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Walk", ipAddressObjectID, 4).Return(map[string]snmp.PDU{
 			ipAddressObjectID: {Value: "192.168.1.1", Type: gosnmp.IPAddress, IdentifierSize: 4},
 		}, nil)
-		mockWalker.On("Walk", interfaceObjectID, 1).Return(map[string]snmp.PDU{
-			interfaceObjectID + ".1": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString, IdentifierSize: 1},
-			interfaceObjectID + ".2": {Value: 1000000, Type: gosnmp.Integer, IdentifierSize: 1},
+		mockWalker.On("Walk", interfaceNameOID, 1).Return(map[string]snmp.PDU{
+			interfaceNameOID + ".1": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString, IdentifierSize: 1},
+		}, nil)
+		mockWalker.On("Walk", interfaceSpeedOID, 1).Return(map[string]snmp.PDU{
+			interfaceSpeedOID + ".1": {Value: 1000000, Type: gosnmp.Integer, IdentifierSize: 1},
 		}, nil)
 
 		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
@@ -118,8 +122,8 @@ func TestSNMPHost(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, 3, len(oids))
 		assert.Equal(t, mapping.Value{Value: "192.168.1.1", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4}, oids[ipAddressObjectID])
-		assert.Equal(t, mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1}, oids[interfaceObjectID+".1"])
-		assert.Equal(t, mapping.Value{Value: "1000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1}, oids[interfaceObjectID+".2"])
+		assert.Equal(t, mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1}, oids[interfaceNameOID+".1"])
+		assert.Equal(t, mapping.Value{Value: "1000000", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 1}, oids[interfaceSpeedOID+".1"])
 		mockWalker.AssertExpectations(t)
 	})
 
@@ -196,9 +200,11 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Walk", ipAddressObjectID, 4).Return(map[string]snmp.PDU{
 			ipAddressObjectID: {Value: "192.168.1.1", Type: gosnmp.IPAddress, IdentifierSize: 4},
 		}, nil)
-		mockWalker.On("Walk", interfaceObjectID, 1).Return(map[string]snmp.PDU{
-			interfaceObjectID + ".1": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString, IdentifierSize: 1},
-			interfaceObjectID + ".2": {Value: "invalid", Type: gosnmp.Asn1BER(255), IdentifierSize: 1}, // Invalid type
+		mockWalker.On("Walk", interfaceNameOID, 1).Return(map[string]snmp.PDU{
+			interfaceNameOID + ".1": {Value: "GigabitEthernet1/0/1", Type: gosnmp.OctetString, IdentifierSize: 1},
+		}, nil)
+		mockWalker.On("Walk", interfaceSpeedOID, 1).Return(map[string]snmp.PDU{
+			interfaceSpeedOID + ".1": {Value: "invalid", Type: gosnmp.Asn1BER(255), IdentifierSize: 1}, // Invalid type
 		}, nil)
 
 		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
@@ -213,9 +219,9 @@ func TestSNMPHost(t *testing.T) {
 		assert.NoError(t, err)        // Walk should continue despite PDU mapping error
 		assert.Equal(t, 2, len(oids)) // Should have 2 valid PDUs
 		assert.Equal(t, mapping.Value{Value: "192.168.1.1", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4}, oids[ipAddressObjectID])
-		assert.Equal(t, mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1}, oids[interfaceObjectID+".1"])
+		assert.Equal(t, mapping.Value{Value: "GigabitEthernet1/0/1", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1}, oids[interfaceNameOID+".1"])
 		// The invalid PDU should be skipped
-		_, exists := oids[interfaceObjectID+".2"]
+		_, exists := oids[interfaceSpeedOID+".1"]
 		assert.False(t, exists)
 		mockWalker.AssertExpectations(t)
 	})


### PR DESCRIPTION
This pull request introduces several key updates to the `snmp-discovery` package, focusing on improving interface type mappings, adding validation for MTU values, and refactoring the `ObjectIDMapper` to use a new `Config` struct. The changes enhance functionality, improve code clarity, and ensure more robust handling of edge cases in mapping operations.

### Interface Type Mapping Updates:
* Adjusted the mapping logic in `getEthernetInterfaceType` to classify speeds below or equal to 10 Mbps as `100base-tx` instead of `10base-t`. Updated corresponding test cases to reflect this change. (`snmp-discovery/mapping/interface_types.go` - [[1]](diffhunk://#diff-336574a932e727b8a71ed372b0a2f0723b4f2f3bb3cdf50f9ece13b0c5ab64bfL152-L154) `snmp-discovery/mapping/interface_types_test.go` - [[2]](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acL218-R219) [[3]](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acL266-R267)

### MTU Validation Enhancements:
* Introduced constants for valid MTU ranges (`minInterfaceMTU` and `maxInterfaceMTU`) and updated the `Map` method in `InterfaceMapper` to validate MTU values against these ranges. Added multiple test cases to verify behavior for MTU values at, above, and below the valid range, as well as for values that overflow `int32`. (`snmp-discovery/mapping/mappers.go` - [[1]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR23-R28) [[2]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL300-R308) `snmp-discovery/mapping/mappers_test.go` - [[3]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R870-R1247)

### Refactoring ObjectIDMapper:
* Replaced the `mapping` field in `ObjectIDMapper` with a new `Config` struct containing the mapping logic. Refactored methods for mapping entries and retrieving ObjectIDs to operate on the `Config` struct. Updated corresponding test cases to use the new `Config`. (`snmp-discovery/mapping/mapping.go` - [[1]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L119-R119) [[2]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L153-R159) [[3]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40R182-R190) [[4]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L281-R292) [[5]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L334-R371) [[6]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40L350-R406) `snmp-discovery/mapping/mapping_test.go` - [[7]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L270-L274) [[8]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L349-R349) [[9]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L388-R378) [[10]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L409-R408)

### Handling Assigned Interfaces:
* Added logic to exclude assigned interfaces from the final entity list in `MapObjectIDsToEntity` to prevent duplicate ingestion. Introduced a helper method `getAssignedInterfaces` to identify assigned interfaces. (`snmp-discovery/mapping/mapping.go` - [snmp-discovery/mapping/mapping.goR302-R337](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40R302-R337))

### Test Case Adjustments:
* Updated test cases to reflect the refactored `ObjectIDMapper` and new interface type mappings. Added comprehensive tests for MTU validation and edge cases. (`snmp-discovery/mapping/mapping_test.go` - [[1]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L270-L274) [[2]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L349-R349) [[3]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L388-R378) [[4]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L409-R408)