### PR TITLE
feat: device discovery jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ __pycache__/
 
 .cursor/
 .cursor.md
+
+.venv/

--- a/device-discovery/Makefile
+++ b/device-discovery/Makefile
@@ -1,0 +1,23 @@
+.PHONY: install-dev-tools
+install-dev-tools:
+	@python -m pip install --upgrade pip
+	@pip install .
+	@pip install .[dev]
+	@pip install .[test]
+
+.PHONY: test
+test:
+	@pytest --cov-report=term-missing:skip-covered --cov=device_discovery/
+
+.PHONY: lint
+lint:
+	@ruff check --output-format=github device_discovery/ tests/
+
+.PHONY: fix-lint
+fix-lint:
+	@ruff check --fix device_discovery/ tests/
+
+.PHONY: format
+format:
+	@ruff format device_discovery/ tests/
+

--- a/device-discovery/README.md
+++ b/device-discovery/README.md
@@ -88,7 +88,31 @@ docker run  -e DIODE_CLIENT_ID=${YOUR_CLIENT} -e DIODE_CLIENT_SECRET=${YOUR_SECR
 
 > | http code     | content-type                      | response                                                            |
 > |---------------|-----------------------------------|---------------------------------------------------------------------|
-> | `200`         | `application/json; charset=utf-8` |  `{"version": "0.1.0","up_time_seconds": 3678 }`                    |
+> | `200`         | `application/json; charset=utf-8` | Status response with version, uptime, and policies with jobs         |
+
+##### Example Response
+
+> ```json
+> {
+>   "version": "0.1.0",
+>   "up_time_seconds": 3678,
+>   "policies": [
+>     {
+>       "name": "discovery_1",
+>       "status": "completed",
+>       "jobs": [
+>         {
+>           "id": "550e8400-e29b-41d4-a716-446655440000",
+>           "status": "completed",
+>           "error": null,
+>           "created_at": "2024-01-01T12:00:00",
+>           "updated_at": "2024-01-01T12:01:00"
+>         }
+>       ]
+>     }
+>   ]
+> }
+> ```
 
 ##### Example cURL
 

--- a/device-discovery/device_discovery/policy/job.py
+++ b/device-discovery/device_discovery/policy/job.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python
+# Copyright 2024 NetBox Labs Inc
+"""Device Discovery Job Tracking."""
+
+import threading
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+
+
+class JobStatus(str, Enum):
+    """Job status enumeration."""
+
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+@dataclass
+class Job:
+    """Represents a single job execution."""
+
+    id: str
+    status: JobStatus
+    error: str | None = None
+    created_at: datetime = field(default_factory=datetime.now)
+    updated_at: datetime = field(default_factory=datetime.now)
+
+
+class JobStore:
+    """Manages jobs in memory with thread-safe operations."""
+
+    MAX_JOBS_PER_POLICY = 5
+
+    def __init__(self):
+        """Initialize the JobStore."""
+        self._lock = threading.RLock()
+        self._jobs: dict[str, list[Job]] = {}  # policy_name -> jobs
+
+    def create_job(self, policy_name: str) -> Job:
+        """
+        Create a new job for the given policy.
+
+        Args:
+        ----
+            policy_name: Name of the policy.
+
+        Returns:
+        -------
+            Job: The created job.
+
+        """
+        with self._lock:
+            now = datetime.now()
+            job = Job(
+                id=str(uuid.uuid4()),
+                status=JobStatus.RUNNING,
+                created_at=now,
+                updated_at=now,
+            )
+
+            # Add job to the policy's job list
+            jobs = self._jobs.get(policy_name, [])
+            jobs.append(job)
+
+            # Keep only the last MAX_JOBS_PER_POLICY jobs
+            if len(jobs) > self.MAX_JOBS_PER_POLICY:
+                jobs = jobs[-self.MAX_JOBS_PER_POLICY :]
+
+            self._jobs[policy_name] = jobs
+            return job
+
+    def update_job(
+        self, policy_name: str, job_id: str, status: JobStatus, error: Exception | None
+    ) -> None:
+        """
+        Update the status of a job.
+
+        Args:
+        ----
+            policy_name: Name of the policy.
+            job_id: ID of the job to update.
+            status: New status for the job.
+            error: Optional error exception.
+
+        """
+        with self._lock:
+            jobs = self._jobs.get(policy_name, [])
+            for job in jobs:
+                if job.id == job_id:
+                    job.status = status
+                    job.updated_at = datetime.now()
+                    if error is not None:
+                        job.error = str(error)
+                    return
+
+    def get_jobs_for_policy(self, policy_name: str) -> list[Job]:
+        """
+        Get all jobs for a given policy.
+
+        Args:
+        ----
+            policy_name: Name of the policy.
+
+        Returns:
+        -------
+            list[Job]: List of jobs for the policy (copy to avoid race conditions).
+
+        """
+        with self._lock:
+            jobs = self._jobs.get(policy_name, [])
+            # Return a copy to avoid race conditions
+            return [Job(**job.__dict__) for job in jobs]
+
+    def get_all_policies_with_jobs(self) -> dict[str, list[Job]]:
+        """
+        Get all policies with their jobs.
+
+        Returns:
+        -------
+            dict[str, list[Job]]: Dictionary mapping policy names to their jobs.
+
+        """
+        with self._lock:
+            result = {}
+            for policy_name, jobs in self._jobs.items():
+                # Return a copy to avoid race conditions
+                result[policy_name] = [Job(**job.__dict__) for job in jobs]
+            return result
+

--- a/device-discovery/device_discovery/policy/job.py
+++ b/device-discovery/device_discovery/policy/job.py
@@ -117,7 +117,7 @@ class JobStore:
         """
         Get all policies with their jobs.
 
-        Returns:
+        Returns
         -------
             dict[str, list[Job]]: Dictionary mapping policy names to their jobs.
 

--- a/device-discovery/device_discovery/policy/job.py
+++ b/device-discovery/device_discovery/policy/job.py
@@ -23,7 +23,8 @@ class Job:
 
     id: str
     status: JobStatus
-    error: str | None = None
+    reason: str | None = None
+    entity_count: int | None = None
     created_at: datetime = field(default_factory=datetime.now)
     updated_at: datetime = field(default_factory=datetime.now)
 
@@ -72,7 +73,12 @@ class JobStore:
             return job
 
     def update_job(
-        self, policy_name: str, job_id: str, status: JobStatus, error: Exception | None
+        self,
+        policy_name: str,
+        job_id: str,
+        status: JobStatus,
+        reason: Exception | str | None = None,
+        entity_count: int | None = None,
     ) -> None:
         """
         Update the status of a job.
@@ -82,7 +88,8 @@ class JobStore:
             policy_name: Name of the policy.
             job_id: ID of the job to update.
             status: New status for the job.
-            error: Optional error exception.
+            reason: Optional reason (exception or string).
+            entity_count: Optional entity count.
 
         """
         with self._lock:
@@ -91,8 +98,13 @@ class JobStore:
                 if job.id == job_id:
                     job.status = status
                     job.updated_at = datetime.now()
-                    if error is not None:
-                        job.error = str(error)
+                    if reason is not None:
+                        if isinstance(reason, Exception):
+                            job.reason = str(reason)
+                        else:
+                            job.reason = reason
+                    if entity_count is not None:
+                        job.entity_count = entity_count
                     return
 
     def get_jobs_for_policy(self, policy_name: str) -> list[Job]:

--- a/device-discovery/device_discovery/policy/manager.py
+++ b/device-discovery/device_discovery/policy/manager.py
@@ -143,7 +143,8 @@ class PolicyManager:
                         {
                             "id": job.id,
                             "status": job.status.value,
-                            "error": job.error,
+                            "reason": job.reason,
+                            "entity_count": job.entity_count,
                             "created_at": job.created_at.isoformat(),
                             "updated_at": job.updated_at.isoformat(),
                         }
@@ -167,7 +168,8 @@ class PolicyManager:
                             {
                                 "id": job.id,
                                 "status": job.status.value,
-                                "error": job.error,
+                                "reason": job.reason,
+                                "entity_count": job.entity_count,
                                 "created_at": job.created_at.isoformat(),
                                 "updated_at": job.updated_at.isoformat(),
                             }

--- a/device-discovery/device_discovery/policy/manager.py
+++ b/device-discovery/device_discovery/policy/manager.py
@@ -7,6 +7,7 @@ import os
 
 import yaml
 
+from device_discovery.policy.job import JobStore
 from device_discovery.policy.models import Policy, PolicyRequest
 from device_discovery.policy.runner import PolicyRunner
 
@@ -43,6 +44,7 @@ class PolicyManager:
     def __init__(self):
         """Initialize the PolicyManager instance with an empty list of policies."""
         self.runners = dict[str, PolicyRunner]()
+        self.job_store = JobStore()
 
     def start_policy(self, name: str, policy: Policy):
         """
@@ -58,7 +60,7 @@ class PolicyManager:
             raise ValueError(f"policy '{name}' already exists")
 
         runner = PolicyRunner()
-        runner.setup(name, policy.config, policy.scope)
+        runner.setup(name, policy.config, policy.scope, self.job_store)
         self.runners[name] = runner
 
     def parse_policy(self, config_data: bytes) -> PolicyRequest:
@@ -113,3 +115,66 @@ class PolicyManager:
             logger.info(f"Stopping policy '{name}'")
             runner.stop()
         self.runners = {}
+
+    def get_policy_statuses(self) -> list[dict]:
+        """
+        Get all policies with their status and jobs.
+
+        Returns:
+        -------
+            list[dict]: List of policy status dictionaries with name, status, and jobs.
+
+        """
+        all_jobs = self.job_store.get_all_policies_with_jobs()
+        statuses = []
+
+        # Get statuses for all policies that have runners
+        for name in self.runners:
+            jobs = self.job_store.get_jobs_for_policy(name)
+            status = "unknown"
+            if len(jobs) > 0:
+                latest_job = jobs[-1]
+                status = latest_job.status.value
+            statuses.append(
+                {
+                    "name": name,
+                    "status": status,
+                    "jobs": [
+                        {
+                            "id": job.id,
+                            "status": job.status.value,
+                            "error": job.error,
+                            "created_at": job.created_at.isoformat(),
+                            "updated_at": job.updated_at.isoformat(),
+                        }
+                        for job in jobs
+                    ],
+                }
+            )
+
+        # Also include policies that have jobs but no active runner
+        for name, jobs in all_jobs.items():
+            if name not in self.runners:
+                status = "unknown"
+                if len(jobs) > 0:
+                    latest_job = jobs[-1]
+                    status = latest_job.status.value
+                statuses.append(
+                    {
+                        "name": name,
+                        "status": status,
+                        "jobs": [
+                            {
+                                "id": job.id,
+                                "status": job.status.value,
+                                "error": job.error,
+                                "created_at": job.created_at.isoformat(),
+                                "updated_at": job.updated_at.isoformat(),
+                            }
+                            for job in jobs
+                        ],
+                    }
+                )
+
+        return statuses
+

--- a/device-discovery/device_discovery/policy/manager.py
+++ b/device-discovery/device_discovery/policy/manager.py
@@ -120,7 +120,7 @@ class PolicyManager:
         """
         Get all policies with their status and jobs.
 
-        Returns:
+        Returns
         -------
             list[dict]: List of policy status dictionaries with name, status, and jobs.
 

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -110,7 +110,7 @@ class PolicyRunner:
         policy_executions = get_metric("policy_executions")
         if policy_executions:
             policy_executions.add(1, {"policy": self.name})
-        
+
         # Create a job for this policy execution cycle
         if self.job_store:
             self.job_store.create_job(self.name)
@@ -204,7 +204,7 @@ class PolicyRunner:
             if discovery_success:
                 discovery_success.add(1, {"policy": self.name})
 
-    def run(self, id: str, scope: Napalm, config: Config):
+    def run(self, id: str, scope: Napalm, config: Config):  # noqa: C901
         """
         Run the device driver code for a single scope item.
 
@@ -217,7 +217,7 @@ class PolicyRunner:
         """
         discovery_start_time = time.perf_counter()
         sanitized_hostname = scope.hostname.replace("\r\n", "").replace("\n", "")
-        
+
         # Get the latest job for this policy to track execution
         job_id = None
         if self.job_store:
@@ -269,7 +269,7 @@ class PolicyRunner:
                         "driver": scope.driver,
                     },
                 )
-            
+
             # Update job status to completed on success
             if self.job_store and job_id:
                 self.job_store.update_job(self.name, job_id, JobStatus.COMPLETED, None)
@@ -294,7 +294,7 @@ class PolicyRunner:
                         "status": "failed",
                     },
                 )
-            
+
             # Update job status to failed
             if self.job_store and job_id:
                 self.job_store.update_job(self.name, job_id, JobStatus.FAILED, e)

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -144,7 +144,7 @@ class PolicyRunner:
 
     def _collect_device_data(
         self, scope: Napalm, sanitized_hostname: str, config: Config, job_id: str | None = None
-    ):
+    ) -> int:
         """
         Connect to device and collect data.
 
@@ -154,6 +154,10 @@ class PolicyRunner:
             sanitized_hostname: Sanitized hostname for logging.
             config: Configuration data containing site information.
             job_id: Optional job ID to include in metadata.
+
+        Returns:
+        -------
+            int: Number of entities ingested.
 
         """
         np_driver = get_network_driver(scope.driver)
@@ -199,10 +203,18 @@ class PolicyRunner:
             metadata = {"policy_name": self.name, "hostname": sanitized_hostname}
             if job_id:
                 metadata["job_id"] = job_id
+            
+            # Translate data to get entity count
+            from device_discovery.translate import translate_data
+            entities = list(translate_data(data))
+            entity_count = len(entities)
+            
             Client().ingest(metadata, data)
             discovery_success = get_metric("discovery_success")
             if discovery_success:
                 discovery_success.add(1, {"policy": self.name})
+            
+            return entity_count
 
     def run(self, id: str, scope: Napalm, config: Config):  # noqa: C901
         """
@@ -241,7 +253,7 @@ class PolicyRunner:
                     self.name,
                     job_id,
                     JobStatus.FAILED,
-                    Exception(f"Failed to discover driver for {sanitized_hostname}"),
+                    reason=f"Failed to discover driver for {sanitized_hostname}",
                 )
             return
 
