### PR TITLE
fix: normalize VLAN names

### DIFF
--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -254,9 +254,10 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
         tenant = defaults.vlan.tenant
         role = defaults.vlan.role
 
+    clean_name = " ".join(vlan_name.strip().split())
     vlan = VLAN(
         vid=int(vid),
-        name=vlan_name,
+        name=clean_name,
         group=group,
         tenant=tenant,
         role=role,

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -221,13 +221,24 @@ def test_translate_data(
 def test_translate_vlan(sample_defaults):
     """Ensure VLAN translation is correct."""
     vid = "1"
-    vlan_name = "Test VLAN"
+    vlan_name = "Test  VLAN   "
     vlan = translate_vlan(vid, vlan_name, sample_defaults)
 
     assert vlan.vid == 1
     assert vlan.name == "Test VLAN"
     assert len(vlan.tags) == 2
     assert vlan.comments == "test"
+
+    vid = "2"
+    vlan_name = "Test - VLAN   "
+    vlan = translate_vlan(vid, vlan_name, sample_defaults)
+    assert vlan.vid == 2
+    assert vlan.name == "Test - VLAN"
+
+    vlan_name = "info-vlan "
+    vlan = translate_vlan(vid, vlan_name, sample_defaults)
+    assert vlan.vid == 2
+    assert vlan.name == "info-vlan"
 
 
 def test_translate_vlan_with_defaults(sample_defaults):


### PR DESCRIPTION
This pull request improves the handling of VLAN names in the `translate_vlan` function by normalizing whitespace and adds corresponding test cases to ensure the functionality works as expected.

### Improvements to VLAN name handling:

* [`device-discovery/device_discovery/translate.py`](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R257-R260): Added logic to normalize whitespace in VLAN names by stripping leading/trailing spaces and collapsing multiple spaces into a single space before assigning it to the `name` attribute of the `VLAN` object.

### Test coverage enhancements:

* [`device-discovery/tests/test_translate.py`](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R232-R242): Added test cases to verify that VLAN names are correctly normalized, ensuring that leading/trailing spaces are removed and multiple spaces are collapsed.