### PR TITLE
chore: bump network discovery go version and loosen peer dep checks

### DIFF
--- a/.github/workflows/device-discovery-release.yaml
+++ b/.github/workflows/device-discovery-release.yaml
@@ -103,7 +103,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: release dry-run
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_SEMANTIC_RELEASE_WEBHOOK }}
@@ -246,7 +246,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: Release
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}

--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -91,7 +91,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: release dry-run
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_SEMANTIC_RELEASE_WEBHOOK }}
@@ -251,7 +251,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: Release
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -91,7 +91,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: release dry-run
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_SEMANTIC_RELEASE_WEBHOOK }}
@@ -251,7 +251,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: Release
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}

--- a/.github/workflows/worker-release.yaml
+++ b/.github/workflows/worker-release.yaml
@@ -103,7 +103,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: release dry-run
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_SEMANTIC_RELEASE_WEBHOOK }}
@@ -246,7 +246,7 @@ jobs:
               ]
             }
       - name: setup semantic-release
-        run: npm i
+        run: npm install --legacy-peer-deps
       - name: Release
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_OBSERVABILITY_RELEASE_WEBHOOK }}

--- a/network-discovery/go.mod
+++ b/network-discovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/orb-discovery/network-discovery
 
-go 1.24.2
+go 1.24.6
 
 require (
 	github.com/Ullaakut/nmap/v3 v3.0.4


### PR DESCRIPTION
- to try and get upgraded version of semantic release working correctly