@@ -255,7 +267,7 @@ class PolicyRunner:
                 discovery_attempts.add(1, {"policy": self.name})
 
             # Collect data from device
-            self._collect_device_data(scope, sanitized_hostname, config, job_id)
+            entity_count = self._collect_device_data(scope, sanitized_hostname, config, job_id)
 
             # Record total discovery duration
             discovery_latency = get_metric("discovery_latency")
@@ -272,7 +284,9 @@ class PolicyRunner:
 
             # Update job status to completed on success
             if self.job_store and job_id:
-                self.job_store.update_job(self.name, job_id, JobStatus.COMPLETED, None)
+                self.job_store.update_job(
+                    self.name, job_id, JobStatus.COMPLETED, reason=None, entity_count=entity_count
+                )
 
         except Exception as e:
             discovery_failure = get_metric("discovery_failure")
@@ -297,7 +311,7 @@ class PolicyRunner:
 
             # Update job status to failed
             if self.job_store and job_id:
-                self.job_store.update_job(self.name, job_id, JobStatus.FAILED, e)
+                self.job_store.update_job(self.name, job_id, JobStatus.FAILED, reason=e)
 
     def stop(self):
         """Stop the policy runner."""

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -15,6 +15,7 @@ from napalm import get_network_driver
 from device_discovery.client import Client
 from device_discovery.discovery import discover_device_driver, supported_drivers
 from device_discovery.metrics import get_metric
