### PR TITLE
chore: run snmp target in its own job and improve parse targets

### DIFF
--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log/slog"
 	"os"
 	"os/signal"
 	"syscall"
@@ -99,7 +98,7 @@ func main() {
 			logger.Error("failed to setup metrics export", "error", err)
 			os.Exit(1)
 		}
-		logger.Info("Metrics export configured", slog.String("endpoint", *otelEndpoint), slog.Int("period_seconds", *otelExportPeriod))
+		logger.Info("Metrics export configured", "endpoint", *otelEndpoint, "period_seconds", *otelExportPeriod)
 	}
 
 	manufacturers, err := data.NewManufacturerLookup()

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -32,7 +32,7 @@ const (
 type Runner struct {
 	scheduler     gocron.Scheduler
 	ctx           context.Context
-	task          gocron.Task
+	tasks         []gocron.Task
 	client        diode.Client
 	logger        *slog.Logger
 	timeout       time.Duration
@@ -64,16 +64,6 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 		jobStore:      jobStore,
 	}
 
-	runner.task = gocron.NewTask(runner.run)
-	if policy.Config.Schedule != nil {
-		_, err = runner.scheduler.NewJob(gocron.CronJob(*policy.Config.Schedule, false), runner.task, gocron.WithSingletonMode(gocron.LimitModeReschedule))
-	} else {
-		_, err = runner.scheduler.NewJob(gocron.OneTimeJob(
-			gocron.OneTimeJobStartDateTime(time.Now().Add(1*time.Second))), runner.task, gocron.WithSingletonMode(gocron.LimitModeReschedule))
-	}
-	if err != nil {
-		return nil, err
-	}
 	runner.timeout = time.Duration(policy.Config.Timeout) * time.Second
 	if runner.timeout == 0 {
 		runner.timeout = defaultTimeout
@@ -85,11 +75,29 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	runner.ctx = context.WithValue(ctx, policyKey, name)
 	runner.scope = policy.Scope
 	runner.config = policy.Config
+
+	expandedTargets := runner.expandTargetRanges(runner.scope.Targets)
+
+	for _, target := range expandedTargets {
+		task := gocron.NewTask(runner.run, target)
+		if policy.Config.Schedule != nil {
+			_, err = runner.scheduler.NewJob(gocron.CronJob(*policy.Config.Schedule, false), task,
+				gocron.WithSingletonMode(gocron.LimitModeReschedule))
+		} else {
+			_, err = runner.scheduler.NewJob(gocron.OneTimeJob(
+				gocron.OneTimeJobStartDateTime(time.Now().Add(1*time.Second))), task,
+				gocron.WithSingletonMode(gocron.LimitModeReschedule))
+		}
+		if err != nil {
+			return nil, err
+		}
+		runner.tasks = append(runner.tasks, task)
+	}
 	return runner, nil
 }
 
 // run runs the policy
-func (r *Runner) run() {
+func (r *Runner) run(target config.Target) {
 	policyName := r.ctx.Value(policyKey).(string)
 
 	// Create job at start
@@ -117,16 +125,11 @@ func (r *Runner) run() {
 	ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 	defer cancel()
 
-	r.logger.Info("Starting SNMP crawl of targets", slog.Any("targetCount", len(r.scope.Targets)))
-
-	// Expand all targets
-	expandedTargets := r.expandTargetRanges(r.scope.Targets)
-
-	entities := r.queryTargets(expandedTargets)
-	r.logger.Info("SNMP crawl complete", slog.Any("policy", r.ctx.Value(policyKey)), slog.Any("entityCount", len(entities)))
+	entities := r.queryTarget(target)
+	r.logger.Info("SNMP crawl complete", "policy", policyName, "entityCount", len(entities))
 
 	if len(entities) == 0 {
-		r.logger.Info("No entities to ingest", slog.Any("policy", r.ctx.Value(policyKey)))
+		r.logger.Info("No entities to ingest", "policy", policyName)
 		// Update job status to completed even if no entities
 		r.jobStore.UpdateJob(policyName, job.ID, JobStatusCompleted, nil, 0)
 		return
@@ -139,84 +142,83 @@ func (r *Runner) run() {
 		"job_id":      job.ID,
 	}))
 	if err != nil {
-		r.logger.Error("error ingesting entities", slog.Any("error", err), slog.Any("policy", r.ctx.Value(policyKey)))
+		r.logger.Error("error ingesting entities", "error", err, "policy", policyName)
 		r.jobStore.UpdateJob(policyName, job.ID, JobStatusFailed, err, len(entities))
 	} else if resp != nil && resp.Errors != nil {
 		ingestErr := fmt.Errorf("ingestion errors: %v", resp.Errors)
-		r.logger.Error("error ingesting entities", slog.Any("error", resp.Errors), slog.Any("policy", r.ctx.Value(policyKey)))
+		r.logger.Error("error ingesting entities", "error", resp.Errors, "policy", policyName)
 		r.jobStore.UpdateJob(policyName, job.ID, JobStatusFailed, ingestErr, len(entities))
 	} else {
-		r.logger.Info("entities ingested successfully", slog.Any("policy", r.ctx.Value(policyKey)))
+		r.logger.Info("entities ingested successfully", "policy", policyName)
 		r.jobStore.UpdateJob(policyName, job.ID, JobStatusCompleted, nil, len(entities))
 	}
 }
 
 func (r *Runner) logEntitiesForIngestion(entities []diode.Entity) {
 	for _, entity := range entities {
-		r.logger.Debug("Entity for ingestion", slog.Any("entity", entity.ConvertToProtoMessage()))
+		r.logger.Debug("Entity for ingestion", "entity", entity.ConvertToProtoMessage())
 	}
 }
 
-func (r *Runner) queryTargets(expandedTargets []config.Target) []diode.Entity {
+func (r *Runner) queryTarget(target config.Target) []diode.Entity {
 	mappingConfig := mapping.NewConfig(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup)
 	objectIDs := mappingConfig.ObjectIDs()
-	r.logger.Info("Querying targets", slog.Any("targetCount", len(expandedTargets)), slog.Any("objectCount", len(objectIDs)))
+	r.logger.Info("Querying target", "target", target, "objectCount", len(objectIDs))
 
 	entities := make([]diode.Entity, 0)
 
-	for _, target := range expandedTargets {
-		mapper := mapping.NewObjectIDMapper(mappingConfig, r.logger, &r.config.Defaults)
-		policyName := r.ctx.Value(policyKey).(string)
-		// Track discovery attempt
-		if rMetric := metrics.GetDiscoveryAttempts(); rMetric != nil {
-			rMetric.Add(r.ctx, 1,
-				metric.WithAttributes(
-					attribute.String("policy", policyName)))
-		}
-
-		// Start timing the discovery
-		startTime := time.Now()
-
-		host := snmp.NewHost(target.Host, target.Port, r.config.Retries, r.snmpTimeout, &r.scope.Authentication, r.logger, r.ClientFactory)
-		oids, err := host.Walk(objectIDs)
-		if err != nil {
-			r.logger.Warn("Error crawling host", "host", target.Host, "error", err)
-			// Track failed discovery
-			if rMetric := metrics.GetDiscoveryFailure(); rMetric != nil {
-				policyName := r.ctx.Value(policyKey).(string)
-				rMetric.Add(r.ctx, 1,
-					metric.WithAttributes(
-						attribute.String("policy", policyName),
-						attribute.String("error", err.Error()),
-					))
-			}
-			continue
-		}
-
-		// Track successful discovery
-		if rMetric := metrics.GetDiscoverySuccess(); rMetric != nil {
-			rMetric.Add(r.ctx, 1,
-				metric.WithAttributes(
-					attribute.String("policy", policyName)))
-		}
-
-		// Record discovery latency
-		if rMetric := metrics.GetDiscoveryLatency(); rMetric != nil {
-			rMetric.Record(r.ctx, time.Since(startTime).Seconds(),
-				metric.WithAttributes(
-					attribute.String("policy", policyName)))
-		}
-
-		entitiesForTarget := mapper.MapObjectIDsToEntity(oids)
-		entities = append(entities, entitiesForTarget...)
-
-		// Update discovered hosts gauge
-		if rMetric := metrics.GetDiscoveredHosts(); rMetric != nil {
-			rMetric.Record(r.ctx, int64(len(entitiesForTarget)),
-				metric.WithAttributes(
-					attribute.String("policy", policyName)))
-		}
+	mapper := mapping.NewObjectIDMapper(mappingConfig, r.logger, &r.config.Defaults)
+	policyName := r.ctx.Value(policyKey).(string)
+	// Track discovery attempt
+	if rMetric := metrics.GetDiscoveryAttempts(); rMetric != nil {
+		rMetric.Add(r.ctx, 1,
+			metric.WithAttributes(
+				attribute.String("policy", policyName)))
 	}
+
+	// Start timing the discovery
+	startTime := time.Now()
+
+	host := snmp.NewHost(target.Host, target.Port, r.config.Retries, r.snmpTimeout, &r.scope.Authentication, r.logger, r.ClientFactory)
+	oids, err := host.Walk(objectIDs)
+	if err != nil {
+		r.logger.Warn("Error crawling host", "host", target.Host, "error", err)
+		// Track failed discovery
+		if rMetric := metrics.GetDiscoveryFailure(); rMetric != nil {
+			policyName := r.ctx.Value(policyKey).(string)
+			rMetric.Add(r.ctx, 1,
+				metric.WithAttributes(
+					attribute.String("policy", policyName),
+					attribute.String("error", err.Error()),
+				))
+		}
+		return entities
+	}
+
+	// Track successful discovery
+	if rMetric := metrics.GetDiscoverySuccess(); rMetric != nil {
+		rMetric.Add(r.ctx, 1,
+			metric.WithAttributes(
+				attribute.String("policy", policyName)))
+	}
+
+	// Record discovery latency
+	if rMetric := metrics.GetDiscoveryLatency(); rMetric != nil {
+		rMetric.Record(r.ctx, time.Since(startTime).Seconds(),
+			metric.WithAttributes(
+				attribute.String("policy", policyName)))
+	}
+
+	entitiesForTarget := mapper.MapObjectIDsToEntity(oids)
+	entities = append(entities, entitiesForTarget...)
+
+	// Update discovered hosts gauge
+	if rMetric := metrics.GetDiscoveredHosts(); rMetric != nil {
+		rMetric.Record(r.ctx, int64(len(entitiesForTarget)),
+			metric.WithAttributes(
+				attribute.String("policy", policyName)))
+	}
+
 	return entities
 }
 
@@ -240,7 +242,7 @@ func (r *Runner) expandTargetRanges(configuredTargets []config.Target) []config.
 
 // Start starts the policy runner
 func (r *Runner) Start() {
-	r.logger.Info("Starting policy runner", slog.Any("policy", r.ctx.Value(policyKey)))
+	r.logger.Info("Starting policy runner", "policy", r.ctx.Value(policyKey))
 	r.scheduler.Start()
 }
 

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -104,6 +104,33 @@ func TestNewRunner(t *testing.T) {
 	assert.NoError(t, err, "policy.NewRunner should not return an error")
 }
 
+func TestNewRunnerInvalidSchedule(t *testing.T) {
+	setupTestMetrics(t)
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+	mockClient := new(MockDiodeClient)
+	cron := "invalid cron expression"
+	policyConfig := config.Policy{
+		Config: config.PolicyConfig{
+			Schedule: &cron,
+		},
+		Scope: config.Scope{
+			Targets: []config.Target{
+				{
+					Host: "localhost",
+					Port: 161,
+				},
+			},
+		},
+	}
+	mappingConfig := config.Mapping{}
+	ctx := context.Background()
+	jobStore := policy.NewJobStore()
+
+	runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, &mappingConfig, nil, nil, jobStore)
+	assert.Error(t, err, "policy.NewRunner should return an error for invalid schedule")
+	assert.Nil(t, runner, "Runner should be nil when creation fails")
+}
+
 func TestRunnerRun(t *testing.T) {
 	setupTestMetrics(t)
 	tests := []*struct {

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -18,12 +18,12 @@ type SlogAdapter struct {
 }
 
 // Print implements gosnmp.LoggerInterface by logging at Debug level
-func (s *SlogAdapter) Print(v ...interface{}) {
+func (s *SlogAdapter) Print(v ...any) {
 	s.logger.Debug(fmt.Sprint(v...))
 }
 
 // Printf implements gosnmp.LoggerInterface by logging at Debug level
-func (s *SlogAdapter) Printf(format string, v ...interface{}) {
+func (s *SlogAdapter) Printf(format string, v ...any) {
 	s.logger.Debug(fmt.Sprintf(format, v...))
 }
 

--- a/snmp-discovery/targets/targets.go
+++ b/snmp-discovery/targets/targets.go
@@ -1,31 +1,40 @@
 package targets
 
 import (
+	"encoding/binary"
+	"errors"
 	"fmt"
-	"net"
+	"net/netip"
 	"strconv"
 	"strings"
+	"unicode"
 )
 
 // Expand takes a target string and returns a slice of individual IP addresses or hostnames.
 // It supports the following formats:
 // - CIDR notation (e.g., 10.10.10.0/24)
-// - IP range notation (e.g., 10.10.10.0-100)
+// - IP range notation (e.g., 10.10.10.0-100 or 10.10.10.0-10.10.10.100)
 // - Single IP address (e.g., 192.168.1.1)
 // - Hostname (e.g., example.com)
 func Expand(target string) ([]string, error) {
-	// Try parsing as CIDR first
+	// Attempt IP range expansion first so we can gracefully skip hostnames that contain hyphens.
+	if strings.Contains(target, "-") && (strings.Contains(target, ":") || !hasLetters(target)) {
+		ips, err := expandIPRange(target)
+		if err == nil {
+			return ips, nil
+		}
+		if !errors.Is(err, errNotRange) {
+			return nil, err
+		}
+	}
+
+	// Try parsing as CIDR (only when not handled as a range above)
 	if strings.Contains(target, "/") {
 		return expandCIDR(target)
 	}
 
-	// Try parsing as IP range
-	if strings.Contains(target, "-") {
-		return expandIPRange(target)
-	}
-
 	// Try parsing as single IP
-	if ip := net.ParseIP(target); ip != nil {
+	if _, err := netip.ParseAddr(target); err == nil {
 		return []string{target}, nil
 	}
 
@@ -35,92 +44,201 @@ func Expand(target string) ([]string, error) {
 
 // expandCIDR expands a CIDR notation into individual IP addresses
 func expandCIDR(cidr string) ([]string, error) {
-	_, ipnet, err := net.ParseCIDR(cidr)
+	prefix, err := netip.ParsePrefix(cidr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid CIDR notation: %w", err)
 	}
 
-	// Convert IPNet to IP
-	ip := ipnet.IP.To4()
-	if ip == nil {
+	if !prefix.Addr().Is4() {
 		return nil, fmt.Errorf("only IPv4 addresses are supported")
 	}
 
-	// Get network and broadcast addresses
-	mask := ipnet.Mask
-	network := ip.Mask(mask)
-	broadcast := make(net.IP, len(network))
-	for i := range network {
-		broadcast[i] = network[i] | ^mask[i]
+	const maxPrealloc = 1_048_576 // avoid huge upfront allocations for very large networks
+
+	prefix = prefix.Masked()
+	startVal := addrToUint32(prefix.Addr())
+	hostBits := 32 - prefix.Bits()
+	count := uint64(1) << hostBits
+	endVal := uint32(uint64(startVal) + count - 1)
+
+	rangeLen := uint64(endVal-startVal) + 1
+	capacity := 0
+	if rangeLen <= maxPrealloc {
+		capacity = int(rangeLen)
 	}
 
-	// Generate all IPs in range
-	var ips []string
-	ip = make(net.IP, len(network))
-	copy(ip, network)
-
-	// Include network address
-	ips = append(ips, ip.String())
-
-	// Generate all IPs including broadcast
-	for inc(ip); ip.To4() != nil && !ip.Equal(broadcast); inc(ip) {
-		ips = append(ips, ip.String())
+	ips := make([]string, 0, capacity)
+	for val := startVal; ; val++ {
+		ips = append(ips, uint32ToAddr(val).String())
+		if val == endVal {
+			break
+		}
 	}
-
-	// Include broadcast address
-	ips = append(ips, broadcast.String())
 
 	return ips, nil
 }
 
-// expandIPRange expands an IP range notation (e.g., 10.10.10.0-100) into individual IP addresses
+// errNotRange indicates the input does not represent an IP range and should be treated as a hostname.
+var errNotRange = errors.New("not an IP range")
+
+// expandIPRange expands an IP range notation (e.g., 10.10.10.0-100 or 10.10.10.0-10.10.10.100) into individual IP addresses.
+// If the input does not resemble an IP range (e.g., it's a hostname with a hyphen), it returns errNotRange so callers can fall back.
 func expandIPRange(rangeStr string) ([]string, error) {
-	parts := strings.Split(rangeStr, "-")
-	if len(parts) != 2 {
-		return nil, fmt.Errorf("invalid IP range format")
+	baseRaw, endRaw, ok := strings.Cut(rangeStr, "-")
+	if !ok {
+		return nil, errNotRange
+	}
+	if strings.Contains(endRaw, "-") {
+		if looksLikeIPNotation(strings.TrimSpace(baseRaw)) {
+			return nil, fmt.Errorf("invalid IP range format")
+		}
+		return nil, errNotRange
 	}
 
-	baseIP := net.ParseIP(strings.TrimSpace(parts[0]))
-	if baseIP == nil {
-		return nil, fmt.Errorf("invalid base IP address")
+	baseIP, looksLikeBase, err := parseRangeAddrPart(baseRaw)
+	if !looksLikeBase {
+		return nil, errNotRange
 	}
-
-	baseIP = baseIP.To4()
-	if baseIP == nil {
-		return nil, fmt.Errorf("only IPv4 addresses are supported")
-	}
-
-	endNum, err := strconv.Atoi(strings.TrimSpace(parts[1]))
 	if err != nil {
-		return nil, fmt.Errorf("invalid end number in range: %w", err)
+		return nil, fmt.Errorf("invalid base IP address: %w", err)
 	}
 
+	endRaw = strings.TrimSpace(endRaw)
+	endNum, err := strconv.Atoi(stripCIDR(endRaw))
+	if err == nil {
+		return expandLastOctetRange(baseIP, endNum)
+	}
+
+	endIP, looksLikeEnd, parseErr := parseRangeAddrPart(endRaw)
+	if !looksLikeEnd {
+		return nil, errNotRange
+	}
+	if parseErr != nil {
+		return nil, fmt.Errorf("invalid end IP address: %w", parseErr)
+	}
+
+	return expandFullIPRange(baseIP, endIP)
+}
+
+// expandLastOctetRange handles ranges like 10.10.10.0-100.
+func expandLastOctetRange(baseIP netip.Addr, endNum int) ([]string, error) {
 	if endNum < 0 || endNum > 255 {
 		return nil, fmt.Errorf("end number must be between 0 and 255")
 	}
 
-	var ips []string
-	baseNum := int(baseIP[3])
+	base4 := baseIP.As4()
+	baseNum := int(base4[3])
 	if endNum < baseNum {
 		return nil, fmt.Errorf("end number must be greater than or equal to the last octet of the base IP")
 	}
 
+	ips := make([]string, 0, endNum-baseNum+1)
 	for i := baseNum; i <= endNum; i++ {
-		ip := make(net.IP, len(baseIP))
-		copy(ip, baseIP)
-		ip[3] = byte(i)
-		ips = append(ips, ip.String())
+		ip4 := base4
+		ip4[3] = byte(i)
+		ips = append(ips, netip.AddrFrom4(ip4).String())
 	}
 
 	return ips, nil
 }
 
-// inc increments an IP address
-func inc(ip net.IP) {
-	for j := len(ip) - 1; j >= 0; j-- {
-		ip[j]++
-		if ip[j] > 0 {
+// expandFullIPRange handles ranges like 10.10.10.0-10.10.10.100 (CIDR suffixes are ignored).
+func expandFullIPRange(baseIP, endIP netip.Addr) ([]string, error) {
+	baseVal := addrToUint32(baseIP)
+	endVal := addrToUint32(endIP)
+
+	if endVal < baseVal {
+		return nil, fmt.Errorf("end IP must be greater than or equal to the base IP")
+	}
+
+	rangeLen := uint64(endVal-baseVal) + 1
+	capacity := 0
+	if rangeLen <= 1_048_576 {
+		capacity = int(rangeLen)
+	}
+	ips := make([]string, 0, capacity)
+	for val := baseVal; ; val++ {
+		ips = append(ips, uint32ToAddr(val).String())
+		if val == endVal {
 			break
 		}
 	}
+
+	return ips, nil
+}
+
+// parseRangeAddrPart parses a part of a range, returning whether the part resembled an IP and the parsed IPv4 address if possible.
+func parseRangeAddrPart(part string) (netip.Addr, bool, error) {
+	clean := stripCIDR(strings.TrimSpace(part))
+	if clean == "" {
+		return netip.Addr{}, false, nil
+	}
+
+	parsed, err := netip.ParseAddr(clean)
+	if err == nil {
+		if !parsed.Is4() {
+			return netip.Addr{}, true, fmt.Errorf("only IPv4 addresses are supported")
+		}
+		return parsed, true, nil
+	}
+
+	if isIPv4Like(clean) {
+		return netip.Addr{}, true, fmt.Errorf("invalid IP address")
+	}
+
+	return netip.Addr{}, false, nil
+}
+
+// looksLikeIPNotation returns true if the string resembles an IP (even if invalid).
+func looksLikeIPNotation(part string) bool {
+	_, looksLike, _ := parseRangeAddrPart(part)
+	return looksLike
+}
+
+// stripCIDR removes any CIDR suffix from an IP/CIDR string.
+func stripCIDR(value string) string {
+	if idx := strings.Index(value, "/"); idx != -1 {
+		return value[:idx]
+	}
+	return value
+}
+
+// isIPv4Like checks whether a string resembles an IPv4 address (digits and three dots).
+func isIPv4Like(value string) bool {
+	parts := strings.Split(value, ".")
+	if len(parts) != 4 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, r := range part {
+			if r < '0' || r > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// hasLetters reports whether the string contains alphabetic characters.
+func hasLetters(value string) bool {
+	for _, r := range value {
+		if unicode.IsLetter(r) {
+			return true
+		}
+	}
+	return false
+}
+
+func addrToUint32(ip netip.Addr) uint32 {
+	ip4 := ip.As4()
+	return binary.BigEndian.Uint32(ip4[:])
+}
+
+func uint32ToAddr(val uint32) netip.Addr {
+	var ip4 [4]byte
+	binary.BigEndian.PutUint32(ip4[:], val)
+	return netip.AddrFrom4(ip4)
 }

--- a/snmp-discovery/targets/targets_test.go
+++ b/snmp-discovery/targets/targets_test.go
@@ -22,6 +22,16 @@ func TestExpand(t *testing.T) {
 			want:   []string{"example.com"},
 		},
 		{
+			name:   "Hostname With Hyphen",
+			target: "my-hostname",
+			want:   []string{"my-hostname"},
+		},
+		{
+			name:   "Hostname Starting With IP And Hyphen",
+			target: "10.10.10.1-host",
+			want:   []string{"10.10.10.1-host"},
+		},
+		{
 			name:        "Invalid CIDR",
 			target:      "192.168.1.1/33",
 			shouldError: true,
@@ -38,7 +48,7 @@ func TestExpand(t *testing.T) {
 		},
 		{
 			name:        "Invalid Base IP",
-			target:      "invalid-100",
+			target:      "256.0.0.1-5",
 			shouldError: true,
 		},
 		{
@@ -55,6 +65,16 @@ func TestExpand(t *testing.T) {
 			name:        "IPv6 Range",
 			target:      "2001:db8::1-100",
 			shouldError: true,
+		},
+		{
+			name:   "Full IP Range",
+			target: "10.10.10.0-10.10.10.2",
+			want:   []string{"10.10.10.0", "10.10.10.1", "10.10.10.2"},
+		},
+		{
+			name:   "Full IP Range With CIDR Suffix",
+			target: "10.10.10.0/24-10.10.10.2/24",
+			want:   []string{"10.10.10.0", "10.10.10.1", "10.10.10.2"},
 		},
 	}
 
@@ -88,6 +108,11 @@ func TestExpandCIDR(t *testing.T) {
 			name: "Valid /30 CIDR",
 			cidr: "192.168.1.0/30",
 			want: 4,
+		},
+		{
+			name: "Valid /32 CIDR",
+			cidr: "192.168.1.1/32",
+			want: 1,
 		},
 		{
 			name:        "Invalid CIDR",
@@ -139,7 +164,7 @@ func TestExpandIPRange(t *testing.T) {
 		},
 		{
 			name:        "Invalid Base IP",
-			rangeStr:    "invalid-100",
+			rangeStr:    "256.0.0.1-5",
 			shouldError: true,
 		},
 		{
@@ -156,6 +181,16 @@ func TestExpandIPRange(t *testing.T) {
 			name:        "Non-numeric Range End",
 			rangeStr:    "192.168.0.0-ten",
 			shouldError: true,
+		},
+		{
+			name:     "Full IP Range",
+			rangeStr: "10.10.10.0-10.10.10.2",
+			want:     3,
+		},
+		{
+			name:     "Full IP Range With CIDR Suffix",
+			rangeStr: "10.10.10.0/24-10.10.10.2/24",
+			want:     3,
 		},
 	}
 


### PR DESCRIPTION
This pull request introduces significant improvements to SNMP target expansion and policy runner scheduling, with a focus on more robust and flexible IP/hostname parsing and per-target scheduling. It also includes several test enhancements to cover new behaviors and error cases.

**Target Expansion and Parsing Improvements:**

* Refactored the `targets.Expand` function and related helpers to use the `net/netip` package for safer and more accurate IP parsing and expansion. The function now robustly distinguishes between hostnames (even those with hyphens) and IP ranges, supports both short and full IP range notations (e.g., `10.10.10.0-100` and `10.10.10.0-10.10.10.100`), and handles CIDR suffixes more gracefully. Helper functions were added for IP arithmetic and validation.
* Expanded test coverage in `targets_test.go` to include new edge cases: hostnames with hyphens, full IP range notations, and validation of error handling for invalid IPs and ranges. [[1]](diffhunk://#diff-057be885d70a5aa154b88809cab96e9a602f104c8531ce44e5365586d799a4a7R24-R33) [[2]](diffhunk://#diff-057be885d70a5aa154b88809cab96e9a602f104c8531ce44e5365586d799a4a7L41-R51) [[3]](diffhunk://#diff-057be885d70a5aa154b88809cab96e9a602f104c8531ce44e5365586d799a4a7R69-R78) [[4]](diffhunk://#diff-057be885d70a5aa154b88809cab96e9a602f104c8531ce44e5365586d799a4a7R112-R116) [[5]](diffhunk://#diff-057be885d70a5aa154b88809cab96e9a602f104c8531ce44e5365586d799a4a7L142-R167) [[6]](diffhunk://#diff-057be885d70a5aa154b88809cab96e9a602f104c8531ce44e5365586d799a4a7R185-R194)

**Policy Runner Scheduling and Execution:**

* Modified the `Runner` in `policy/runner.go` to schedule a separate task for each expanded target, rather than running all targets in a single job. The runner now iterates over expanded targets, creating individual tasks and jobs, and the `run` method operates per target. This allows for finer-grained scheduling and error handling. [[1]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL35-R35) [[2]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL67-L76) [[3]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdR78-R100) [[4]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL120-R132) [[5]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL142-L167) [[6]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL193-R195) [[7]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL219-R221) [[8]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL243-R245)
* Added a new test to ensure that invalid cron expressions for policy schedules result in runner creation errors, improving robustness and feedback for misconfigurations.

**General Logging and Code Consistency:**

* Standardized logger usage throughout the codebase to use consistent key-value pairs rather than `slog`-specific types, improving log readability and compatibility. [[1]](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L7) [[2]](diffhunk://#diff-08cb12983d08e9d6370e03e2761fc8d686dba3469fd5914ef1a912471b482139L102-R101) [[3]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL120-R132) [[4]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL142-L167) [[5]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL243-R245)
* Updated `SlogAdapter` to use `any` instead of `interface{}` for variadic parameters, following Go 1.18+ conventions.

These changes collectively make target expansion more reliable, scheduling more granular, and logging and error handling more consistent across the SNMP discovery service.