### PR TITLE
chore: allow insecure otlp endpoint if prefix is http

### DIFF
--- a/device-discovery/device_discovery/metrics.py
+++ b/device-discovery/device_discovery/metrics.py
@@ -138,10 +138,7 @@ def setup_metrics_export(endpoint: str | None, export_period_seconds: int) -> No
 
     try:
         # Set up the exporter with the provided endpoint and timeouts
-        insecure = None
-        if endpoint.startswith("grpc://"):
-            insecure = True
-
+        insecure = True if endpoint.startswith("grpc://") else None
         exporter = OTLPMetricExporter(endpoint=endpoint, timeout=10, insecure=insecure)
         logger.info(f"OTLP metrics exporter configured with endpoint: {endpoint}")
 

--- a/device-discovery/device_discovery/metrics.py
+++ b/device-discovery/device_discovery/metrics.py
@@ -138,11 +138,11 @@ def setup_metrics_export(endpoint: str | None, export_period_seconds: int) -> No
 
     try:
         # Set up the exporter with the provided endpoint and timeouts
-        exporter = OTLPMetricExporter(
-            endpoint=endpoint,
-            timeout=10,  # Add timeout to prevent hangs on connection issues
-            insecure=True if endpoint.startswith("grpc://") else False,
-        )
+        insecure = None
+        if endpoint.startswith("grpc://"):
+            insecure = True
+
+        exporter = OTLPMetricExporter(endpoint=endpoint, timeout=10, insecure=insecure)
         logger.info(f"OTLP metrics exporter configured with endpoint: {endpoint}")
 
         export_period_millis = export_period_seconds * 1000

--- a/worker/worker/metrics.py
+++ b/worker/worker/metrics.py
@@ -128,10 +128,7 @@ def setup_metrics_export(endpoint: str | None, export_period_seconds: int) -> No
 
     try:
         # Set up the exporter with the provided endpoint and timeouts
-        insecure = None
-        if endpoint.startswith("grpc://"):
-            insecure = True
-
+        insecure = True if endpoint.startswith("grpc://") else None
         exporter = OTLPMetricExporter(endpoint=endpoint, timeout=10, insecure=insecure)
         logger.info(f"OTLP metrics exporter configured with endpoint: {endpoint}")
 

--- a/worker/worker/metrics.py
+++ b/worker/worker/metrics.py
@@ -128,11 +128,11 @@ def setup_metrics_export(endpoint: str | None, export_period_seconds: int) -> No
 
     try:
         # Set up the exporter with the provided endpoint and timeouts
-        exporter = OTLPMetricExporter(
-            endpoint=endpoint,
-            timeout=10,  # Add timeout to prevent hangs on connection issues
-            insecure=True if endpoint.startswith("grpc://") else False,
-        )
+        insecure = None
+        if endpoint.startswith("grpc://"):
+            insecure = True
+
+        exporter = OTLPMetricExporter(endpoint=endpoint, timeout=10, insecure=insecure)
         logger.info(f"OTLP metrics exporter configured with endpoint: {endpoint}")
 
         export_period_millis = export_period_seconds * 1000


### PR DESCRIPTION
This pull request updates the way the `insecure` parameter is set for the `OTLPMetricExporter` in both the `device_discovery/metrics.py` and `worker/metrics.py` modules. Instead of always passing a boolean, the code now conditionally sets `insecure` to `True` only when the endpoint starts with `"grpc://"`, and otherwise leaves it as `None`. This change makes the exporter configuration more explicit and avoids unnecessary parameter settings.

**Metrics exporter configuration:**

* Updated the logic for setting the `insecure` parameter in the `setup_metrics_export` function of both `device_discovery/metrics.py` and `worker/metrics.py`, so that `insecure` is only set to `True` if the endpoint starts with `"grpc://"`, and otherwise left as `None`. This makes the exporter configuration clearer and potentially avoids unintended behavior when not using gRPC endpoints. [[1]](diffhunk://#diff-7945675f26721f34133f6f7da72eecd422943f4b666b44683aa0adbd49752859L141-R145) [[2]](diffhunk://#diff-9b9d3ca4319cd64cd9b1d337829bec9025f70c11329dfadab0481b7383244c29L131-R135)