+from device_discovery.policy.job import JobStatus, JobStore
 from device_discovery.policy.models import Config, Defaults, Napalm, Options, Status
 
 # Set up logging
@@ -32,8 +33,9 @@ class PolicyRunner:
         self.config = None
         self.status = Status.NEW
         self.scheduler = BackgroundScheduler()
+        self.job_store: JobStore | None = None
 
-    def setup(self, name: str, config: Config, scopes: list[Napalm]):
+    def setup(self, name: str, config: Config, scopes: list[Napalm], job_store: JobStore | None = None):
         """
         Set up the policy runner.
 
@@ -42,8 +44,10 @@ class PolicyRunner:
             name: Policy name.
             config: Configuration data containing site information.
             scopes: scope data for the devices.
+            job_store: Optional JobStore for tracking jobs.
 
         """
+        self.job_store = job_store
         self.name = name.replace("\r\n", "").replace("\n", "")
         self.config = config
 
@@ -106,6 +110,10 @@ class PolicyRunner:
         policy_executions = get_metric("policy_executions")
         if policy_executions:
             policy_executions.add(1, {"policy": self.name})
+        
+        # Create a job for this policy execution cycle
+        if self.job_store:
+            self.job_store.create_job(self.name)
 
     def _discover_driver(self, scope: Napalm, sanitized_hostname: str) -> bool:
         """
@@ -135,7 +143,7 @@ class PolicyRunner:
         return True
 
     def _collect_device_data(
-        self, scope: Napalm, sanitized_hostname: str, config: Config
+        self, scope: Napalm, sanitized_hostname: str, config: Config, job_id: str | None = None
     ):
         """
         Connect to device and collect data.
@@ -145,6 +153,7 @@ class PolicyRunner:
             scope: Scope data for the device.
             sanitized_hostname: Sanitized hostname for logging.
             config: Configuration data containing site information.
+            job_id: Optional job ID to include in metadata.
 
         """
         np_driver = get_network_driver(scope.driver)
@@ -188,6 +197,8 @@ class PolicyRunner:
                     f"Policy {self.name}, Hostname {sanitized_hostname}: Error getting VLANs: {e}. Continuing without VLAN data."
                 )
             metadata = {"policy_name": self.name, "hostname": sanitized_hostname}
+            if job_id:
+                metadata["job_id"] = job_id
             Client().ingest(metadata, data)
             discovery_success = get_metric("discovery_success")
             if discovery_success:
@@ -206,6 +217,15 @@ class PolicyRunner:
         """
         discovery_start_time = time.perf_counter()
         sanitized_hostname = scope.hostname.replace("\r\n", "").replace("\n", "")
