### PR TITLE
fix: device discovery no VLAN error handling

### DIFF
--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -264,7 +264,7 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN | None:
     """
     try:
         vid_int = int(vid)
-    except ValueError:
+    except (ValueError, TypeError):
         return None
     tags = list(defaults.tags) if defaults.tags else []
     comments = None

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -386,6 +386,12 @@ def test_translate_vlan(sample_defaults):
     assert vlan is None
 
 
+def test_translate_vlan_with_none_id(sample_defaults):
+    """Ensure translate_vlan returns None for invalid None VLAN IDs."""
+    vlan = translate_vlan(None, "Invalid VLAN", sample_defaults)
+    assert vlan is None
+
+
 def test_translate_vlan_with_defaults(sample_defaults):
     """Ensure VLAN translation includes default values."""
     sample_defaults.vlan = VlanParameters(


### PR DESCRIPTION
This pull request improves the robustness of the `translate_vlan` function by enhancing its error handling, and adds a new test to ensure proper behavior when a `None` VLAN ID is provided.

Error handling improvements:

* Updated `translate_vlan` in `device-discovery/device_discovery/translate.py` to catch both `ValueError` and `TypeError` when converting `vid` to an integer, ensuring the function returns `None` for invalid or missing VLAN IDs.

Test coverage enhancements:

* Added `test_translate_vlan_with_none_id` in `device-discovery/tests/test_translate.py` to verify that `translate_vlan` returns `None` when passed a `None` VLAN ID.