### PR TITLE
feat: add worker kwargs

### DIFF
--- a/.github/workflows/device-discovery-lint-tests.yaml
+++ b/.github/workflows/device-discovery-lint-tests.yaml
@@ -58,4 +58,3 @@ jobs:
     - name: Lint with Ruff
       run: |
         ruff check --output-format=github device_discovery/ tests/
-      continue-on-error: true

--- a/.github/workflows/worker-lint-tests.yaml
+++ b/.github/workflows/worker-lint-tests.yaml
@@ -58,4 +58,3 @@ jobs:
     - name: Lint with Ruff
       run: |
         ruff check --output-format=github worker/ tests/
-      continue-on-error: true

--- a/worker/tests/nbl-custom/nbl_custom/impl.py
+++ b/worker/tests/nbl-custom/nbl_custom/impl.py
@@ -73,9 +73,9 @@ class MockBackend(Backend):
             )
 
             entities.append(Entity(device=device))
-        cache = kwargs.get("cache", {})
+        #cache = kwargs.get("cache", {})
 
         logger.info(f"Policy '{policy_name}' config: {config}")
         logger.info(f"Policy '{policy_name}' scope: {scope}")
-        logger.info(f"Policy '{policy_name}' cache keys: {list(cache.keys())}")
+        #logger.info(f"Policy '{policy_name}' cache keys: {list(cache.keys())}")
         return entities

--- a/worker/tests/nbl-custom/nbl_custom/impl.py
+++ b/worker/tests/nbl-custom/nbl_custom/impl.py
@@ -73,6 +73,9 @@ class MockBackend(Backend):
             )
 
             entities.append(Entity(device=device))
+        cache = kwargs.get("cache", {})
+
         logger.info(f"Policy '{policy_name}' config: {config}")
         logger.info(f"Policy '{policy_name}' scope: {scope}")