+        
+        # Get the latest job for this policy to track execution
+        job_id = None
+        if self.job_store:
+            jobs = self.job_store.get_jobs_for_policy(self.name)
+            if jobs:
+                latest_job = jobs[-1]
+                if latest_job.status == JobStatus.RUNNING:
+                    job_id = latest_job.id
 
         # Try to discover driver if needed
         if not self._discover_driver(scope, sanitized_hostname):
@@ -214,6 +234,14 @@ class PolicyRunner:
             except Exception as e:
                 logger.error(
                     f"Policy {self.name}, Hostname {sanitized_hostname}: Error removing job: {e}"
+                )
+            # Update job status to failed if job tracking is enabled
+            if self.job_store and job_id:
+                self.job_store.update_job(
+                    self.name,
+                    job_id,
+                    JobStatus.FAILED,
+                    Exception(f"Failed to discover driver for {sanitized_hostname}"),
                 )
             return
 
@@ -227,7 +255,7 @@ class PolicyRunner:
                 discovery_attempts.add(1, {"policy": self.name})
 
             # Collect data from device
-            self._collect_device_data(scope, sanitized_hostname, config)
+            self._collect_device_data(scope, sanitized_hostname, config, job_id)
 
             # Record total discovery duration
             discovery_latency = get_metric("discovery_latency")
@@ -241,6 +269,10 @@ class PolicyRunner:
                         "driver": scope.driver,
                     },
                 )
+            
+            # Update job status to completed on success
+            if self.job_store and job_id:
+                self.job_store.update_job(self.name, job_id, JobStatus.COMPLETED, None)
 
         except Exception as e:
             discovery_failure = get_metric("discovery_failure")
@@ -262,6 +294,10 @@ class PolicyRunner:
                         "status": "failed",
                     },
                 )
+            
+            # Update job status to failed
+            if self.job_store and job_id:
+                self.job_store.update_job(self.name, job_id, JobStatus.FAILED, e)
 
     def stop(self):
         """Stop the policy runner."""

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -203,17 +203,17 @@ class PolicyRunner:
             metadata = {"policy_name": self.name, "hostname": sanitized_hostname}
             if job_id:
                 metadata["job_id"] = job_id
-            
+
             # Translate data to get entity count
             from device_discovery.translate import translate_data
             entities = list(translate_data(data))
             entity_count = len(entities)
-            
+
             Client().ingest(metadata, data)
             discovery_success = get_metric("discovery_success")
             if discovery_success:
                 discovery_success.add(1, {"policy": self.name})
-            
+
             return entity_count
 
     def run(self, id: str, scope: Napalm, config: Config):  # noqa: C901

--- a/device-discovery/device_discovery/server.py
+++ b/device-discovery/device_discovery/server.py
@@ -121,13 +121,14 @@ def read_status():
 
     Returns
     -------
