### PR TITLE
fix: inherit the ID size

### DIFF
--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -217,20 +217,28 @@ func newMappingEntry(m config.MappingEntry, logger *slog.Logger, entityMappers m
 		Field:          m.Field,
 		Mapper:         mapper,
 		IdentifierSize: m.IdentifierSize,
-		MappingEntries: newChildMappingEntries(m.MappingEntries, logger),
+		MappingEntries: newChildMappingEntries(m.MappingEntries, logger, m.IdentifierSize),
 		Relationship:   m.Relationship,
 	}
 }
 
-func newChildMappingEntries(configMappingEntries []config.MappingEntry, logger *slog.Logger) []Entry {
+func newChildMappingEntries(configMappingEntries []config.MappingEntry, logger *slog.Logger, parentIdentifierSize int) []Entry {
 	childMappingEntries := make([]Entry, 0, len(configMappingEntries))
 	for _, m := range configMappingEntries {
 		logger.Debug("Adding child mapping entry", "oid", m.OID, "entity", m.Entity, "field", m.Field, "relationship", m.Relationship)
+
+		// Use child's IdentifierSize if specified, otherwise inherit from parent
+		identifierSize := m.IdentifierSize
+		if identifierSize == 0 {
+			identifierSize = parentIdentifierSize
+		}
+
 		child := &Entry{
 			OID:            m.OID,
 			Entity:         m.Entity,
 			Field:          m.Field,
-			MappingEntries: newChildMappingEntries(m.MappingEntries, logger),
+			IdentifierSize: identifierSize,
+			MappingEntries: newChildMappingEntries(m.MappingEntries, logger, identifierSize),
 			Relationship:   m.Relationship,
 		}
 		childMappingEntries = append(childMappingEntries, *child)

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -467,3 +467,240 @@ func TestObjectIDIndex_HasParent(t *testing.T) {
 		})
 	}
 }
