### PR TITLE
feat: adds support for env var replacement for auth policy values

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -67,7 +67,7 @@ policies:
       authentication:
         protocol_version: "v2c"
         community: "public"
-        # For SNMPv3, use these fields instead (all support env vars):
+        # For SNMPv3, use these fields instead:
         # security_level: "authPriv"
         # username: "${SNMP_USERNAME}"
         # auth_protocol: "SHA"

--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -67,13 +67,35 @@ policies:
       authentication:
         protocol_version: "v2c"
         community: "public"
-        # For SNMPv3, use these fields instead:
+        # For SNMPv3, use these fields instead (all support env vars):
         # security_level: "authPriv"
-        # username: "snmp-user"
+        # username: "${SNMP_USERNAME}"
         # auth_protocol: "SHA"
-        # auth_passphrase: "auth-password"
+        # auth_passphrase: "${SNMP_AUTH_PASS}"
         # priv_protocol: "AES"
-        # priv_passphrase: "priv-password"
+        # priv_passphrase: "${SNMP_PRIV_PASS}"
+
+**Note:** The following authentication fields support environment variable substitution using the `${VARNAME}` syntax:
+
+- `community`
+- `username`
+- `auth_passphrase`
+- `priv_passphrase`
+
+For example:
+
+```yaml
+authentication:
+  protocol_version: "v3"
+  security_level: "authPriv"
+  username: "${SNMP_USERNAME}"
+  auth_protocol: "SHA"
+  auth_passphrase: "${SNMP_AUTH_PASS}"
+  priv_protocol: "AES"
+  priv_passphrase: "${SNMP_PRIV_PASS}"
+```
+
+If the referenced environment variable is not set, the service will exit with an error.
   discover_once: # will run only once
     scope:
       targets:

--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
@@ -16,28 +15,12 @@ import (
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/metrics"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/server"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/utils"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/version"
 )
 
 // AppName is the application name
 const AppName = "snmp-discovery"