-        dict: The status of the server.
+        dict: The status of the server including policies with jobs.
 
     """
     time_diff = datetime.now() - start_time
     return {
         "version": version_semver(),
         "up_time_seconds": round(time_diff.total_seconds()),
+        "policies": manager.get_policy_statuses(),
     }
 
 

--- a/device-discovery/tests/policy/test_job.py
+++ b/device-discovery/tests/policy/test_job.py
@@ -22,7 +22,8 @@ def test_job_store_create_job():
     assert job.id is not None
     assert len(job.id) > 0
     assert job.status == JobStatus.RUNNING
-    assert job.error is None
+    assert job.reason is None
+    assert job.entity_count is None
     assert job.created_at is not None
     assert job.updated_at is not None
     assert job.created_at == job.updated_at
@@ -34,30 +35,38 @@ def test_job_store_create_job():
 
 
 def test_job_store_update_job():
-    """Test updating job status and error."""
+    """Test updating job status, reason, and entity_count."""
     store = JobStore()
     policy_name = "test-policy"
 
     job = store.create_job(policy_name)
     job_id = job.id
 
-    # Update to completed
-    store.update_job(policy_name, job_id, JobStatus.COMPLETED, None)
+    # Update to completed with entity count
+    store.update_job(policy_name, job_id, JobStatus.COMPLETED, reason=None, entity_count=10)
 
     jobs = store.get_jobs_for_policy(policy_name)
     assert len(jobs) == 1
     assert jobs[0].status == JobStatus.COMPLETED
-    assert jobs[0].error is None
+    assert jobs[0].reason is None
+    assert jobs[0].entity_count == 10
     assert jobs[0].updated_at > jobs[0].created_at
 
-    # Update to failed with error
+    # Update to failed with reason
     test_error = Exception("test error")
-    store.update_job(policy_name, job_id, JobStatus.FAILED, test_error)
+    store.update_job(policy_name, job_id, JobStatus.FAILED, reason=test_error)
 
     jobs = store.get_jobs_for_policy(policy_name)
     assert len(jobs) == 1
     assert jobs[0].status == JobStatus.FAILED
-    assert jobs[0].error == "test error"
+    assert jobs[0].reason == "test error"
+    assert jobs[0].entity_count == 10  # Should still be set from previous update
+
+    # Update with string reason
+    store.update_job(policy_name, job_id, JobStatus.FAILED, reason="test reason string")
+    jobs = store.get_jobs_for_policy(policy_name)
+    assert len(jobs) == 1
+    assert jobs[0].reason == "test reason string"
 
 
 def test_job_store_max_five_jobs():
@@ -115,7 +124,7 @@ def test_job_store_concurrency():
         for _ in range(num_threads):
             thread = threading.Thread(
                 target=lambda: store.update_job(
-                    policy_name, job_id, JobStatus.COMPLETED, None
+                    policy_name, job_id, JobStatus.COMPLETED, reason=None
                 )
             )
             threads.append(thread)
@@ -168,7 +177,7 @@ def test_job_store_update_job_nonexistent():
 
     # Update a job that doesn't exist - should not raise
     store.update_job(
-        "non-existent-policy", "non-existent-id", JobStatus.FAILED, Exception("test")
+        "non-existent-policy", "non-existent-id", JobStatus.FAILED, reason=Exception("test")
     )
 
     # Verify no jobs were created
@@ -182,14 +191,16 @@ def test_job_dataclass():
     job = Job(
         id="test-id",
         status=JobStatus.RUNNING,
-        error=None,
+        reason=None,
+        entity_count=None,
         created_at=now,
         updated_at=now,
     )
 
     assert job.id == "test-id"
     assert job.status == JobStatus.RUNNING
-    assert job.error is None
+    assert job.reason is None
+    assert job.entity_count is None
     assert job.created_at == now
     assert job.updated_at == now
 

--- a/device-discovery/tests/policy/test_job.py
+++ b/device-discovery/tests/policy/test_job.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python
+# Copyright 2024 NetBox Labs Inc
+"""NetBox Labs - Job Store Unit Tests."""
+
+import threading
+import time
+from datetime import datetime
+
+import pytest
+
+from device_discovery.policy.job import Job, JobStatus, JobStore
+
+
+def test_job_store_create_job():
+    """Test creating a job with correct fields."""
+    store = JobStore()
+    policy_name = "test-policy"
+
+    job = store.create_job(policy_name)
+
+    # Verify job properties
+    assert job.id is not None
+    assert len(job.id) > 0
+    assert job.status == JobStatus.RUNNING
+    assert job.error is None
+    assert job.created_at is not None
+    assert job.updated_at is not None
+    assert job.created_at == job.updated_at
+
+    # Verify job is stored
+    jobs = store.get_jobs_for_policy(policy_name)
+    assert len(jobs) == 1
+    assert jobs[0].id == job.id
+
+
+def test_job_store_update_job():
+    """Test updating job status and error."""
+    store = JobStore()
+    policy_name = "test-policy"
+
+    job = store.create_job(policy_name)
+    job_id = job.id
+
+    # Update to completed
+    store.update_job(policy_name, job_id, JobStatus.COMPLETED, None)
+
+    jobs = store.get_jobs_for_policy(policy_name)
+    assert len(jobs) == 1
+    assert jobs[0].status == JobStatus.COMPLETED
+    assert jobs[0].error is None
+    assert jobs[0].updated_at > jobs[0].created_at
+
+    # Update to failed with error
+    test_error = Exception("test error")
+    store.update_job(policy_name, job_id, JobStatus.FAILED, test_error)
+
+    jobs = store.get_jobs_for_policy(policy_name)
+    assert len(jobs) == 1
+    assert jobs[0].status == JobStatus.FAILED
+    assert jobs[0].error == "test error"
+
+
+def test_job_store_max_five_jobs():
+    """Test that only the last 5 jobs are retained per policy."""
+    store = JobStore()
+    policy_name = "test-policy"
+
+    # Create 7 jobs
+    job_ids = []
+    for i in range(7):
+        job = store.create_job(policy_name)
+        job_ids.append(job.id)
+        time.sleep(0.01)  # Small delay to ensure different timestamps
+
+    # Verify only last 5 jobs are retained
+    jobs = store.get_jobs_for_policy(policy_name)
+    assert len(jobs) == 5
+
+    # Verify the last 5 jobs are the ones retained
+    expected_ids = job_ids[2:]  # Last 5 jobs
+    actual_ids = [job.id for job in jobs]
+    assert actual_ids == expected_ids
+
+
+def test_job_store_concurrency():
+    """Test thread-safety with concurrent operations."""
+    store = JobStore()
+    policy_name = "test-policy"
+
+    num_threads = 10
+    jobs_per_thread = 5
+
+    def create_jobs():
+        for _ in range(jobs_per_thread):
+            store.create_job(policy_name)
+
+    # Create jobs concurrently
+    threads = []
+    for _ in range(num_threads):
+        thread = threading.Thread(target=create_jobs)
+        threads.append(thread)
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    # Verify all jobs were created (should have max 5 per policy)
+    jobs = store.get_jobs_for_policy(policy_name)
+    assert len(jobs) <= 5
+
+    # Test concurrent updates
+    if len(jobs) > 0:
+        job_id = jobs[0].id
+        threads = []
+        for _ in range(num_threads):
+            thread = threading.Thread(
+                target=lambda: store.update_job(
+                    policy_name, job_id, JobStatus.COMPLETED, None
+                )
+            )
+            threads.append(thread)
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # Verify job was updated
+        jobs = store.get_jobs_for_policy(policy_name)
+        found = False
+        for job in jobs:
+            if job.id == job_id:
+                assert job.status == JobStatus.COMPLETED
+                found = True
+                break
+        assert found, "Job should be found after concurrent updates"
+
+
+def test_job_store_get_all_policies_with_jobs():
+    """Test getting all policies with their jobs."""
+    store = JobStore()
+
+    # Create jobs for multiple policies
+    policy1 = "policy-1"
+    policy2 = "policy-2"
+
+    store.create_job(policy1)
+    store.create_job(policy1)
+    store.create_job(policy2)
+
+    all_jobs = store.get_all_policies_with_jobs()
+
+    assert len(all_jobs) == 2
+    assert len(all_jobs[policy1]) == 2
+    assert len(all_jobs[policy2]) == 1
+
+
+def test_job_store_get_jobs_for_policy_empty():
+    """Test getting jobs for a non-existent policy."""
+    store = JobStore()
+
+    jobs = store.get_jobs_for_policy("non-existent-policy")
+    assert len(jobs) == 0
+
+
+def test_job_store_update_job_nonexistent():
+    """Test updating a job that doesn't exist - should not raise error."""
+    store = JobStore()
+
+    # Update a job that doesn't exist - should not raise
+    store.update_job(
+        "non-existent-policy", "non-existent-id", JobStatus.FAILED, Exception("test")
+    )
+
+    # Verify no jobs were created
+    jobs = store.get_jobs_for_policy("non-existent-policy")
+    assert len(jobs) == 0
+
+
+def test_job_dataclass():
+    """Test Job dataclass initialization."""
+    now = datetime.now()
+    job = Job(
+        id="test-id",
+        status=JobStatus.RUNNING,
+        error=None,
+        created_at=now,
+        updated_at=now,
+    )
+
+    assert job.id == "test-id"
+    assert job.status == JobStatus.RUNNING
+    assert job.error is None
+    assert job.created_at == now
+    assert job.updated_at == now
+
+
+def test_job_status_enum():
+    """Test JobStatus enum values."""
+    assert JobStatus.RUNNING.value == "running"
+    assert JobStatus.COMPLETED.value == "completed"
+    assert JobStatus.FAILED.value == "failed"
+

