### PR TITLE
feat: add tenant group support to device-discovery

### DIFF
--- a/device-discovery/device_discovery/policy/models.py
+++ b/device-discovery/device_discovery/policy/models.py
@@ -39,12 +39,17 @@ class DeviceParameters(ObjectParameters):
         default=None, description="Device platform override, optional"
     )
 
+class TenantParameters(ObjectParameters):
+    """Model for Tenant parameters."""
+
+    name : str
+    group: str | None = Field(default=None, description="Tenant group, optional")
 
 class VlanParameters(ObjectParameters):
     """Model for VLAN parameters."""
 
     group: str | None = Field(default=None, description="VLAN group, optional")
-    tenant: str | None = Field(default=None, description="VLAN tenant, optional")
+    tenant: str | TenantParameters | None = Field(default=None, description="VLAN tenant, optional")
     role: str | None = Field(default=None, description="VLAN role, optional")
 
 
@@ -52,7 +57,7 @@ class IpamParameters(ObjectParameters):
     """Model for IPAM parameters."""
 
     role: str | None = Field(default=None, description="IPAM role, optional")
-    tenant: str | None = Field(default=None, description="IPAM tenant, optional")
+    tenant: str | TenantParameters | None = Field(default=None, description="IPAM tenant, optional")
     vrf: str | None = Field(default=None, description="IPAM VRF, optional")
 
 
@@ -65,7 +70,7 @@ class Defaults(BaseModel):
     )
     if_type: str | None = Field(default="other", description="Interface type, optional")
     location: str | None = Field(default=None, description="Location name, optional")
