### PR TITLE
feat: add config options and os_version in platform name

### DIFF
--- a/device-discovery/device_discovery/policy/models.py
+++ b/device-discovery/device_discovery/policy/models.py
@@ -35,6 +35,9 @@ class DeviceParameters(ObjectParameters):
     manufacturer: str | None = Field(
         default=None, description="Device manufacturer override, optional"
     )
+    platform: str | None = Field(
+        default=None, description="Device platform override, optional"
+    )
 
 
 class VlanParameters(ObjectParameters):
@@ -81,12 +84,23 @@ class Defaults(BaseModel):
     )
 
 
+class Options(BaseModel):
+    """Model for discovery options."""
+
+    platform_omit_version: bool | None = Field(
+        default=False, description="Omit platform version, optional"
+    )
+
+
 class Config(BaseModel):
     """Model for discovery configuration."""
 
     schedule: str | None = Field(default=None, description="cron interval, optional")
     defaults: Defaults | None = Field(
         default=None, description="Default configuration, optional"
+    )
+    options: Options | None = Field(
+        default=None, description="Discovery options, optional"
     )
 
     @field_validator("schedule")

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -176,6 +176,7 @@ class PolicyRunner:
                 "interface": device.get_interfaces(),
                 "interface_ip": device.get_interfaces_ip(),
                 "defaults": config.defaults,
+                "options": config.options,
             }
             try:
                 data["vlan"] = device.get_vlans()

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -17,7 +17,7 @@ from netboxlabs.diode.sdk.ingester import (
     Prefix,
 )
 
-from device_discovery.policy.models import Defaults
+from device_discovery.policy.models import Defaults, Options
 
 
 def int32_overflows(number: int) -> bool:
@@ -55,6 +55,7 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
     tags = list(defaults.tags) if defaults.tags else []
     model = device_info.get("model")
     manufacturer = device_info.get("vendor")
+    platform = device_info.get("platform")
     description = None
     comments = None
     location = None
@@ -65,6 +66,7 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
         comments = defaults.device.comments
         model = defaults.device.model or model
         manufacturer = defaults.device.manufacturer or manufacturer
+        platform = defaults.device.platform or platform
 
     if defaults.location:
         location = Location(name=defaults.location, site=defaults.site)
@@ -72,7 +74,7 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
     device = Device(
         name=device_info.get("hostname"),
         device_type=DeviceType(model=model, manufacturer=manufacturer),
-        platform=Platform(name=device_info.get("driver"), manufacturer=manufacturer),
+        platform=Platform(name=platform, manufacturer=manufacturer),
         role=defaults.role,
         serial=device_info.get("serial_number"),
         status="active",
@@ -289,12 +291,19 @@ def translate_data(data: dict) -> Iterable[Entity]:
     entities = []
 
     defaults = data.get("defaults", Defaults())
+    options = data.get("options", Options())
 
     device_info = data.get("device", {})
     interfaces = data.get("interface", {})
     interfaces_ip = data.get("interface_ip", {})
     if device_info:
-        device_info["driver"] = data.get("driver")
+        if options.platform_omit_version:
+            device_info["platform"] = data.get("driver")
+        else:
+
+            device_info["platform"] = (
+                f"{data.get('driver').upper()} {device_info.get('os_version')}"
+            )
         device = translate_device(device_info, defaults)
         entities.append(Entity(device=device))
 

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -302,7 +302,7 @@ def translate_data(data: dict) -> Iterable[Entity]:
         else:
 
             device_info["platform"] = (
-                f"{data.get('driver').upper()} {device_info.get('os_version')}"
+                f"{data.get('driver', '').upper()} {device_info.get('os_version')}"
             )
         device = translate_device(device_info, defaults)
         entities.append(Entity(device=device))

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -9,6 +9,7 @@ from device_discovery.policy.models import (
     DeviceParameters,
     IpamParameters,
     ObjectParameters,
+    Options,
     VlanParameters,
 )
 from device_discovery.translate import (
@@ -28,7 +29,8 @@ def sample_device_info():
         "model": "ISR4451",
         "vendor": "Cisco",
         "serial_number": "123456789",
-        "driver": "ios",
+        "os_version": "v15.2",
+        "platform": "ios",
         "interface_list": ["GigabitEthernet0/0", "GigabitEthernet0/0/1"],
     }
 
@@ -200,7 +202,7 @@ def test_translate_interface_ips(
 
 
 def test_translate_data(
-    sample_device_info, sample_interface_info, sample_interfaces_ip
+    sample_device_info, sample_interface_info, sample_interfaces_ip, sample_defaults
 ):
     """Ensure data translation is correct."""
     data = {
@@ -212,10 +214,27 @@ def test_translate_data(
     entities = list(translate_data(data))
     assert len(entities) == 5
     assert entities[0].device.name == "router1"
+    assert entities[0].device.site.name == "undefined"
+    assert entities[0].device.platform.name == "IOS v15.2"
     assert entities[1].interface.name == "GigabitEthernet0/0"
     assert entities[2].interface.name == "GigabitEthernet0/0/1"
     assert entities[3].prefix.prefix == "192.0.2.0/24"
     assert entities[4].ip_address.address == "192.0.2.1/24"
+
+    data["defaults"] = sample_defaults
+    data["options"] = Options(platform_omit_version=True)
+
+    entities = list(translate_data(data))
+    assert entities[0].device.site.name == "New York"
+    assert entities[0].device.platform.name == "ios"
+
+    data["defaults"].role = "switch"
+    data["defaults"].device.platform = "custom"
+    data["options"].platform_omit_version = False
+
+    entities = list(translate_data(data))
+    assert entities[0].device.platform.name == "custom"
+    assert entities[0].device.role.name == "switch"
 
 
 def test_translate_vlan(sample_defaults):


### PR DESCRIPTION
This pull request adds support for device platform overrides and configurable handling of platform version information in device discovery and translation. The changes include new model fields, configuration options, logic updates in translation, and expanded tests to cover these scenarios.

### Model and Configuration Enhancements

* Added a `platform` field to `DeviceParameters` in `policy/models.py` to allow device-specific platform overrides.
* Introduced a new `Options` model with a `platform_omit_version` field, and updated the main `Config` model to include an `options` attribute for discovery configuration.

### Translation Logic Improvements

* Updated translation logic in `translate.py` to use the new `platform_omit_version` option: if set, the platform name omits the OS version; otherwise, it includes it. Also, platform overrides from defaults are respected. [[1]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R294-R306) [[2]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R69-R77)
* Modified the construction of the `Platform` object in device translation to use the new logic and field.

### Test Coverage Expansion

* Updated and expanded tests in `test_translate.py` to cover platform overrides, the new options model, and various combinations of configuration and translation behavior. [[1]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R217-R238) [[2]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4L203-R205) [[3]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4L31-R33) [[4]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R12)