### PR TITLE
fix: ignore vlans with invalid VID

### DIFF
--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -228,7 +228,7 @@ def translate_interface_ips(
     return ip_entities
 
 
-def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
+def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN | None:
     """
     Translate VLAN information for a given VLAN ID.
 
@@ -239,6 +239,10 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
         defaults (Defaults): Default configuration.
 
     """
+    try:
+        vid_int = int(vid)
+    except ValueError:
+        return None
     tags = list(defaults.tags) if defaults.tags else []
     comments = None
     description = None
@@ -256,7 +260,7 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
 
     clean_name = " ".join(vlan_name.strip().split())
     vlan = VLAN(
-        vid=int(vid),
+        vid=vid_int,
         name=clean_name,
         group=group,
         tenant=tenant,
@@ -302,6 +306,7 @@ def translate_data(data: dict) -> Iterable[Entity]:
     if data.get("vlan"):
         for vid, vlan_info in data.get("vlan").items():
             vlan = translate_vlan(vid, vlan_info.get("name"), defaults)
-            entities.append(Entity(vlan=vlan))
+            if vlan:
+                entities.append(Entity(vlan=vlan))
 
     return entities

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -240,6 +240,10 @@ def test_translate_vlan(sample_defaults):
     assert vlan.vid == 2
     assert vlan.name == "info-vlan"
 
+    vid = "NA"
+    vlan = translate_vlan(vid, vlan_name, sample_defaults)
+    assert vlan is None
+
 
 def test_translate_vlan_with_defaults(sample_defaults):
     """Ensure VLAN translation includes default values."""


### PR DESCRIPTION
This pull request refines the VLAN translation logic in the `device-discovery` module to handle invalid VLAN IDs gracefully. The most important changes include updating the `translate_vlan` function to return `None` for invalid VLAN IDs, modifying the `translate_data` function to skip invalid VLANs, and adding a test case to validate this behavior.

### Enhancements to VLAN translation:

* [`device-discovery/device_discovery/translate.py`](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L231-R231): Updated the `translate_vlan` function to return `None` if the VLAN ID is not a valid integer, using a `try-except` block to handle `ValueError`. The function's type hint was also updated to reflect the possibility of returning `None`. [[1]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L231-R231) [[2]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R242-R245)
* [`device-discovery/device_discovery/translate.py`](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L259-R263): Changed the `vid` parameter in the `VLAN` object creation to use the validated `vid_int` variable instead of directly converting `vid` to an integer.

### Improvements to data translation:

* [`device-discovery/device_discovery/translate.py`](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R309): Updated the `translate_data` function to skip appending entities for VLANs that are `None`, ensuring only valid VLANs are processed.

### Test coverage:

* [`device-discovery/tests/test_translate.py`](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R243-R246): Added a test case to verify that `translate_vlan` returns `None` when provided with an invalid VLAN ID, ensuring the new behavior is tested.