### PR TITLE
Release :rocket: 

### DIFF
--- a/network-discovery/docker/Dockerfile
+++ b/network-discovery/docker/Dockerfile
@@ -13,9 +13,9 @@ ARG TARGETOS TARGETARCH
 RUN --mount=target=. \
     --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
-    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/network-discovery ./cmd/main.go
+    CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -trimpath -o /build/network-discovery ./cmd/main.go
 
-FROM alpine:3.20
+FROM alpine:3.22
 
 RUN apk update && apk add --no-cache nmap
 

--- a/snmp-discovery/docker/Dockerfile
+++ b/snmp-discovery/docker/Dockerfile
@@ -8,7 +8,7 @@ COPY .. .
 
 ARG TARGETOS TARGETARCH
 
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o /build/snmp-discovery ./cmd/main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -trimpath -o /build/snmp-discovery ./cmd/main.go
 
 FROM alpine:3.22
 

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
@@ -193,7 +194,12 @@ func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 			m.logger.Info("Loaded device lookup extensions", "directory", policy.Config.LookupExtensionsDir)
 		}
 
-		r, err := NewRunner(m.ctx, m.logger, name, policy, m.client, snmp.NewClient, &m.mappingConfig, m.manufacturers, deviceLookup)
+		// Create logger-aware ClientFactory wrapper
+		clientFactory := func(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication, logger *slog.Logger) (snmp.Walker, error) {
+			return snmp.NewClient(host, port, retries, timeout, authentication, logger)
+		}
+
+		r, err := NewRunner(m.ctx, m.logger, name, policy, m.client, clientFactory, &m.mappingConfig, m.manufacturers, deviceLookup)
 		if err != nil {
 			return err
 		}

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -353,7 +353,7 @@ func TestRunnerWalkError(t *testing.T) {
 	mockHost.On("Walk", mock.Anything, mock.Anything).Return(nil, errors.New("walk error"))
 
 	// Create a mock client factory that returns the mock host
-	mockClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+	mockClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 		return mockHost, nil
 	}
 

