### PR TITLE
chore: add timeout message to network discovery

### DIFF
--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -287,6 +287,7 @@ func (r *Runner) run() {
 				slog.Duration("timeout", r.timeout),
 				slog.String("policy", policyName),
 			)
+			err = fmt.Errorf("nmap scan timed out after %s: %w", r.timeout, err)
 		}
 		r.logger.Error("error running scanner", slog.Any("error", err), slog.String("policy", policyName))
 		r.jobStore.UpdateJob(policyName, job.ID, JobStatusFailed, err, 0)

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -3,6 +3,7 @@ package policy
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -281,6 +282,12 @@ func (r *Runner) run() {
 		r.logger.Warn("run finished with warnings", slog.String("warnings", fmt.Sprintf("%v", *warnings)))
 	}
 	if err != nil {
+		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
+			r.logger.Warn("nmap scan timed out; consider increasing policy timeout",
+				slog.Duration("timeout", r.timeout),
+				slog.String("policy", policyName),
+			)
+		}
 		r.logger.Error("error running scanner", slog.Any("error", err), slog.String("policy", policyName))
 		r.jobStore.UpdateJob(policyName, job.ID, JobStatusFailed, err, 0)
 		if rMetric := metrics.GetDiscoveryFailure(); rMetric != nil {


### PR DESCRIPTION
This pull request adds improved error handling for timeouts during the network discovery policy scan. Specifically, it introduces a warning log when the scan times out, suggesting to increase the policy timeout.

Error handling and logging improvements:

* Added a check for `context.DeadlineExceeded` errors in the `run` method of the `Runner` to log a warning if the nmap scan times out, including the current timeout and policy name. This helps users identify when a scan fails due to timeout and suggests increasing the timeout as a possible resolution.
* Imported the `errors` package to support the new error handling logic.