### PR TITLE
release 🚚 

### DIFF
--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -254,9 +254,10 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
         tenant = defaults.vlan.tenant
         role = defaults.vlan.role
 
+    clean_name = " ".join(vlan_name.strip().split())
     vlan = VLAN(
         vid=int(vid),
-        name=vlan_name,
+        name=clean_name,
         group=group,
         tenant=tenant,
         role=role,

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -228,7 +228,7 @@ def translate_interface_ips(
     return ip_entities
 
 
-def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
+def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN | None:
     """
     Translate VLAN information for a given VLAN ID.
 
@@ -239,6 +239,10 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
         defaults (Defaults): Default configuration.
 
     """
+    try:
+        vid_int = int(vid)
+    except ValueError:
+        return None
     tags = list(defaults.tags) if defaults.tags else []
     comments = None
     description = None
@@ -256,7 +260,7 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN:
 
     clean_name = " ".join(vlan_name.strip().split())
     vlan = VLAN(
-        vid=int(vid),
+        vid=vid_int,
         name=clean_name,
         group=group,
         tenant=tenant,
@@ -302,6 +306,7 @@ def translate_data(data: dict) -> Iterable[Entity]:
     if data.get("vlan"):
         for vid, vlan_info in data.get("vlan").items():
             vlan = translate_vlan(vid, vlan_info.get("name"), defaults)
-            entities.append(Entity(vlan=vlan))
+            if vlan:
+                entities.append(Entity(vlan=vlan))
 
     return entities

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -221,13 +221,24 @@ def test_translate_data(
 def test_translate_vlan(sample_defaults):
     """Ensure VLAN translation is correct."""
     vid = "1"
-    vlan_name = "Test VLAN"
+    vlan_name = "Test  VLAN   "
     vlan = translate_vlan(vid, vlan_name, sample_defaults)
 
     assert vlan.vid == 1
     assert vlan.name == "Test VLAN"
     assert len(vlan.tags) == 2
     assert vlan.comments == "test"
+
+    vid = "2"
+    vlan_name = "Test - VLAN   "
+    vlan = translate_vlan(vid, vlan_name, sample_defaults)
+    assert vlan.vid == 2
+    assert vlan.name == "Test - VLAN"
+
+    vlan_name = "info-vlan "
+    vlan = translate_vlan(vid, vlan_name, sample_defaults)
+    assert vlan.vid == 2
+    assert vlan.name == "info-vlan"
 
 
 def test_translate_vlan_with_defaults(sample_defaults):

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -240,6 +240,10 @@ def test_translate_vlan(sample_defaults):
     assert vlan.vid == 2
     assert vlan.name == "info-vlan"
 
+    vid = "NA"
+    vlan = translate_vlan(vid, vlan_name, sample_defaults)
+    assert vlan is None
+
 
 def test_translate_vlan_with_defaults(sample_defaults):
     """Ensure VLAN translation includes default values."""


### PR DESCRIPTION
This pull request improves the robustness and data cleanliness of VLAN translation in the `device-discovery` module. Key changes include handling invalid VLAN IDs, normalizing VLAN names, and updating the corresponding tests to ensure correctness.

### Enhancements to VLAN translation:
* Updated `translate_vlan` to return `None` for invalid VLAN IDs by adding a `try-except` block to handle `ValueError` during ID conversion. (`device-discovery/device_discovery/translate.py`, [device-discovery/device_discovery/translate.pyR242-R245](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R242-R245))
* Added normalization of VLAN names by stripping extra whitespace and collapsing multiple spaces into a single space. (`device-discovery/device_discovery/translate.py`, [device-discovery/device_discovery/translate.pyR261-R264](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R261-R264))
* Modified the `translate_data` function to skip appending entities when `translate_vlan` returns `None`. (`device-discovery/device_discovery/translate.py`, [device-discovery/device_discovery/translate.pyR309](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R309))

### Test improvements:
* Enhanced `test_translate_vlan` to include cases for invalid VLAN IDs and to validate VLAN name normalization. (`device-discovery/tests/test_translate.py`, [device-discovery/tests/test_translate.pyR232-R246](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R232-R246))