### PR TITLE
feat: turn on gosnmp logging in debug mode

### DIFF
--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
@@ -193,7 +194,12 @@ func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 			m.logger.Info("Loaded device lookup extensions", "directory", policy.Config.LookupExtensionsDir)
 		}
 
-		r, err := NewRunner(m.ctx, m.logger, name, policy, m.client, snmp.NewClient, &m.mappingConfig, m.manufacturers, deviceLookup)
+		// Create logger-aware ClientFactory wrapper
+		clientFactory := func(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication, logger *slog.Logger) (snmp.Walker, error) {
+			return snmp.NewClient(host, port, retries, timeout, authentication, logger)
+		}
+
+		r, err := NewRunner(m.ctx, m.logger, name, policy, m.client, clientFactory, &m.mappingConfig, m.manufacturers, deviceLookup)
 		if err != nil {
 			return err
 		}

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -353,7 +353,7 @@ func TestRunnerWalkError(t *testing.T) {
 	mockHost.On("Walk", mock.Anything, mock.Anything).Return(nil, errors.New("walk error"))
 
 	// Create a mock client factory that returns the mock host
-	mockClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+	mockClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 		return mockHost, nil
 	}
 

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -1,6 +1,7 @@
 package snmp
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -51,6 +52,6 @@ func (n *FakeSNMPWalker) Walk(oid string, _ int) (map[string]PDU, error) {
 }
 
 // NewFakeSNMPWalker creates a new FakeSNMPWalker
