### PR TITLE
chore: gracefully exit on REST server shutdown

### DIFF
--- a/network-discovery/cmd/main.go
+++ b/network-discovery/cmd/main.go
@@ -123,6 +123,10 @@ func main() {
 			case <-sigs:
 				logger.Warn("stop signal received, stopping network-discovery")
 				server.Stop()
+				// Shutdown metrics
+				if err := metrics.Shutdown(ctx); err != nil {
+					logger.Error("failed to shutdown metrics", "error", err)
+				}
 				cancelFunc()
 			case <-rootCtx.Done():
 				logger.Warn("main context cancelled")
@@ -137,6 +141,10 @@ func main() {
 	go func() {
 		if err, ok := <-serverErrCh; ok && err != nil {
 			logger.Error("network-discovery server encountered an error", "error", err)
+			server.Stop()
+			if shutdownErr := metrics.Shutdown(ctx); shutdownErr != nil {
+				logger.Error("failed to shutdown metrics", "error", shutdownErr)
+			}
 			cancelFunc()
 		}
 	}()

--- a/network-discovery/cmd/main.go
+++ b/network-discovery/cmd/main.go
@@ -132,7 +132,14 @@ func main() {
 		}
 	}()
 
-	server.Start()
+	serverErrCh := server.Start()
+
+	go func() {
+		if err, ok := <-serverErrCh; ok && err != nil {
+			logger.Error("network-discovery server encountered an error", "error", err)
+			cancelFunc()
+		}
+	}()
 
 	<-done
 }