-    tenant: str | None = Field(default=None, description="Tenant name, optional")
+    tenant: str | TenantParameters | None = Field(default=None, description="Tenant, optional")
     tags: list[str] | None = Field(default=None, description="Tags, optional")
     device: DeviceParameters | None = Field(
         default=None, description="Device parameters, optional"

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -5,6 +5,7 @@
 import ipaddress
 from collections.abc import Iterable
 
+from netboxlabs.diode.sdk.diode.v1 import ingester_pb2 as pb
 from netboxlabs.diode.sdk.ingester import (
     VLAN,
     Device,
@@ -15,9 +16,11 @@ from netboxlabs.diode.sdk.ingester import (
     Location,
     Platform,
     Prefix,
+    Tenant,
+    TenantGroup,
 )
 
-from device_discovery.policy.models import Defaults, Options
+from device_discovery.policy.models import Defaults, Options, TenantParameters
 
 
 def int32_overflows(number: int) -> bool:
@@ -36,6 +39,26 @@ def int32_overflows(number: int) -> bool:
     INT32_MIN = -2147483648
     INT32_MAX = 2147483647
     return not (INT32_MIN <= number <= INT32_MAX)
+
+
+def translate_tenant(
+    tenant: str | TenantParameters | pb.Tenant | None,
+) -> pb.Tenant | None:
+    """Convert tenant input into a Diode Tenant message."""
+    if tenant is None or isinstance(tenant, pb.Tenant):
+        return tenant
+
+    if isinstance(tenant, TenantParameters):
+        tenant_group = TenantGroup(name=tenant.group) if tenant.group else None
+        return Tenant(
+            name=tenant.name,
+            group=tenant_group,
+            comments=tenant.comments,
+            description=tenant.description,
+            tags=tenant.tags,
+        )
+
+    return Tenant(name=tenant)
 
 
 def translate_device(device_info: dict, defaults: Defaults) -> Device:
@@ -98,7 +121,7 @@ def translate_device(device_info: dict, defaults: Defaults) -> Device:
         site=defaults.site,
         tags=tags,
         location=location,
-        tenant=defaults.tenant,
+        tenant=translate_tenant(defaults.tenant),
         description=description,
         comments=comments,
     )
@@ -214,7 +237,7 @@ def translate_interface_ips(
         ip_comments = defaults.ipaddress.comments
         ip_description = defaults.ipaddress.description
         ip_role = defaults.ipaddress.role
-        ip_tenant = defaults.ipaddress.tenant
+        ip_tenant = translate_tenant(defaults.ipaddress.tenant)
         ip_vrf = defaults.ipaddress.vrf
 
     if defaults.prefix:
@@ -222,7 +245,7 @@ def translate_interface_ips(
         prefix_comments = defaults.prefix.comments
         prefix_description = defaults.prefix.description
         prefix_role = defaults.prefix.role
-        prefix_tenant = defaults.prefix.tenant
+        prefix_tenant = translate_tenant(defaults.prefix.tenant)
         prefix_vrf = defaults.prefix.vrf
 
     ip_entities = []
@@ -295,7 +318,7 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN | None:
         comments = defaults.vlan.comments
         description = defaults.vlan.description
         group = defaults.vlan.group
-        tenant = defaults.vlan.tenant
+        tenant = translate_tenant(defaults.vlan.tenant)
         role = defaults.vlan.role
 
     clean_name = " ".join(vlan_name.strip().split())

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -10,6 +10,7 @@ from device_discovery.policy.models import (
     IpamParameters,
     ObjectParameters,
     Options,
+    TenantParameters,
     VlanParameters,
 )
 from device_discovery.translate import (
@@ -94,6 +95,18 @@ def sample_defaults():
 
 
 @pytest.fixture
+def sample_tenant_parameters():
+    """Sample tenant parameters for testing."""
+    return TenantParameters(
+        name="Tenant With Group",
+        group="Tenant Group",
+        description="Tenant description",
+        comments="Tenant comments",
+        tags=["tenant-tag"],
+    )
+
+
+@pytest.fixture
 def sample_override_defaults(sample_defaults):
     """Sample defaults with device overrides."""
     sample_defaults.device.model = "Catalyst"
@@ -121,6 +134,20 @@ def test_translate_device_with_overrides(sample_device_info, sample_override_def
     device = translate_device(sample_device_info, sample_override_defaults)
     assert device.device_type.model == "Catalyst"
     assert device.device_type.manufacturer.name == "Cisco"
+
+
+def test_translate_device_with_tenant_parameters(
+    sample_device_info, sample_defaults, sample_tenant_parameters
+):
+    """Ensure tenant parameters translate into Tenant entities."""
+    sample_defaults.tenant = sample_tenant_parameters
+    device = translate_device(sample_device_info, sample_defaults)
+
+    assert device.tenant.name == "Tenant With Group"
+    assert device.tenant.group.name == "Tenant Group"
+    assert device.tenant.description == "Tenant description"
+    assert device.tenant.comments == "Tenant comments"
+    assert len(device.tenant.tags) == 1
 
 
 def test_translate_device_serial_list(sample_device_info, sample_defaults):
@@ -209,6 +236,36 @@ def test_translate_interface_ips(
     assert ip_entities[1].ip_address.description == "ip test"
     assert len(ip_entities[0].prefix.tags) == 3
     assert len(ip_entities[1].ip_address.tags) == 3
+
+
+def test_translate_interface_ips_with_tenant_parameters(
+    sample_device_info,
+    sample_interface_info,
+    sample_interfaces_ip,
+    sample_defaults,
+    sample_tenant_parameters,
+):
+    """Ensure interface IP translation supports tenant parameters."""
+    sample_defaults.ipaddress.tenant = sample_tenant_parameters
+    sample_defaults.prefix.tenant = TenantParameters(
+        name="Prefix Tenant", group="Prefix Group"
+    )
+    device = translate_device(sample_device_info, sample_defaults)
+    interface = translate_interface(
+        device,
+        "GigabitEthernet0/0/1",
+        sample_interface_info["GigabitEthernet0/0/1"],
+        sample_defaults,
+    )
+    ip_entities = list(
+        translate_interface_ips(interface, sample_interfaces_ip, sample_defaults)
+    )
+
+    assert len(ip_entities) == 2
+    assert ip_entities[0].prefix.tenant.name == "Prefix Tenant"
+    assert ip_entities[0].prefix.tenant.group.name == "Prefix Group"
+    assert ip_entities[1].ip_address.tenant.name == "Tenant With Group"
+    assert ip_entities[1].ip_address.tenant.group.name == "Tenant Group"
 
 
 def test_translate_data(
@@ -424,3 +481,17 @@ def test_translate_vlan_with_defaults(sample_defaults):
     assert vlan.tenant.name == "Default Tenant"
     assert vlan.role.name == "Default Role"
     assert len(vlan.tags) == 3
+
+
+def test_translate_vlan_with_tenant_parameters(
+    sample_defaults, sample_tenant_parameters
+):
+    """Ensure VLAN translation supports tenant parameter objects."""
+    sample_defaults.vlan = VlanParameters(
+        tenant=sample_tenant_parameters, description="Tenant VLAN"
+    )
+    vlan = translate_vlan("201", "Tenant VLAN", sample_defaults)
+
+    assert vlan.tenant.name == "Tenant With Group"
+    assert vlan.tenant.group.name == "Tenant Group"
+    assert vlan.description == "Tenant VLAN"


### PR DESCRIPTION
This pull request enhances tenant handling in the device discovery policy and translation logic. It introduces a new `TenantParameters` model to support richer tenant information (such as group, description, comments, and tags) across device, VLAN, and IPAM parameters. The translation functions and tests are updated to handle and validate this expanded tenant representation.

**Model and Schema Enhancements:**

* Added a new `TenantParameters` class to represent tenants with additional fields (group, description, comments, tags), and updated `VlanParameters`, `IpamParameters`, and `Defaults` to accept either a string or a `TenantParameters` object for the `tenant` field. [[1]](diffhunk://#diff-6a336230783aebcdf213f14e3c6628fe4b4c705e8e65a7367e072ea77836b684R42-R60) [[2]](diffhunk://#diff-6a336230783aebcdf213f14e3c6628fe4b4c705e8e65a7367e072ea77836b684L68-R73)

**Translation Logic Updates:**

* Introduced the `translate_tenant` function to convert tenant input (string or `TenantParameters`) into a Diode SDK `Tenant` message, and updated all relevant translation functions (`translate_device`, `translate_interface_ips`, `translate_vlan`) to use this function for tenant fields. [[1]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R19-R23) [[2]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R44-R63) [[3]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L101-R124) [[4]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L217-R248) [[5]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527L298-R321) [[6]](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R8)

**Testing Improvements:**

* Added fixtures and new tests to verify that tenant parameters are correctly translated and handled in devices, interfaces, IP addresses, prefixes, and VLANs. This ensures the new tenant model is robustly supported throughout the translation process. [[1]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R13) [[2]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R97-R108) [[3]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R139-R152) [[4]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R241-R270) [[5]](diffhunk://#diff-e789055b8686658d5ec6dba2de50f92993cbd46b3c2ef4675b15b0cfbed465c4R484-R497)