-
-func resolveEnv(value string) string {
-	// Check if the value starts with ${ and ends with }
-	if strings.HasPrefix(value, "${") && strings.HasSuffix(value, "}") {
-		// Extract the environment variable name
-		envVar := value[2 : len(value)-1]
-		// Get the value of the environment variable
-		envValue := os.Getenv(envVar)
-		if envValue != "" {
-			return envValue
-		}
-		fmt.Printf("error: a provided environment %s variable is not set\n", envVar)
-		os.Exit(1)
-	}
-	// Return the original value if no substitution occurs
-	return value
-}
 
 func main() {
 	host := flag.String("host", "0.0.0.0", "server host")
@@ -84,15 +67,15 @@ func main() {
 	if *dryRun {
 		client, err = diode.NewDryRunClient(
 			producerName,
-			resolveEnv(*dryRunOutputDir),
+			utils.ResolveEnvOrExit(*dryRunOutputDir),
 		)
 	} else {
 		client, err = diode.NewClient(
-			resolveEnv(*diodeTarget),
+			utils.ResolveEnvOrExit(*diodeTarget),
 			producerName,
 			version.GetBuildVersion(),
-			diode.WithClientID(resolveEnv(*diodeClientID)),
-			diode.WithClientSecret(resolveEnv(*diodeClientSecret)),
+			diode.WithClientID(utils.ResolveEnvOrExit(*diodeClientID)),
+			diode.WithClientSecret(utils.ResolveEnvOrExit(*diodeClientSecret)),
 		)
 	}
 	if err != nil {

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/data"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/utils"
 	"gopkg.in/yaml.v3"
 )
 
@@ -71,6 +72,7 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 		// Create a new policy with updated mappings
 		updatedPolicy := payload.Policies[name]
 		m.applyDefaults(&updatedPolicy)
+		m.resolveAuthenticationEnvVars(&updatedPolicy)
 		payload.Policies[name] = updatedPolicy
 	}
 
@@ -212,4 +214,23 @@ func (m *Manager) Stop() error {
 // GetCapabilities returns the capabilities of snm-discovery
 func (m *Manager) GetCapabilities() []string {
 	return []string{"targets"}
+}
+
+// resolveAuthenticationEnvVars resolves environment variables in authentication configuration
+func (m *Manager) resolveAuthenticationEnvVars(policy *config.Policy) {
+	auth := &policy.Scope.Authentication
+
+	// Resolve environment variables for authentication fields
+	if resolved, err := utils.ResolveEnv(auth.Community); err == nil {
+		auth.Community = resolved
+	}
+	if resolved, err := utils.ResolveEnv(auth.Username); err == nil {
+		auth.Username = resolved
+	}
+	if resolved, err := utils.ResolveEnv(auth.AuthPassphrase); err == nil {
+		auth.AuthPassphrase = resolved
+	}
+	if resolved, err := utils.ResolveEnv(auth.PrivPassphrase); err == nil {
+		auth.PrivPassphrase = resolved
+	}
 }

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -72,7 +72,9 @@ func (m *Manager) ParsePolicies(data []byte) (map[string]config.Policy, error) {
 		// Create a new policy with updated mappings
 		updatedPolicy := payload.Policies[name]
 		m.applyDefaults(&updatedPolicy)
-		m.resolveAuthenticationEnvVars(&updatedPolicy)
+		if err := m.resolveAuthenticationEnvVars(&updatedPolicy); err != nil {
+			return nil, fmt.Errorf("%s : failed to resolve environment variables : %w", name, err)
+		}
 		payload.Policies[name] = updatedPolicy
 	}
 
@@ -217,20 +219,33 @@ func (m *Manager) GetCapabilities() []string {
 }
 
 // resolveAuthenticationEnvVars resolves environment variables in authentication configuration
-func (m *Manager) resolveAuthenticationEnvVars(policy *config.Policy) {
+func (m *Manager) resolveAuthenticationEnvVars(policy *config.Policy) error {
 	auth := &policy.Scope.Authentication
 
 	// Resolve environment variables for authentication fields
-	if resolved, err := utils.ResolveEnv(auth.Community); err == nil {
-		auth.Community = resolved
+	resolved, err := utils.ResolveEnv(auth.Community)
+	if err != nil {
+		return fmt.Errorf("failed to resolve community environment variable: %w", err)
 	}
-	if resolved, err := utils.ResolveEnv(auth.Username); err == nil {
-		auth.Username = resolved
+	auth.Community = resolved
+
+	resolved, err = utils.ResolveEnv(auth.Username)
+	if err != nil {
+		return fmt.Errorf("failed to resolve username environment variable: %w", err)
 	}
-	if resolved, err := utils.ResolveEnv(auth.AuthPassphrase); err == nil {
-		auth.AuthPassphrase = resolved
+	auth.Username = resolved
+
+	resolved, err = utils.ResolveEnv(auth.AuthPassphrase)
+	if err != nil {
+		return fmt.Errorf("failed to resolve auth_passphrase environment variable: %w", err)
 	}
-	if resolved, err := utils.ResolveEnv(auth.PrivPassphrase); err == nil {
-		auth.PrivPassphrase = resolved
+	auth.AuthPassphrase = resolved
+
+	resolved, err = utils.ResolveEnv(auth.PrivPassphrase)
+	if err != nil {
+		return fmt.Errorf("failed to resolve priv_passphrase environment variable: %w", err)
 	}
+	auth.PrivPassphrase = resolved
+
+	return nil
 }

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -221,31 +221,23 @@ func (m *Manager) GetCapabilities() []string {
 // resolveAuthenticationEnvVars resolves environment variables in authentication configuration
 func (m *Manager) resolveAuthenticationEnvVars(policy *config.Policy) error {
 	auth := &policy.Scope.Authentication
-
-	// Resolve environment variables for authentication fields
-	resolved, err := utils.ResolveEnv(auth.Community)
-	if err != nil {
-		return fmt.Errorf("failed to resolve community environment variable: %w", err)
+	fields := []struct {
+		field *string
+		label string
+	}{
+		{&auth.Community, "community"},
+		{&auth.Username, "username"},
+		{&auth.AuthPassphrase, "auth_passphrase"},
+		{&auth.PrivPassphrase, "priv_passphrase"},
 	}
-	auth.Community = resolved
-
-	resolved, err = utils.ResolveEnv(auth.Username)
-	if err != nil {
-		return fmt.Errorf("failed to resolve username environment variable: %w", err)
+	// Iterate over the fields and resolve environment variables
+	for _, f := range fields {
+		resolved, err := utils.ResolveEnv(*f.field)
+		if err != nil {
+			return fmt.Errorf("failed to resolve %s environment variable: %w", f.label, err)
+		}
+		*f.field = resolved
 	}
-	auth.Username = resolved
-
-	resolved, err = utils.ResolveEnv(auth.AuthPassphrase)
-	if err != nil {
-		return fmt.Errorf("failed to resolve auth_passphrase environment variable: %w", err)
-	}
-	auth.AuthPassphrase = resolved
-
-	resolved, err = utils.ResolveEnv(auth.PrivPassphrase)
-	if err != nil {
-		return fmt.Errorf("failed to resolve priv_passphrase environment variable: %w", err)
-	}
-	auth.PrivPassphrase = resolved
 
 	return nil
 }

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -317,6 +317,59 @@ func TestManagerParsePolicies(t *testing.T) {
 		// Check policy2 (without env var)
 		assert.Equal(t, "public", policies["policy2"].Scope.Authentication.Community)
 	})
+
+	t.Run("Environment Variable Resolution - Missing Environment Variable", func(t *testing.T) {
+		// Ensure the environment variable is not set
+		err := os.Unsetenv("MISSING_SNMP_COMMUNITY")
+		require.NoError(t, err)
+
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv2c
+                community: ${MISSING_SNMP_COMMUNITY}
+       `)
+
+		_, err = manager.ParsePolicies(yamlData)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "policy1 : failed to resolve environment variables")
+		assert.Contains(t, err.Error(), "failed to resolve community environment variable")
+		assert.Contains(t, err.Error(), "environment variable MISSING_SNMP_COMMUNITY is not set")
+	})
+
+	t.Run("Environment Variable Resolution - Missing Username Environment Variable", func(t *testing.T) {
+		// Ensure the environment variable is not set
+		err := os.Unsetenv("MISSING_SNMP_USERNAME")
+		require.NoError(t, err)
+
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv3
+                security_level: authNoPriv
+                username: ${MISSING_SNMP_USERNAME}
+                auth_protocol: SHA
+                auth_passphrase: test-pass
+       `)
+
+		_, err = manager.ParsePolicies(yamlData)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "policy1 : failed to resolve environment variables")
+		assert.Contains(t, err.Error(), "failed to resolve username environment variable")
+		assert.Contains(t, err.Error(), "environment variable MISSING_SNMP_USERNAME is not set")
+	})
 }
 
 func TestManagerPolicyLifecycle(t *testing.T) {

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -139,6 +139,175 @@ func TestManagerParsePolicies(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, "no policies found in the request", err.Error())
 	})
+
+	t.Run("Environment Variable Resolution - Community", func(t *testing.T) {
+		// Set test environment variable
+		os.Setenv("SNMP_COMMUNITY", "test-community")
+		defer os.Unsetenv("SNMP_COMMUNITY")
+
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv2c
+                community: ${SNMP_COMMUNITY}
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		assert.Equal(t, "test-community", policies["policy1"].Scope.Authentication.Community)
+	})
+
+	t.Run("Environment Variable Resolution - Username", func(t *testing.T) {
+		// Set test environment variables
+		os.Setenv("SNMP_USERNAME", "test-user")
+		os.Setenv("SNMP_AUTH_PASS", "test-auth-pass")
+		defer func() {
+			os.Unsetenv("SNMP_USERNAME")
+			os.Unsetenv("SNMP_AUTH_PASS")
+		}()
+
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv3
+                security_level: authNoPriv
+                username: ${SNMP_USERNAME}
+                auth_protocol: SHA
+                auth_passphrase: ${SNMP_AUTH_PASS}
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		assert.Equal(t, "test-user", policies["policy1"].Scope.Authentication.Username)
+		assert.Equal(t, "test-auth-pass", policies["policy1"].Scope.Authentication.AuthPassphrase)
+	})
+
+	t.Run("Environment Variable Resolution - All Auth Fields", func(t *testing.T) {
+		// Set test environment variables
+		os.Setenv("SNMP_COMMUNITY", "test-community")
+		os.Setenv("SNMP_USERNAME", "test-user")
+		os.Setenv("SNMP_AUTH_PASS", "test-auth-pass")
+		os.Setenv("SNMP_PRIV_PASS", "test-priv-pass")
+		defer func() {
+			os.Unsetenv("SNMP_COMMUNITY")
+			os.Unsetenv("SNMP_USERNAME")
+			os.Unsetenv("SNMP_AUTH_PASS")
+			os.Unsetenv("SNMP_PRIV_PASS")
+		}()
+
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv3
+                security_level: authPriv
+                username: ${SNMP_USERNAME}
+                auth_protocol: SHA
+                auth_passphrase: ${SNMP_AUTH_PASS}
+                priv_protocol: AES
+                priv_passphrase: ${SNMP_PRIV_PASS}
+          policy2:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.2
+              authentication:
+                protocol_version: SNMPv2c
+                community: ${SNMP_COMMUNITY}
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		assert.Contains(t, policies, "policy2")
+
+		// Check policy1 (SNMPv3)
+		assert.Equal(t, "test-user", policies["policy1"].Scope.Authentication.Username)
+		assert.Equal(t, "test-auth-pass", policies["policy1"].Scope.Authentication.AuthPassphrase)
+		assert.Equal(t, "test-priv-pass", policies["policy1"].Scope.Authentication.PrivPassphrase)
+
+		// Check policy2 (SNMPv2c)
+		assert.Equal(t, "test-community", policies["policy2"].Scope.Authentication.Community)
+	})
+
+	t.Run("Environment Variable Resolution - No Substitution", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		assert.Equal(t, "public", policies["policy1"].Scope.Authentication.Community)
+	})
+
+	t.Run("Environment Variable Resolution - Mixed Values", func(t *testing.T) {
+		// Set test environment variable
+		os.Setenv("SNMP_COMMUNITY", "test-community")
+		defer os.Unsetenv("SNMP_COMMUNITY")
+
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv2c
+                community: ${SNMP_COMMUNITY}
+          policy2:
+            config:
+              lookup_extensions_dir: /tmp/extensions
+            scope:
+              targets:
+                - host: 192.168.1.2
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		assert.Contains(t, policies, "policy2")
+
+		// Check policy1 (with env var)
+		assert.Equal(t, "test-community", policies["policy1"].Scope.Authentication.Community)
+
+		// Check policy2 (without env var)
+		assert.Equal(t, "public", policies["policy2"].Scope.Authentication.Community)
+	})
 }
 
 func TestManagerPolicyLifecycle(t *testing.T) {

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 // MockRunner mocks the Runner
@@ -142,8 +143,9 @@ func TestManagerParsePolicies(t *testing.T) {
 
 	t.Run("Environment Variable Resolution - Community", func(t *testing.T) {
 		// Set test environment variable
-		os.Setenv("SNMP_COMMUNITY", "test-community")
-		defer os.Unsetenv("SNMP_COMMUNITY")
+		err := os.Setenv("SNMP_COMMUNITY", "test-community")
+		require.NoError(t, err)
+		defer func() { _ = os.Unsetenv("SNMP_COMMUNITY") }()
 
 		yamlData := []byte(`
         policies:
@@ -166,11 +168,13 @@ func TestManagerParsePolicies(t *testing.T) {
 
 	t.Run("Environment Variable Resolution - Username", func(t *testing.T) {
 		// Set test environment variables
-		os.Setenv("SNMP_USERNAME", "test-user")
-		os.Setenv("SNMP_AUTH_PASS", "test-auth-pass")
+		err := os.Setenv("SNMP_USERNAME", "test-user")
+		require.NoError(t, err)
+		err = os.Setenv("SNMP_AUTH_PASS", "test-auth-pass")
+		require.NoError(t, err)
 		defer func() {
-			os.Unsetenv("SNMP_USERNAME")
-			os.Unsetenv("SNMP_AUTH_PASS")
+			_ = os.Unsetenv("SNMP_USERNAME")
+			_ = os.Unsetenv("SNMP_AUTH_PASS")
 		}()
 
 		yamlData := []byte(`
@@ -198,15 +202,19 @@ func TestManagerParsePolicies(t *testing.T) {
 
 	t.Run("Environment Variable Resolution - All Auth Fields", func(t *testing.T) {
 		// Set test environment variables
-		os.Setenv("SNMP_COMMUNITY", "test-community")
-		os.Setenv("SNMP_USERNAME", "test-user")
-		os.Setenv("SNMP_AUTH_PASS", "test-auth-pass")
-		os.Setenv("SNMP_PRIV_PASS", "test-priv-pass")
+		err := os.Setenv("SNMP_COMMUNITY", "test-community")
+		require.NoError(t, err)
+		err = os.Setenv("SNMP_USERNAME", "test-user")
+		require.NoError(t, err)
+		err = os.Setenv("SNMP_AUTH_PASS", "test-auth-pass")
+		require.NoError(t, err)
+		err = os.Setenv("SNMP_PRIV_PASS", "test-priv-pass")
+		require.NoError(t, err)
 		defer func() {
-			os.Unsetenv("SNMP_COMMUNITY")
-			os.Unsetenv("SNMP_USERNAME")
-			os.Unsetenv("SNMP_AUTH_PASS")
-			os.Unsetenv("SNMP_PRIV_PASS")
+			_ = os.Unsetenv("SNMP_COMMUNITY")
+			_ = os.Unsetenv("SNMP_USERNAME")
+			_ = os.Unsetenv("SNMP_AUTH_PASS")
+			_ = os.Unsetenv("SNMP_PRIV_PASS")
 		}()
 
 		yamlData := []byte(`
@@ -272,8 +280,9 @@ func TestManagerParsePolicies(t *testing.T) {
 
 	t.Run("Environment Variable Resolution - Mixed Values", func(t *testing.T) {
 		// Set test environment variable
-		os.Setenv("SNMP_COMMUNITY", "test-community")
-		defer os.Unsetenv("SNMP_COMMUNITY")
+		err := os.Setenv("SNMP_COMMUNITY", "test-community")
+		require.NoError(t, err)
+		defer func() { _ = os.Unsetenv("SNMP_COMMUNITY") }()
 
 		yamlData := []byte(`
         policies:

--- a/snmp-discovery/utils/utils.go
+++ b/snmp-discovery/utils/utils.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// ResolveEnv resolves environment variables in a string value.
+// If the value starts with ${ and ends with }, it extracts the environment variable name
+// and returns its value. If the environment variable is not set, it returns an error.
+// Otherwise, it returns the original value.
+func ResolveEnv(value string) (string, error) {
+	// Check if the value starts with ${ and ends with }
+	if strings.HasPrefix(value, "${") && strings.HasSuffix(value, "}") {
+		// Extract the environment variable name
+		envVar := value[2 : len(value)-1]
+		// Skip empty environment variable names
+		if envVar == "" {
+			return value, nil
+		}
+		// Get the value of the environment variable
+		envValue := os.Getenv(envVar)
+		if envValue != "" {
+			return envValue, nil
+		}
+		return "", fmt.Errorf("environment variable %s is not set", envVar)
+	}
+	// Return the original value if no substitution occurs
+	return value, nil
+}
+
+// ResolveEnvOrExit resolves environment variables in a string value.
+// If the value starts with ${ and ends with }, it extracts the environment variable name
+// and returns its value. If the environment variable is not set, it prints an error
+// and exits with code 1. Otherwise, it returns the original value.
+func ResolveEnvOrExit(value string) string {
+	resolved, err := ResolveEnv(value)
+	if err != nil {
+		fmt.Printf("error: %v\n", err)
+		os.Exit(1)
+	}
+	return resolved
+}

--- a/snmp-discovery/utils/utils_test.go
+++ b/snmp-discovery/utils/utils_test.go
@@ -1,0 +1,121 @@
+package utils_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveEnv(t *testing.T) {
+	t.Run("No environment variable substitution", func(t *testing.T) {
+		result, err := utils.ResolveEnv("simple-value")
+		assert.NoError(t, err)
+		assert.Equal(t, "simple-value", result)
+	})
+
+	t.Run("Environment variable substitution - set", func(t *testing.T) {
+		// Set test environment variable
+		os.Setenv("TEST_VAR", "test-value")
+		defer os.Unsetenv("TEST_VAR")
+
+		result, err := utils.ResolveEnv("${TEST_VAR}")
+		assert.NoError(t, err)
+		assert.Equal(t, "test-value", result)
+	})
+
+	t.Run("Environment variable substitution - not set", func(t *testing.T) {
+		// Ensure the environment variable is not set
+		os.Unsetenv("NONEXISTENT_VAR")
+
+		result, err := utils.ResolveEnv("${NONEXISTENT_VAR}")
+		assert.Error(t, err)
+		assert.Equal(t, "", result)
+		assert.Contains(t, err.Error(), "environment variable NONEXISTENT_VAR is not set")
+	})
+
+	t.Run("Partial environment variable syntax", func(t *testing.T) {
+		result, err := utils.ResolveEnv("${TEST_VAR")
+		assert.NoError(t, err)
+		assert.Equal(t, "${TEST_VAR", result)
+	})
+
+	t.Run("Partial environment variable syntax 2", func(t *testing.T) {
+		result, err := utils.ResolveEnv("TEST_VAR}")
+		assert.NoError(t, err)
+		assert.Equal(t, "TEST_VAR}", result)
+	})
+
+	t.Run("Empty environment variable name", func(t *testing.T) {
+		result, err := utils.ResolveEnv("${}")
+		assert.NoError(t, err)
+		assert.Equal(t, "${}", result)
+	})
+
+	t.Run("Mixed content with environment variable", func(t *testing.T) {
+		os.Setenv("TEST_VAR", "test-value")
+		defer os.Unsetenv("TEST_VAR")
+
+		result, err := utils.ResolveEnv("prefix-${TEST_VAR}-suffix")
+		assert.NoError(t, err)
+		assert.Equal(t, "prefix-${TEST_VAR}-suffix", result)
+	})
+
+	t.Run("Multiple environment variables in same string", func(t *testing.T) {
+		os.Setenv("VAR1", "value1")
+		os.Setenv("VAR2", "value2")
+		defer func() {
+			os.Unsetenv("VAR1")
+			os.Unsetenv("VAR2")
+		}()
+
+		// Current implementation only handles single environment variables
+		// Multiple variables in one string are not supported and will return an error
+		result, err := utils.ResolveEnv("${VAR1}-${VAR2}")
+		assert.Error(t, err)
+		assert.Equal(t, "", result)
+		assert.Contains(t, err.Error(), "environment variable VAR1}-${VAR2 is not set")
+	})
+
+	t.Run("Environment variable with special characters", func(t *testing.T) {
+		os.Setenv("TEST_VAR_123", "test-value-123")
+		defer os.Unsetenv("TEST_VAR_123")
+
+		result, err := utils.ResolveEnv("${TEST_VAR_123}")
+		assert.NoError(t, err)
+		assert.Equal(t, "test-value-123", result)
+	})
+
+	t.Run("Empty string", func(t *testing.T) {
+		result, err := utils.ResolveEnv("")
+		assert.NoError(t, err)
+		assert.Equal(t, "", result)
+	})
+
+	t.Run("Only braces", func(t *testing.T) {
+		result, err := utils.ResolveEnv("{}")
+		assert.NoError(t, err)
+		assert.Equal(t, "{}", result)
+	})
+}
+
+func TestResolveEnvOrExit(t *testing.T) {
+	t.Run("No environment variable substitution", func(t *testing.T) {
+		result := utils.ResolveEnvOrExit("simple-value")
+		assert.Equal(t, "simple-value", result)
+	})
+
+	t.Run("Environment variable substitution - set", func(t *testing.T) {
+		// Set test environment variable
+		os.Setenv("TEST_VAR", "test-value")
+		defer os.Unsetenv("TEST_VAR")
+
+		result := utils.ResolveEnvOrExit("${TEST_VAR}")
+		assert.Equal(t, "test-value", result)
+	})
+
+	// Note: Testing the case where environment variable is not set is not practical
+	// because ResolveEnvOrExit calls os.Exit(1), which terminates the test process.
+	// This behavior is expected and documented.
+}

--- a/snmp-discovery/utils/utils_test.go
+++ b/snmp-discovery/utils/utils_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveEnv(t *testing.T) {
@@ -16,9 +17,9 @@ func TestResolveEnv(t *testing.T) {
 	})
 
 	t.Run("Environment variable substitution - set", func(t *testing.T) {
-		// Set test environment variable
-		os.Setenv("TEST_VAR", "test-value")
-		defer os.Unsetenv("TEST_VAR")
+		err := os.Setenv("TEST_VAR", "test-value")
+		require.NoError(t, err)
+		defer func() { _ = os.Unsetenv("TEST_VAR") }()
 
 		result, err := utils.ResolveEnv("${TEST_VAR}")
 		assert.NoError(t, err)
@@ -26,8 +27,8 @@ func TestResolveEnv(t *testing.T) {
 	})
 
 	t.Run("Environment variable substitution - not set", func(t *testing.T) {
-		// Ensure the environment variable is not set
-		os.Unsetenv("NONEXISTENT_VAR")
+		err := os.Unsetenv("NONEXISTENT_VAR")
+		require.NoError(t, err)
 
 		result, err := utils.ResolveEnv("${NONEXISTENT_VAR}")
 		assert.Error(t, err)
@@ -54,8 +55,9 @@ func TestResolveEnv(t *testing.T) {
 	})
 
 	t.Run("Mixed content with environment variable", func(t *testing.T) {
-		os.Setenv("TEST_VAR", "test-value")
-		defer os.Unsetenv("TEST_VAR")
+		err := os.Setenv("TEST_VAR", "test-value")
+		require.NoError(t, err)
+		defer func() { _ = os.Unsetenv("TEST_VAR") }()
 
 		result, err := utils.ResolveEnv("prefix-${TEST_VAR}-suffix")
 		assert.NoError(t, err)
@@ -63,11 +65,13 @@ func TestResolveEnv(t *testing.T) {
 	})
 
 	t.Run("Multiple environment variables in same string", func(t *testing.T) {
-		os.Setenv("VAR1", "value1")
-		os.Setenv("VAR2", "value2")
+		err := os.Setenv("VAR1", "value1")
+		require.NoError(t, err)
+		err = os.Setenv("VAR2", "value2")
+		require.NoError(t, err)
 		defer func() {
-			os.Unsetenv("VAR1")
-			os.Unsetenv("VAR2")
+			_ = os.Unsetenv("VAR1")
+			_ = os.Unsetenv("VAR2")
 		}()
 
 		// Current implementation only handles single environment variables
@@ -79,8 +83,9 @@ func TestResolveEnv(t *testing.T) {
 	})
 
 	t.Run("Environment variable with special characters", func(t *testing.T) {
-		os.Setenv("TEST_VAR_123", "test-value-123")
-		defer os.Unsetenv("TEST_VAR_123")
+		err := os.Setenv("TEST_VAR_123", "test-value-123")
+		require.NoError(t, err)
+		defer func() { _ = os.Unsetenv("TEST_VAR_123") }()
 
 		result, err := utils.ResolveEnv("${TEST_VAR_123}")
 		assert.NoError(t, err)
@@ -107,9 +112,9 @@ func TestResolveEnvOrExit(t *testing.T) {
 	})
 
 	t.Run("Environment variable substitution - set", func(t *testing.T) {
-		// Set test environment variable
-		os.Setenv("TEST_VAR", "test-value")
-		defer os.Unsetenv("TEST_VAR")
+		err := os.Setenv("TEST_VAR", "test-value")
+		require.NoError(t, err)
+		defer func() { _ = os.Unsetenv("TEST_VAR") }()
 
 		result := utils.ResolveEnvOrExit("${TEST_VAR}")
 		assert.Equal(t, "test-value", result)
@@ -117,5 +122,4 @@ func TestResolveEnvOrExit(t *testing.T) {
 
 	// Note: Testing the case where environment variable is not set is not practical
 	// because ResolveEnvOrExit calls os.Exit(1), which terminates the test process.
-	// This behavior is expected and documented.
 }


### PR DESCRIPTION
This pull request introduces environment variable substitution for SNMP authentication fields, refactors the code to centralize environment variable resolution logic, and adds comprehensive tests for the new functionality. The changes improve configurability, code reuse, and reliability.

### Enhancements to SNMP Authentication Configuration:
* Updated `snmp-discovery/README.md` to document environment variable substitution for SNMP authentication fields (`community`, `username`, `auth_passphrase`, `priv_passphrase`) and added an example configuration. If an environment variable is not set, the service exits with an error.

### Code Refactoring:
* Removed the `resolveEnv` function from `snmp-discovery/cmd/main.go` and replaced its usage with the new utility function `utils.ResolveEnvOrExit`. [[1]](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L10) [[2]](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L87-R78)
* Added `resolveAuthenticationEnvVars` to `snmp-discovery/policy/manager.go` to handle environment variable resolution for authentication fields in policies.

### Utility Functions:
* Introduced `ResolveEnv` and `ResolveEnvOrExit` utility functions in `snmp-discovery/utils/utils.go` for resolving environment variables, with error handling and process termination for unset variables.

### Unit Tests:
* Added comprehensive tests in `snmp-discovery/utils/utils_test.go` for `ResolveEnv` and `ResolveEnvOrExit`, covering various edge cases such as unset variables, partial syntax, and mixed content.
* Extended tests in `snmp-discovery/policy/manager_test.go` to validate environment variable resolution in policies, including scenarios with mixed values and multiple policies.