### PR TITLE
fix: adds wider protocol support

### DIFF
--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -252,6 +252,14 @@ func getPrivProtocol(privProtocol string) (gosnmp.SnmpV3PrivProtocol, error) {
 		return gosnmp.DES, nil
 	case "AES":
 		return gosnmp.AES, nil
+	case "AES192":
+		return gosnmp.AES192, nil
+	case "AES256":
+		return gosnmp.AES256, nil
+	case "AES192C":
+		return gosnmp.AES192C, nil
+	case "AES256C":
+		return gosnmp.AES256C, nil
 	}
 	return gosnmp.NoPriv, fmt.Errorf("unsupported privacy protocol: %s", privProtocol)
 }

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -232,6 +232,14 @@ func getAuthProtocol(authProtocol string) (gosnmp.SnmpV3AuthProtocol, error) {
 		return gosnmp.MD5, nil
 	case "SHA":
 		return gosnmp.SHA, nil
+	case "SHA224":
+		return gosnmp.SHA224, nil
+	case "SHA256":
+		return gosnmp.SHA256, nil
+	case "SHA384":
+		return gosnmp.SHA384, nil
+	case "SHA512":
+		return gosnmp.SHA512, nil
 	}
 	return gosnmp.NoAuth, fmt.Errorf("unsupported authentication protocol: %s", authProtocol)
 }

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -342,7 +342,58 @@ func TestNewClient(t *testing.T) {
 			},
 			expectError: false,
 		},
-
+		{
+			name: "Creates SNMPv3 client successfully with MD5/AES192",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "MD5",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "AES192",
+				PrivPassphrase:  "testpass",
+				SecurityLevel:   "authPriv",
+			},
+			expectError: false,
+		},
+		{
+			name: "Creates SNMPv3 client successfully with MD5/AES256",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "MD5",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "AES256",
+				PrivPassphrase:  "testpass",
+				SecurityLevel:   "authPriv",
+			},
+			expectError: false,
+		},
+		{
+			name: "Creates SNMPv3 client successfully with MD5/AES192C",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "MD5",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "AES192C",
+				PrivPassphrase:  "testpass",
+				SecurityLevel:   "authPriv",
+			},
+			expectError: false,
+		},
+		{
+			name: "Creates SNMPv3 client successfully with MD5/AES256C",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "MD5",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "AES256C",
+				PrivPassphrase:  "testpass",
+				SecurityLevel:   "authPriv",
+			},
+			expectError: false,
+		},
 		{
 			name: "Invalid SNMPv3 auth protocol",
 			auth: &config.Authentication{

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -282,6 +282,54 @@ func TestNewClient(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "Creates SNMPv3 client successfully with SHA224/AES",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "SHA224",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "AES",
+				PrivPassphrase:  "testpass",
+			},
+			expectError: false,
+		},
+		{
+			name: "Creates SNMPv3 client successfully with SHA256/AES",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "SHA256",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "AES",
+				PrivPassphrase:  "testpass",
+			},
+			expectError: false,
+		},
+		{
+			name: "Creates SNMPv3 client successfully with SHA384/AES",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "SHA384",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "AES",
+				PrivPassphrase:  "testpass",
+			},
+			expectError: false,
+		},
+		{
+			name: "Creates SNMPv3 client successfully with SHA512/AES",
+			auth: &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    "SHA512",
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    "AES",
+				PrivPassphrase:  "testpass",
+			},
+			expectError: false,
+		},
+		{
 			name: "Creates SNMPv3 client successfully with MD5/DES",
 			auth: &config.Authentication{
 				ProtocolVersion: snmp.ProtocolVersion3,


### PR DESCRIPTION
This pull request extends SNMPv3 authentication and privacy protocol support in the `snmp-discovery/snmp` package. It adds new protocol options for both authentication and privacy, and updates the test suite to ensure these new options are covered and work as expected.

**Expanded protocol support:**

* Added support for additional SNMPv3 authentication protocols: `SHA224`, `SHA256`, `SHA384`, and `SHA512` in the `getAuthProtocol` function (`snmp-discovery/snmp/snmp.go`).
* Added support for additional SNMPv3 privacy protocols: `AES192`, `AES256`, `AES192C`, and `AES256C` in the `getPrivProtocol` function (`snmp-discovery/snmp/snmp.go`).

**Test coverage improvements:**

* Added new test cases to `TestNewClient` to verify SNMPv3 client creation with the newly supported authentication protocols (`SHA224`, `SHA256`, `SHA384`, `SHA512`) using `AES` privacy protocol (`snmp-discovery/snmp/snmp_test.go`).
* Added new test cases to `TestNewClient` to verify SNMPv3 client creation with the newly supported privacy protocols (`AES192`, `AES256`, `AES192C`, `AES256C`) using `MD5` authentication protocol (`snmp-discovery/snmp/snmp_test.go`).