### PR TITLE
release 🚚 

### DIFF
--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -93,7 +93,7 @@ def translate_interface(
     if_name: str,
     interface_info: dict,
     defaults: Defaults,
-    parent: Interface | None = None,
+    parent: str | None = None,
 ) -> Interface:
     """
     Translate interface information from NAPALM format to Diode SDK Interface entity.
@@ -104,7 +104,7 @@ def translate_interface(
         if_name (str): The name of the interface.
         interface_info (dict): Dictionary containing interface information.
         defaults (Defaults): Default configuration.
-        parent (Interface | None): Parent interface, if any.
+        parent (str | None): Parent interface name, if any.
 
     Returns:
     -------
@@ -228,7 +228,7 @@ def translate_interface_ips(
                         Entity(
                             ip_address=IPAddress(
                                 address=ip_address,
-                                assigned_object_interface=interface,
+                                assigned_object_interface=interface.name,
                                 role=ip_role,
                                 tenant=ip_tenant,
                                 vrf=ip_vrf,
@@ -312,11 +312,13 @@ def build_interface_entities(
         separator_score = name.count(".") + name.count(":")
         return (separator_score, name)
 
-    def resolve_parent(name: str) -> Interface | None:
+    def resolve_parent(name: str) -> str | None:
         parent_name = extract_parent_interface_name(name)
-        if not parent_name or parent_name not in defined_interface_names:
+        if parent_name is None:
             return None
-        return interface_entities.get(parent_name)
+        if parent_name in defined_interface_names or parent_name in interface_entities:
+            return parent_name
+        return None
 
     for if_name, interface_info in sorted(
         interfaces.items(), key=lambda item: interface_sort_key(item[0])

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -338,6 +338,42 @@ def test_translate_data_creates_missing_subinterface_with_parent(
     assert ip_entity.address == "10.0.0.1/30"
     assert ip_entity.assigned_object_interface.name == "ethernet-1/1.0"
 
+
+def test_translate_data_creates_ip_only_subinterface_parent_relationship(
+    sample_device_info, sample_defaults
+):
+    """Ensure subinterfaces derived solely from IP data still link to existing parents."""
+    interfaces: dict[str, dict] = {}
+    interfaces_ip = {
+        "Bundle1": {"ipv4": {"198.51.100.1": {"prefix_length": 30}}},
+        "Bundle1.100": {"ipv4": {"198.51.100.5": {"prefix_length": 30}}},
+    }
+    data = {
+        "device": sample_device_info,
+        "interface": interfaces,
+        "interface_ip": interfaces_ip,
+        "driver": "ios",
+    }
+
+    entities = list(translate_data(data))
+
+    bundle_parent = next(
+        entity.interface
+        for entity in entities
+        if entity.WhichOneof("entity") == "interface"
+        and entity.interface.name == "Bundle1"
+    )
+    bundle_subinterface = next(
+        entity.interface
+        for entity in entities
+        if entity.WhichOneof("entity") == "interface"
+        and entity.interface.name == "Bundle1.100"
+    )
+
+    assert bundle_subinterface.parent.name == "Bundle1"
+    assert bundle_subinterface.parent.name == bundle_parent.name
+
+
 def test_translate_data_handles_none_defaults_and_options(
     sample_device_info, sample_interface_info, sample_interfaces_ip
 ):

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -266,6 +266,13 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				case "name":
 					interfaceEntity.Name = &value.Value
 					fieldFound = true
+				case "description":
+					description := strings.TrimRight(value.Value, " \t\n\r")
+					if len(description) > 200 {
+						description = description[:197] + "..."
+					}
+					interfaceEntity.Description = &description
+					fieldFound = true
 				case "type":
 					defaultType := ""
 					if defaults != nil && defaults.Interface.Type != "" {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -388,6 +388,13 @@ func TestInterfaceMapper_Map(t *testing.T) {
 					Value:  "1",
 					Type:   mapping.Integer,
 				},
+				"1.3.6.1.2.1.31.1.1.1.18.1": {
+					OID:    "1.3.6.1.2.1.31.1.1.1.18.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.31.1.1.1.18",
+					Value:  "uplink interface",
+					Type:   mapping.OctetString,
+				},
 			},
 			mappingEntry: &mapping.Entry{
 				OID:    "1.3.6.1.2.1.2.2.1.1",
@@ -424,6 +431,11 @@ func TestInterfaceMapper_Map(t *testing.T) {
 						Entity: "interface",
 						Field:  "adminStatus",
 					},
+					{
+						OID:    "1.3.6.1.2.1.31.1.1.1.18",
+						Entity: "interface",
+						Field:  "description",
+					},
 				},
 			},
 			defaults: nil,
@@ -433,6 +445,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 				Mtu:               int64Ptr(1500),
 				PrimaryMacAddress: &diode.MACAddress{MacAddress: mapping.StringPtr("00:11:22:33:44:55")},
 				Enabled:           boolPtr(true),
+				Description:       mapping.StringPtr("uplink interface"),
 			},
 			expectError: false,
 		},

--- a/snmp-discovery/policy/mapping.yaml
+++ b/snmp-discovery/policy/mapping.yaml
@@ -23,6 +23,9 @@ entries:
       - oid: ".1.3.6.1.2.1.2.2.1.7"
         entity: "interface"
         field: "adminStatus"
+      - oid: ".1.3.6.1.2.1.31.1.1.1.18"
+        entity: "interface"
+        field: "description"
 
   # IP Address mappings
   - oid: ".1.3.6.1.2.1.4.20.1"


### PR DESCRIPTION
This pull request introduces several improvements and fixes to both the device discovery and SNMP discovery modules. The main focus is on standardizing how parent interfaces are referenced by name instead of by object, ensuring that subinterfaces derived solely from IP data are correctly linked to their parent interfaces, and adding support for mapping and storing interface descriptions from SNMP data.

**Device Discovery Improvements:**

* Standardized parent interface references to use the interface name (`str`) instead of the `Interface` object throughout the `translate.py` module, including function signatures, docstrings, and parent resolution logic. [[1]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L96-R96) [[2]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L107-R107) [[3]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L315-L319)
* Fixed assignment of IP addresses to interfaces by using the interface name rather than the interface object in the `assigned_object_interface` field.
* Added a new test to verify that subinterfaces created only from IP data are properly linked to their parent interfaces by name.

**SNMP Discovery Enhancements:**

* Added support for mapping and storing the `description` field for interfaces, including trimming whitespace and truncating long descriptions to 200 characters.
* Updated SNMP mapping policy and tests to include the new `description` field, ensuring that it is correctly mapped and validated. [[1]](diffhunk://#diff-b7cede7e8e7568c61abe873dd0ab8f4f7fa2a47b9a3c047c8410b1b0fc971b38R26-R28) [[2]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R391-R397) [[3]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R434-R438) [[4]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R448)