+
+func TestIPAddressIdentifierSizeInheritance(t *testing.T) {
+	tests := []struct {
+		name        string
+		mapping     []config.MappingEntry
+		objectIDs   mapping.ObjectIDValueMap
+		expected    []diode.Entity
+		description string
+	}{
+		{
+			name: "IP address child mappings inherit identifier size from parent (replicates log scenario)",
+			mapping: []config.MappingEntry{
+				{
+					OID:            ".1.3.6.1.2.1.4.20.1",
+					Entity:         "ipAddress",
+					Field:          "_id",
+					IdentifierSize: 4, // Parent has identifier size 4 for IPv4 addresses
+					MappingEntries: []config.MappingEntry{
+						{
+							OID:    ".1.3.6.1.2.1.4.20.1.1",
+							Entity: "ipAddress",
+							Field:  "address",
+							// No IdentifierSize specified - should inherit from parent
+						},
+						{
+							OID:    ".1.3.6.1.2.1.4.20.1.3",
+							Entity: "ipAddress",
+							Field:  "address_prefixSize",
+							// No IdentifierSize specified - should inherit from parent
+						},
+					},
+				},
+			},
+			objectIDs: mapping.ObjectIDValueMap{
+				// This simulates the scenario from the logs where we have a full IP address in the OID
+				".1.3.6.1.2.1.4.20.1.1.192.168.1.100": mapping.Value{
+					Value:          "192.168.1.100",
+					Type:           mapping.Asn1BER(mapping.IPAddress),
+					IdentifierSize: 4, // This should be inherited by child mappings
+				},
+				".1.3.6.1.2.1.4.20.1.3.192.168.1.100": mapping.Value{
+					Value:          "255.255.255.0", // Netmask
+					Type:           mapping.Asn1BER(mapping.IPAddress),
+					IdentifierSize: 4,
+				},
+			},
+			expected: []diode.Entity{
+				&diode.IPAddress{
+					Address: diode.String("192.168.1.100/24"), // Should get full IP with correct prefix
+				},
+			},
+			description: "This test verifies that IP addresses are parsed correctly with all 4 octets instead of just the last octet",
+		},
+		{
+			name: "Child mapping with explicit identifier size overrides parent",
+			mapping: []config.MappingEntry{
+				{
+					OID:            ".1.3.6.1.2.1.4.20.1",
+					Entity:         "ipAddress",
+					Field:          "_id",
+					IdentifierSize: 4, // Parent has identifier size 4
+					MappingEntries: []config.MappingEntry{
+						{
+							OID:            ".1.3.6.1.2.1.4.20.1.1",
+							Entity:         "ipAddress",
+							Field:          "address",
+							IdentifierSize: 2, // Child explicitly sets different size
+						},
+					},
+				},
+			},
+			objectIDs: mapping.ObjectIDValueMap{
+				".1.3.6.1.2.1.4.20.1.1.1.2": mapping.Value{
+					Value:          "1.2",
+					Type:           mapping.Asn1BER(mapping.IPAddress),
+					IdentifierSize: 2, // Should use child's explicit size
+				},
+			},
+			expected: []diode.Entity{
+				&diode.IPAddress{
+					Address: diode.String("1.2/32"), // Uses child's identifier size of 2
+				},
+			},
+			description: "This test verifies that child mappings can override parent identifier size when explicitly specified",
+		},
+		{
+			name: "Zero identifier size on parent defaults correctly",
+			mapping: []config.MappingEntry{
+				{
+					OID:            ".1.3.6.1.2.1.4.20.1",
+					Entity:         "ipAddress",
+					Field:          "_id",
+					IdentifierSize: 0, // Parent has zero identifier size
+					MappingEntries: []config.MappingEntry{
+						{
+							OID:    ".1.3.6.1.2.1.4.20.1.1",
+							Entity: "ipAddress",
+							Field:  "address",
+							// Should inherit 0 from parent
+						},
+					},
+				},
+			},
+			objectIDs: mapping.ObjectIDValueMap{
+				".1.3.6.1.2.1.4.20.1.1.192": mapping.Value{
+					Value:          "192",
+					Type:           mapping.Asn1BER(mapping.IPAddress),
+					IdentifierSize: 0, // This would default to 1 in ObjectIDs() function
+				},
+			},
+			expected: []diode.Entity{
+				&diode.IPAddress{
+					Address: diode.String("/32"), // When identifier size is 0, no index is captured
+				},
+			},
+			description: "This test verifies behavior when parent has zero identifier size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+			mappingConfig := mapping.NewConfig(tt.mapping, logger, &FakeManufacturers{}, &FakeDeviceLookup{})
+			objectIDMapper := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{})
+
+			entities := objectIDMapper.MapObjectIDsToEntity(tt.objectIDs)
+
+			// Sort both slices for consistent comparison
+			assert.ElementsMatch(t, tt.expected, entities, tt.description)
+
+			// Additional verification: check that ObjectIDs() returns correct identifier sizes
+			objectIDs := mappingConfig.ObjectIDs()
+			for oid, expectedSize := range map[string]int{
+				".1.3.6.1.2.1.4.20.1.1": func() int {
+					if tt.mapping[0].MappingEntries[0].IdentifierSize != 0 {
+						return tt.mapping[0].MappingEntries[0].IdentifierSize
+					}
+					if tt.mapping[0].IdentifierSize == 0 {
+						return 1 // Default value when parent is 0
+					}
+					return tt.mapping[0].IdentifierSize
+				}(),
+			} {
+				if actualSize, exists := objectIDs[oid]; exists {
+					assert.Equal(t, expectedSize, actualSize,
+						"OID %s should have identifier size %d but got %d", oid, expectedSize, actualSize)
+				}
+			}
+		})
+	}
+}
+
+func TestObjectIDsMethodWithIdentifierSizeInheritance(t *testing.T) {
+	tests := []struct {
+		name         string
+		mapping      []config.MappingEntry
+		expectedOIDs map[string]int
+		description  string
+	}{
+		{
+			name: "IP address mappings with inherited identifier sizes",
+			mapping: []config.MappingEntry{
+				{
+					OID:            ".1.3.6.1.2.1.4.20.1",
+					Entity:         "ipAddress",
+					Field:          "_id",
+					IdentifierSize: 4,
+					MappingEntries: []config.MappingEntry{
+						{
+							OID:    ".1.3.6.1.2.1.4.20.1.1",
+							Entity: "ipAddress",
+							Field:  "address",
+							// Should inherit IdentifierSize 4 from parent
+						},
+						{
+							OID:    ".1.3.6.1.2.1.4.20.1.3",
+							Entity: "ipAddress",
+							Field:  "address_prefixSize",
+							// Should inherit IdentifierSize 4 from parent
+						},
+					},
+				},
+			},
+			expectedOIDs: map[string]int{
+				".1.3.6.1.2.1.4.20.1.1": 4, // Should inherit from parent
+				".1.3.6.1.2.1.4.20.1.3": 4, // Should inherit from parent
+			},
+			description: "Child OIDs should inherit identifier size 4 from parent for IP address parsing",
+		},
+		{
+			name: "Mixed inheritance and explicit identifier sizes",
+			mapping: []config.MappingEntry{
+				{
+					OID:            ".1.3.6.1.2.1.2.2.1",
+					Entity:         "interface",
+					Field:          "_id",
+					IdentifierSize: 1,
+					MappingEntries: []config.MappingEntry{
+						{
+							OID:    ".1.3.6.1.2.1.2.2.1.2",
+							Entity: "interface",
+							Field:  "name",
+							// Should inherit IdentifierSize 1 from parent
+						},
+						{
+							OID:            ".1.3.6.1.2.1.2.2.1.5",
+							Entity:         "interface",
+							Field:          "speed",
+							IdentifierSize: 2, // Explicit override
+						},
+					},
+				},
+			},
+			expectedOIDs: map[string]int{
+				".1.3.6.1.2.1.2.2.1.2": 1, // Inherited from parent
+				".1.3.6.1.2.1.2.2.1.5": 2, // Explicit override
+			},
+			description: "Mix of inherited and explicit identifier sizes should work correctly",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+			mappingConfig := mapping.NewConfig(tt.mapping, logger, &FakeManufacturers{}, &FakeDeviceLookup{})
+			objectIDs := mappingConfig.ObjectIDs()
+
+			for expectedOID, expectedSize := range tt.expectedOIDs {
+				actualSize, exists := objectIDs[expectedOID]
+				assert.True(t, exists, "OID %s should exist in ObjectIDs() output", expectedOID)
+				assert.Equal(t, expectedSize, actualSize,
+					"OID %s should have identifier size %d but got %d. %s",
+					expectedOID, expectedSize, actualSize, tt.description)
+			}
+		})
+	}
+}

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -468,6 +468,16 @@ func TestObjectIDIndex_HasParent(t *testing.T) {
 	}
 }
 
