### PR TITLE
feat: worker jobs

### DIFF
--- a/worker/tests/policy/test_manager.py
+++ b/worker/tests/policy/test_manager.py
@@ -37,7 +37,7 @@ def test_start_policy(policy_manager, sample_policy):
         policy_manager.start_policy("policy1", sample_policy)
 
         # Check that PolicyRunner.setup was called with correct arguments
-        mock_runner.setup.assert_called_once_with("policy1", None, sample_policy)
+        mock_runner.setup.assert_called_once_with("policy1", None, sample_policy, policy_manager.job_store)
 
         # Ensure the policy runner was added to the manager's runners
         assert "policy1" in policy_manager.runners

--- a/worker/tests/test_server.py
+++ b/worker/tests/test_server.py
@@ -154,8 +154,11 @@ def test_read_status(mock_version_semver):
         response = client.get("/api/v1/status")
         mock_version_semver.assert_called_once()
         assert response.status_code == 200
-        assert response.json()["version"] == "1.0.0"
-        assert "up_time_seconds" in response.json()
+        data = response.json()
+        assert data["version"] == "1.0.0"
+        assert "up_time_seconds" in data
+        assert "policies" in data
+        assert isinstance(data["policies"], list)
         assert mock_api_requests.add.call_count == 1
         assert mock_api_response_latency.record.call_count == 1
 

--- a/worker/worker/policy/manager.py
+++ b/worker/worker/policy/manager.py
@@ -8,6 +8,7 @@ import os
 import yaml
 
 from worker.models import DiodeConfig, Policy, PolicyRequest
+from worker.policy.job import JobStore
 from worker.policy.runner import PolicyRunner
 
 # Set up logging
@@ -46,6 +47,7 @@ class PolicyManager:
         self.runners = dict[str, PolicyRunner]()
         self.config = None
         self.loaded_modules = set()
+        self.job_store = JobStore()
 
     def get_loaded_modules(self):
         """Return the loaded modules."""
@@ -76,7 +78,7 @@ class PolicyManager:
             raise ValueError(f"policy '{name}' already exists")
 
         runner = PolicyRunner()
-        runner.setup(name, self.config, policy)
+        runner.setup(name, self.config, policy, self.job_store)
         self.loaded_modules.add(policy.config.package)
         self.runners[name] = runner
 
@@ -132,3 +134,67 @@ class PolicyManager:
             logger.info(f"Stopping policy '{name}'")
             runner.stop()
         self.runners = {}
