### PR TITLE
fix: do not skip job if not executed yet

### DIFF
--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -82,7 +82,11 @@ class PolicyRunner:
                     update=scope.override_defaults.model_dump(exclude_none=True)
                 )
             self.scheduler.add_job(
-                self.run, id=id, trigger=trigger, args=[id, scope, config]
+                self.run,
+                id=id,
+                trigger=trigger,
+                args=[id, scope, config],
+                misfire_grace_time=None,
             )
             if set_telemetry:
                 set_telemetry = False

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -81,7 +81,23 @@ def test_setup_policy_runner_with_one_time_run(policy_runner, sample_scopes):
         trigger = mock_add_job.call_args[1]["trigger"]
         assert isinstance(trigger, DateTrigger)
         assert mock_start.called
-        assert policy_runner.status == Status.RUNNING
+    assert policy_runner.status == Status.RUNNING
+
+
+def test_setup_sets_misfire_grace_time_none(
+    policy_runner, sample_config, sample_scopes
+):
+    """Ensure jobs are added with misfire_grace_time=None (run even if late)."""
+    with (
+        patch.object(policy_runner.scheduler, "start"),
+        patch.object(policy_runner.scheduler, "add_job") as mock_add_job,
+    ):
+        policy_runner.setup("policy1", sample_config, sample_scopes)
+
+        # First add_job call corresponds to the device run job
+        first_call_kwargs = mock_add_job.call_args_list[0][1]
+        assert "misfire_grace_time" in first_call_kwargs
+        assert first_call_kwargs["misfire_grace_time"] is None
 
 
 def test_setup_policy_runner_with_none_config(policy_runner, sample_scopes):


### PR DESCRIPTION
This pull request introduces a minor change to the job scheduling logic in the `device-discovery/device_discovery/policy/runner.py` file. The most notable update is the addition of a `misfire_grace_time=None` parameter to the job configuration, which explicitly sets the grace period for handling misfires to `None`.

>    :param int misfire_grace_time: seconds after the designated runtime that the job is still  allowed to be run (or `None` to allow the job to run no matter how late it is)

Job scheduling configuration:

* Added `misfire_grace_time=None` to the `self.scheduler.add_job` call in `runner.py`, clarifying misfire handling for scheduled jobs.