+func extractIdentifierSize(mappingEntry config.MappingEntry) int {
+	if mappingEntry.MappingEntries[0].IdentifierSize != 0 {
+		return mappingEntry.MappingEntries[0].IdentifierSize
+	}
+	if mappingEntry.IdentifierSize == 0 {
+		return 1 // Default value when parent is 0
+	}
+	return mappingEntry.IdentifierSize
+}
+
 func TestIPAddressIdentifierSizeInheritance(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -600,15 +610,7 @@ func TestIPAddressIdentifierSizeInheritance(t *testing.T) {
 			// Additional verification: check that ObjectIDs() returns correct identifier sizes
 			objectIDs := mappingConfig.ObjectIDs()
 			for oid, expectedSize := range map[string]int{
-				".1.3.6.1.2.1.4.20.1.1": func() int {
-					if tt.mapping[0].MappingEntries[0].IdentifierSize != 0 {
-						return tt.mapping[0].MappingEntries[0].IdentifierSize
-					}
-					if tt.mapping[0].IdentifierSize == 0 {
-						return 1 // Default value when parent is 0
-					}
-					return tt.mapping[0].IdentifierSize
-				}(),
+				".1.3.6.1.2.1.4.20.1.1": extractIdentifierSize(tt.mapping[0]),
 			} {
 				if actualSize, exists := objectIDs[oid]; exists {
 					assert.Equal(t, expectedSize, actualSize,


### PR DESCRIPTION
This pull request enhances the handling of `IdentifierSize` inheritance in SNMP mapping logic, ensuring that child mapping entries correctly inherit or override identifier size from their parent. It also adds comprehensive tests to verify this behavior across various scenarios.

### Improvements to mapping logic

* Updated the `newChildMappingEntries` function in `mapping.go` to accept a `parentIdentifierSize` argument and ensure child entries inherit the parent's identifier size when not explicitly set. This change also propagates the correct size recursively to deeper child mappings.

### Enhancements to testing

* Added the `TestIPAddressIdentifierSizeInheritance` unit test in `mapping_test.go` to verify that child IP address mappings inherit identifier size from the parent, can override it, and handle zero/unspecified values correctly.
* Added the `TestObjectIDsMethodWithIdentifierSizeInheritance` unit test in `mapping_test.go` to ensure that the `ObjectIDs()` method returns the correct identifier sizes for both inherited and explicitly set values in mapping entries.