### PR TITLE
chore: upgrade semantic release

### DIFF
--- a/.github/workflows/device-discovery-release.yaml
+++ b/.github/workflows/device-discovery-release.yaml
@@ -55,7 +55,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^24.2.7",
+                "semantic-release": "^v25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -198,7 +198,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^24.2.7",
+                "semantic-release": "^v25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }

--- a/.github/workflows/device-discovery-release.yaml
+++ b/.github/workflows/device-discovery-release.yaml
@@ -55,7 +55,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^v25.0.0-beta.6",
+                "semantic-release": "^25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -198,7 +198,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^v25.0.0-beta.6",
+                "semantic-release": "^25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }

--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -43,7 +43,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^v25.0.0-beta.6",
+                "semantic-release": "^25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -203,7 +203,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^v25.0.0-beta.6",
+                "semantic-release": "^25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }

--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -43,7 +43,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^24.2.7",
+                "semantic-release": "^v25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -203,7 +203,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^24.2.7",
+                "semantic-release": "^v25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -43,7 +43,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^v25.0.0-beta.6",
+                "semantic-release": "^25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -203,7 +203,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^v25.0.0-beta.6",
+                "semantic-release": "^25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -43,7 +43,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^24.2.7",
+                "semantic-release": "^v25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -203,7 +203,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^24.2.7",
+                "semantic-release": "^v25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }

--- a/.github/workflows/worker-release.yaml
+++ b/.github/workflows/worker-release.yaml
@@ -55,7 +55,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^24.2.7",
+                "semantic-release": "^v25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -198,7 +198,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^24.2.7",
+                "semantic-release": "^v25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }

--- a/.github/workflows/worker-release.yaml
+++ b/.github/workflows/worker-release.yaml
@@ -55,7 +55,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^v25.0.0-beta.6",
+                "semantic-release": "^25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }
@@ -198,7 +198,7 @@ jobs:
               "name": "${{ env.APP_NAME }}",
               "version": "1.0.0",
               "devDependencies": {
-                "semantic-release": "^v25.0.0-beta.6",
+                "semantic-release": "^25.0.0-beta.6",
                 "semantic-release-export-data": "^1.0.1",
                 "@semantic-release/changelog": "^6.0.3"
               }


### PR DESCRIPTION
- use beta version of semantic release to avoid issues with deprecated API