### PR TITLE
chore: bump go version

### DIFF
--- a/snmp-discovery/go.mod
+++ b/snmp-discovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/orb-discovery/snmp-discovery
 
-go 1.24.2
+go 1.24.6
 
 require (
 	github.com/gin-gonic/gin v1.10.0


### PR DESCRIPTION
This pull request makes a minor update to the Go toolchain version used in the `snmp-discovery/go.mod` file, upgrading from 1.24.2 to 1.24.6. This ensures the project uses the latest patch release for Go 1.24.

([snmp-discovery/go.modL3-R3](diffhunk://#diff-b317fe0c907478d97c235e904821194309658448be78cf050d9ada1dd275ec8fL3-R3))