### PR TITLE
chore: push docker images to JFROG for xray scanning

### DIFF
--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -21,6 +21,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   get-next-version:
@@ -143,6 +144,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Setup JFrog CLI
+        id: setup-jfrog-cli
+        uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
+        env:
+          JF_URL: https://netboxlabs.jfrog.io
+          JF_PROJECT: obs
+        with:
+          oidc-provider-name: github-ci
+
+      - name: Login to JFrog Artifactory
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3
+        with:
+          registry: netboxlabs.jfrog.io
+          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
+          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
+
       - name: Set build info
         run: |
           echo $BUILD_COMMIT > ./network-discovery/version/BUILD_COMMIT.txt
@@ -160,6 +177,8 @@ jobs:
           tags: |
             netboxlabs/network-discovery:latest
             netboxlabs/network-discovery:${{ env.BUILD_VERSION }}
+            netboxlabs.jfrog.io/obs-builds/network-discovery:latest
+            netboxlabs.jfrog.io/obs-builds/network-discovery:${{ env.BUILD_VERSION }}
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
 

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -21,6 +21,7 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
+  id-token: write
 
 jobs:
   get-next-version:
@@ -143,6 +144,22 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Setup JFrog CLI
+        id: setup-jfrog-cli
+        uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
+        env:
+          JF_URL: https://netboxlabs.jfrog.io
+          JF_PROJECT: obs
+        with:
+          oidc-provider-name: github-ci
+
+      - name: Login to JFrog Artifactory
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3
+        with:
+          registry: netboxlabs.jfrog.io
+          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
+          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
+
       - name: Set build info
         run: |
           echo $BUILD_COMMIT > ./snmp-discovery/version/BUILD_COMMIT.txt
@@ -160,6 +177,8 @@ jobs:
           tags: |
             netboxlabs/snmp-discovery:latest
             netboxlabs/snmp-discovery:${{ env.BUILD_VERSION }}
+            netboxlabs.jfrog.io/obs-builds/snmp-discovery:latest
+            netboxlabs.jfrog.io/obs-builds/snmp-discovery:${{ env.BUILD_VERSION }}
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for `network-discovery-release` and `snmp-discovery-release` to integrate with JFrog Artifactory and improve artifact management. The changes include adding permissions for OpenID Connect (OIDC), setting up JFrog CLI, logging in to Artifactory, and tagging Docker images for JFrog repositories.

### Workflow Enhancements for Artifact Management:

* **Added OIDC permissions**: Updated `permissions:` in both `.github/workflows/network-discovery-release.yaml` and `.github/workflows/snmp-discovery-release.yaml` to include `id-token: write`, enabling OIDC authentication. [[1]](diffhunk://#diff-9e83be94be4c5a084d3b8bd5b054f1fd774314525af718e3a1a03b1f2fa09421R24) [[2]](diffhunk://#diff-97f7673ffb778603a67a9739dfc61695ae28aa5d9fa8d1c8c4014c6a0feca04eR24)

* **Setup JFrog CLI and Artifactory login**:
  - Added a step to set up the JFrog CLI using the `jfrog/setup-jfrog-cli` action in both workflows. This includes specifying the JFrog URL, project, and OIDC provider. [[1]](diffhunk://#diff-9e83be94be4c5a084d3b8bd5b054f1fd774314525af718e3a1a03b1f2fa09421R147-R162) [[2]](diffhunk://#diff-97f7673ffb778603a67a9739dfc61695ae28aa5d9fa8d1c8c4014c6a0feca04eR147-R162)
  - Added a step to log in to JFrog Artifactory using the `docker/login-action` action, with credentials derived from the JFrog CLI setup step. [[1]](diffhunk://#diff-9e83be94be4c5a084d3b8bd5b054f1fd774314525af718e3a1a03b1f2fa09421R147-R162) [[2]](diffhunk://#diff-97f7673ffb778603a67a9739dfc61695ae28aa5d9fa8d1c8c4014c6a0feca04eR147-R162)

### Docker Image Tagging Updates:

* **Added JFrog Artifactory-specific tags**: Updated the `tags:` section in both workflows to include tags for JFrog Artifactory repositories (`netboxlabs.jfrog.io/obs-builds`). [[1]](diffhunk://#diff-9e83be94be4c5a084d3b8bd5b054f1fd774314525af718e3a1a03b1f2fa09421R180-R181) [[2]](diffhunk://#diff-97f7673ffb778603a67a9739dfc61695ae28aa5d9fa8d1c8c4014c6a0feca04eR180-R181)