### PR TITLE
feat: adds jobs to snmp discovery

### DIFF
--- a/snmp-discovery/policy/job.go
+++ b/snmp-discovery/policy/job.go
@@ -113,4 +113,3 @@ func (js *JobStore) GetAllPoliciesWithJobs() map[string][]*Job {
 	}
 	return result
 }
-

--- a/snmp-discovery/policy/job.go
+++ b/snmp-discovery/policy/job.go
@@ -21,11 +21,12 @@ const (
 
 // Job represents a single job execution
 type Job struct {
-	ID        string    `json:"id"`
-	Status    JobStatus `json:"status"`
-	Reason    string    `json:"reason,omitempty"`
-	CreatedAt time.Time `json:"created_at"`
-	UpdatedAt time.Time `json:"updated_at"`
+	ID          string    `json:"id"`
+	Status      JobStatus `json:"status"`
+	Reason      string    `json:"reason,omitempty"`
+	EntityCount int       `json:"entity_count"`
+	CreatedAt   time.Time `json:"created_at"`
+	UpdatedAt   time.Time `json:"updated_at"`
 }
 
 // JobStore manages jobs in memory
@@ -70,7 +71,7 @@ func (js *JobStore) CreateJob(policyName string) *Job {
 }
 
 // UpdateJob updates the status of a job
-func (js *JobStore) UpdateJob(policyName, jobID string, status JobStatus, err error) {
+func (js *JobStore) UpdateJob(policyName, jobID string, status JobStatus, err error, entityCount int) {
 	js.mu.Lock()
 	defer js.mu.Unlock()
 
@@ -78,6 +79,7 @@ func (js *JobStore) UpdateJob(policyName, jobID string, status JobStatus, err er
 	for _, job := range jobs {
 		if job.ID == jobID {
 			job.Status = status
+			job.EntityCount = entityCount
 			job.UpdatedAt = time.Now()
 			if err != nil {
 				job.Reason = err.Error()

--- a/snmp-discovery/policy/job.go
+++ b/snmp-discovery/policy/job.go
@@ -1,0 +1,116 @@
+package policy
+
+import (
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// JobStatus represents the status of a job
+type JobStatus string
+
+const (
+	// JobStatusRunning indicates the job is currently running
+	JobStatusRunning JobStatus = "running"
+	// JobStatusCompleted indicates the job completed successfully
+	JobStatusCompleted JobStatus = "completed"
+	// JobStatusFailed indicates the job failed with an error
+	JobStatusFailed JobStatus = "failed"
+)
+
+// Job represents a single job execution
+type Job struct {
+	ID        string    `json:"id"`
+	Status    JobStatus `json:"status"`
+	Error     string    `json:"error,omitempty"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// JobStore manages jobs in memory
+type JobStore struct {
+	mu   sync.RWMutex
+	jobs map[string][]*Job // policyName -> jobs (max 5)
+}
+
+const maxJobsPerPolicy = 5
+
+// NewJobStore creates a new JobStore
+func NewJobStore() *JobStore {
+	return &JobStore{
+		jobs: make(map[string][]*Job),
+	}
+}
+
+// CreateJob creates a new job for the given policy and returns it
+func (js *JobStore) CreateJob(policyName string) *Job {
+	js.mu.Lock()
+	defer js.mu.Unlock()
+
+	now := time.Now()
+	job := &Job{
+		ID:        uuid.New().String(),
+		Status:    JobStatusRunning,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	// Add job to the policy's job list
+	jobs := js.jobs[policyName]
+	jobs = append(jobs, job)
+
+	// Keep only the last maxJobsPerPolicy jobs
+	if len(jobs) > maxJobsPerPolicy {
+		jobs = jobs[len(jobs)-maxJobsPerPolicy:]
+	}
+
+	js.jobs[policyName] = jobs
+	return job
+}
+
+// UpdateJob updates the status of a job
+func (js *JobStore) UpdateJob(policyName, jobID string, status JobStatus, err error) {
+	js.mu.Lock()
+	defer js.mu.Unlock()
+
+	jobs := js.jobs[policyName]
+	for _, job := range jobs {
+		if job.ID == jobID {
+			job.Status = status
+			job.UpdatedAt = time.Now()
+			if err != nil {
+				job.Error = err.Error()
+			}
+			return
+		}
+	}
+}
+
+// GetJobsForPolicy returns all jobs for a given policy
+func (js *JobStore) GetJobsForPolicy(policyName string) []*Job {
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+
+	jobs := js.jobs[policyName]
+	// Return a copy to avoid race conditions
+	result := make([]*Job, len(jobs))
+	copy(result, jobs)
+	return result
+}
+
+// GetAllPoliciesWithJobs returns all policies with their jobs
+func (js *JobStore) GetAllPoliciesWithJobs() map[string][]*Job {
+	js.mu.RLock()
+	defer js.mu.RUnlock()
+
+	result := make(map[string][]*Job)
+	for policyName, jobs := range js.jobs {
+		// Return a copy to avoid race conditions
+		jobsCopy := make([]*Job, len(jobs))
+		copy(jobsCopy, jobs)
+		result[policyName] = jobsCopy
+	}
+	return result
+}
+

--- a/snmp-discovery/policy/job.go
+++ b/snmp-discovery/policy/job.go
@@ -23,7 +23,7 @@ const (
 type Job struct {
 	ID        string    `json:"id"`
 	Status    JobStatus `json:"status"`
-	Error     string    `json:"error,omitempty"`
+	Reason    string    `json:"reason,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }
@@ -80,7 +80,7 @@ func (js *JobStore) UpdateJob(policyName, jobID string, status JobStatus, err er
 			job.Status = status
 			job.UpdatedAt = time.Now()
 			if err != nil {
-				job.Error = err.Error()
+				job.Reason = err.Error()
 			}
 			return
 		}

--- a/snmp-discovery/policy/job_test.go
+++ b/snmp-discovery/policy/job_test.go
@@ -21,6 +21,7 @@ func TestJobStore_CreateJob(t *testing.T) {
 	assert.NotEmpty(t, job.ID)
 	assert.Equal(t, policy.JobStatusRunning, job.Status)
 	assert.Empty(t, job.Reason)
+	assert.Equal(t, 0, job.EntityCount)
 	assert.False(t, job.CreatedAt.IsZero())
 	assert.False(t, job.UpdatedAt.IsZero())
 	assert.Equal(t, job.CreatedAt, job.UpdatedAt)
@@ -39,22 +40,26 @@ func TestJobStore_UpdateJob(t *testing.T) {
 	jobID := job.ID
 
 	// Update to completed
-	store.UpdateJob(policyName, jobID, policy.JobStatusCompleted, nil)
+	entityCount := 5
+	store.UpdateJob(policyName, jobID, policy.JobStatusCompleted, nil, entityCount)
 
 	jobs := store.GetJobsForPolicy(policyName)
 	require.Len(t, jobs, 1)
 	assert.Equal(t, policy.JobStatusCompleted, jobs[0].Status)
 	assert.Empty(t, jobs[0].Reason)
+	assert.Equal(t, entityCount, jobs[0].EntityCount)
 	assert.True(t, jobs[0].UpdatedAt.After(jobs[0].CreatedAt))
 
 	// Update to failed with error
 	testError := errors.New("test error")
-	store.UpdateJob(policyName, jobID, policy.JobStatusFailed, testError)
+	entityCount = 10
+	store.UpdateJob(policyName, jobID, policy.JobStatusFailed, testError, entityCount)
 
 	jobs = store.GetJobsForPolicy(policyName)
 	require.Len(t, jobs, 1)
 	assert.Equal(t, policy.JobStatusFailed, jobs[0].Status)
 	assert.Equal(t, testError.Error(), jobs[0].Reason)
+	assert.Equal(t, entityCount, jobs[0].EntityCount)
 }
 
 func TestJobStore_MaxFiveJobs(t *testing.T) {
@@ -110,12 +115,13 @@ func TestJobStore_Concurrency(t *testing.T) {
 	// Test concurrent updates
 	if len(jobs) > 0 {
 		jobID := jobs[0].ID
+		entityCount := 3
 		wg = sync.WaitGroup{}
 		for i := 0; i < numGoroutines; i++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				store.UpdateJob(policyName, jobID, policy.JobStatusCompleted, nil)
+				store.UpdateJob(policyName, jobID, policy.JobStatusCompleted, nil, entityCount)
 			}()
 		}
 		wg.Wait()
@@ -126,6 +132,7 @@ func TestJobStore_Concurrency(t *testing.T) {
 		for _, job := range jobs {
 			if job.ID == jobID {
 				assert.Equal(t, policy.JobStatusCompleted, job.Status)
+				assert.Equal(t, entityCount, job.EntityCount)
 				found = true
 				break
 			}
@@ -163,7 +170,7 @@ func TestJobStore_UpdateJob_NonExistent(t *testing.T) {
 	store := policy.NewJobStore()
 
 	// Update a job that doesn't exist - should not panic
-	store.UpdateJob("non-existent-policy", "non-existent-id", policy.JobStatusFailed, errors.New("test"))
+	store.UpdateJob("non-existent-policy", "non-existent-id", policy.JobStatusFailed, errors.New("test"), 0)
 
 	// Verify no jobs were created
 	jobs := store.GetJobsForPolicy("non-existent-policy")

--- a/snmp-discovery/policy/job_test.go
+++ b/snmp-discovery/policy/job_test.go
@@ -1,0 +1,172 @@
+package policy_test
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/policy"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJobStore_CreateJob(t *testing.T) {
+	store := policy.NewJobStore()
+	policyName := "test-policy"
+
+	job := store.CreateJob(policyName)
+
+	// Verify job properties
+	assert.NotEmpty(t, job.ID)
+	assert.Equal(t, policy.JobStatusRunning, job.Status)
+	assert.Empty(t, job.Error)
+	assert.False(t, job.CreatedAt.IsZero())
+	assert.False(t, job.UpdatedAt.IsZero())
+	assert.Equal(t, job.CreatedAt, job.UpdatedAt)
+
+	// Verify job is stored
+	jobs := store.GetJobsForPolicy(policyName)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, job.ID, jobs[0].ID)
+}
+
+func TestJobStore_UpdateJob(t *testing.T) {
+	store := policy.NewJobStore()
+	policyName := "test-policy"
+
+	job := store.CreateJob(policyName)
+	jobID := job.ID
+
+	// Update to completed
+	store.UpdateJob(policyName, jobID, policy.JobStatusCompleted, nil)
+
+	jobs := store.GetJobsForPolicy(policyName)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, policy.JobStatusCompleted, jobs[0].Status)
+	assert.Empty(t, jobs[0].Error)
+	assert.True(t, jobs[0].UpdatedAt.After(jobs[0].CreatedAt))
+
+	// Update to failed with error
+	testError := errors.New("test error")
+	store.UpdateJob(policyName, jobID, policy.JobStatusFailed, testError)
+
+	jobs = store.GetJobsForPolicy(policyName)
+	require.Len(t, jobs, 1)
+	assert.Equal(t, policy.JobStatusFailed, jobs[0].Status)
+	assert.Equal(t, testError.Error(), jobs[0].Error)
+}
+
+func TestJobStore_MaxFiveJobs(t *testing.T) {
+	store := policy.NewJobStore()
+	policyName := "test-policy"
+
+	// Create 7 jobs
+	var jobIDs []string
+	for i := 0; i < 7; i++ {
+		job := store.CreateJob(policyName)
+		jobIDs = append(jobIDs, job.ID)
+		time.Sleep(10 * time.Millisecond) // Small delay to ensure different timestamps
+	}
+
+	// Verify only last 5 jobs are retained
+	jobs := store.GetJobsForPolicy(policyName)
+	require.Len(t, jobs, 5)
+
+	// Verify the last 5 jobs are the ones retained
+	expectedIDs := jobIDs[2:] // Last 5 jobs
+	actualIDs := make([]string, len(jobs))
+	for i, job := range jobs {
+		actualIDs[i] = job.ID
+	}
+	assert.Equal(t, expectedIDs, actualIDs)
+}
+
+func TestJobStore_Concurrency(t *testing.T) {
+	store := policy.NewJobStore()
+	policyName := "test-policy"
+
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	jobsPerGoroutine := 5
+
+	// Create jobs concurrently
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < jobsPerGoroutine; j++ {
+				store.CreateJob(policyName)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Verify all jobs were created (should have max 5 per policy)
+	jobs := store.GetJobsForPolicy(policyName)
+	assert.LessOrEqual(t, len(jobs), 5)
+
+	// Test concurrent updates
+	if len(jobs) > 0 {
+		jobID := jobs[0].ID
+		wg = sync.WaitGroup{}
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				store.UpdateJob(policyName, jobID, policy.JobStatusCompleted, nil)
+			}()
+		}
+		wg.Wait()
+
+		// Verify job was updated
+		jobs = store.GetJobsForPolicy(policyName)
+		found := false
+		for _, job := range jobs {
+			if job.ID == jobID {
+				assert.Equal(t, policy.JobStatusCompleted, job.Status)
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "Job should be found after concurrent updates")
+	}
+}
+
+func TestJobStore_GetAllPoliciesWithJobs(t *testing.T) {
+	store := policy.NewJobStore()
+
+	// Create jobs for multiple policies
+	policy1 := "policy-1"
+	policy2 := "policy-2"
+
+	store.CreateJob(policy1)
+	store.CreateJob(policy1)
+	store.CreateJob(policy2)
+
+	allJobs := store.GetAllPoliciesWithJobs()
+
+	assert.Len(t, allJobs, 2)
+	assert.Len(t, allJobs[policy1], 2)
+	assert.Len(t, allJobs[policy2], 1)
+}
+
+func TestJobStore_GetJobsForPolicy_Empty(t *testing.T) {
+	store := policy.NewJobStore()
+
+	jobs := store.GetJobsForPolicy("non-existent-policy")
+	assert.Empty(t, jobs)
+}
+
+func TestJobStore_UpdateJob_NonExistent(t *testing.T) {
+	store := policy.NewJobStore()
+
+	// Update a job that doesn't exist - should not panic
+	store.UpdateJob("non-existent-policy", "non-existent-id", policy.JobStatusFailed, errors.New("test"))
+
+	// Verify no jobs were created
+	jobs := store.GetJobsForPolicy("non-existent-policy")
+	assert.Empty(t, jobs)
+}
+

--- a/snmp-discovery/policy/job_test.go
+++ b/snmp-discovery/policy/job_test.go
@@ -20,7 +20,7 @@ func TestJobStore_CreateJob(t *testing.T) {
 	// Verify job properties
 	assert.NotEmpty(t, job.ID)
 	assert.Equal(t, policy.JobStatusRunning, job.Status)
-	assert.Empty(t, job.Error)
+	assert.Empty(t, job.Reason)
 	assert.False(t, job.CreatedAt.IsZero())
 	assert.False(t, job.UpdatedAt.IsZero())
 	assert.Equal(t, job.CreatedAt, job.UpdatedAt)
@@ -44,7 +44,7 @@ func TestJobStore_UpdateJob(t *testing.T) {
 	jobs := store.GetJobsForPolicy(policyName)
 	require.Len(t, jobs, 1)
 	assert.Equal(t, policy.JobStatusCompleted, jobs[0].Status)
-	assert.Empty(t, jobs[0].Error)
+	assert.Empty(t, jobs[0].Reason)
 	assert.True(t, jobs[0].UpdatedAt.After(jobs[0].CreatedAt))
 
 	// Update to failed with error
@@ -54,7 +54,7 @@ func TestJobStore_UpdateJob(t *testing.T) {
 	jobs = store.GetJobsForPolicy(policyName)
 	require.Len(t, jobs, 1)
 	assert.Equal(t, policy.JobStatusFailed, jobs[0].Status)
-	assert.Equal(t, testError.Error(), jobs[0].Error)
+	assert.Equal(t, testError.Error(), jobs[0].Reason)
 }
 
 func TestJobStore_MaxFiveJobs(t *testing.T) {

--- a/snmp-discovery/policy/job_test.go
+++ b/snmp-discovery/policy/job_test.go
@@ -169,4 +169,3 @@ func TestJobStore_UpdateJob_NonExistent(t *testing.T) {
 	jobs := store.GetJobsForPolicy("non-existent-policy")
 	assert.Empty(t, jobs)
 }
-

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -262,19 +262,19 @@ func (m *Manager) resolveAuthenticationEnvVars(policy *config.Policy) error {
 	return nil
 }
 
-// PolicyStatus represents the status of a policy with its jobs
-type PolicyStatus struct {
-	Name   string  `json:"name"`
-	Status string  `json:"status"` // derived from latest job
-	Jobs   []*Job  `json:"jobs"`
+// Status represents the status of a policy with its jobs
+type Status struct {
+	Name   string `json:"name"`
+	Status string `json:"status"` // derived from latest job
+	Jobs   []*Job `json:"jobs"`
 }
 
 // GetPolicyStatuses returns all policies with their status and jobs
-func (m *Manager) GetPolicyStatuses() []PolicyStatus {
+func (m *Manager) GetPolicyStatuses() []Status {
 	allJobs := m.jobStore.GetAllPoliciesWithJobs()
-	
-	var statuses []PolicyStatus
-	
+
+	var statuses []Status
+
 	// Get statuses for all policies that have runners
 	for name := range m.policies {
 		jobs := m.jobStore.GetJobsForPolicy(name)
@@ -283,13 +283,13 @@ func (m *Manager) GetPolicyStatuses() []PolicyStatus {
 			latestJob := jobs[len(jobs)-1]
 			status = string(latestJob.Status)
 		}
-		statuses = append(statuses, PolicyStatus{
+		statuses = append(statuses, Status{
 			Name:   name,
 			Status: status,
 			Jobs:   jobs,
 		})
 	}
-	
+
 	// Also include policies that have jobs but no active runner
 	for name, jobs := range allJobs {
 		if !m.HasPolicy(name) {
@@ -298,13 +298,13 @@ func (m *Manager) GetPolicyStatuses() []PolicyStatus {
 				latestJob := jobs[len(jobs)-1]
 				status = string(latestJob.Status)
 			}
-			statuses = append(statuses, PolicyStatus{
+			statuses = append(statuses, Status{
 				Name:   name,
 				Status: status,
 				Jobs:   jobs,
 			})
 		}
 	}
-	
+
 	return statuses
 }

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -32,6 +32,7 @@ type Manager struct {
 	ctx           context.Context
 	mappingConfig config.Mapping
 	manufacturers data.ManufacturerRetriever
+	jobStore      *JobStore
 }
 
 // NewManager returns a new policy manager
@@ -49,6 +50,7 @@ func NewManager(ctx context.Context, logger *slog.Logger, client diode.Client, m
 		mappingConfig: mappingConfig,
 		policies:      make(map[string]*Runner),
 		manufacturers: manufacturers,
+		jobStore:      NewJobStore(),
 	}, nil
 }
 
@@ -199,7 +201,7 @@ func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 			return snmp.NewClient(host, port, retries, timeout, authentication, logger)
 		}
 
-		r, err := NewRunner(m.ctx, m.logger, name, policy, m.client, clientFactory, &m.mappingConfig, m.manufacturers, deviceLookup)
+		r, err := NewRunner(m.ctx, m.logger, name, policy, m.client, clientFactory, &m.mappingConfig, m.manufacturers, deviceLookup, m.jobStore)
 		if err != nil {
 			return err
 		}
@@ -258,4 +260,51 @@ func (m *Manager) resolveAuthenticationEnvVars(policy *config.Policy) error {
 	}
 
 	return nil
+}
+
+// PolicyStatus represents the status of a policy with its jobs
+type PolicyStatus struct {
+	Name   string  `json:"name"`
+	Status string  `json:"status"` // derived from latest job
+	Jobs   []*Job  `json:"jobs"`
+}
+
+// GetPolicyStatuses returns all policies with their status and jobs
+func (m *Manager) GetPolicyStatuses() []PolicyStatus {
+	allJobs := m.jobStore.GetAllPoliciesWithJobs()
+	
+	var statuses []PolicyStatus
+	
+	// Get statuses for all policies that have runners
+	for name := range m.policies {
+		jobs := m.jobStore.GetJobsForPolicy(name)
+		status := "unknown"
+		if len(jobs) > 0 {
+			latestJob := jobs[len(jobs)-1]
+			status = string(latestJob.Status)
+		}
+		statuses = append(statuses, PolicyStatus{
+			Name:   name,
+			Status: status,
+			Jobs:   jobs,
+		})
+	}
+	
+	// Also include policies that have jobs but no active runner
+	for name, jobs := range allJobs {
+		if !m.HasPolicy(name) {
+			status := "unknown"
+			if len(jobs) > 0 {
+				latestJob := jobs[len(jobs)-1]
+				status = string(latestJob.Status)
+			}
+			statuses = append(statuses, PolicyStatus{
+				Name:   name,
+				Status: status,
+				Jobs:   jobs,
+			})
+		}
+	}
+	
+	return statuses
 }

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -2,6 +2,7 @@ package policy
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -42,10 +43,11 @@ type Runner struct {
 	manufacturers data.ManufacturerRetriever
 	mappingConfig *config.Mapping
 	deviceLookup  data.DeviceRetriever
+	jobStore      *JobStore
 }
 
 // NewRunner returns a new policy runner
-func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, client diode.Client, ClientFactory snmp.ClientFactory, mappingConfig *config.Mapping, manufacturers data.ManufacturerRetriever, deviceLookup data.DeviceRetriever) (*Runner, error) {
+func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy config.Policy, client diode.Client, ClientFactory snmp.ClientFactory, mappingConfig *config.Mapping, manufacturers data.ManufacturerRetriever, deviceLookup data.DeviceRetriever, jobStore *JobStore) (*Runner, error) {
 	s, err := gocron.NewScheduler()
 	if err != nil {
 		return nil, err
@@ -59,6 +61,7 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 		manufacturers: manufacturers,
 		mappingConfig: mappingConfig,
 		deviceLookup:  deviceLookup,
+		jobStore:      jobStore,
 	}
 
 	runner.task = gocron.NewTask(runner.run)
@@ -87,7 +90,12 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 
 // run runs the policy
 func (r *Runner) run() {
+
 	policyName := r.ctx.Value(policyKey).(string)
+
+	// Create job at start
+	job := r.jobStore.CreateJob(policyName)
+
 	// Track policy execution
 	if rMetric := metrics.GetPolicyExecutions(); rMetric != nil {
 		rMetric.Add(r.ctx, 1,
@@ -120,6 +128,8 @@ func (r *Runner) run() {
 
 	if len(entities) == 0 {
 		r.logger.Info("No entities to ingest", slog.Any("policy", r.ctx.Value(policyKey)))
+		// Update job status to completed even if no entities
+		r.jobStore.UpdateJob(policyName, job.ID, JobStatusCompleted, nil)
 		return
 	}
 
@@ -127,13 +137,18 @@ func (r *Runner) run() {
 
 	resp, err := r.client.Ingest(ctx, entities, diode.WithIngestMetadata(diode.Metadata{
 		"policy_name": policyName,
+		"job_id":      job.ID,
 	}))
 	if err != nil {
 		r.logger.Error("error ingesting entities", slog.Any("error", err), slog.Any("policy", r.ctx.Value(policyKey)))
+		r.jobStore.UpdateJob(policyName, job.ID, JobStatusFailed, err)
 	} else if resp != nil && resp.Errors != nil {
+		ingestErr := fmt.Errorf("ingestion errors: %v", resp.Errors)
 		r.logger.Error("error ingesting entities", slog.Any("error", resp.Errors), slog.Any("policy", r.ctx.Value(policyKey)))
+		r.jobStore.UpdateJob(policyName, job.ID, JobStatusFailed, ingestErr)
 	} else {
 		r.logger.Info("entities ingested successfully", slog.Any("policy", r.ctx.Value(policyKey)))
+		r.jobStore.UpdateJob(policyName, job.ID, JobStatusCompleted, nil)
 	}
 }
 

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -128,7 +128,7 @@ func (r *Runner) run() {
 	if len(entities) == 0 {
 		r.logger.Info("No entities to ingest", slog.Any("policy", r.ctx.Value(policyKey)))
 		// Update job status to completed even if no entities
-		r.jobStore.UpdateJob(policyName, job.ID, JobStatusCompleted, nil)
+		r.jobStore.UpdateJob(policyName, job.ID, JobStatusCompleted, nil, 0)
 		return
 	}
 
@@ -140,14 +140,14 @@ func (r *Runner) run() {
 	}))
 	if err != nil {
 		r.logger.Error("error ingesting entities", slog.Any("error", err), slog.Any("policy", r.ctx.Value(policyKey)))
-		r.jobStore.UpdateJob(policyName, job.ID, JobStatusFailed, err)
+		r.jobStore.UpdateJob(policyName, job.ID, JobStatusFailed, err, len(entities))
 	} else if resp != nil && resp.Errors != nil {
 		ingestErr := fmt.Errorf("ingestion errors: %v", resp.Errors)
 		r.logger.Error("error ingesting entities", slog.Any("error", resp.Errors), slog.Any("policy", r.ctx.Value(policyKey)))
-		r.jobStore.UpdateJob(policyName, job.ID, JobStatusFailed, ingestErr)
+		r.jobStore.UpdateJob(policyName, job.ID, JobStatusFailed, ingestErr, len(entities))
 	} else {
 		r.logger.Info("entities ingested successfully", slog.Any("policy", r.ctx.Value(policyKey)))
-		r.jobStore.UpdateJob(policyName, job.ID, JobStatusCompleted, nil)
+		r.jobStore.UpdateJob(policyName, job.ID, JobStatusCompleted, nil, len(entities))
 	}
 }
 

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -90,7 +90,6 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 
 // run runs the policy
 func (r *Runner) run() {
-
 	policyName := r.ctx.Value(policyKey).(string)
 
 	// Create job at start

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -224,11 +224,13 @@ func TestRunnerRun(t *testing.T) {
 			require.Len(t, jobs, 1, "Job should be created")
 			if tt.expectSuccess {
 				assert.Equal(t, policy.JobStatusCompleted, jobs[0].Status, "Job should be completed on success")
+				assert.Equal(t, 1, jobs[0].EntityCount, "Job should have entity count set")
 				assert.NotNil(t, metrics.GetDiscoverySuccess())
 			}
 			if tt.expectFailure {
 				assert.Equal(t, policy.JobStatusFailed, jobs[0].Status, "Job should be failed on error")
 				assert.NotEmpty(t, jobs[0].Reason, "Job should have error message")
+				assert.Equal(t, 1, jobs[0].EntityCount, "Job should have entity count set even on failure")
 				assert.NotNil(t, metrics.GetDiscoveryFailure())
 			}
 			assert.NotNil(t, metrics.GetDiscoveryAttempts())
@@ -337,6 +339,7 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	jobs := jobStore.GetJobsForPolicy("test-policy")
 	require.Len(t, jobs, 1, "Job should be created")
 	assert.Equal(t, policy.JobStatusCompleted, jobs[0].Status, "Job should be completed")
+	assert.Equal(t, 1, jobs[0].EntityCount, "Job should have entity count set")
 }
 
 func TestRunnerWalkError(t *testing.T) {
@@ -404,4 +407,5 @@ func TestRunnerWalkError(t *testing.T) {
 	jobs := jobStore.GetJobsForPolicy("test-policy")
 	require.Len(t, jobs, 1, "Job should be created even when walk fails")
 	assert.Equal(t, policy.JobStatusCompleted, jobs[0].Status, "Job should be completed when no entities to ingest")
+	assert.Equal(t, 0, jobs[0].EntityCount, "Job should have zero entity count when no entities discovered")
 }

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -228,7 +228,7 @@ func TestRunnerRun(t *testing.T) {
 			}
 			if tt.expectFailure {
 				assert.Equal(t, policy.JobStatusFailed, jobs[0].Status, "Job should be failed on error")
-				assert.NotEmpty(t, jobs[0].Error, "Job should have error message")
+				assert.NotEmpty(t, jobs[0].Reason, "Job should have error message")
 				assert.NotNil(t, metrics.GetDiscoveryFailure())
 			}
 			assert.NotNil(t, metrics.GetDiscoveryAttempts())

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -97,9 +97,10 @@ func TestNewRunner(t *testing.T) {
 		},
 	}
 	ctx := context.Background()
+	jobStore := policy.NewJobStore()
 
 	// Create new runner
-	_, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, &mappingConfig, nil, nil)
+	_, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, &mappingConfig, nil, nil, jobStore)
 	assert.NoError(t, err, "policy.NewRunner should not return an error")
 }
 
@@ -173,6 +174,7 @@ func TestRunnerRun(t *testing.T) {
 				},
 			}
 			ctx := context.Background()
+			jobStore := policy.NewJobStore()
 
 			mappingConfig := config.Mapping{
 				Entries: []config.MappingEntry{
@@ -192,7 +194,7 @@ func TestRunnerRun(t *testing.T) {
 			}
 
 			// Create runner
-			runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, &mappingConfig, nil, nil)
+			runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, &mappingConfig, nil, nil, jobStore)
 			assert.NoError(t, err, "policy.NewRunner should not return an error")
 
 			// Use a channel to signal that Ingest was called
@@ -217,11 +219,16 @@ func TestRunnerRun(t *testing.T) {
 			err = runner.Stop()
 			assert.NoError(t, err, "Runner.Stop should not return an error")
 
-			// Verify metrics were recorded
+			// Verify job was created and updated
+			jobs := jobStore.GetJobsForPolicy("test-policy")
+			require.Len(t, jobs, 1, "Job should be created")
 			if tt.expectSuccess {
+				assert.Equal(t, policy.JobStatusCompleted, jobs[0].Status, "Job should be completed on success")
 				assert.NotNil(t, metrics.GetDiscoverySuccess())
 			}
 			if tt.expectFailure {
+				assert.Equal(t, policy.JobStatusFailed, jobs[0].Status, "Job should be failed on error")
+				assert.NotEmpty(t, jobs[0].Error, "Job should have error message")
 				assert.NotNil(t, metrics.GetDiscoveryFailure())
 			}
 			assert.NotNil(t, metrics.GetDiscoveryAttempts())
@@ -235,6 +242,7 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	mockClient := new(MockDiodeClient)
 	ctx := context.Background()
+	jobStore := policy.NewJobStore()
 
 	policyConfig := config.Policy{
 		Config: config.PolicyConfig{
@@ -283,7 +291,7 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	}
 
 	// Create runner
-	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, &mappingConfig, nil, nil)
+	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, &mappingConfig, nil, nil, jobStore)
 	assert.NoError(t, err)
 
 	// Use a channel to signal that Ingest was called
@@ -324,6 +332,11 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	// Stop the process
 	err = runner.Stop()
 	assert.NoError(t, err, "Runner.Stop should not return an error")
+	
+	// Verify job was created and completed
+	jobs := jobStore.GetJobsForPolicy("test-policy")
+	require.Len(t, jobs, 1, "Job should be created")
+	assert.Equal(t, policy.JobStatusCompleted, jobs[0].Status, "Job should be completed")
 }
 
 func TestRunnerWalkError(t *testing.T) {
@@ -331,6 +344,7 @@ func TestRunnerWalkError(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	mockClient := new(MockDiodeClient)
 	ctx := context.Background()
+	jobStore := policy.NewJobStore()
 
 	policyConfig := config.Policy{
 		Config: config.PolicyConfig{},
@@ -362,7 +376,7 @@ func TestRunnerWalkError(t *testing.T) {
 	}
 
 	// Create runner with the mock client factory
-	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, mockClientFactory, &mappingConfig, nil, nil)
+	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, mockClientFactory, &mappingConfig, nil, nil, jobStore)
 	assert.NoError(t, err)
 
 	// Set up a channel to detect if Ingest is called (it shouldn't be)
@@ -385,4 +399,9 @@ func TestRunnerWalkError(t *testing.T) {
 	// Stop the process
 	err = runner.Stop()
 	assert.NoError(t, err, "Runner.Stop should not return an error")
+	
+	// Verify job was created even when no entities are ingested
+	jobs := jobStore.GetJobsForPolicy("test-policy")
+	require.Len(t, jobs, 1, "Job should be created even when walk fails")
+	assert.Equal(t, policy.JobStatusCompleted, jobs[0].Status, "Job should be completed when no entities to ingest")
 }

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -332,7 +332,7 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	// Stop the process
 	err = runner.Stop()
 	assert.NoError(t, err, "Runner.Stop should not return an error")
-	
+
 	// Verify job was created and completed
 	jobs := jobStore.GetJobsForPolicy("test-policy")
 	require.Len(t, jobs, 1, "Job should be created")
@@ -399,7 +399,7 @@ func TestRunnerWalkError(t *testing.T) {
 	// Stop the process
 	err = runner.Stop()
 	assert.NoError(t, err, "Runner.Stop should not return an error")
-	
+
 	// Verify job was created even when no entities are ingested
 	jobs := jobStore.GetJobsForPolicy("test-policy")
 	require.Len(t, jobs, 1, "Job should be created even when walk fails")

--- a/snmp-discovery/server/server.go
+++ b/snmp-discovery/server/server.go
@@ -32,7 +32,7 @@ type Capabilities struct {
 // StatusResponse represents the status response including policies
 type StatusResponse struct {
 	config.Status
-	Policies []policy.PolicyStatus `json:"policies"`
+	Policies []policy.Status `json:"policies"`
 }
 
 // Server represents the snmp-discovery server

--- a/snmp-discovery/server/server.go
+++ b/snmp-discovery/server/server.go
@@ -29,6 +29,12 @@ type Capabilities struct {
 	Capabilities []string `json:"capabilities"`
 }
 
+// StatusResponse represents the status response including policies
+type StatusResponse struct {
+	config.Status
+	Policies []policy.PolicyStatus `json:"policies"`
+}
+
 // Server represents the snmp-discovery server
 type Server struct {
 	router     *gin.Engine
@@ -135,7 +141,13 @@ func (s *Server) Start() <-chan error {
 
 func (s *Server) getStatus(c *gin.Context) {
 	s.stat.UpTimeSeconds = int64(math.Round(time.Since(s.stat.StartTime).Seconds()))
-	c.IndentedJSON(http.StatusOK, s.stat)
+
+	response := StatusResponse{
+		Status:   s.stat,
+		Policies: s.manager.GetPolicyStatuses(),
+	}
+
+	c.IndentedJSON(http.StatusOK, response)
 }
 
 func (s *Server) getCapabilities(c *gin.Context) {

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -112,19 +112,19 @@ func TestServerGetStatusWithPolicies(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	bodyStr := w.Body.String()
-	
+
 	// Verify status fields
 	assert.Contains(t, bodyStr, `"version": "1.0.0"`)
 	assert.Contains(t, bodyStr, `"start_time":`)
 	assert.Contains(t, bodyStr, `"up_time_seconds":`)
 	assert.Contains(t, bodyStr, `"policies":`)
-	
+
 	// Verify policy structure
 	assert.Contains(t, bodyStr, `"test-policy"`)
 	assert.Contains(t, bodyStr, `"name":`)
 	assert.Contains(t, bodyStr, `"status":`)
 	assert.Contains(t, bodyStr, `"jobs":`)
-	
+
 	// Clean up
 	srv.Stop()
 }

--- a/snmp-discovery/server/server_test.go
+++ b/snmp-discovery/server/server_test.go
@@ -67,6 +67,66 @@ func TestServerConfigureAndStart(t *testing.T) {
 	assert.Contains(t, w.Body.String(), `"version": "1.0.0"`)
 	assert.Contains(t, w.Body.String(), `"start_time":`)
 	assert.Contains(t, w.Body.String(), `"up_time_seconds": 0`)
+	assert.Contains(t, w.Body.String(), `"policies":`)
+}
+
+func TestServerGetStatusWithPolicies(t *testing.T) {
+	ctx := context.Background()
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+	client := new(MockClient)
+	policyManager, err := policy.NewManager(ctx, logger, client, nil)
+	require.NoError(t, err)
+
+	err = setupTestMeter(t)
+	require.NoError(t, err)
+
+	srv := server.NewServer("localhost", 8082, logger, policyManager, "1.0.0")
+
+	// Create a policy first
+	body := []byte(`
+    policies:
+      test-policy:
+        config:
+          lookup_extensions_dir: /tmp/lookup_extensions
+          defaults:
+            site: New York NY
+        scope:
+          targets: 
+            - host: 192.168.31.1
+          authentication:
+            protocol_version: SNMPv2c
+            community: public
+    `)
+
+	w := httptest.NewRecorder()
+	request, _ := http.NewRequest(http.MethodPost, "/api/v1/policies", bytes.NewReader(body))
+	request.Header.Set("Content-Type", "application/x-yaml")
+	srv.Router().ServeHTTP(w, request)
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	// Check /status endpoint
+	w = httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request, _ = http.NewRequest(http.MethodGet, "/api/v1/status", nil)
+	srv.Router().ServeHTTP(w, c.Request)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	bodyStr := w.Body.String()
+	
+	// Verify status fields
+	assert.Contains(t, bodyStr, `"version": "1.0.0"`)
+	assert.Contains(t, bodyStr, `"start_time":`)
+	assert.Contains(t, bodyStr, `"up_time_seconds":`)
+	assert.Contains(t, bodyStr, `"policies":`)
+	
+	// Verify policy structure
+	assert.Contains(t, bodyStr, `"test-policy"`)
+	assert.Contains(t, bodyStr, `"name":`)
+	assert.Contains(t, bodyStr, `"status":`)
+	assert.Contains(t, bodyStr, `"jobs":`)
+	
+	// Clean up
+	srv.Stop()
 }
 
 func TestServerGetCapabilities(t *testing.T) {


### PR DESCRIPTION
This pull request introduces a robust job tracking system for SNMP discovery policy executions, enabling better observability and status reporting of policy runs. The changes add a `JobStore` for managing job lifecycles, integrate job tracking into the policy execution flow, and expose policy/job statuses via the server API. Comprehensive unit tests are also included to ensure correctness and concurrency safety.

**Job Management and Tracking:**

- Added a new `JobStore` in `job.go` to manage job creation, status updates, and retrieval per policy, limiting history to the last 5 jobs per policy. The `Job` struct tracks status, errors, and timestamps.
- Integrated `JobStore` into the `Manager` and `Runner` components, ensuring each policy execution creates and updates a job record reflecting its outcome. [[1]](diffhunk://#diff-97d32253107e3c811caf8c6de6078b90fc18fbfecca66691424c657d8b77651cR35) [[2]](diffhunk://#diff-97d32253107e3c811caf8c6de6078b90fc18fbfecca66691424c657d8b77651cR53) [[3]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdR46-R50) [[4]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdR64) [[5]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdR93-R98) [[6]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdR131-R151)

**Policy Status Reporting:**

- Added a `PolicyStatus` struct and a `GetPolicyStatuses` method to `Manager`, aggregating the latest job status and history for each policy.
- Modified the server's `/status` endpoint to include policy/job statuses in the response, providing better visibility into policy execution state. [[1]](diffhunk://#diff-6b3406fdd3e26ab7dd44a8fae75ae1153bdfa88502cabb06e2481cf82ed6f5e3R32-R37) [[2]](diffhunk://#diff-6b3406fdd3e26ab7dd44a8fae75ae1153bdfa88502cabb06e2481cf82ed6f5e3L138-R150)

**Testing and Reliability:**

- Introduced extensive tests for `JobStore` covering creation, updating, concurrency, and edge cases, ensuring thread safety and correctness.
- Updated runner tests to validate job creation and status updates for successful, failed, and no-entity runs. [[1]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fR100-R103) [[2]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fR177) [[3]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL195-R197) [[4]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL220-R231) [[5]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fR245) [[6]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL286-R294) [[7]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fR335-R347) [[8]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fL365-R379) [[9]](diffhunk://#diff-bbc860544a5e41d7a2f0276de913788d6bd8f73ea0f41553da62db94e8fe466fR402-R406)

These changes collectively improve the observability, reliability, and testability of policy executions in the SNMP discovery service.