### PR TITLE
fix: chunk entities to stay under 4MB

### DIFF
--- a/.github/workflows/device-discovery-release.yaml
+++ b/.github/workflows/device-discovery-release.yaml
@@ -55,6 +55,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
+                "semantic-release": "^24.2.7",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -197,6 +198,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
+                "semantic-release": "^24.2.7",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }

--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -43,6 +43,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
+                "semantic-release": "^24.2.7",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -202,6 +203,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
+                "semantic-release": "^24.2.7",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -43,6 +43,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
+                "semantic-release": "^24.2.7",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -202,6 +203,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
+                "semantic-release": "^24.2.7",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }

--- a/.github/workflows/worker-release.yaml
+++ b/.github/workflows/worker-release.yaml
@@ -55,6 +55,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
+                "semantic-release": "^24.2.7",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -197,6 +198,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
+                "semantic-release": "^24.2.7",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }

--- a/worker/tests/nbl-custom/nbl_custom/impl.py
+++ b/worker/tests/nbl-custom/nbl_custom/impl.py
@@ -55,22 +55,24 @@ class MockBackend(Backend):
         # Sample of how to handle a scope dictionary
         elif isinstance(policy.scope, dict):
             scope = ScopeMap(**policy.scope)
-        device = Device(
-            name="Device A",
-            device_type="Device Type A",
-            platform="Platform A",
-            manufacturer="Manufacturer A",
-            description=policy_name,
-            comments=policy.model_dump_json(),
-            site="Site ABC",
-            role="Role ABC",
-            serial="123456",
-            asset_tag="123456",
-            status="active",
-            tags=["tag 1", "tag 2"],
-        )
+        
+        for i in range(100000):
+            device = Device(
+                name=f"Device A {i}",
+                device_type="Device Type A",
+                platform="Platform A",
+                manufacturer="Manufacturer A",
+                description=policy_name,
+                comments=policy.model_dump_json(),
+                site="Site ABC",
+                role="Role ABC",
+                serial="123456",
+                asset_tag="123456",
+                status="active",
+                tags=["tag 1", "tag 2"],
+            )
+
+            entities.append(Entity(device=device))
         logger.info(f"Policy '{policy_name}' config: {config}")
         logger.info(f"Policy '{policy_name}' scope: {scope}")
-
-        entities.append(Entity(device=device))
         return entities

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -489,7 +489,7 @@ def test_run_with_multiple_chunks(policy_runner, sample_policy, mock_diode_clien
         return_value=1024
     ):
         
-        with caplog.at_level("INFO"):
+        with caplog.at_level("DEBUG"):
             policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
         # Should call chunking method

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from apscheduler.triggers.date import DateTrigger
+from netboxlabs.diode.sdk.diode.v1 import ingester_pb2
 
 from worker.backend import Backend
 from worker.models import Config, DiodeConfig, Metadata, Policy, Status