-func NewFakeSNMPWalker(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (Walker, error) {
+func NewFakeSNMPWalker(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (Walker, error) {
 	return &FakeSNMPWalker{}, nil
 }

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -1,6 +1,7 @@
 package snmp
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -10,6 +11,21 @@ import (
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
 )
+
+// SlogAdapter adapts slog.Logger to implement gosnmp.LoggerInterface
+type SlogAdapter struct {
+	logger *slog.Logger
+}
+
+// Print implements gosnmp.LoggerInterface by logging at Debug level
+func (s *SlogAdapter) Print(v ...interface{}) {
+	s.logger.Debug(fmt.Sprint(v...))
+}
+
+// Printf implements gosnmp.LoggerInterface by logging at Debug level
+func (s *SlogAdapter) Printf(format string, v ...interface{}) {
+	s.logger.Debug(fmt.Sprintf(format, v...))
+}
 
 // Host is a struct that represents an SNMP host
 type Host struct {
@@ -39,7 +55,7 @@ func NewHost(host string, port uint16, retries int, timeout time.Duration, authe
 func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) {
 	s.logger.Info("Scanning", "host", s.address)
 
-	snmpClient, err := s.ClientFactory(s.address, s.port, s.retries, s.timeout, s.authentication)
+	snmpClient, err := s.ClientFactory(s.address, s.port, s.retries, s.timeout, s.authentication, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -167,10 +183,16 @@ const (
 )
 
 // ClientFactory is a function that creates a new SNMPClient
-type ClientFactory func(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication) (Walker, error)
+type ClientFactory func(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication, logger *slog.Logger) (Walker, error)
 
 // NewClient creates a new SNMPClient for the given target host
-func NewClient(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication) (Walker, error) {
+func NewClient(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication, logger *slog.Logger) (Walker, error) {
+	// Check if debug logging is enabled
+	var gosnmpLogger gosnmp.Logger
+	if logger.Enabled(context.Background(), slog.LevelDebug) {
+		gosnmpLogger = gosnmp.NewLogger(&SlogAdapter{logger})
+	}
+
 	switch authentication.ProtocolVersion {
 	case ProtocolVersion1:
 		return &Client{
@@ -181,6 +203,7 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 				Version:   gosnmp.Version1,
 				Timeout:   timeout,
 				Retries:   retries,
+				Logger:    gosnmpLogger,
 			},
 		}, nil
 	case ProtocolVersion2c:
@@ -192,6 +215,7 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 				Version:   gosnmp.Version2c,
 				Timeout:   timeout,
 				Retries:   retries,
+				Logger:    gosnmpLogger,
 			},
 		}, nil
 	case ProtocolVersion3:
@@ -211,6 +235,7 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 				Timeout:       timeout,
 				Retries:       retries,
 				SecurityModel: gosnmp.UserSecurityModel,
+				Logger:        gosnmpLogger,
 				SecurityParameters: &gosnmp.UsmSecurityParameters{
 					UserName:                 authentication.Username,
 					AuthenticationProtocol:   authProtocol,

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -78,8 +78,8 @@ func TestSNMPHost(t *testing.T) {
 
 	t.Run("Successfully walks a host", func(t *testing.T) {
 		// Setup
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
-			fakeWalker, _ := snmp.NewFakeSNMPWalker("192.168.1.1", 161, 3, 1*time.Second, nil)
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, logger *slog.Logger) (snmp.Walker, error) {
+			fakeWalker, _ := snmp.NewFakeSNMPWalker("192.168.1.1", 161, 3, 1*time.Second, nil, logger)
 			return fakeWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -110,7 +110,7 @@ func TestSNMPHost(t *testing.T) {
 			interfaceSpeedOID + ".1": {Value: 1000000, Type: gosnmp.Integer, IdentifierSize: 1},
 		}, nil)
 
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -136,7 +136,7 @@ func TestSNMPHost(t *testing.T) {
 			ipAddressObjectID: {Value: "192.168.1.1", Type: gosnmp.IPAddress, IdentifierSize: 4},
 		}, nil)
 
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -158,7 +158,7 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker := &MockSNMP{}
 		mockWalker.On("Connect").Return(assert.AnError)
 		mockWalker.On("Close").Return(nil)
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -178,7 +178,7 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
 		mockWalker.On("Walk", mock.Anything, mock.Anything).Return(make(map[string]snmp.PDU), assert.AnError)
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -207,7 +207,7 @@ func TestSNMPHost(t *testing.T) {
 			interfaceSpeedOID + ".1": {Value: "invalid", Type: gosnmp.Asn1BER(255), IdentifierSize: 1}, // Invalid type
 		}, nil)
 
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -232,7 +232,7 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
 		mockWalker.On("Walk", mock.Anything, mock.Anything).Return(nil, assert.AnError)
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			return nil, fmt.Errorf("error creating client")
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -434,7 +434,8 @@ func TestNewClient(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client, err := snmp.NewClient("192.168.1.1", 161, 3, 1*time.Second, tc.auth)
+			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			client, err := snmp.NewClient("192.168.1.1", 161, 3, 1*time.Second, tc.auth, logger)
 
 			if tc.expectError {
 				assert.Error(t, err)


### PR DESCRIPTION
This pull request refactors the SNMP client factory and related code to allow passing a logger for improved logging and debugging. It introduces a new `SlogAdapter` to integrate structured logging with the underlying SNMP library, and updates all usages and tests to support the new logger-aware client factory signature.

### Logging integration and client factory refactor

* Refactored the `ClientFactory` type and all usages to accept a `*slog.Logger` parameter, enabling logger-aware SNMP client creation throughout the codebase. (`snmp-discovery/snmp/snmp.go`, `snmp-discovery/policy/manager.go`, `snmp-discovery/snmp/mocks.go`, `snmp-discovery/snmp/snmp_test.go`) [[1]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L170-R195) [[2]](diffhunk://#diff-97d32253107e3c811caf8c6de6078b90fc18fbfecca66691424c657d8b77651cL196-R202) [[3]](diffhunk://#diff-ca04d639e95ac1098548f63ed2dcc476d1fd18379c7a3d4bccadeae762362138L54-R55) [[4]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L81-R82) [[5]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L113-R113) [[6]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L139-R139) [[7]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L161-R161) [[8]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L181-R181) [[9]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L210-R210) [[10]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L235-R235) [[11]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL356-R356) [[12]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L437-R438)
* Added the `SlogAdapter` type to bridge `slog.Logger` with the `gosnmp.LoggerInterface`, ensuring SNMP debug output is captured in structured logs when debug is enabled. (`snmp-discovery/snmp/snmp.go`)
* Updated the `NewClient` function to attach a `gosnmp.Logger` when debug logging is enabled, and propagate the logger to SNMP client instances for all supported protocol versions. (`snmp-discovery/snmp/snmp.go`) [[1]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L42-R58) [[2]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R206) [[3]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R218) [[4]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R238)

### Test and mock updates

* Updated all SNMP client factory mocks and test cases to use the new logger-aware signature, ensuring tests remain compatible with the refactored interface. (`snmp-discovery/snmp/snmp_test.go`, `snmp-discovery/snmp/mocks.go`, `snmp-discovery/policy/runner_test.go`) [[1]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L81-R82) [[2]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L113-R113) [[3]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L139-R139) [[4]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L161-R161) [[5]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L181-R181) [[6]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L210-R210) [[7]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L235-R235) [[8]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL356-R356) [[9]](diffhunk://#diff-ca04d639e95ac1098548f63ed2dcc476d1fd18379c7a3d4bccadeae762362138L54-R55)

### Minor improvements

* Added missing imports (`time`, `log/slog`, `context`) to support new functionality. (`snmp-discovery/policy/manager.go`, `snmp-discovery/snmp/mocks.go`, `snmp-discovery/snmp/snmp.go`) [[1]](diffhunk://#diff-97d32253107e3c811caf8c6de6078b90fc18fbfecca66691424c657d8b77651cR9) [[2]](diffhunk://#diff-ca04d639e95ac1098548f63ed2dcc476d1fd18379c7a3d4bccadeae762362138R4) [[3]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R4)

This refactor improves observability and debugging for SNMP operations, making it easier to trace issues and monitor SNMP interactions in production environments.


### Example output
```
{"time":"2025-11-19T15:05:57.005187711Z","level":"DEBUG","msg":"getResponseLength: 36","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.005189606Z","level":"DEBUG","msg":"parseRawField: request id","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.00522451Z","level":"DEBUG","msg":"requestID: 1610386809","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.005227198Z","level":"DEBUG","msg":"parseRawField: error-status","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.005229406Z","level":"DEBUG","msg":"errorStatus: 0","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.005230908Z","level":"DEBUG","msg":"parseRawField: error index","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.00523241Z","level":"DEBUG","msg":"error-index: 0","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.005235546Z","level":"DEBUG","msg":"vblLength: 22","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.005239569Z","level":"DEBUG","msg":"parseRawField: OID","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.005242016Z","level":"DEBUG","msg":"OID: .1.3.6.1.2.1.2.2.1.5.1","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.005244157Z","level":"DEBUG","msg":"decodeValue: type is Gauge32","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.005246679Z","level":"DEBUG","msg":"decodeValue: value is 0x989680","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.005248993Z","level":"DEBUG","msg":"Walk completed with NoError","backend":"snmp_discovery"}
{"time":"2025-11-19T15:05:57.005251966Z","level":"DEBUG","msg":"SEND INIT","backend":"snmp_discovery"}
```