### PR TITLE
feat: add icmp options to network_discovery

### DIFF
--- a/network-discovery/config/config.go
+++ b/network-discovery/config/config.go
@@ -50,6 +50,9 @@ type Scope struct {
 	DNSServers     []string `yaml:"dns_servers,omitempty"`
 	OSDetection    *bool    `yaml:"os_detection,omitempty"`
 	UseTargetMasks *bool    `yaml:"use_target_masks,omitempty"`
+	ICMPEcho       *bool    `yaml:"icmp_echo,omitempty"`
+	ICMPTimestamp  *bool    `yaml:"icmp_timestamp,omitempty"`
+	ICMPNetMask    *bool    `yaml:"icmp_netmask,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -180,6 +180,18 @@ func (r *Runner) run() {
 		options = append(options, nmap.WithMostCommonPorts(*r.scope.TopPorts))
 	}
 
+	if r.scope.ICMPEcho != nil && *r.scope.ICMPEcho {
+		options = append(options, nmap.WithICMPEchoDiscovery())
+	}
+
+	if r.scope.ICMPTimestamp != nil && *r.scope.ICMPTimestamp {
+		options = append(options, nmap.WithICMPTimestampDiscovery())
+	}
+
+	if r.scope.ICMPNetMask != nil && *r.scope.ICMPNetMask {
+		options = append(options, nmap.WithICMPNetMaskDiscovery())
+	}
+
 	hasOtherScans := false
 	selectedTCPScan := ""
 	if len(r.scope.ScanTypes) > 0 {

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -196,6 +196,18 @@ func TestRunnerWithOptions(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "with icmp options",
+			policy: config.Policy{
+				Config: config.PolicyConfig{},
+				Scope: config.Scope{
+					Targets:       []string{"localhost"},
+					ICMPEcho:      boolPtr(true),
+					ICMPTimestamp: boolPtr(true),
+					ICMPNetMask:   boolPtr(true),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This pull request introduces support for additional ICMP discovery options in the network discovery tool. The key changes include updates to the configuration structure, runner logic, and test cases to handle these new options.

### Support for ICMP Discovery Options:

* [`network-discovery/config/config.go`](diffhunk://#diff-59269b85fd407098f9e2a3964ea7b0a3ec94355d9a1a65043bf2415b7a39affbR53-R55): Added three new fields to the `Scope` struct: `ICMPEcho`, `ICMPTimestamp`, and `ICMPNetMask`, enabling configuration of ICMP discovery options.
* [`network-discovery/policy/runner.go`](diffhunk://#diff-cd137d22aa443fd1284d18bdc5bae57a78e9a4352e5fc306c1efd5b09681da4cR183-R194): Updated the `run` method in the `Runner` struct to append corresponding nmap options (`WithICMPEchoDiscovery`, `WithICMPTimestampDiscovery`, and `WithICMPNetMaskDiscovery`) based on the new ICMP fields in the scope.

### Test Coverage:

* [`network-discovery/policy/runner_test.go`](diffhunk://#diff-54d75091996dda1b5aae635a59d4eeb70051f1031594507c1702c48cb379d891R199-R210): Added a new test case to validate the runner's behavior when ICMP options (`ICMPEcho`, `ICMPTimestamp`, `ICMPNetMask`) are enabled in the policy scope.