+        logger.info(f"Policy '{policy_name}' cache keys: {list(cache.keys())}")
         return entities

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -111,6 +111,14 @@ def test_setup_policy_runner_with_cron(
         mock_start.assert_called_once()
         mock_add_job.assert_called_once()
         mock_load_class.assert_called_once()
+        mock_load_class.return_value.assert_called_once_with()
+        job_kwargs = mock_add_job.call_args[1]["kwargs"]
+        assert job_kwargs["schedule"] == "0 * * * *"
+        assert "cache" in job_kwargs
+        assert job_kwargs["cache"] is policy_runner.cache
+        schedule_now_callable = job_kwargs["schedule_now"]
+        assert schedule_now_callable.__self__ is policy_runner
+        assert schedule_now_callable.__func__ is PolicyRunner.schedule_now
         mock_diode_client.assert_called_once()
         assert policy_runner.status == Status.RUNNING
 
@@ -133,6 +141,13 @@ def test_setup_policy_runner_with_one_time_run(
         # Verify that DateTrigger is used for one-time scheduling
         trigger = mock_add_job.call_args[1]["trigger"]
         mock_load_class.assert_called_once()
+        mock_load_class.return_value.assert_called_once_with()
+        job_kwargs = mock_add_job.call_args[1]["kwargs"]
+        assert set(job_kwargs.keys()) == {"cache", "schedule_now"}
+        assert job_kwargs["cache"] is policy_runner.cache
+        schedule_now_callable = job_kwargs["schedule_now"]
+        assert schedule_now_callable.__self__ is policy_runner
+        assert schedule_now_callable.__func__ is PolicyRunner.schedule_now
         mock_diode_client.assert_called_once()
         assert isinstance(trigger, DateTrigger)
         assert mock_start.called
@@ -156,12 +171,88 @@ def test_setup_policy_runner_dry_run(
         mock_start.assert_called_once()
         mock_add_job.assert_called_once()
         mock_load_class.assert_called_once()
+        mock_load_class.return_value.assert_called_once_with()
+        job_kwargs = mock_add_job.call_args[1]["kwargs"]
+        assert job_kwargs["schedule"] == "0 * * * *"
+        assert job_kwargs["cache"] is policy_runner.cache
+        schedule_now_callable = job_kwargs["schedule_now"]
+        assert schedule_now_callable.__self__ is policy_runner
+        assert schedule_now_callable.__func__ is PolicyRunner.schedule_now
         mock_diode_dry_run_client.assert_called_once()
         assert policy_runner.status == Status.RUNNING
+
+
+def test_setup_uses_backend_cache_factory(
+    policy_runner, sample_diode_config, sample_policy, mock_diode_client
+):
+    """Ensure PolicyRunner uses backend cache factory when available."""
+    backend_instance = MagicMock()
+    backend_instance.setup.return_value = Metadata(
+        name="my_backend",
+        app_name="app",
+        app_version="1.0",
+    )
+    backend_instance.create_cache.return_value = {"token": "value"}
+
+    backend_class = MagicMock(return_value=backend_instance)
+
+    with patch("worker.policy.runner.load_class", return_value=backend_class), patch.object(
+        policy_runner.scheduler, "start"
+    ), patch.object(policy_runner.scheduler, "add_job") as mock_add_job:
+        policy_runner.setup("policy1", sample_diode_config, sample_policy)
+
+    backend_instance.create_cache.assert_called_once()
+    assert policy_runner.cache == {"token": "value"}
+    job_kwargs = mock_add_job.call_args[1]["kwargs"]
+    assert job_kwargs["cache"] == {"token": "value"}
+    schedule_now_callable = job_kwargs["schedule_now"]
+    assert schedule_now_callable.__self__ is policy_runner
+    assert schedule_now_callable.__func__ is PolicyRunner.schedule_now
+
+
+def test_schedule_now_adds_job(
+    policy_runner,
+    sample_diode_config,
+    sample_policy,
+    mock_diode_client,
+):
+    """Ensure schedule_now queues an immediate job with merged kwargs."""
+    backend_instance = MagicMock()
+    backend_instance.setup.return_value = Metadata(
+        name="backend",
+        app_name="app",
+        app_version="1.0",
+    )
+
+    backend_class = MagicMock(return_value=backend_instance)
+
+    with patch("worker.policy.runner.load_class", return_value=backend_class), patch.object(
+        policy_runner.scheduler, "start"
+    ), patch.object(policy_runner.scheduler, "add_job"):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy)
+
+    with patch.object(policy_runner.scheduler, "add_job") as mock_add_job:
+        policy_runner.schedule_now({"custom": "value"})
+
+    mock_add_job.assert_called_once()
+    call_args, call_kwargs = mock_add_job.call_args
+    run_callable = call_args[0]
+    assert run_callable.__self__ is policy_runner
+    assert run_callable.__func__ is PolicyRunner.run
+    scheduled_trigger = call_kwargs["trigger"]
+    assert isinstance(scheduled_trigger, DateTrigger)
+    scheduled_kwargs = call_kwargs["kwargs"]
+    assert scheduled_kwargs["custom"] == "value"
+    assert scheduled_kwargs["cache"] is policy_runner.cache
+    schedule_now_callable = scheduled_kwargs["schedule_now"]
+    assert schedule_now_callable.__self__ is policy_runner
+    assert schedule_now_callable.__func__ is PolicyRunner.schedule_now
+
 
 def test_run_success(policy_runner, sample_policy, mock_diode_client, mock_backend):
     """Test the run function for a successful execution."""
     policy_runner.name = "test_policy"
+    policy_runner.cache = {}
 
     # Create mock entities
     entities = []
@@ -177,12 +268,39 @@ def test_run_success(policy_runner, sample_policy, mock_diode_client, mock_backe
     policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Assertions
-    mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
+    mock_backend.run.assert_called_once_with(
+        policy_runner.name, sample_policy, cache=policy_runner.cache
+    )
     # Should call ingest once for the single chunk
     mock_diode_client.ingest.assert_called_once()
     # Check that entities were passed correctly
     call_args = mock_diode_client.ingest.call_args[1]['entities']
     assert len(call_args) == 3
+
+
+def test_run_forwards_backend_kwargs(policy_runner, sample_policy, mock_diode_client, mock_backend):
+    """Ensure PolicyRunner forwards keyword arguments to the backend run method."""
+    policy_runner.name = "test_policy"
+    mock_backend.run.return_value = []
+    mock_diode_client.ingest.return_value.errors = []
+    mock_cache = {}
+
+    policy_runner.run(
+        mock_diode_client,
+        mock_backend,
+        sample_policy,
+        schedule="0 * * * *",
+        custom="value",
+        cache=mock_cache,
+    )
+
+    mock_backend.run.assert_called_once_with(
+        policy_runner.name,
+        sample_policy,
+        schedule="0 * * * *",
+        custom="value",
+        cache=mock_cache,
+    )
 
 
 def test_run_ingestion_errors(
@@ -194,6 +312,7 @@ def test_run_ingestion_errors(
 ):
     """Test the run function when ingestion has errors."""
     policy_runner.name = "test_policy"
+    policy_runner.cache = {}
 
     # Create mock entities
     entities = []
@@ -212,7 +331,9 @@ def test_run_ingestion_errors(
         policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Assertions
-    mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
+    mock_backend.run.assert_called_once_with(
+        policy_runner.name, sample_policy, cache=policy_runner.cache
+    )
     mock_diode_client.ingest.assert_called_once()
     assert (
         "Policy test_policy: Chunk 1 ingestion failed: ['error1', 'error2']"
@@ -229,6 +350,7 @@ def test_run_backend_exception(
 ):
     """Test the run function when an exception is raised by the backend."""
     policy_runner.name = "test_policy"
+    policy_runner.cache = {}
 
     # Simulate backend throwing an exception
     mock_backend.run.side_effect = Exception("Backend error")
@@ -238,19 +360,23 @@ def test_run_backend_exception(
         policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Assertions
-    mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
+    mock_backend.run.assert_called_once_with(
+        policy_runner.name, sample_policy, cache=policy_runner.cache
+    )
     mock_diode_client.ingest.assert_not_called()  # Client ingestion should not be called
     assert "Policy test_policy: Backend error" in caplog.text
 
 
 def test_stop_policy_runner(policy_runner):
     """Test stopping the PolicyRunner."""
+    policy_runner.cache = {}
     with patch.object(policy_runner.scheduler, "shutdown") as mock_shutdown:
         policy_runner.stop()
 
         # Ensure scheduler shutdown is called and status is updated
         mock_shutdown.assert_called_once()
         assert policy_runner.status == Status.FINISHED
+        assert policy_runner.cache is None
 
 
 def test_metrics_during_policy_lifecycle(
@@ -279,6 +405,8 @@ def test_metrics_during_policy_lifecycle(
         app_name="test_app",
         app_version="1.0",
     )
+    policy_runner.cache = {}
+    policy_runner.cache = {}
 
     # Create mock entities
     entities = []
@@ -299,7 +427,9 @@ def test_metrics_during_policy_lifecycle(
 
         policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
-        mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
+        mock_backend.run.assert_called_once_with(
+            policy_runner.name, sample_policy, cache=policy_runner.cache
+        )
         mock_diode_client.ingest.assert_called_once()
 
         mock_policy_executions.add.assert_called_once_with(1, {"policy": "test_policy"})

--- a/worker/tests/test_backend.py
+++ b/worker/tests/test_backend.py
@@ -36,6 +36,19 @@ def test_backend_run_not_implemented():
         list(backend.run("mock", mock_policy))
 
 
+def test_backend_run_accepts_kwargs():
+    """Test that Backend subclasses can accept keyword arguments in run."""
+
+    class DummyBackend(Backend):
+        def run(self, policy_name, policy, **kwargs):
+            return kwargs
+
+    backend = DummyBackend()
+    mock_policy = MagicMock(spec=Policy)
+    result = backend.run("mock", mock_policy, foo="bar", answer=42)
+    assert result == {"foo": "bar", "answer": 42}
+
+
 def test_load_class_valid_backend_class(mock_import_module):
     """Test that load_class successfully loads a valid Backend class."""
     mock_module_name = "worker.test_module"

--- a/worker/worker/backend.py
+++ b/worker/worker/backend.py
@@ -25,7 +25,7 @@ class Backend:
         """
         raise NotImplementedError("The 'setup' method must be implemented.")
 
-    def run(self, policy_name: str, policy: Policy) -> Iterable[Entity]:
+    def run(self, policy_name: str, policy: Policy, **kwargs) -> Iterable[Entity]:
         """
         Run the backend.
 
@@ -33,6 +33,7 @@ class Backend:
         ----
             policy_name (str): The name of the policy.
             policy (Policy): The policy to run.
+            **kwargs: Additional parameters provided by the runner.
 
         Returns:
         -------

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -5,6 +5,7 @@
 import logging
 import time
 from datetime import datetime, timedelta
+from typing import Any
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -33,6 +34,9 @@ class PolicyRunner:
         self.policy = None
         self.status = Status.NEW
         self.scheduler = BackgroundScheduler()
+        self.cache: Any = None
+        self._job_args: tuple[Any, ...] = ()
+        self._job_kwargs: dict[str, Any] = {}
 
     def setup(self, name: str, diode_config: DiodeConfig, policy: Policy):
         """
@@ -51,6 +55,10 @@ class PolicyRunner:
         )
         backend_class = load_class(policy.config.package)
         backend = backend_class()
+        backend_kwargs = policy.config.model_dump(
+            exclude={"package"}, exclude_none=True
+        )
+        cache_config = backend_kwargs.pop("cache", None)
 
         metadata = backend.setup()
         app_name = (
@@ -72,8 +80,15 @@ class PolicyRunner:
                 client_secret=diode_config.client_secret,
             )
 
+        self.cache = self._create_cache(backend, cache_config)
+        backend_kwargs["cache"] = self.cache
+        backend_kwargs["schedule_now"] = self.schedule_now
+
         self.metadata = metadata
         self.policy = policy
+
+        self._job_args = (client, backend, self.policy)
+        self._job_kwargs = dict(backend_kwargs)
 
         self.scheduler.start()
 
@@ -91,7 +106,8 @@ class PolicyRunner:
         self.scheduler.add_job(
             self.run,
             trigger=trigger,
-            args=[client, backend, self.policy],
+            args=self._job_args,
+            kwargs=self._job_kwargs,
         )
 
         self.status = Status.RUNNING
@@ -101,7 +117,11 @@ class PolicyRunner:
             active_policies.add(1, {"policy": self.name})
 
     def run(
-        self, client: DiodeClient | DiodeDryRunClient, backend: Backend, policy: Policy
+        self,
+        client: DiodeClient | DiodeDryRunClient,
+        backend: Backend,
+        policy: Policy,
+        **backend_kwargs,
     ):
         """
         Run the custom backend code for the specified scope.
@@ -118,8 +138,11 @@ class PolicyRunner:
             policy_executions.add(1, {"policy": self.name})
 
         exec_start_time = time.perf_counter()
+        if "cache" not in backend_kwargs and self.cache is not None:
+            backend_kwargs["cache"] = self.cache
+
         try:
-            entities = backend.run(self.name, policy)
+            entities = backend.run(self.name, policy, **backend_kwargs)
 
             for chunk_num, entity_chunk in enumerate(self._create_message_chunks(entities), 1):
                 chunk_size_mb = self._estimate_message_size(entity_chunk) / (1024 * 1024)
@@ -174,9 +197,29 @@ class PolicyRunner:
         """Stop the policy runner."""
         self.scheduler.shutdown()
         self.status = Status.FINISHED
+        self.cache = None
+        self._job_args = ()
+        self._job_kwargs = {}
         active_policies = get_metric("active_policies")
         if active_policies:
             active_policies.add(-1, {"policy": self.name})
+
+    def schedule_now(self, extra_kwargs: dict[str, Any] | None = None) -> None:
+        """Schedule the backend to run immediately, merging any extra kwargs."""
+        if not self._job_args:
+            raise RuntimeError("PolicyRunner is not initialized; cannot schedule now")
+
+        job_kwargs = dict(self._job_kwargs)
+        if extra_kwargs:
+            job_kwargs.update(extra_kwargs)
+
+        immediate_trigger = DateTrigger(run_date=datetime.now())
+        self.scheduler.add_job(
+            self.run,
+            trigger=immediate_trigger,
+            args=self._job_args,
+            kwargs=job_kwargs,
+        )
 
     def _create_message_chunks(self, entities: list[ingester_pb2.Entity]) -> list[list[ingester_pb2.Entity]]:
         """Create 3.5MB chunks from entities, always returning at least one chunk."""
@@ -208,3 +251,14 @@ class PolicyRunner:
         request = ingester_pb2.IngestRequest()
         request.entities.extend(entities)
         return request.ByteSize()
+
+    def _create_cache(self, backend: Backend, cache_config: Any) -> Any:
+        """Create a cache object that backends can reuse across runs."""
+        cache_factory = getattr(backend, "create_cache", None)
+        if callable(cache_factory):
+            cache = cache_factory(cache_config)
+            if cache is not None:
+                return cache
+        if cache_config is not None:
+            return cache_config
+        return {}

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -131,6 +131,7 @@ class PolicyRunner:
             client: Diode client.
             backend: Backend class.
             policy: Policy configuration.
+            **backend_kwargs: Additional keyword arguments for the backend.
 
         """
         policy_executions = get_metric("policy_executions")


### PR DESCRIPTION
This pull request introduces significant improvements to the policy runner's backend integration and job scheduling, focusing on supporting backend caching, forwarding additional arguments, and enhancing test coverage. It also includes minor workflow adjustments for linting jobs.

**Backend extensibility and caching:**

* The `Backend.run` method now accepts arbitrary keyword arguments (`**kwargs`), allowing the policy runner to pass additional parameters such as cache objects and scheduling controls. (`[worker/worker/backend.pyL28-R36](diffhunk://#diff-3b735cc0006b8dac829eecfb9a8832393219518c12aaed7535e4410a5c36ab10L28-R36)`)
* The policy runner (`PolicyRunner`) now supports a backend cache mechanism: it attempts to create a cache using a backend's `create_cache` method if available, or falls back to cache config or an empty dict. The cache is injected into backend runs and reset on runner stop. (`[[1]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R37-R39)`, `[[2]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R58-R61)`, `[[3]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R83-R92)`, `[[4]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R254-R264)`, `[[5]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R200-R223)`)
* The runner also forwards `schedule_now` and any other relevant configuration to backend jobs, making the job execution context more flexible. (`[[1]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R83-R92)`, `[[2]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2L94-R110)`)

**Job scheduling and execution improvements:**

* The runner maintains internal job args and kwargs, uses them for scheduled and immediate jobs, and provides a `schedule_now` method to trigger immediate backend runs with merged kwargs. (`[[1]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R37-R39)`, `[[2]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R83-R92)`, `[[3]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2L94-R110)`, `[[4]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R200-R223)`)
* The `run` method ensures the cache is always passed to the backend, either from the runner or from explicit kwargs. (`[[1]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2L104-R124)`, `[[2]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R141-R145)`)

**Testing enhancements:**

* Extensive new and updated tests verify that caches and extra kwargs are forwarded correctly, that backend cache factories are used, and that immediate scheduling works as intended. Tests for error handling and metrics are also updated to reflect the new cache logic. (`[[1]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R114-R121)`, `[[2]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R144-R150)`, `[[3]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R174-R255)`, `[[4]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L180-R305)`, `[[5]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R315)`, `[[6]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L215-R336)`, `[[7]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R353)`, `[[8]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L241-R379)`, `[[9]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R408-R409)`, `[[10]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L302-R432)`, `[[11]](diffhunk://#diff-d55e46e202e1443376814c891586fe105d25509f22b905c49f66421d6818fc31R39-R51)`, `[[12]](diffhunk://#diff-759b8898f054470a76ad681c97fa2375588f74cd9cfc60bd7a633854ecf2af78R76-R80)`)

**Workflow/linting:**

* The GitHub Actions workflows for device discovery and worker linting are tightened by removing `continue-on-error: true`, making lint failures blocking. (`[[1]](diffhunk://#diff-5825ca970a22eff6f4d1f512a9fcf8b6dd6cc38e2a132379c39062ad2482ababL61)`, `[[2]](diffhunk://#diff-cc57007a672d909cc9b067a40e7402b56b05e647ae6aaab926f4bf8b9115a129L61)`)

These changes make the policy runner more robust, extensible, and testable, especially for backends that need persistent state or custom job parameters.