### PR TITLE
feat: add interface description mapping for snmp discovery

### DIFF
--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -266,6 +266,13 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				case "name":
 					interfaceEntity.Name = &value.Value
 					fieldFound = true
+				case "description":
+					description := strings.TrimRight(value.Value, " \t\n\r")
+					if len(description) > 200 {
+						description = description[:197] + "..."
+					}
+					interfaceEntity.Description = &description
+					fieldFound = true
 				case "type":
 					defaultType := ""
 					if defaults != nil && defaults.Interface.Type != "" {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -388,6 +388,13 @@ func TestInterfaceMapper_Map(t *testing.T) {
 					Value:  "1",
 					Type:   mapping.Integer,
 				},
+				"1.3.6.1.2.1.31.1.1.1.18.1": {
+					OID:    "1.3.6.1.2.1.31.1.1.1.18.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.31.1.1.1.18",
+					Value:  "uplink interface",
+					Type:   mapping.OctetString,
+				},
 			},
 			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.2.2.1.1",
@@ -424,6 +431,11 @@ func TestInterfaceMapper_Map(t *testing.T) {
 						Entity: "interface",
 						Field:  "adminStatus",
 					},
+					{
+						OID:    "1.3.6.1.2.1.31.1.1.1.18",
+						Entity: "interface",
+						Field:  "description",
+					},
 				},
 			},
 			defaults: nil,
@@ -433,6 +445,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				Mtu:               int64Ptr(1500),
 				PrimaryMacAddress: &diode.MACAddress{MacAddress: mapping.StringPtr("00:11:22:33:44:55")},
 				Enabled:           boolPtr(true),
+				Description:       mapping.StringPtr("uplink interface"),
 			},
 			expectError: false,
 		},

--- a/snmp-discovery/policy/mapping.yaml
+++ b/snmp-discovery/policy/mapping.yaml
@@ -23,6 +23,9 @@ entries:
       - oid: ".1.3.6.1.2.1.2.2.1.7"
         entity: "interface"
         field: "adminStatus"
+      - oid: ".1.3.6.1.2.1.31.1.1.1.18"
+        entity: "interface"
+        field: "description"
 
   # IP Address mappings
   - oid: ".1.3.6.1.2.1.4.20.1"


### PR DESCRIPTION
This change improves interface mapping in snmp discovery to include interface description using OID 1.3.6.1.2.1.31.1.1.1.18 (ifAlias)