+
+    def get_policy_statuses(self) -> list[dict]:
+        """
+        Get all policies with their status and jobs.
+
+        Returns
+        -------
+            list[dict]: List of policy status dictionaries with name, status, and jobs.
+
+        """
+        all_jobs = self.job_store.get_all_policies_with_jobs()
+        statuses = []
+
+        # Get statuses for all policies that have runners
+        for name in self.runners:
+            jobs = self.job_store.get_jobs_for_policy(name)
+            status = "unknown"
+            if len(jobs) > 0:
+                latest_job = jobs[-1]
+                status = latest_job.status.value
+            statuses.append(
+                {
+                    "name": name,
+                    "status": status,
+                    "jobs": [
+                        {
+                            "id": job.id,
+                            "status": job.status.value,
+                            "reason": job.reason,
+                            "entity_count": job.entity_count,
+                            "created_at": job.created_at.isoformat(),
+                            "updated_at": job.updated_at.isoformat(),
+                        }
+                        for job in jobs
+                    ],
+                }
+            )
+
+        # Also include policies that have jobs but no active runner
+        for name, jobs in all_jobs.items():
+            if name not in self.runners:
+                status = "unknown"
+                if len(jobs) > 0:
+                    latest_job = jobs[-1]
+                    status = latest_job.status.value
+                statuses.append(
+                    {
+                        "name": name,
+                        "status": status,
+                        "jobs": [
+                            {
+                                "id": job.id,
+                                "status": job.status.value,
+                                "reason": job.reason,
+                                "entity_count": job.entity_count,
+                                "created_at": job.created_at.isoformat(),
+                                "updated_at": job.updated_at.isoformat(),
+                            }
+                            for job in jobs
+                        ],
+                    }
+                )
+
+        return statuses

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -124,85 +124,108 @@ class PolicyRunner:
             policy: Policy configuration.
 
         """
-        # Create job at start
-        job = None
-        if self.job_store:
-            job = self.job_store.create_job(self.name)
-
-        policy_executions = get_metric("policy_executions")
-        if policy_executions:
-            policy_executions.add(1, {"policy": self.name})
+        job = self._create_job()
+        self._record_execution_metrics()
 
         exec_start_time = time.perf_counter()
         entity_count = 0
         try:
             entities = backend.run(self.name, policy)
-            metadata = {
-                "policy_name": self.name,
-                "worker_backend": self.metadata.name,
-            }
-            if job:
-                metadata["job_id"] = job.id
+            metadata = self._build_metadata(job)
 
             entity_count = len(entities)
             if entity_count == 0:
                 logger.info(f"Policy {self.name}: No entities to ingest")
-                if self.job_store and job:
-                    self.job_store.update_job(
-                        self.name, job.id, JobStatus.COMPLETED, reason=None, entity_count=0
-                    )
+                self._update_job_status(job, JobStatus.COMPLETED, None, 0)
                 return
 
-            for chunk_num, entity_chunk in enumerate(self._create_message_chunks(entities), 1):
-                chunk_size_mb = self._estimate_message_size(entity_chunk) / (1024 * 1024)
-                logger.debug(
-                    f"Ingesting chunk {chunk_num} with {len(entity_chunk)} entities (~{chunk_size_mb:.2f} MB)"
-                )
-                response = client.ingest(entities=entity_chunk, metadata=metadata)
-                if response.errors:
-                    raise RuntimeError(f"Chunk {chunk_num} ingestion failed: {response.errors}")
-                logger.debug(f"Chunk {chunk_num} ingested successfully")
-
+            chunk_num = self._ingest_entities(client, entities, metadata)
             logger.info(f"Policy {self.name}: Successfully ingested {entity_count} entities in {chunk_num} chunks")
-            
-            # Update job status to completed on success
-            if self.job_store and job:
-                self.job_store.update_job(
-                    self.name, job.id, JobStatus.COMPLETED, reason=None, entity_count=entity_count
-                )
 
-            run_success = get_metric("backend_execution_success")
-            if run_success:
-                run_success.add(
-                    1,
-                    {
-                        "policy": self.name,
-                        "backend": self.metadata.name,
-                        "app_name": self.metadata.app_name,
-                        "app_version": self.metadata.app_version,
-                    },
-                )
+            self._handle_success(job, entity_count)
         except Exception as e:
             logger.error(f"Policy {self.name}: {e}")
-            
-            # Update job status to failed
-            if self.job_store and job:
-                self.job_store.update_job(
-                    self.name, job.id, JobStatus.FAILED, reason=e, entity_count=entity_count
-                )
+            self._handle_failure(job, e, entity_count)
 
-            run_failure = get_metric("backend_execution_failure")
-            if run_failure:
-                run_failure.add(
-                    1,
-                    {
-                        "policy": self.name,
-                        "backend": self.metadata.name,
-                        "app_name": self.metadata.app_name,
-                        "app_version": self.metadata.app_version,
-                    },
-                )
+        self._record_latency_metric(exec_start_time)
 
+    def _create_job(self):
+        """Create a job if job_store is available."""
+        if self.job_store:
+            return self.job_store.create_job(self.name)
+        return None
+
+    def _record_execution_metrics(self):
+        """Record policy execution metrics."""
+        policy_executions = get_metric("policy_executions")
+        if policy_executions:
+            policy_executions.add(1, {"policy": self.name})
+
+    def _build_metadata(self, job):
+        """Build metadata dictionary for ingestion."""
+        metadata = {
+            "policy_name": self.name,
+            "worker_backend": self.metadata.name,
+        }
+        if job:
+            metadata["job_id"] = job.id
+        return metadata
+
+    def _update_job_status(self, job, status: JobStatus, reason, entity_count: int):
+        """Update job status if job_store and job are available."""
+        if self.job_store and job:
+            self.job_store.update_job(self.name, job.id, status, reason=reason, entity_count=entity_count)
+
+    def _ingest_entities(
+        self, client: DiodeClient | DiodeDryRunClient, entities: list[ingester_pb2.Entity], metadata: dict
+    ) -> int:
+        """Ingest entities in chunks and return the number of chunks."""
+        chunk_num = 0
+        for chunk_num, entity_chunk in enumerate(self._create_message_chunks(entities), 1):
+            chunk_size_mb = self._estimate_message_size(entity_chunk) / (1024 * 1024)
+            logger.debug(
+                f"Ingesting chunk {chunk_num} with {len(entity_chunk)} entities (~{chunk_size_mb:.2f} MB)"
+            )
+            response = client.ingest(entities=entity_chunk, metadata=metadata)
+            if response.errors:
+                raise RuntimeError(f"Chunk {chunk_num} ingestion failed: {response.errors}")
+            logger.debug(f"Chunk {chunk_num} ingested successfully")
+        return chunk_num
+
+    def _handle_success(self, job, entity_count: int):
+        """Handle successful execution by updating job status and recording success metrics."""
+        self._update_job_status(job, JobStatus.COMPLETED, None, entity_count)
+
+        run_success = get_metric("backend_execution_success")
+        if run_success:
+            run_success.add(
+                1,
+                {
+                    "policy": self.name,
+                    "backend": self.metadata.name,
+                    "app_name": self.metadata.app_name,
+                    "app_version": self.metadata.app_version,
+                },
+            )
+
+    def _handle_failure(self, job, error: Exception, entity_count: int):
+        """Handle failed execution by updating job status and recording failure metrics."""
+        self._update_job_status(job, JobStatus.FAILED, error, entity_count)
+
+        run_failure = get_metric("backend_execution_failure")
+        if run_failure:
+            run_failure.add(
+                1,
+                {
+                    "policy": self.name,
+                    "backend": self.metadata.name,
+                    "app_name": self.metadata.app_name,
+                    "app_version": self.metadata.app_version,
+                },
+            )
+
+    def _record_latency_metric(self, exec_start_time: float):
+        """Record backend execution latency metric."""
         backend_execution_latency = get_metric("backend_execution_latency")
         if backend_execution_latency:
             exec_duration = (time.perf_counter() - exec_start_time) * 1000

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -15,6 +15,7 @@ from netboxlabs.diode.sdk.diode.v1 import ingester_pb2
 from worker.backend import Backend, load_class
 from worker.metrics import get_metric
 from worker.models import DiodeConfig, Policy, Status
+from worker.policy.job import JobStatus, JobStore
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -33,8 +34,9 @@ class PolicyRunner:
         self.policy = None
         self.status = Status.NEW
         self.scheduler = BackgroundScheduler()
+        self.job_store: JobStore | None = None
 
-    def setup(self, name: str, diode_config: DiodeConfig, policy: Policy):
+    def setup(self, name: str, diode_config: DiodeConfig, policy: Policy, job_store: JobStore | None = None):
         """
         Set up the policy runner.
 
