### PR TITLE
fix: mac addresses duplicated due to same interface object being re-ingested

### DIFF
--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -93,7 +93,7 @@ def translate_interface(
     if_name: str,
     interface_info: dict,
     defaults: Defaults,
-    parent: Interface | None = None,
+    parent: str | None = None,
 ) -> Interface:
     """
     Translate interface information from NAPALM format to Diode SDK Interface entity.
@@ -104,7 +104,7 @@ def translate_interface(
         if_name (str): The name of the interface.
         interface_info (dict): Dictionary containing interface information.
         defaults (Defaults): Default configuration.
-        parent (Interface | None): Parent interface, if any.
+        parent (str | None): Parent interface name, if any.
 
     Returns:
     -------
@@ -228,7 +228,7 @@ def translate_interface_ips(
                         Entity(
                             ip_address=IPAddress(
                                 address=ip_address,
-                                assigned_object_interface=interface,
+                                assigned_object_interface=interface.name,
                                 role=ip_role,
                                 tenant=ip_tenant,
                                 vrf=ip_vrf,
@@ -312,11 +312,13 @@ def build_interface_entities(
         separator_score = name.count(".") + name.count(":")
         return (separator_score, name)
 
-    def resolve_parent(name: str) -> Interface | None:
+    def resolve_parent(name: str) -> str | None:
         parent_name = extract_parent_interface_name(name)
-        if not parent_name or parent_name not in defined_interface_names:
+        if parent_name is None:
             return None
-        return interface_entities.get(parent_name)
+        if parent_name in defined_interface_names or parent_name in interface_entities:
+            return parent_name
+        return None
 
     for if_name, interface_info in sorted(
         interfaces.items(), key=lambda item: interface_sort_key(item[0])

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -338,6 +338,42 @@ def test_translate_data_creates_missing_subinterface_with_parent(
     assert ip_entity.address == "10.0.0.1/30"
     assert ip_entity.assigned_object_interface.name == "ethernet-1/1.0"
 
+
+def test_translate_data_creates_ip_only_subinterface_parent_relationship(
+    sample_device_info, sample_defaults
+):
+    """Ensure subinterfaces derived solely from IP data still link to existing parents."""
+    interfaces: dict[str, dict] = {}
+    interfaces_ip = {
+        "Bundle1": {"ipv4": {"198.51.100.1": {"prefix_length": 30}}},
+        "Bundle1.100": {"ipv4": {"198.51.100.5": {"prefix_length": 30}}},
+    }
+    data = {
+        "device": sample_device_info,
+        "interface": interfaces,
+        "interface_ip": interfaces_ip,
+        "driver": "ios",
+    }
+
+    entities = list(translate_data(data))
+
+    bundle_parent = next(
+        entity.interface
+        for entity in entities
+        if entity.WhichOneof("entity") == "interface"
+        and entity.interface.name == "Bundle1"
+    )
+    bundle_subinterface = next(
+        entity.interface
+        for entity in entities
+        if entity.WhichOneof("entity") == "interface"
+        and entity.interface.name == "Bundle1.100"
+    )
+
+    assert bundle_subinterface.parent.name == "Bundle1"
+    assert bundle_subinterface.parent.name == bundle_parent.name
+
+
 def test_translate_data_handles_none_defaults_and_options(
     sample_device_info, sample_interface_info, sample_interfaces_ip
 ):


### PR DESCRIPTION
This pull request refactors how parent interfaces are represented and resolved in the translation logic for device discovery, focusing on simplifying parent-child relationships by storing and passing parent interface names instead of full interface objects. It also introduces a new test to ensure subinterfaces derived only from IP data correctly link to their parent interfaces.

### Refactoring parent interface representation

* Changed the `parent` parameter in `translate_interface` and related docstrings to use `str | None` (interface name) instead of `Interface | None` (full object), streamlining how parent relationships are handled. [[1]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L96-R96) [[2]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L107-R107)
* Updated the assignment of `assigned_object_interface` in IP entity creation to use the interface name rather than the interface object.
* Refactored the `resolve_parent` function to return the parent interface name (`str | None`) instead of the full interface object, and adjusted the logic to check both defined and entity names for parent existence.

### Testing parent-child relationships

* Added a new test, `test_translate_data_creates_ip_only_subinterface_parent_relationship`, which verifies that subinterfaces created solely from IP data correctly reference their parent interface by name.