--- a/network-discovery/metrics/metrics.go
+++ b/network-discovery/metrics/metrics.go
@@ -176,3 +176,11 @@ func GetActivePolicies() metric.Int64UpDownCounter {
 func ResetMeter() {
 	meter = nil
 }
+
+// Shutdown gracefully shuts down the metrics exporter
+func Shutdown(ctx context.Context) error {
+	if meterProvider != nil {
+		return meterProvider.Shutdown(ctx)
+	}
+	return nil
+}

--- a/network-discovery/server/server.go
+++ b/network-discovery/server/server.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -29,12 +31,13 @@ type Capabilities struct {
 
 // Server represents the network-discovery server
 type Server struct {
-	router  *gin.Engine
-	manager *policy.Manager
-	stat    config.Status
-	logger  *slog.Logger
-	host    string
-	port    int
+	router     *gin.Engine
+	manager    *policy.Manager
+	stat       config.Status
+	logger     *slog.Logger
+	host       string
+	port       int
+	httpServer *http.Server
 }
 
 func init() {
@@ -53,6 +56,10 @@ func NewServer(host string, port int, logger *slog.Logger, manager *policy.Manag
 		logger: logger,
 		host:   host,
 		port:   port,
+	}
+	server.httpServer = &http.Server{
+		Addr:    fmt.Sprintf("%s:%d", host, port),
+		Handler: server.router,
 	}
 	// Custom middleware to count API calls and measure latency
 	server.router.Use(func(c *gin.Context) {
@@ -102,14 +109,20 @@ func (s *Server) Router() *gin.Engine {
 }
 
 // Start starts the network-discovery server
-func (s *Server) Start() {
+func (s *Server) Start() <-chan error {
+	errCh := make(chan error, 1)
 	go func() {
-		serv := fmt.Sprintf("%s:%d", s.host, s.port)
-		s.logger.Info("starting network-discovery server at: " + serv)
-		if err := s.router.Run(serv); err != nil {
-			s.logger.Error("shutting down the server", "error", err)
+		s.logger.Info("starting network-discovery server", "address", s.httpServer.Addr)
+		if err := s.httpServer.ListenAndServe(); err != nil {
+			if errors.Is(err, http.ErrServerClosed) {
+				close(errCh)
+				return
+			}
+			errCh <- err
 		}
+		close(errCh)
 	}()
+	return errCh
 }
 
 func (s *Server) getStatus(c *gin.Context) {
@@ -182,6 +195,13 @@ func (s *Server) deletePolicy(c *gin.Context) {
 
 // Stop stops the network-discovery server
 func (s *Server) Stop() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := s.httpServer.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		s.logger.Error("shutting down HTTP server", "error", err)
+	}
+
 	if err := s.manager.Stop(); err != nil {
 		s.logger.Error("stopping policy manager", "error", err)
 	}

--- a/network-discovery/server/server_test.go
+++ b/network-discovery/server/server_test.go
@@ -48,7 +48,11 @@ func TestServerConfigureAndStart(t *testing.T) {
 	assert.NoError(t, err, "metrics.SetupMetricsExport should not return an error")
 
 	srv := server.NewServer("localhost", 8080, logger, policyManager, "1.0.0")
-	srv.Start()
+	serverErrCh := srv.Start()
+	t.Cleanup(func() {
+		srv.Stop()
+		<-serverErrCh
+	})
 
 	// Check /status endpoint
 	w := httptest.NewRecorder()
@@ -61,8 +65,6 @@ func TestServerConfigureAndStart(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"version": "1.0.0"`)
 	assert.Contains(t, w.Body.String(), `"start_time":`)
 	assert.Contains(t, w.Body.String(), `"up_time_seconds": 0`)
-
-	srv.Stop()
 }
 
 func TestServerGetCapabilities(t *testing.T) {

--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -132,7 +132,18 @@ func main() {
 		}
 	}()
 
-	server.Start()
+	serverErrCh := server.Start()
+
+	go func() {
+		if err, ok := <-serverErrCh; ok && err != nil {
+			logger.Error("snmp-discovery server encountered an error", "error", err)
+			server.Stop()
+			if shutdownErr := metrics.Shutdown(ctx); shutdownErr != nil {
+				logger.Error("failed to shutdown metrics", "error", shutdownErr)
+			}
+			cancelFunc()
+		}
+	}()
 
 	<-done
 }

--- a/snmp-discovery/server/server.go
+++ b/snmp-discovery/server/server.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -29,12 +31,13 @@ type Capabilities struct {
 
 // Server represents the snmp-discovery server
 type Server struct {
-	router  *gin.Engine
-	manager *policy.Manager
-	stat    config.Status
-	logger  *slog.Logger
-	host    string
-	port    int
+	router     *gin.Engine
+	manager    *policy.Manager
+	stat       config.Status
+	logger     *slog.Logger
+	host       string
+	port       int
+	httpServer *http.Server
 }
 
 func init() {
@@ -89,6 +92,10 @@ func NewServer(host string, port int, logger *slog.Logger, manager *policy.Manag
 		host:   host,
 		port:   port,
 	}
+	server.httpServer = &http.Server{
+		Addr:    fmt.Sprintf("%s:%d", host, port),
+		Handler: server.router,
+	}
 
 	// Add metrics middleware
 	server.router.Use(metricsMiddleware())
@@ -110,14 +117,20 @@ func (s *Server) Router() *gin.Engine {
 }
 
 // Start starts the snmp-discovery server
-func (s *Server) Start() {
+func (s *Server) Start() <-chan error {
+	errCh := make(chan error, 1)
 	go func() {
-		serv := fmt.Sprintf("%s:%d", s.host, s.port)
-		s.logger.Info("starting snmp-discovery server at: " + serv)
-		if err := s.router.Run(serv); err != nil {
-			s.logger.Error("shutting down the server", "error", err)
+		s.logger.Info("starting snmp-discovery server", "address", s.httpServer.Addr)
+		if err := s.httpServer.ListenAndServe(); err != nil {
+			if errors.Is(err, http.ErrServerClosed) {
+				close(errCh)
+				return
+			}
+			errCh <- err
 		}
+		close(errCh)
 	}()
+	return errCh
 }
 
 func (s *Server) getStatus(c *gin.Context) {
@@ -193,6 +206,13 @@ func (s *Server) deletePolicy(c *gin.Context) {
 
 // Stop stops the snmp-discovery server
 func (s *Server) Stop() {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := s.httpServer.Shutdown(ctx); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		s.logger.Error("shutting down HTTP server", "error", err)
+	}
+
 	if err := s.manager.Stop(); err != nil {
 		s.logger.Error("stopping policy manager", "error", err)
 	}

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -50,7 +50,11 @@ func TestServerConfigureAndStart(t *testing.T) {
 	require.NoError(t, err)
 
 	srv := server.NewServer("localhost", 8081, logger, policyManager, "1.0.0")
-	srv.Start()
+	serverErrCh := srv.Start()
+	t.Cleanup(func() {
+		srv.Stop()
+		<-serverErrCh
+	})
 
 	// Check /status endpoint
 	w := httptest.NewRecorder()
@@ -63,8 +67,6 @@ func TestServerConfigureAndStart(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"version": "1.0.0"`)
 	assert.Contains(t, w.Body.String(), `"start_time":`)
 	assert.Contains(t, w.Body.String(), `"up_time_seconds": 0`)
-
-	srv.Stop()
 }
 
 func TestServerGetCapabilities(t *testing.T) {


### PR DESCRIPTION
This pull request refactors the server startup and shutdown logic for both the `network-discovery` and `snmp-discovery` services to improve error handling, enable graceful shutdowns, and enhance test reliability. The changes introduce the use of Go's `http.Server` for more robust server lifecycle management, propagate server errors via channels, and update tests to properly clean up server resources.

**Server lifecycle management improvements:**

* Both `network-discovery/server/server.go` and `snmp-discovery/server/server.go` now use an `http.Server` instance for starting and stopping the HTTP server, enabling graceful shutdowns. The `Stop()` method shuts down the server with a timeout context and logs any errors encountered during shutdown. [[1]](diffhunk://#diff-0f3c2a6559253cc8ea5abdcade593519bb2cd51f3a17373fd96cbc78709d66e3R40) [[2]](diffhunk://#diff-0f3c2a6559253cc8ea5abdcade593519bb2cd51f3a17373fd96cbc78709d66e3R60-R63) [[3]](diffhunk://#diff-0f3c2a6559253cc8ea5abdcade593519bb2cd51f3a17373fd96cbc78709d66e3R198-R204) [[4]](diffhunk://#diff-6b3406fdd3e26ab7dd44a8fae75ae1153bdfa88502cabb06e2481cf82ed6f5e3R40) [[5]](diffhunk://#diff-6b3406fdd3e26ab7dd44a8fae75ae1153bdfa88502cabb06e2481cf82ed6f5e3R95-R98) [[6]](diffhunk://#diff-6b3406fdd3e26ab7dd44a8fae75ae1153bdfa88502cabb06e2481cf82ed6f5e3R209-R215)

* The `Start()` method in both servers has been refactored to launch the server in a goroutine and return a channel for error reporting. Errors are propagated through this channel, and the main program listens for server errors to trigger shutdown procedures. [[1]](diffhunk://#diff-0f3c2a6559253cc8ea5abdcade593519bb2cd51f3a17373fd96cbc78709d66e3L105-R125) [[2]](diffhunk://#diff-d72917593858580ada0014ddab78df86e3d1dcecd37ef0e1caf2258ad7ad9fb6L135-R142) [[3]](diffhunk://#diff-6b3406fdd3e26ab7dd44a8fae75ae1153bdfa88502cabb06e2481cf82ed6f5e3L113-R133) [[4]](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L135-R146)

**Test reliability enhancements:**

* The server tests in both `network-discovery/server/server_test.go` and `snmp-discovery/server/server_test.go` have been updated to use the new error channel from `Start()`, and now properly clean up server resources using `t.Cleanup` to ensure graceful shutdown after each test. [[1]](diffhunk://#diff-05d87c2bf7cc60ec2d4528a650c0fa46d72602807c60d0bcb04b99b1bbd77583L51-R55) [[2]](diffhunk://#diff-05d87c2bf7cc60ec2d4528a650c0fa46d72602807c60d0bcb04b99b1bbd77583L64-L65) [[3]](diffhunk://#diff-dd2e681eb687c29c248a79d49e7ff2634765985bdba868594effaf8b485bf614L53-R57) [[4]](diffhunk://#diff-dd2e681eb687c29c248a79d49e7ff2634765985bdba868594effaf8b485bf614L66-L67)

**Error handling improvements:**

* Application entrypoints (`main.go`) now listen for errors on the server error channel and trigger shutdown procedures, including stopping the server and shutting down metrics where appropriate, ensuring the application exits cleanly on server failure. [[1]](diffhunk://#diff-d72917593858580ada0014ddab78df86e3d1dcecd37ef0e1caf2258ad7ad9fb6L135-R142) [[2]](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L135-R146)