--- a/snmp-discovery/snmp/mocks.go
+++ b/snmp-discovery/snmp/mocks.go
@@ -1,6 +1,7 @@
 package snmp
 
 import (
+	"log/slog"
 	"time"
 
 	"github.com/gosnmp/gosnmp"
@@ -51,6 +52,6 @@ func (n *FakeSNMPWalker) Walk(oid string, _ int) (map[string]PDU, error) {
 }
 
 // NewFakeSNMPWalker creates a new FakeSNMPWalker
-func NewFakeSNMPWalker(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (Walker, error) {
+func NewFakeSNMPWalker(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (Walker, error) {
 	return &FakeSNMPWalker{}, nil
 }

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -1,6 +1,7 @@
 package snmp
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"reflect"
@@ -10,6 +11,21 @@ import (
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
 )
+
+// SlogAdapter adapts slog.Logger to implement gosnmp.LoggerInterface
+type SlogAdapter struct {
+	logger *slog.Logger
+}
+
+// Print implements gosnmp.LoggerInterface by logging at Debug level
+func (s *SlogAdapter) Print(v ...interface{}) {
+	s.logger.Debug(fmt.Sprint(v...))
+}
+
+// Printf implements gosnmp.LoggerInterface by logging at Debug level
+func (s *SlogAdapter) Printf(format string, v ...interface{}) {
+	s.logger.Debug(fmt.Sprintf(format, v...))
+}
 
 // Host is a struct that represents an SNMP host
 type Host struct {
@@ -39,7 +55,7 @@ func NewHost(host string, port uint16, retries int, timeout time.Duration, authe
 func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) {
 	s.logger.Info("Scanning", "host", s.address)
 
-	snmpClient, err := s.ClientFactory(s.address, s.port, s.retries, s.timeout, s.authentication)
+	snmpClient, err := s.ClientFactory(s.address, s.port, s.retries, s.timeout, s.authentication, s.logger)
 	if err != nil {
 		return nil, err
 	}
@@ -167,10 +183,16 @@ const (
 )
 
 // ClientFactory is a function that creates a new SNMPClient
-type ClientFactory func(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication) (Walker, error)
+type ClientFactory func(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication, logger *slog.Logger) (Walker, error)
 
 // NewClient creates a new SNMPClient for the given target host
-func NewClient(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication) (Walker, error) {
+func NewClient(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication, logger *slog.Logger) (Walker, error) {
+	// Check if debug logging is enabled
+	var gosnmpLogger gosnmp.Logger
+	if logger.Enabled(context.Background(), slog.LevelDebug) {
+		gosnmpLogger = gosnmp.NewLogger(&SlogAdapter{logger})
+	}
+
 	switch authentication.ProtocolVersion {
 	case ProtocolVersion1:
 		return &Client{
@@ -181,6 +203,7 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 				Version:   gosnmp.Version1,
 				Timeout:   timeout,
 				Retries:   retries,
+				Logger:    gosnmpLogger,
 			},
 		}, nil
 	case ProtocolVersion2c:
@@ -192,6 +215,7 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 				Version:   gosnmp.Version2c,
 				Timeout:   timeout,
 				Retries:   retries,
+				Logger:    gosnmpLogger,
 			},
 		}, nil
 	case ProtocolVersion3:
@@ -211,6 +235,7 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 				Timeout:       timeout,
 				Retries:       retries,
 				SecurityModel: gosnmp.UserSecurityModel,
+				Logger:        gosnmpLogger,
 				SecurityParameters: &gosnmp.UsmSecurityParameters{
 					UserName:                 authentication.Username,
 					AuthenticationProtocol:   authProtocol,

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -78,8 +78,8 @@ func TestSNMPHost(t *testing.T) {
 
 	t.Run("Successfully walks a host", func(t *testing.T) {
 		// Setup
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
-			fakeWalker, _ := snmp.NewFakeSNMPWalker("192.168.1.1", 161, 3, 1*time.Second, nil)
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, logger *slog.Logger) (snmp.Walker, error) {
+			fakeWalker, _ := snmp.NewFakeSNMPWalker("192.168.1.1", 161, 3, 1*time.Second, nil, logger)
 			return fakeWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -110,7 +110,7 @@ func TestSNMPHost(t *testing.T) {
 			interfaceSpeedOID + ".1": {Value: 1000000, Type: gosnmp.Integer, IdentifierSize: 1},
 		}, nil)
 
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -136,7 +136,7 @@ func TestSNMPHost(t *testing.T) {
 			ipAddressObjectID: {Value: "192.168.1.1", Type: gosnmp.IPAddress, IdentifierSize: 4},
 		}, nil)
 
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -158,7 +158,7 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker := &MockSNMP{}
 		mockWalker.On("Connect").Return(assert.AnError)
 		mockWalker.On("Close").Return(nil)
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -178,7 +178,7 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
 		mockWalker.On("Walk", mock.Anything, mock.Anything).Return(make(map[string]snmp.PDU), assert.AnError)
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -207,7 +207,7 @@ func TestSNMPHost(t *testing.T) {
 			interfaceSpeedOID + ".1": {Value: "invalid", Type: gosnmp.Asn1BER(255), IdentifierSize: 1}, // Invalid type
 		}, nil)
 
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			return mockWalker, nil
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -232,7 +232,7 @@ func TestSNMPHost(t *testing.T) {
 		mockWalker.On("Connect").Return(nil)
 		mockWalker.On("Close").Return(nil)
 		mockWalker.On("Walk", mock.Anything, mock.Anything).Return(nil, assert.AnError)
-		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication) (snmp.Walker, error) {
+		snmpClientFactory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			return nil, fmt.Errorf("error creating client")
 		}
 		host := snmp.NewHost("192.168.1.1", 161, 3, 1*time.Second, nil, logger, snmpClientFactory)
@@ -434,7 +434,8 @@ func TestNewClient(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client, err := snmp.NewClient("192.168.1.1", 161, 3, 1*time.Second, tc.auth)
+			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			client, err := snmp.NewClient("192.168.1.1", 161, 3, 1*time.Second, tc.auth, logger)
 
 			if tc.expectError {
 				assert.Error(t, err)


### PR DESCRIPTION
This pull request refactors the SNMP client factory interface to include logger support, enabling enhanced debug logging through the `slog` logger. It also updates Dockerfiles for both network and SNMP discovery services to optimize builds and ensure compatibility with newer Alpine versions. The changes improve testability and observability in SNMP operations, and update related test and mock code to match the new interface.

**Logging and SNMP Client Improvements:**

* Refactored the `ClientFactory` type and related functions (`NewClient`, `NewFakeSNMPWalker`) to accept a `*slog.Logger`, enabling SNMP clients to use structured logging and support debug-level logs via a new `SlogAdapter`. This improves observability and troubleshooting for SNMP operations. [[1]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R15-R29) [[2]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L170-R195) [[3]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R206) [[4]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R218) [[5]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R238) [[6]](diffhunk://#diff-ca04d639e95ac1098548f63ed2dcc476d1fd18379c7a3d4bccadeae762362138L54-R55)
* Updated the SNMP host logic and policy manager to pass the logger to the client factory, ensuring all SNMP client instances are logger-aware. [[1]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560L42-R58) [[2]](diffhunk://#diff-97d32253107e3c811caf8c6de6078b90fc18fbfecca66691424c657d8b77651cL196-R202)

**Testing and Mocks:**

* Modified all SNMP client factory usages in unit tests and mocks to include the logger parameter, maintaining test compatibility with the new interface. [[1]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L81-R82) [[2]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L113-R113) [[3]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L139-R139) [[4]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L161-R161) [[5]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L181-R181) [[6]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L210-R210) [[7]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L235-R235) [[8]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL356-R356) [[9]](diffhunk://#diff-ca04d639e95ac1098548f63ed2dcc476d1fd18379c7a3d4bccadeae762362138L54-R55) [[10]](diffhunk://#diff-9ac64d82cf6c7273acea713a0af83ccbc61cb26224e90cb322ef5a179a5b4a58L437-R438)

**Dependency and Build Optimizations:**

* Updated Dockerfiles for both `network-discovery` and `snmp-discovery` to use Alpine 3.22 and added Go build flags (`-ldflags="-s -w" -trimpath`) for smaller, more secure binaries. [[1]](diffhunk://#diff-509ff02d0e569a0a7033887310e5655a0e8cdb0c0ff006d0f5d845df6cf2e1faL16-R18) [[2]](diffhunk://#diff-f843a06d81f89848c1fd359f129a47d9ae7e1a13f300fc6641222e3786767906L11-R11)

**General Codebase Maintenance:**

* Added missing imports (`time`, `context`, `log/slog`) to files affected by the refactor. [[1]](diffhunk://#diff-97d32253107e3c811caf8c6de6078b90fc18fbfecca66691424c657d8b77651cR9) [[2]](diffhunk://#diff-3ea54790a6b3a532d0177c9b1d79dc60b32462b6e96cd5d51e0adb7d96479560R4) [[3]](diffhunk://#diff-ca04d639e95ac1098548f63ed2dcc476d1fd18379c7a3d4bccadeae762362138R4)

This refactor improves logging, debugging, and maintainability for SNMP discovery operations, while keeping the codebase and tests consistent with the new client factory interface.