@@ -43,8 +45,10 @@ class PolicyRunner:
             name: Policy name.
             diode_config: Diode configuration data.
             policy: Policy configuration data.
+            job_store: Optional JobStore for tracking jobs.
 
         """
+        self.job_store = job_store
         self.name = name.replace("\r\n", "").replace("\n", "")
         policy.config.package = policy.config.package.replace("\r\n", "").replace(
             "\n", ""
@@ -120,17 +124,34 @@ class PolicyRunner:
             policy: Policy configuration.
 
         """
+        # Create job at start
+        job = None
+        if self.job_store:
+            job = self.job_store.create_job(self.name)
+
         policy_executions = get_metric("policy_executions")
         if policy_executions:
             policy_executions.add(1, {"policy": self.name})
 
         exec_start_time = time.perf_counter()
+        entity_count = 0
         try:
             entities = backend.run(self.name, policy)
             metadata = {
                 "policy_name": self.name,
                 "worker_backend": self.metadata.name,
             }
+            if job:
+                metadata["job_id"] = job.id
+
+            entity_count = len(entities)
+            if entity_count == 0:
+                logger.info(f"Policy {self.name}: No entities to ingest")
+                if self.job_store and job:
+                    self.job_store.update_job(
+                        self.name, job.id, JobStatus.COMPLETED, reason=None, entity_count=0
+                    )
+                return
 
             for chunk_num, entity_chunk in enumerate(self._create_message_chunks(entities), 1):
                 chunk_size_mb = self._estimate_message_size(entity_chunk) / (1024 * 1024)
