### PR TITLE
chore: run ruff check on worker backend

### DIFF
--- a/worker/tests/nbl-custom/nbl_custom/impl.py
+++ b/worker/tests/nbl-custom/nbl_custom/impl.py
@@ -55,7 +55,7 @@ class MockBackend(Backend):
         # Sample of how to handle a scope dictionary
         elif isinstance(policy.scope, dict):
             scope = ScopeMap(**policy.scope)
-        
+
         for i in range(100000):
             device = Device(
                 name=f"Device A {i}",

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -169,7 +169,7 @@ def test_run_success(policy_runner, sample_policy, mock_diode_client, mock_backe
         entity = ingester_pb2.Entity()
         entity.device.name = f"test_device_{i}"
         entities.append(entity)
-    
+
     mock_backend.run.return_value = entities
     mock_diode_client.ingest.return_value.errors = []
 
@@ -201,7 +201,7 @@ def test_run_ingestion_errors(
         entity = ingester_pb2.Entity()
         entity.device.name = f"test_device_{i}"
         entities.append(entity)
-    
+
     mock_backend.run.return_value = entities
 
     # Simulate ingestion errors
@@ -286,7 +286,7 @@ def test_metrics_during_policy_lifecycle(
         entity = ingester_pb2.Entity()
         entity.device.name = f"test_device_{i}"
         entities.append(entity)
-    
+
     mock_backend.run.return_value = entities
 
     # Setup mock for get_metric function
@@ -371,7 +371,7 @@ def test_create_message_chunks_empty_list(policy_runner):
     """Test _create_message_chunks with an empty entity list."""
     entities = []
     chunks = policy_runner._create_message_chunks(entities)
-    
+
     assert len(chunks) == 1
     assert chunks[0] == []
 
@@ -384,10 +384,10 @@ def test_create_message_chunks_single_chunk(policy_runner):
         entity = ingester_pb2.Entity()
         entity.device.name = f"test_device_{i}"
         entities.append(entity)
-    
+
     with patch.object(policy_runner, '_estimate_message_size', return_value=1024):  # Small size
         chunks = policy_runner._create_message_chunks(entities)
-    
+
     assert len(chunks) == 1
     assert len(chunks[0]) == 5
     assert chunks[0] == entities
@@ -401,18 +401,18 @@ def test_create_message_chunks_multiple_chunks(policy_runner):
         entity = ingester_pb2.Entity()
         entity.device.name = f"test_device_{i}"
         entities.append(entity)
-    
+
     # Mock size to be larger than target (3.5MB)
     with patch.object(policy_runner, '_estimate_message_size', return_value=5 * 1024 * 1024):  # 5MB
         chunks = policy_runner._create_message_chunks(entities)
-    
+
     # Should have multiple chunks
     assert len(chunks) > 1
-    
+
     # All entities should be present across chunks
     total_entities = sum(len(chunk) for chunk in chunks)
     assert total_entities == 10
-    
+
     # Each chunk should have at least 1 entity
     for chunk in chunks:
         assert len(chunk) >= 1
@@ -425,11 +425,11 @@ def test_create_message_chunks_edge_case_one_entity_per_chunk(policy_runner):
         entity = ingester_pb2.Entity()
         entity.device.name = f"large_device_{i}"
         entities.append(entity)
-    
+
     # Mock very large size to force one entity per chunk
     with patch.object(policy_runner, '_estimate_message_size', return_value=20 * 1024 * 1024):  # 20MB
         chunks = policy_runner._create_message_chunks(entities)
-    
+
     # Should have 3 chunks with 1 entity each
     assert len(chunks) == 3
     for chunk in chunks:
@@ -444,10 +444,10 @@ def test_estimate_message_size(policy_runner):
         entity = ingester_pb2.Entity()
         entity.device.name = f"test_device_{i}"
         entities.append(entity)
-    
+
     # Call the method
     size = policy_runner._estimate_message_size(entities)
-    
+
     # Should return a positive integer (actual protobuf size)
     assert isinstance(size, int)
     assert size > 0
@@ -457,7 +457,7 @@ def test_estimate_message_size_empty_list(policy_runner):
     """Test _estimate_message_size with empty entity list."""
     entities = []
     size = policy_runner._estimate_message_size(entities)
-    
+
     # Even empty request should have some minimal size
     assert isinstance(size, int)
     assert size >= 0
@@ -473,31 +473,31 @@ def test_run_with_multiple_chunks(policy_runner, sample_policy, mock_diode_clien
         entity = ingester_pb2.Entity()
         entity.device.name = f"test_device_{i}"
         entities.append(entity)
-    
+
     mock_backend.run.return_value = entities
     mock_diode_client.ingest.return_value.errors = []
 
     # Mock chunking to return multiple chunks
     with patch.object(
-        policy_runner, 
-        '_create_message_chunks', 
+        policy_runner,
+        '_create_message_chunks',
         return_value=[entities[:5], entities[5:]]
     ) as mock_chunks, \
          patch.object(
-        policy_runner, 
-        '_estimate_message_size', 
+        policy_runner,
+        '_estimate_message_size',
         return_value=1024
     ):
-        
+
         with caplog.at_level("DEBUG"):
             policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
         # Should call chunking method
         mock_chunks.assert_called_once_with(entities)
-        
+
         # Should call ingest twice (once per chunk)
         assert mock_diode_client.ingest.call_count == 2
-        
+
         # Verify log messages for chunking
         assert "Ingesting chunk 1 with 5 entities" in caplog.text
         assert "Ingesting chunk 2 with 5 entities" in caplog.text
@@ -515,33 +515,33 @@ def test_run_chunk_ingestion_error(policy_runner, sample_policy, mock_diode_clie
         entity = ingester_pb2.Entity()
         entity.device.name = f"test_device_{i}"
         entities.append(entity)
-    
+
     mock_backend.run.return_value = entities
 
     # Mock first chunk succeeds, second chunk fails
     responses = [MagicMock(), MagicMock()]
     responses[0].errors = []  # First chunk succeeds
     responses[1].errors = ["Chunk error"]  # Second chunk fails
-    
+
     mock_diode_client.ingest.side_effect = responses
 
     # Mock chunking to return two chunks
     with patch.object(
-        policy_runner, 
-        '_create_message_chunks', 
+        policy_runner,
+        '_create_message_chunks',
         return_value=[entities[:3], entities[3:]]
     ), \
          patch.object(
-        policy_runner, 
-        '_estimate_message_size', 
+        policy_runner,
+        '_estimate_message_size',
         return_value=1024
     ):
-        
+
         with caplog.at_level("ERROR"):
             policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
         # Should call ingest twice but fail on second chunk
         assert mock_diode_client.ingest.call_count == 2
-        
+
         # Should log the chunk error
         assert "Chunk 2 ingestion failed" in caplog.text

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -5,7 +5,6 @@
 import logging
 import time
 from datetime import datetime, timedelta
-from typing import List
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -179,7 +178,7 @@ class PolicyRunner:
         if active_policies:
             active_policies.add(-1, {"policy": self.name})
 
-    def _create_message_chunks(self, entities: List[ingester_pb2.Entity]) -> List[List[ingester_pb2.Entity]]:
+    def _create_message_chunks(self, entities: list[ingester_pb2.Entity]) -> list[list[ingester_pb2.Entity]]:
         """Create 3.5MB chunks from entities, always returning at least one chunk."""
         total_entities = len(entities)
         if total_entities == 0:
@@ -204,7 +203,7 @@ class PolicyRunner:
         return chunks
 
 
-    def _estimate_message_size(self, entities: List[ingester_pb2.Entity]) -> int:
+    def _estimate_message_size(self, entities: list[ingester_pb2.Entity]) -> int:
         """Estimate the serialized size of entities using minimal IngestRequest."""
         request = ingester_pb2.IngestRequest()
         request.entities.extend(entities)


### PR DESCRIPTION
This pull request updates type annotations in the `worker/worker/policy/runner.py` file to use built-in generic types instead of those imported from `typing`. The changes are minor and focused on improving code style and consistency.

Type annotation updates:

* Replaced usage of `List` from the `typing` module with the built-in `list` type in function signatures for `_create_message_chunks` and `_estimate_message_size`. [[1]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2L182-R181) [[2]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2L207-R206)
* Removed the import of `List` from the `typing` module.