### PR TITLE
chore: strip go binaries

### DIFF
--- a/network-discovery/docker/Dockerfile
+++ b/network-discovery/docker/Dockerfile
@@ -13,9 +13,9 @@ ARG TARGETOS TARGETARCH
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/network-discovery ./cmd/main.go
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -trimpath -o /build/network-discovery ./cmd/main.go
 
-FROM alpine:3.20
+FROM alpine:3.22
 
 RUN apk update && apk add --no-cache nmap
 

--- a/snmp-discovery/docker/Dockerfile
+++ b/snmp-discovery/docker/Dockerfile
@@ -8,7 +8,7 @@ COPY .. .
 
 ARG TARGETOS TARGETARCH
 
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/snmp-discovery ./cmd/main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -trimpath -o /build/snmp-discovery ./cmd/main.go
 
 FROM alpine:3.22
 


### PR DESCRIPTION
This pull request updates the Dockerfiles for both the `network-discovery` and `snmp-discovery` services to optimize the build process and update the base image version. The most important changes are grouped below:

Build optimizations:
* Added `-ldflags="-s -w"` and `-trimpath` to the `go build` command in both `network-discovery/docker/Dockerfile` and `snmp-discovery/docker/Dockerfile` to reduce binary size and remove file system paths from the compiled binaries. [[1]](diffhunk://#diff-509ff02d0e569a0a7033887310e5655a0e8cdb0c0ff006d0f5d845df6cf2e1faL16-R18) [[2]](diffhunk://#diff-f843a06d81f89848c1fd359f129a47d9ae7e1a13f300fc6641222e3786767906L11-R11)

Base image updates:
* Upgraded the Alpine Linux base image from version `3.20` to `3.22` in `network-discovery/docker/Dockerfile` and confirmed its usage in `snmp-discovery/docker/Dockerfile` for improved security and compatibility. [[1]](diffhunk://#diff-509ff02d0e569a0a7033887310e5655a0e8cdb0c0ff006d0f5d845df6cf2e1faL16-R18) [[2]](diffhunk://#diff-f843a06d81f89848c1fd359f129a47d9ae7e1a13f300fc6641222e3786767906L11-R11)