@@ -142,7 +163,14 @@ class PolicyRunner:
                     raise RuntimeError(f"Chunk {chunk_num} ingestion failed: {response.errors}")
                 logger.debug(f"Chunk {chunk_num} ingested successfully")
 
-            logger.info(f"Policy {self.name}: Successfully ingested {len(entities)} entities in {chunk_num} chunks")
+            logger.info(f"Policy {self.name}: Successfully ingested {entity_count} entities in {chunk_num} chunks")
+            
+            # Update job status to completed on success
+            if self.job_store and job:
+                self.job_store.update_job(
+                    self.name, job.id, JobStatus.COMPLETED, reason=None, entity_count=entity_count
+                )
+
             run_success = get_metric("backend_execution_success")
             if run_success:
                 run_success.add(
@@ -156,6 +184,13 @@ class PolicyRunner:
                 )
         except Exception as e:
             logger.error(f"Policy {self.name}: {e}")
+            
+            # Update job status to failed
+            if self.job_store and job:
+                self.job_store.update_job(
+                    self.name, job.id, JobStatus.FAILED, reason=e, entity_count=entity_count
+                )
+
             run_failure = get_metric("backend_execution_failure")
             if run_failure:
                 run_failure.add(

--- a/worker/worker/server.py
+++ b/worker/worker/server.py
@@ -120,13 +120,14 @@ def read_status():
 
     Returns
     -------
-        dict: The status of the server.
+        dict: The status of the server including policies with jobs.
 
     """
     time_diff = datetime.now() - start_time
     return {
         "version": version_semver(),
         "up_time_seconds": round(time_diff.total_seconds()),
+        "policies": manager.get_policy_statuses(),
     }
 
 


### PR DESCRIPTION
This pull request introduces significant improvements to job tracking and policy status reporting in the policy management system. The main changes include integrating a `JobStore` into the policy manager and runner, enabling detailed tracking of job executions for each policy, and exposing comprehensive policy/job status information via the server status endpoint. Additionally, the `PolicyRunner` logic is refactored for cleaner job lifecycle management and metric reporting.

**Job tracking and policy status enhancements:**

- Integrated a `JobStore` instance into `PolicyManager` and passed it to each `PolicyRunner`, allowing centralized tracking of jobs associated with policy executions. (`worker/worker/policy/manager.py`, `worker/worker/policy/runner.py`) [[1]](diffhunk://#diff-a9fc052d6dc03d7c0b255e9079f560d3767935adc86ac43e60cb9f033404be75R11) [[2]](diffhunk://#diff-a9fc052d6dc03d7c0b255e9079f560d3767935adc86ac43e60cb9f033404be75R50) [[3]](diffhunk://#diff-a9fc052d6dc03d7c0b255e9079f560d3767935adc86ac43e60cb9f033404be75L79-R81) [[4]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R18) [[5]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R37-R39) [[6]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R48-R51)
- Added a new `get_policy_statuses` method to `PolicyManager` that returns a list of policies with their status and associated jobs, including those with jobs but no active runner. (`worker/worker/policy/manager.py`)

**PolicyRunner job lifecycle and metric refactoring:**

- Refactored `PolicyRunner.run` to use helper methods for job creation, status updates, and metric recording, ensuring job status is updated on both success and failure, and added more granular metrics and logging. (`worker/worker/policy/runner.py`) [[1]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2L123-R183) [[2]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R193-L145) [[3]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2L157-R214) [[4]](diffhunk://#diff-77ccd0c70b117c80a734aad5873b3fce2bfca6d5d1486c8bcf12f6e19cdd57e2R227-R228)

**API and test updates:**

- Updated the server status endpoint to include the new detailed policies/job status in its response. (`worker/worker/server.py`)
- Adjusted and extended tests to verify the new job tracking and policy status reporting behavior. (`worker/tests/policy/test_manager.py`, `worker/tests/test_server.py`) [[1]](diffhunk://#diff-1a7788aca7065180e3b939777776453d5a9d752b0e28c32168dcf27bb9727fd8L40-R40) [[2]](diffhunk://#diff-b84f35faddf31d973e982311c3ea4af3d90099439912cb7c4e23cf311e6e7bbbL157-R161)