### PR TITLE
feat: allow skip host (-Pn) in network discovery

### DIFF
--- a/network-discovery/config/config.go
+++ b/network-discovery/config/config.go
@@ -38,22 +38,22 @@ type Status struct {
 
 // Scope represents the scope of a policy
 type Scope struct {
-	Targets           []string `yaml:"targets"`
-	Ports             []string `yaml:"ports,omitempty"`
-	ExcludePorts      []string `yaml:"exclude_ports,omitempty"`
-	Timing            *int     `yaml:"timing,omitempty"`
-	FastMode          *bool    `yaml:"fast_mode,omitempty"`
-	PingScan          *bool    `yaml:"ping_scan,omitempty"`
-	TopPorts          *int     `yaml:"top_ports,omitempty"`
-	ScanTypes         []string `yaml:"scan_types,omitempty"`
-	MaxRetries        *int     `yaml:"max_retries,omitempty"`
-	DNSServers        []string `yaml:"dns_servers,omitempty"`
-	OSDetection       *bool    `yaml:"os_detection,omitempty"`
-	UseTargetMasks    *bool    `yaml:"use_target_masks,omitempty"`
-	ICMPEcho          *bool    `yaml:"icmp_echo,omitempty"`
-	ICMPTimestamp     *bool    `yaml:"icmp_timestamp,omitempty"`
-	ICMPNetMask       *bool    `yaml:"icmp_netmask,omitempty"`
-	SkipHostDiscovery *bool    `yaml:"skip_host_discovery,omitempty"`
+	Targets        []string `yaml:"targets"`
+	Ports          []string `yaml:"ports,omitempty"`
+	ExcludePorts   []string `yaml:"exclude_ports,omitempty"`
+	Timing         *int     `yaml:"timing,omitempty"`
+	FastMode       *bool    `yaml:"fast_mode,omitempty"`
+	PingScan       *bool    `yaml:"ping_scan,omitempty"`
+	TopPorts       *int     `yaml:"top_ports,omitempty"`
+	ScanTypes      []string `yaml:"scan_types,omitempty"`
+	MaxRetries     *int     `yaml:"max_retries,omitempty"`
+	DNSServers     []string `yaml:"dns_servers,omitempty"`
+	OSDetection    *bool    `yaml:"os_detection,omitempty"`
+	UseTargetMasks *bool    `yaml:"use_target_masks,omitempty"`
+	ICMPEcho       *bool    `yaml:"icmp_echo,omitempty"`
+	ICMPTimestamp  *bool    `yaml:"icmp_timestamp,omitempty"`
+	ICMPNetMask    *bool    `yaml:"icmp_netmask,omitempty"`
+	SkipHost       *bool    `yaml:"skip_host,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy

--- a/network-discovery/config/config.go
+++ b/network-discovery/config/config.go
@@ -38,21 +38,22 @@ type Status struct {
 
 // Scope represents the scope of a policy
 type Scope struct {
-	Targets        []string `yaml:"targets"`
-	Ports          []string `yaml:"ports,omitempty"`
-	ExcludePorts   []string `yaml:"exclude_ports,omitempty"`
-	Timing         *int     `yaml:"timing,omitempty"`
-	FastMode       *bool    `yaml:"fast_mode,omitempty"`
-	PingScan       *bool    `yaml:"ping_scan,omitempty"`
-	TopPorts       *int     `yaml:"top_ports,omitempty"`
-	ScanTypes      []string `yaml:"scan_types,omitempty"`
-	MaxRetries     *int     `yaml:"max_retries,omitempty"`
-	DNSServers     []string `yaml:"dns_servers,omitempty"`
-	OSDetection    *bool    `yaml:"os_detection,omitempty"`
-	UseTargetMasks *bool    `yaml:"use_target_masks,omitempty"`
-	ICMPEcho       *bool    `yaml:"icmp_echo,omitempty"`
-	ICMPTimestamp  *bool    `yaml:"icmp_timestamp,omitempty"`
-	ICMPNetMask    *bool    `yaml:"icmp_netmask,omitempty"`
+	Targets           []string `yaml:"targets"`
+	Ports             []string `yaml:"ports,omitempty"`
+	ExcludePorts      []string `yaml:"exclude_ports,omitempty"`
+	Timing            *int     `yaml:"timing,omitempty"`
+	FastMode          *bool    `yaml:"fast_mode,omitempty"`
+	PingScan          *bool    `yaml:"ping_scan,omitempty"`
+	TopPorts          *int     `yaml:"top_ports,omitempty"`
+	ScanTypes         []string `yaml:"scan_types,omitempty"`
+	MaxRetries        *int     `yaml:"max_retries,omitempty"`
+	DNSServers        []string `yaml:"dns_servers,omitempty"`
+	OSDetection       *bool    `yaml:"os_detection,omitempty"`
+	UseTargetMasks    *bool    `yaml:"use_target_masks,omitempty"`
+	ICMPEcho          *bool    `yaml:"icmp_echo,omitempty"`
+	ICMPTimestamp     *bool    `yaml:"icmp_timestamp,omitempty"`
+	ICMPNetMask       *bool    `yaml:"icmp_netmask,omitempty"`
+	SkipHostDiscovery *bool    `yaml:"skip_host_discovery,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -192,7 +192,7 @@ func (r *Runner) run() {
 		options = append(options, nmap.WithICMPNetMaskDiscovery())
 	}
 
-	if r.scope.SkipHostDiscovery != nil && *r.scope.SkipHostDiscovery {
+	if r.scope.SkipHost != nil && *r.scope.SkipHost {
 		options = append(options, nmap.WithSkipHostDiscovery())
 	}
 

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -192,6 +192,10 @@ func (r *Runner) run() {
 		options = append(options, nmap.WithICMPNetMaskDiscovery())
 	}
 
+	if r.scope.SkipHostDiscovery != nil && *r.scope.SkipHostDiscovery {
+		options = append(options, nmap.WithSkipHostDiscovery())
+	}
+
 	hasOtherScans := false
 	selectedTCPScan := ""
 	if len(r.scope.ScanTypes) > 0 {

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -201,10 +201,11 @@ func TestRunnerWithOptions(t *testing.T) {
 			policy: config.Policy{
 				Config: config.PolicyConfig{},
 				Scope: config.Scope{
-					Targets:       []string{"localhost"},
-					ICMPEcho:      boolPtr(true),
-					ICMPTimestamp: boolPtr(true),
-					ICMPNetMask:   boolPtr(true),
+					Targets:           []string{"localhost"},
+					ICMPEcho:          boolPtr(true),
+					ICMPTimestamp:     boolPtr(true),
+					ICMPNetMask:       boolPtr(true),
+					SkipHostDiscovery: boolPtr(true),
 				},
 			},
 		},

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -201,11 +201,11 @@ func TestRunnerWithOptions(t *testing.T) {
 			policy: config.Policy{
 				Config: config.PolicyConfig{},
 				Scope: config.Scope{
-					Targets:           []string{"localhost"},
-					ICMPEcho:          boolPtr(true),
-					ICMPTimestamp:     boolPtr(true),
-					ICMPNetMask:       boolPtr(true),
-					SkipHostDiscovery: boolPtr(true),
+					Targets:       []string{"localhost"},
+					ICMPEcho:      boolPtr(true),
+					ICMPTimestamp: boolPtr(true),
+					ICMPNetMask:   boolPtr(true),
+					SkipHost:      boolPtr(true),
 				},
 			},
 		},


### PR DESCRIPTION
This pull request adds support for skipping host discovery in the network discovery runner by introducing a new `SkipHost` configuration option. The main changes update the configuration struct, runner logic, and unit tests to handle this new option.

**Configuration changes:**

* Added a new `SkipHost` field to the `Scope` struct in `config.go` to allow users to specify whether host discovery should be skipped.

**Runner logic changes:**

* Updated the `Runner.run()` method in `runner.go` to check the `SkipHost` option and, if enabled, append the `nmap.WithSkipHostDiscovery()` option to the nmap runner.

**Testing updates:**

* Modified the `TestRunnerWithOptions` test in `runner_test.go` to include the new `SkipHost` option in the test configuration, ensuring the feature is covered by unit tests.