### PR TITLE
fix: napalm drivers may return a list of serial numbers

### DIFF
--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -245,8 +245,9 @@ class PolicyRunner:
             discovery_failure = get_metric("discovery_failure")
             if discovery_failure:
                 discovery_failure.add(1, {"policy": self.name})
-            logger.error(f"Policy {self.name}, Hostname {sanitized_hostname}: {e}")
-
+            logger.error(
+                f"Policy {self.name}, Hostname {sanitized_hostname}: {e}", exc_info=True
+            )
             # Still record discovery duration on failure
             discovery_latency = get_metric("discovery_latency")
             if discovery_latency:

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -71,12 +71,29 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
     if defaults.location:
         location = Location(name=defaults.location, site=defaults.site)
 
+    serial_number = device_info.get("serial_number")
+    if isinstance(serial_number, list | tuple):
+        if not serial_number:
+            serial_number = None
+        else:
+            string_values = [
+                value
+                for value in serial_number
+                if isinstance(value, str | bytes) and value
+            ]
+            if string_values:
+                serial_number = string_values[0]
+            else:
+                serial_number = str(serial_number[0])
+    elif serial_number is not None and not isinstance(serial_number, str | bytes):
+        serial_number = str(serial_number)
+
     device = Device(
         name=device_info.get("hostname"),
         device_type=DeviceType(model=model, manufacturer=manufacturer),
         platform=Platform(name=platform, manufacturer=manufacturer),
         role=defaults.role,
-        serial=device_info.get("serial_number"),
+        serial=serial_number,
         status="active",
         site=defaults.site,
         tags=tags,

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -123,6 +123,16 @@ def test_translate_device_with_overrides(sample_device_info, sample_override_def
     assert device.device_type.manufacturer.name == "Cisco"
 
 
+def test_translate_device_serial_list(sample_device_info, sample_defaults):
+    """Ensure device translation handles list serial numbers."""
+    sample_device_info["serial_number"] = ["123456789", "987654321"]
+    device = translate_device(sample_device_info, sample_defaults)
+    assert device.serial == "123456789"
+    sample_device_info["serial_number"] = []
+    device = translate_device(sample_device_info, sample_defaults)
+    assert device.serial == ""
+
+
 def test_translate_interface(
     sample_device_info, sample_interface_info, sample_defaults
 ):


### PR DESCRIPTION
This pull request improves device serial number handling in the translation logic and enhances error logging for policy execution failures. The main changes focus on making serial number extraction more robust and ensuring better visibility into errors.

**Device translation improvements:**

* Updated the `translate_device` function in `translate.py` to handle cases where the `serial_number` field is a list or tuple. It now selects the first valid string value, or converts non-string values to strings, ensuring consistent device serial assignment.

* Added a new test `test_translate_device_serial_list` in `test_translate.py` to verify correct handling of list serial numbers, including empty lists.

**Error logging enhancement:**

* Improved error logging in the `run` method of `runner.py` by including exception info (`exc_info=True`) in the log output, which will provide stack traces for easier debugging.