--- a/device-discovery/tests/policy/test_manager.py
+++ b/device-discovery/tests/policy/test_manager.py
@@ -41,7 +41,7 @@ def test_start_policy(policy_manager, sample_policy):
 
         # Check that PolicyRunner.setup was called with correct arguments
         mock_runner.setup.assert_called_once_with(
-            "policy1", sample_policy.config, sample_policy.scope
+            "policy1", sample_policy.config, sample_policy.scope, policy_manager.job_store
         )
 
         # Ensure the policy runner was added to the manager's runners

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -146,9 +146,18 @@ def test_run_device_with_discovered_driver(policy_runner, sample_scopes, sample_
         mock_get_driver.return_value.return_value.__enter__.return_value = (
             mock_driver_instance
         )
-        mock_driver_instance.get_facts.return_value = {"model": "SampleModel"}
-        mock_driver_instance.get_interfaces.return_value = {"eth0": "up"}
-        mock_driver_instance.get_interfaces_ip.return_value = {"eth0": "192.168.1.1"}
+        mock_driver_instance.get_facts.return_value = {
+            "hostname": "router1",
+            "model": "SampleModel",
+            "vendor": "Cisco",
+            "os_version": "15.0",
+        }
+        mock_driver_instance.get_interfaces.return_value = {
+            "eth0": {"is_enabled": True, "description": "test interface"}
+        }
+        mock_driver_instance.get_interfaces_ip.return_value = {
+            "eth0": {"ipv4": {"192.168.1.1": {"prefix_length": 24}}}
+        }
 
         # Run the device with the setup runner
         policy_runner.run("test_id", sample_scopes[0], sample_config)
@@ -162,9 +171,12 @@ def test_run_device_with_discovered_driver(policy_runner, sample_scopes, sample_
             "hostname": sample_scopes[0].hostname,
         }
         assert data["driver"] == "ios"
-        assert data["device"] == {"model": "SampleModel"}
-        assert data["interface"] == {"eth0": "up"}
-        assert data["interface_ip"] == {"eth0": "192.168.1.1"}
+        assert data["device"]["model"] == "SampleModel"
+        assert "eth0" in data["interface"]
+        assert "eth0" in data["interface_ip"]
+        # Verify interface structure is correct
+        assert isinstance(data["interface"]["eth0"], dict)
+        assert "is_enabled" in data["interface"]["eth0"]
 
 
 def test_run_discovered_driver_error(policy_runner, sample_scopes, sample_config):
@@ -240,9 +252,26 @@ def test_metrics_during_policy_lifecycle(policy_runner, sample_config, sample_sc
         patch("device_discovery.policy.runner.get_metric", side_effect=mock_get_metric),
         patch.object(policy_runner.scheduler, "start"),
         patch.object(policy_runner.scheduler, "add_job"),
-        patch("device_discovery.policy.runner.get_network_driver"),
+        patch("device_discovery.policy.runner.get_network_driver") as mock_get_driver,
         patch("device_discovery.client.Client.ingest"),
     ):
+        # Mock the network driver instance with proper data structure
+        mock_driver_instance = MagicMock()
+        mock_get_driver.return_value.return_value.__enter__.return_value = (
+            mock_driver_instance
+        )
+        mock_driver_instance.get_facts.return_value = {
+            "hostname": "router1",
+            "model": "SampleModel",
+            "vendor": "Cisco",
+            "os_version": "15.0",
+        }
+        mock_driver_instance.get_interfaces.return_value = {
+            "eth0": {"is_enabled": True, "description": "test interface"}
+        }
+        mock_driver_instance.get_interfaces_ip.return_value = {
+            "eth0": {"ipv4": {"192.168.1.1": {"prefix_length": 24}}}
+        }
 
         # Test setup - should increment active_policies
         policy_runner.setup("test_policy", sample_config, sample_scopes)

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -352,12 +352,11 @@ def test_run_updates_job_on_success(policy_runner, sample_scopes, sample_config)
     policy_runner.job_store = job_store
 
     # Create a job first
-    job = job_store.create_job("test_policy")
-    job_id = job.id
+    job_store.create_job("test_policy")
 
     with (
         patch("device_discovery.policy.runner.get_network_driver") as mock_get_driver,
-        patch("device_discovery.client.Client.ingest") as mock_ingest,
+        patch("device_discovery.client.Client.ingest"),
     ):
         mock_driver_instance = MagicMock()
         mock_get_driver.return_value.return_value.__enter__.return_value = (
@@ -383,12 +382,10 @@ def test_run_updates_job_on_failure(policy_runner, sample_scopes, sample_config)
     policy_runner.job_store = job_store
 
     # Create a job first
-    job = job_store.create_job("test_policy")
-    job_id = job.id
+    job_store.create_job("test_policy")
 
     with (
         patch("device_discovery.policy.runner.get_network_driver") as mock_get_driver,
-        patch("device_discovery.policy.runner.logger.error") as mock_logger_error,
     ):
         mock_get_driver.side_effect = Exception("Connection error")
 
@@ -467,14 +464,12 @@ def test_run_updates_job_on_driver_discovery_failure(policy_runner, sample_scope
     sample_scopes[0].driver = None  # Force driver discovery
 
     # Create a job first
-    job = job_store.create_job("test_policy")
-    job_id = job.id
+    job_store.create_job("test_policy")
 
     with (
         patch(
             "device_discovery.policy.runner.discover_device_driver", return_value=None
         ),
-        patch.object(policy_runner.scheduler, "remove_job") as mock_remove_job,
     ):
         policy_runner.run("test_id", sample_scopes[0], sample_config)
 

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -372,7 +372,9 @@ def test_run_updates_job_on_success(policy_runner, sample_scopes, sample_config)
         jobs = job_store.get_jobs_for_policy("test_policy")
         assert len(jobs) == 1
         assert jobs[0].status == JobStatus.COMPLETED
-        assert jobs[0].error is None
+        assert jobs[0].reason is None
+        assert jobs[0].entity_count is not None
+        assert jobs[0].entity_count > 0
 
 
 def test_run_updates_job_on_failure(policy_runner, sample_scopes, sample_config):
@@ -395,7 +397,7 @@ def test_run_updates_job_on_failure(policy_runner, sample_scopes, sample_config)
         jobs = job_store.get_jobs_for_policy("test_policy")
         assert len(jobs) == 1
         assert jobs[0].status == JobStatus.FAILED
-        assert jobs[0].error == "Connection error"
+        assert jobs[0].reason == "Connection error"
 
 
 def test_run_includes_job_id_in_metadata(policy_runner, sample_scopes, sample_config):
@@ -477,4 +479,4 @@ def test_run_updates_job_on_driver_discovery_failure(policy_runner, sample_scope
         jobs = job_store.get_jobs_for_policy("test_policy")
         assert len(jobs) == 1
         assert jobs[0].status == JobStatus.FAILED
-        assert "Failed to discover driver" in jobs[0].error
+        assert "Failed to discover driver" in jobs[0].reason

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from apscheduler.triggers.date import DateTrigger
 
+from device_discovery.policy.job import JobStatus, JobStore
 from device_discovery.policy.models import Config, Defaults, Napalm, Options, Status
 from device_discovery.policy.runner import PolicyRunner
 
@@ -319,3 +320,166 @@ def test_metrics_during_failed_discovery(policy_runner, sample_config):
         latency_kwargs = mock_discovery_latency.record.call_args[0][1]
         assert latency_args > 0.01
         assert latency_kwargs["status"] == "failed"
+
+
+def test_telemetry_creates_job(policy_runner):
+    """Test that telemetry creates a job when job_store is provided."""
+    job_store = JobStore()
+    policy_runner.name = "test_policy"
+    policy_runner.job_store = job_store
+
+    policy_runner.telemetry()
+
+    # Verify job was created
+    jobs = job_store.get_jobs_for_policy("test_policy")
+    assert len(jobs) == 1
+    assert jobs[0].status == JobStatus.RUNNING
+
+
+def test_telemetry_without_job_store(policy_runner):
+    """Test that telemetry works without job_store."""
+    policy_runner.name = "test_policy"
+    policy_runner.job_store = None
+
+    # Should not raise an error
+    policy_runner.telemetry()
+
+
+def test_run_updates_job_on_success(policy_runner, sample_scopes, sample_config):
+    """Test that run() updates job status to completed on success."""
+    job_store = JobStore()
+    policy_runner.name = "test_policy"
+    policy_runner.job_store = job_store
+
+    # Create a job first
+    job = job_store.create_job("test_policy")
+    job_id = job.id
+
+    with (
+        patch("device_discovery.policy.runner.get_network_driver") as mock_get_driver,
+        patch("device_discovery.client.Client.ingest") as mock_ingest,
+    ):
+        mock_driver_instance = MagicMock()
+        mock_get_driver.return_value.return_value.__enter__.return_value = (
+            mock_driver_instance
+        )
+        mock_driver_instance.get_facts.return_value = {"model": "SampleModel"}
+        mock_driver_instance.get_interfaces.return_value = {}
+        mock_driver_instance.get_interfaces_ip.return_value = {}
+
+        policy_runner.run("test_id", sample_scopes[0], sample_config)
+
+        # Verify job was updated to completed
+        jobs = job_store.get_jobs_for_policy("test_policy")
+        assert len(jobs) == 1
+        assert jobs[0].status == JobStatus.COMPLETED
+        assert jobs[0].error is None
+
+
+def test_run_updates_job_on_failure(policy_runner, sample_scopes, sample_config):
+    """Test that run() updates job status to failed on error."""
+    job_store = JobStore()
+    policy_runner.name = "test_policy"
+    policy_runner.job_store = job_store
+
+    # Create a job first
+    job = job_store.create_job("test_policy")
+    job_id = job.id
+
+    with (
+        patch("device_discovery.policy.runner.get_network_driver") as mock_get_driver,
+        patch("device_discovery.policy.runner.logger.error") as mock_logger_error,
+    ):
+        mock_get_driver.side_effect = Exception("Connection error")
+
+        policy_runner.run("test_id", sample_scopes[0], sample_config)
+
+        # Verify job was updated to failed
+        jobs = job_store.get_jobs_for_policy("test_policy")
+        assert len(jobs) == 1
+        assert jobs[0].status == JobStatus.FAILED
+        assert jobs[0].error == "Connection error"
+
+
+def test_run_includes_job_id_in_metadata(policy_runner, sample_scopes, sample_config):
+    """Test that run() includes job_id in ingestion metadata."""
+    job_store = JobStore()
+    policy_runner.name = "test_policy"
+    policy_runner.job_store = job_store
+
+    # Create a job first
+    job = job_store.create_job("test_policy")
+    job_id = job.id
+
+    with (
+        patch("device_discovery.policy.runner.get_network_driver") as mock_get_driver,
+        patch("device_discovery.client.Client.ingest") as mock_ingest,
+    ):
+        mock_driver_instance = MagicMock()
+        mock_get_driver.return_value.return_value.__enter__.return_value = (
+            mock_driver_instance
+        )
+        mock_driver_instance.get_facts.return_value = {"model": "SampleModel"}
+        mock_driver_instance.get_interfaces.return_value = {}
+        mock_driver_instance.get_interfaces_ip.return_value = {}
+
+        policy_runner.run("test_id", sample_scopes[0], sample_config)
+
+        # Verify job_id is included in metadata
+        mock_ingest.assert_called_once()
+        metadata_arg, _ = mock_ingest.call_args[0]
+        assert metadata_arg["job_id"] == job_id
+        assert metadata_arg["policy_name"] == "test_policy"
+        assert metadata_arg["hostname"] == sample_scopes[0].hostname
+
+
+def test_run_without_job_store(policy_runner, sample_scopes, sample_config):
+    """Test that run() works without job_store."""
+    policy_runner.name = "test_policy"
+    policy_runner.job_store = None
+
+    with (
+        patch("device_discovery.policy.runner.get_network_driver") as mock_get_driver,
+        patch("device_discovery.client.Client.ingest") as mock_ingest,
+    ):
+        mock_driver_instance = MagicMock()
+        mock_get_driver.return_value.return_value.__enter__.return_value = (
+            mock_driver_instance
+        )
+        mock_driver_instance.get_facts.return_value = {"model": "SampleModel"}
+        mock_driver_instance.get_interfaces.return_value = {}
+        mock_driver_instance.get_interfaces_ip.return_value = {}
+
+        # Should not raise an error
+        policy_runner.run("test_id", sample_scopes[0], sample_config)
+
+        # Verify metadata doesn't include job_id
+        mock_ingest.assert_called_once()
+        metadata_arg, _ = mock_ingest.call_args[0]
+        assert "job_id" not in metadata_arg
+
+
+def test_run_updates_job_on_driver_discovery_failure(policy_runner, sample_scopes, sample_config):
+    """Test that run() updates job status when driver discovery fails."""
+    job_store = JobStore()
+    policy_runner.name = "test_policy"
+    policy_runner.job_store = job_store
+    sample_scopes[0].driver = None  # Force driver discovery
+
+    # Create a job first
+    job = job_store.create_job("test_policy")
+    job_id = job.id
+
+    with (
+        patch(
+            "device_discovery.policy.runner.discover_device_driver", return_value=None
+        ),
+        patch.object(policy_runner.scheduler, "remove_job") as mock_remove_job,
+    ):
+        policy_runner.run("test_id", sample_scopes[0], sample_config)
+
+        # Verify job was updated to failed
+        jobs = job_store.get_jobs_for_policy("test_policy")
+        assert len(jobs) == 1
+        assert jobs[0].status == JobStatus.FAILED
+        assert "Failed to discover driver" in jobs[0].error

--- a/device-discovery/tests/test_server.py
+++ b/device-discovery/tests/test_server.py
@@ -162,8 +162,11 @@ def test_read_status(mock_version_semver):
     response = client.get("/api/v1/status")
     mock_version_semver.assert_called_once()
     assert response.status_code == 200
-    assert response.json()["version"] == "1.0.0"
-    assert "up_time_seconds" in response.json()
+    data = response.json()
+    assert data["version"] == "1.0.0"
+    assert "up_time_seconds" in data
+    assert "policies" in data
+    assert isinstance(data["policies"], list)
 
 
 def test_read_capabilities(mock_supported_drivers):
@@ -399,3 +402,44 @@ def test_delete_policy_error(mock_manager):
     response = client.delete("/api/v1/policies/policy1")
     assert response.status_code == 400
     assert response.json()["detail"] == "unexpected error"
+
+
+def test_read_status_with_policies(mock_version_semver):
+    """
+    Test the /api/v1/status endpoint includes policies with jobs.
+
+    Ensures that policies are included in the status response with their jobs.
+
+    Args:
+    ----
+        mock_version_semver: Mocked version_semver function.
+
+    """
+    # Mock get_policy_statuses to return sample data
+    mock_policies = [
+        {
+            "name": "test-policy",
+            "status": "completed",
+            "jobs": [
+                {
+                    "id": "job-1",
+                    "status": "completed",
+                    "error": None,
+                    "created_at": "2024-01-01T00:00:00",
+                    "updated_at": "2024-01-01T00:01:00",
+                }
+            ],
+        }
+    ]
+
+    with patch.object(manager, "get_policy_statuses", return_value=mock_policies):
+        response = client.get("/api/v1/status")
+        assert response.status_code == 200
+        data = response.json()
+        assert "policies" in data
+        assert len(data["policies"]) == 1
+        assert data["policies"][0]["name"] == "test-policy"
+        assert data["policies"][0]["status"] == "completed"
+        assert len(data["policies"][0]["jobs"]) == 1
+        assert data["policies"][0]["jobs"][0]["id"] == "job-1"
+        assert data["policies"][0]["jobs"][0]["status"] == "completed"


### PR DESCRIPTION
This pull request introduces a job tracking system for device discovery policies, enabling detailed status reporting for each policy and its executions. It adds a thread-safe `JobStore` to track job lifecycle (running, completed, failed), integrates job reporting into policy execution, and updates the API and documentation to expose this information. Additionally, it adds developer tooling commands to the Makefile.

**Job tracking and status reporting:**

* Introduced a new `JobStore` class in `policy/job.py` to manage jobs per policy, supporting thread-safe creation, updating, and retrieval of job records, each with status, timestamps, reason, and entity count.
* Integrated `JobStore` into `PolicyManager` and `PolicyRunner` (`manager.py`, `runner.py`), so that each policy execution cycle creates and updates a job record, including error handling and entity counts. [[1]](diffhunk://#diff-c8715c972ae43ba4cd45bd2bb597597f0a2242b48b232aeeff05795199d04724R10) [[2]](diffhunk://#diff-c8715c972ae43ba4cd45bd2bb597597f0a2242b48b232aeeff05795199d04724R47) [[3]](diffhunk://#diff-c8715c972ae43ba4cd45bd2bb597597f0a2242b48b232aeeff05795199d04724L61-R63) [[4]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fR18) [[5]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fR36-R38) [[6]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fR47-R50) [[7]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fR114-R117) [[8]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fL138-R147) [[9]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fR156-R160) [[10]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fR204-R219) [[11]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fR233-R241) [[12]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fR250-R257) [[13]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fL230-R270) [[14]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fR285-R290) [[15]](diffhunk://#diff-39f0ea02f8aa249588ad02adba4c7118014ed39bcc962ae619cb8b20a662220fR312-R315)
* Added a `get_policy_statuses` method to `PolicyManager` that aggregates policy/job statuses for API reporting, and updated the server status endpoint to include this data. [[1]](diffhunk://#diff-c8715c972ae43ba4cd45bd2bb597597f0a2242b48b232aeeff05795199d04724R118-R182) [[2]](diffhunk://#diff-80291323eff883c98ddb82a96c56a5c1370ae747db1a027f78b034186cbb8563L124-R131)

**API and documentation updates:**

* Enhanced the API response and documentation in `README.md` to show detailed policy/job status and example output, reflecting the new job tracking fields.

**Developer tooling:**

* Added Makefile targets for installing dev tools, running tests, linting, and formatting to streamline development.