### PR TITLE
fix: exception when option is none

### DIFF
--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -15,7 +15,7 @@ from napalm import get_network_driver
 from device_discovery.client import Client
 from device_discovery.discovery import discover_device_driver, supported_drivers
 from device_discovery.metrics import get_metric
-from device_discovery.policy.models import Config, Defaults, Napalm, Status, Options
+from device_discovery.policy.models import Config, Defaults, Napalm, Options, Status
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -47,12 +47,9 @@ class PolicyRunner:
         self.name = name.replace("\r\n", "").replace("\n", "")
         self.config = config
 
-        if self.config is None:
-            self.config = Config(defaults=Defaults(), options=Options())
-        if self.config.defaults is None:
-            self.config.defaults = Defaults()
-        if self.config.options is None:
-            self.config.options = Options()
+        self.config = self.config or Config(defaults=Defaults(), options=Options())
+        self.config.defaults = self.config.defaults or Defaults()
+        self.config.options = self.config.options or Options()
 
         self.scheduler.start()
         set_telemetry = True

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -49,6 +49,10 @@ class PolicyRunner:
 
         if self.config is None:
             self.config = Config(defaults=Defaults(), options=Options())
+        if self.config.defaults is None:
+            self.config.defaults = Defaults()
+        if self.config.options is None:
+            self.config.options = Options()
 
         self.scheduler.start()
         set_telemetry = True

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -15,7 +15,7 @@ from napalm import get_network_driver
 from device_discovery.client import Client
 from device_discovery.discovery import discover_device_driver, supported_drivers
 from device_discovery.metrics import get_metric
-from device_discovery.policy.models import Config, Defaults, Napalm, Status
+from device_discovery.policy.models import Config, Defaults, Napalm, Status, Options
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -48,9 +48,7 @@ class PolicyRunner:
         self.config = config
 
         if self.config is None:
-            self.config = Config(defaults=Defaults())
-        elif self.config.defaults is None:
-            self.config.defaults = Defaults()
+            self.config = Config(defaults=Defaults(), options=Options())
 
         self.scheduler.start()
         set_telemetry = True

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -290,12 +290,8 @@ def translate_data(data: dict) -> Iterable[Entity]:
     """
     entities = []
 
-    defaults = data.get("defaults", Defaults())
-    if defaults is None:
-        defaults = Defaults()
-    options = data.get("options", Options())
-    if options is None:
-        options = Options()
+    defaults = data.get("defaults") or Defaults()
+    options = data.get("options") or Options()
 
     device_info = data.get("device", {})
     interfaces = data.get("interface", {})

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -291,7 +291,11 @@ def translate_data(data: dict) -> Iterable[Entity]:
     entities = []
 
     defaults = data.get("defaults", Defaults())
+    if defaults is None:
+        defaults = Defaults()
     options = data.get("options", Options())
+    if options is None:
+        options = Options()
 
     device_info = data.get("device", {})
     interfaces = data.get("interface", {})
@@ -300,7 +304,6 @@ def translate_data(data: dict) -> Iterable[Entity]:
         if options.platform_omit_version:
             device_info["platform"] = data.get("driver")
         else:
-
             device_info["platform"] = (
                 f"{data.get('driver', '').upper()} {device_info.get('os_version')}"
             )

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from apscheduler.triggers.date import DateTrigger
 
-from device_discovery.policy.models import Config, Defaults, Napalm, Status
+from device_discovery.policy.models import Config, Defaults, Napalm, Options, Status
 from device_discovery.policy.runner import PolicyRunner
 
 
@@ -81,6 +81,22 @@ def test_setup_policy_runner_with_one_time_run(policy_runner, sample_scopes):
         trigger = mock_add_job.call_args[1]["trigger"]
         assert isinstance(trigger, DateTrigger)
         assert mock_start.called
+        assert policy_runner.status == Status.RUNNING
+
+
+def test_setup_policy_runner_with_none_config(policy_runner, sample_scopes):
+    """Ensure PolicyRunner uses default config when none is provided."""
+    with (
+        patch.object(policy_runner.scheduler, "start") as mock_start,
+        patch.object(policy_runner.scheduler, "add_job") as mock_add_job,
+    ):
+
+        policy_runner.setup("policy1", None, sample_scopes)
+
+        mock_start.assert_called_once()
+        assert mock_add_job.call_count == 2
+        assert isinstance(policy_runner.config.defaults, Defaults)
+        assert isinstance(policy_runner.config.options, Options)
         assert policy_runner.status == Status.RUNNING
 
 

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -236,6 +236,25 @@ def test_translate_data(
     assert entities[0].device.platform.name == "custom"
     assert entities[0].device.role.name == "switch"
 
+def test_translate_data_handles_none_defaults_and_options(
+    sample_device_info, sample_interface_info, sample_interfaces_ip
+):
+    """Ensure translation works when defaults and options are None."""
+    data = {
+        "device": sample_device_info,
+        "interface": sample_interface_info,
+        "interface_ip": sample_interfaces_ip,
+        "driver": "ios",
+        "defaults": None,
+        "options": None,
+    }
+
+    entities = list(translate_data(data))
+
+    assert len(entities) == 5
+    assert entities[0].device.site.name == "undefined"
+    assert entities[0].device.platform.name == "IOS v15.2"
+
 
 def test_translate_vlan(sample_defaults):
     """Ensure VLAN translation is correct."""


### PR DESCRIPTION
This pull request introduces improvements to how default configuration and options are handled in the device discovery policy and translation logic. The main changes ensure that both `Defaults` and `Options` objects are always initialized, preventing potential issues from missing or `None` values.

Configuration initialization improvements:

* Updated the imports in `device_discovery/policy/runner.py` to include the `Options` model, ensuring it's available for configuration.
* Modified the `setup` method in `device_discovery/policy/runner.py` to always initialize `Config` with both `Defaults` and `Options` if no configuration is provided, improving robustness.

Translation logic enhancements:

* In `device_discovery/translate.py`, ensured that both `defaults` and `options` are always set to their respective default objects if missing or `None`, preventing runtime errors.
* Simplified the logic for setting the device platform string in `translate_data`, removing unnecessary blank lines and clarifying the conditional assignment.