### PR TITLE
feat: return IP DNS name in lowercase

### DIFF
--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -358,9 +358,9 @@ func (r *Runner) run() {
 		if host.Hostnames != nil {
 			var fallbackHostname string
 			for _, hostname := range host.Hostnames {
-				fallbackHostname = hostname.Name
+				fallbackHostname = strings.ToLower(hostname.Name)
 				if hostname.Type == "PTR" {
-					ip.DnsName = diode.String(hostname.Name)
+					ip.DnsName = diode.String(strings.ToLower(hostname.Name))
 					break
 				}
 			}


### PR DESCRIPTION
This pull request makes a small but important change to ensure hostname consistency in the network discovery policy runner. All hostnames are now converted to lowercase before being used or assigned.

* Hostname normalization: In the `run` method of `Runner` (`network-discovery/policy/runner.go`), all hostnames are converted to lowercase before assignment, including both the fallback hostname and the PTR record DNS name.