### PR TITLE
chore: don't post comments ir PR is from outside nbl

### DIFF
--- a/.github/workflows/device-discovery-lint-tests.yaml
+++ b/.github/workflows/device-discovery-lint-tests.yaml
@@ -51,6 +51,7 @@ jobs:
 
     - name: Pytest coverage comment
       uses: MishaKav/pytest-coverage-comment@81882822c5b22af01f91bd3eacb1cefb6ad73dc2 #v1.1.53
+      if: github.event.pull_request.head.repo.full_name == github.repository
       with:
         pytest-coverage-path: ${{ env.BE_DIR }}/pytest-coverage.txt
         junitxml-path: ${{ env.BE_DIR }}/pytest.xml

--- a/.github/workflows/network-discovery-tests.yaml
+++ b/.github/workflows/network-discovery-tests.yaml
@@ -61,6 +61,7 @@ jobs:
           body-includes: Go test coverage
       - name: Post comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4.0.0
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           comment-id: ${{ steps.existing-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/snmp-discovery-tests.yaml
+++ b/.github/workflows/snmp-discovery-tests.yaml
@@ -59,6 +59,7 @@ jobs:
           body-includes: Go test coverage
       - name: Post comment
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 #v4.0.0
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           comment-id: ${{ steps.existing-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This pull request updates several GitHub Actions workflows to add a conditional check before posting comments on pull requests. The main goal is to ensure that comments are only posted when the pull request originates from the same repository, which helps prevent issues with forks.

Workflow improvements:

* Added an `if: github.event.pull_request.head.repo.full_name == github.repository` condition to the "Pytest coverage comment" step in `.github/workflows/device-discovery-lint-tests.yaml` to restrict comment posting to PRs from the same repository.
* Added the same conditional check to the "Post comment" step in `.github/workflows/network-discovery-tests.yaml`.
* Added the same conditional check to the "Post comment" step in `.github/workflows/snmp-discovery-tests.yaml`.