### PR TITLE
feat: truncate platform name if size > than 100

### DIFF
--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -418,6 +418,8 @@ def translate_data(data: dict) -> Iterable[Entity]:
             device_info["platform"] = (
                 f"{data.get('driver', '').upper()} {device_info.get('os_version')}"
             )
+            if len(device_info["platform"]) > 100:
+                device_info["platform"] = device_info.get('os_version')[:100]
         device = translate_device(device_info, defaults)
         entities.append(Entity(device=device))
 

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -304,6 +304,26 @@ def test_translate_data(
     assert entities[0].device.role.name == "switch"
 
 
+def test_translate_data_truncates_platform(sample_device_info, sample_defaults):
+    """Ensure overly long platform strings are truncated to 100 characters."""
+    long_os_version = "v" * 150
+    device_info = sample_device_info.copy()
+    device_info["os_version"] = long_os_version
+    data = {
+        "device": device_info,
+        "interface": {},
+        "interface_ip": {},
+        "driver": "ios",
+        "defaults": sample_defaults,
+    }
+
+    entities = list(translate_data(data))
+
+    assert len(entities) == 1
+    assert entities[0].device.platform.name == long_os_version[:100]
+    assert len(entities[0].device.platform.name) == 100
+
+
 def test_translate_data_creates_missing_interface(sample_device_info, sample_defaults):
     """Ensure translate_data creates interfaces referenced only by IP data."""
     interfaces = {


### PR DESCRIPTION
This pull request addresses an issue with overly long platform strings in device data by ensuring that the `platform` field is truncated to a maximum of 100 characters. It also adds a corresponding test to verify this behavior.

Platform string truncation:

* Updated the `translate_data` function in `device_discovery/translate.py` to truncate the `platform` string to 100 characters if it exceeds that length, using the `os_version` field for truncation.

Testing:

* Added a new test `test_translate_data_truncates_platform` in `tests/test_translate.py` to confirm that the platform string is correctly truncated and does not exceed 100 characters.