@@ -162,14 +163,26 @@ def test_run_success(policy_runner, sample_policy, mock_diode_client, mock_backe
     """Test the run function for a successful execution."""
     policy_runner.name = "test_policy"
 
+    # Create mock entities
+    entities = []
+    for i in range(3):
+        entity = ingester_pb2.Entity()
+        entity.device.name = f"test_device_{i}"
+        entities.append(entity)
+    
+    mock_backend.run.return_value = entities
+    mock_diode_client.ingest.return_value.errors = []
+
     # Call the run method
     policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Assertions
     mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
-    mock_diode_client.ingest.assert_called_once_with(mock_backend.run.return_value)
-    mock_diode_client.ingest.return_value.errors = []
-    assert mock_diode_client.ingest.return_value.errors == []
+    # Should call ingest once for the single chunk
+    mock_diode_client.ingest.assert_called_once()
+    # Check that entities were passed correctly
+    call_args = mock_diode_client.ingest.call_args[1]['entities']
+    assert len(call_args) == 3
 
 
 def test_run_ingestion_errors(
@@ -182,6 +195,15 @@ def test_run_ingestion_errors(
     """Test the run function when ingestion has errors."""
     policy_runner.name = "test_policy"
 
+    # Create mock entities
+    entities = []
+    for i in range(2):
+        entity = ingester_pb2.Entity()
+        entity.device.name = f"test_device_{i}"
+        entities.append(entity)
+    
+    mock_backend.run.return_value = entities
+
     # Simulate ingestion errors
     mock_diode_client.ingest.return_value.errors = ["error1", "error2"]
 
@@ -191,9 +213,9 @@ def test_run_ingestion_errors(
 
     # Assertions
     mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
-    mock_diode_client.ingest.assert_called_once_with(mock_backend.run.return_value)
+    mock_diode_client.ingest.assert_called_once()
     assert (
-        "Policy test_policy: Ingestion failed with errors: ['error1', 'error2']"
+        "Policy test_policy: Chunk 1 ingestion failed: ['error1', 'error2']"
         in caplog.text
     )
 
@@ -258,6 +280,15 @@ def test_metrics_during_policy_lifecycle(
         app_version="1.0",
     )
 
+    # Create mock entities
+    entities = []
+    for i in range(2):
+        entity = ingester_pb2.Entity()
+        entity.device.name = f"test_device_{i}"
+        entities.append(entity)
+    
+    mock_backend.run.return_value = entities
+
     # Setup mock for get_metric function
     def mock_get_metric(name):
         return mock_metrics.get(name)
@@ -269,7 +300,7 @@ def test_metrics_during_policy_lifecycle(
         policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
         mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
-        mock_diode_client.ingest.assert_called_once_with(mock_backend.run.return_value)
+        mock_diode_client.ingest.assert_called_once()
 
         mock_policy_executions.add.assert_called_once_with(1, {"policy": "test_policy"})
         mock_backend_execution_success.add.assert_called_once_with(
@@ -316,7 +347,7 @@ def test_metrics_during_failed_discovery(
 
     with patch("worker.policy.runner.get_metric", side_effect=mock_get_metric):
         mock_diode_client = MagicMock(name="MockDiodeClient")
-        policy_runner.run(mock_diode_client, sample_diode_config, sample_policy)
+        policy_runner.run(mock_diode_client, mock_backend, sample_policy)
         # Verify failure metric was called
         mock_backend_execution_failure.add.assert_called_once_with(
             1,
@@ -334,3 +365,183 @@ def test_metrics_during_failed_discovery(
         latency_kwargs = mock_backend_execution_latency.record.call_args[0][1]
         assert latency_args > 0
         assert latency_kwargs["backend"] == "my_backend"
+
+
+def test_create_message_chunks_empty_list(policy_runner):
+    """Test _create_message_chunks with an empty entity list."""
+    entities = []
+    chunks = policy_runner._create_message_chunks(entities)
+    
+    assert len(chunks) == 1
+    assert chunks[0] == []
+
+
+def test_create_message_chunks_single_chunk(policy_runner):
+    """Test _create_message_chunks when entities fit in a single chunk."""
+    # Create small mock entities that will fit in one chunk
+    entities = []
+    for i in range(5):
+        entity = ingester_pb2.Entity()
+        entity.device.name = f"test_device_{i}"
+        entities.append(entity)
+    
+    with patch.object(policy_runner, '_estimate_message_size', return_value=1024):  # Small size
+        chunks = policy_runner._create_message_chunks(entities)
+    
+    assert len(chunks) == 1
+    assert len(chunks[0]) == 5
+    assert chunks[0] == entities
+
+
+def test_create_message_chunks_multiple_chunks(policy_runner):
+    """Test _create_message_chunks when entities need to be split into multiple chunks."""
+    # Create entities that will exceed the target size
+    entities = []
+    for i in range(10):
+        entity = ingester_pb2.Entity()
+        entity.device.name = f"test_device_{i}"
+        entities.append(entity)
+    
+    # Mock size to be larger than target (3.5MB)
+    with patch.object(policy_runner, '_estimate_message_size', return_value=5 * 1024 * 1024):  # 5MB
+        chunks = policy_runner._create_message_chunks(entities)
+    
+    # Should have multiple chunks
+    assert len(chunks) > 1
+    
+    # All entities should be present across chunks
+    total_entities = sum(len(chunk) for chunk in chunks)
+    assert total_entities == 10
+    
+    # Each chunk should have at least 1 entity
+    for chunk in chunks:
+        assert len(chunk) >= 1
+
+
+def test_create_message_chunks_edge_case_one_entity_per_chunk(policy_runner):
+    """Test _create_message_chunks when each entity needs its own chunk."""
+    entities = []
+    for i in range(3):
+        entity = ingester_pb2.Entity()
+        entity.device.name = f"large_device_{i}"
+        entities.append(entity)
+    
+    # Mock very large size to force one entity per chunk
+    with patch.object(policy_runner, '_estimate_message_size', return_value=20 * 1024 * 1024):  # 20MB
+        chunks = policy_runner._create_message_chunks(entities)
+    
+    # Should have 3 chunks with 1 entity each
+    assert len(chunks) == 3
+    for chunk in chunks:
+        assert len(chunk) == 1
+
+
+def test_estimate_message_size(policy_runner):
+    """Test _estimate_message_size method."""
+    # Create mock entities
+    entities = []
+    for i in range(3):
+        entity = ingester_pb2.Entity()
+        entity.device.name = f"test_device_{i}"
+        entities.append(entity)
+    
+    # Call the method
+    size = policy_runner._estimate_message_size(entities)
+    
+    # Should return a positive integer (actual protobuf size)
+    assert isinstance(size, int)
+    assert size > 0
+
+
+def test_estimate_message_size_empty_list(policy_runner):
+    """Test _estimate_message_size with empty entity list."""
+    entities = []
+    size = policy_runner._estimate_message_size(entities)
+    
+    # Even empty request should have some minimal size
+    assert isinstance(size, int)
+    assert size >= 0
+
+
+def test_run_with_multiple_chunks(policy_runner, sample_policy, mock_diode_client, mock_backend, caplog):
+    """Test the run function with entities that require multiple chunks."""
+    policy_runner.name = "test_policy"
+
+    # Create many mock entities to trigger chunking
+    entities = []
+    for i in range(10):
+        entity = ingester_pb2.Entity()
+        entity.device.name = f"test_device_{i}"
+        entities.append(entity)
+    
+    mock_backend.run.return_value = entities
+    mock_diode_client.ingest.return_value.errors = []
+
+    # Mock chunking to return multiple chunks
+    with patch.object(
+        policy_runner, 
+        '_create_message_chunks', 
+        return_value=[entities[:5], entities[5:]]
+    ) as mock_chunks, \
+         patch.object(
+        policy_runner, 
+        '_estimate_message_size', 
+        return_value=1024
+    ):
+        
+        with caplog.at_level("INFO"):
+            policy_runner.run(mock_diode_client, mock_backend, sample_policy)
+
+        # Should call chunking method
+        mock_chunks.assert_called_once_with(entities)
+        
+        # Should call ingest twice (once per chunk)
+        assert mock_diode_client.ingest.call_count == 2
+        
+        # Verify log messages for chunking
+        assert "Ingesting chunk 1 with 5 entities" in caplog.text
+        assert "Ingesting chunk 2 with 5 entities" in caplog.text
+        assert "Chunk 1 ingested successfully" in caplog.text
+        assert "Chunk 2 ingested successfully" in caplog.text
+
+
+def test_run_chunk_ingestion_error(policy_runner, sample_policy, mock_diode_client, mock_backend, caplog):
+    """Test the run function when a chunk ingestion fails."""
+    policy_runner.name = "test_policy"
+
+    # Create mock entities
+    entities = []
+    for i in range(6):
+        entity = ingester_pb2.Entity()
+        entity.device.name = f"test_device_{i}"
+        entities.append(entity)
+    
+    mock_backend.run.return_value = entities
+
+    # Mock first chunk succeeds, second chunk fails
+    responses = [MagicMock(), MagicMock()]
+    responses[0].errors = []  # First chunk succeeds
+    responses[1].errors = ["Chunk error"]  # Second chunk fails
+    
+    mock_diode_client.ingest.side_effect = responses
+
+    # Mock chunking to return two chunks
+    with patch.object(
+        policy_runner, 
+        '_create_message_chunks', 
+        return_value=[entities[:3], entities[3:]]
+    ), \
+         patch.object(
+        policy_runner, 
+        '_estimate_message_size', 
+        return_value=1024
+    ):
+        
+        with caplog.at_level("ERROR"):
+            policy_runner.run(mock_diode_client, mock_backend, sample_policy)
+
+        # Should call ingest twice but fail on second chunk
+        assert mock_diode_client.ingest.call_count == 2
+        
+        # Should log the chunk error
+        assert "Chunk 2 ingestion failed" in caplog.text

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -132,10 +132,7 @@ class PolicyRunner:
                     raise RuntimeError(f"Chunk {chunk_num} ingestion failed: {response.errors}")
                 logger.info(f"Chunk {chunk_num} ingested successfully")
 
-            logger.info("Successfully ingested all entities into NetBox")
-            if response.errors:
-                raise Exception(f"Ingestion failed with errors: {response.errors}")
-            logger.info(f"Policy {self.name}: Successful ingestion")
+            logger.info(f"Policy {self.name}: Successfully ingested {len(entities)} entities in {entity_chunk} chunks")
             run_success = get_metric("backend_execution_success")
             if run_success:
                 run_success.add(

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -21,6 +21,8 @@ from worker.models import DiodeConfig, Policy, Status
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+TARGET_CHUNK_SIZE = 3.5
+
 
 class PolicyRunner:
     """Policy Runner class."""
@@ -188,7 +190,7 @@ class PolicyRunner:
 
         # Estimate total size and calculate approximate entities per chunk
         total_size = self._estimate_message_size(entities)
-        target_bytes = 3.5 * 1024 * 1024
+        target_bytes = TARGET_CHUNK_SIZE * 1024 * 1024
 
         if total_size <= target_bytes:
             # Single chunk if within limit

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -124,13 +124,13 @@ class PolicyRunner:
 
             for chunk_num, entity_chunk in enumerate(self._create_message_chunks(entities), 1):
                 chunk_size_mb = self._estimate_message_size(entity_chunk) / (1024 * 1024)
-                logger.info(
+                logger.debug(
                     f"Ingesting chunk {chunk_num} with {len(entity_chunk)} entities (~{chunk_size_mb:.2f} MB)"
                 )
                 response = client.ingest(entities=entity_chunk)
                 if response.errors:
                     raise RuntimeError(f"Chunk {chunk_num} ingestion failed: {response.errors}")
-                logger.info(f"Chunk {chunk_num} ingested successfully")
+                logger.debug(f"Chunk {chunk_num} ingested successfully")
 
             logger.info(f"Policy {self.name}: Successfully ingested {len(entities)} entities in {entity_chunk} chunks")
             run_success = get_metric("backend_execution_success")

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -5,11 +5,13 @@
 import logging
 import time
 from datetime import datetime, timedelta
+from typing import List
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 from netboxlabs.diode.sdk import DiodeClient, DiodeDryRunClient
+from netboxlabs.diode.sdk.diode.v1 import ingester_pb2
 
 from worker.backend import Backend, load_class
 from worker.metrics import get_metric
@@ -117,7 +119,18 @@ class PolicyRunner:
         exec_start_time = time.perf_counter()
         try:
             entities = backend.run(self.name, policy)
-            response = client.ingest(entities)
+
+            for chunk_num, entity_chunk in enumerate(self._create_message_chunks(entities), 1):
+                chunk_size_mb = self._estimate_message_size(entity_chunk) / (1024 * 1024)
+                logger.info(
+                    f"Ingesting chunk {chunk_num} with {len(entity_chunk)} entities (~{chunk_size_mb:.2f} MB)"
+                )
+                response = client.ingest(entities=entity_chunk)
+                if response.errors:
+                    raise RuntimeError(f"Chunk {chunk_num} ingestion failed: {response.errors}")
+                logger.info(f"Chunk {chunk_num} ingested successfully")
+
+            logger.info("Successfully ingested all entities into NetBox")
             if response.errors:
                 raise Exception(f"Ingestion failed with errors: {response.errors}")
             logger.info(f"Policy {self.name}: Successful ingestion")
@@ -166,3 +179,34 @@ class PolicyRunner:
         active_policies = get_metric("active_policies")
         if active_policies:
             active_policies.add(-1, {"policy": self.name})
+
+    def _create_message_chunks(self, entities: List[ingester_pb2.Entity]) -> List[List[ingester_pb2.Entity]]:
+        """Create 3.5MB chunks from entities, always returning at least one chunk."""
+        total_entities = len(entities)
+        if total_entities == 0:
+            return [entities]
+
+        # Estimate total size and calculate approximate entities per chunk
+        total_size = self._estimate_message_size(entities)
+        target_bytes = 3.5 * 1024 * 1024
+
+        if total_size <= target_bytes:
+            # Single chunk if within limit
+            return [entities]
+
+        # Calculate entities per chunk based on size ratio
+        entities_per_chunk = max(1, int(total_entities * target_bytes / total_size))
+
+        chunks = []
+        for i in range(0, total_entities, entities_per_chunk):
+            chunk = entities[i : i + entities_per_chunk]
+            chunks.append(chunk)
+
+        return chunks
+
+
+    def _estimate_message_size(self, entities: List[ingester_pb2.Entity]) -> int:
+        """Estimate the serialized size of entities using minimal IngestRequest."""
+        request = ingester_pb2.IngestRequest()
+        request.entities.extend(entities)
+        return request.ByteSize()


### PR DESCRIPTION
This pull request adds comprehensive tests and new chunking logic to the policy runner, improving how entities are ingested and tested. The main changes include implementing chunked ingestion for large entity lists, updating related tests to cover chunking and error scenarios, and adding utility methods for chunking and size estimation.

**Policy runner ingestion logic improvements:**

* Added chunking logic to the `run` method in `runner.py` to split entities into 3.5MB chunks for ingestion, with detailed logging and error handling for each chunk. (`[worker/worker/policy/runner.pyL120-R133](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2L120-R133)`)
* Implemented `_create_message_chunks` and `_estimate_message_size` methods in `runner.py` to support chunked ingestion and accurate message size calculation. (`[worker/worker/policy/runner.pyR182-R212](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R182-R212)`)

**Test suite enhancements:**

* Updated existing tests in `test_runner.py` to use mock entities and verify chunked ingestion behavior, including error handling and logging for individual chunks. (`[[1]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R166-R185)`, `[[2]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R198-R206)`, `[[3]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L194-R218)`, `[[4]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R283-R291)`, `[[5]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L272-R303)`, `[[6]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L319-R350)`)
* Added new tests for `_create_message_chunks` and `_estimate_message_size` covering empty lists, single/multiple chunks, edge cases, and size estimation. (`[worker/tests/policy/test_runner.pyR368-R547](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R368-R547)`)
* Added a test for the `run` method with multiple chunks and chunk-specific error handling, verifying correct logging and ingest calls. (`[worker/tests/policy/test_runner.pyR368-R547](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R368-R547)`)

**Imports and setup:**

* Added import for `ingester_pb2` in both `runner.py` and `test_runner.py` to support entity creation and size estimation. (`[[1]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R9)`, `[[2]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R8-R14)`)