### PR TITLE
feat: adds policy id to jobs/runs

### DIFF
--- a/network-discovery/policy/run.go
+++ b/network-discovery/policy/run.go
@@ -22,6 +22,7 @@ const (
 // Run represents a single run execution
 type Run struct {
 	ID          string    `json:"id"`
+	PolicyID    string    `json:"policy_id"`
 	Status      RunStatus `json:"status"`
 	Reason      string    `json:"reason,omitempty"`
 	EntityCount int       `json:"entity_count"`
@@ -52,6 +53,7 @@ func (rs *RunStore) CreateRun(policyName string) *Run {
 	now := time.Now()
 	run := &Run{
 		ID:        uuid.New().String(),
+		PolicyID:  policyName,
 		Status:    RunStatusRunning,
 		CreatedAt: now,
 		UpdatedAt: now,

--- a/network-discovery/policy/run_test.go
+++ b/network-discovery/policy/run_test.go
@@ -19,6 +19,7 @@ func TestRunStore_CreateRun(t *testing.T) {
 
 	// Verify run properties
 	assert.NotEmpty(t, run.ID)
+	assert.Equal(t, policyName, run.PolicyID)
 	assert.Equal(t, policy.RunStatusRunning, run.Status)
 	assert.Empty(t, run.Reason)
 	assert.Equal(t, 0, run.EntityCount)
@@ -30,6 +31,7 @@ func TestRunStore_CreateRun(t *testing.T) {
 	runs := store.GetRunsForPolicy(policyName)
 	require.Len(t, runs, 1)
 	assert.Equal(t, run.ID, runs[0].ID)
+	assert.Equal(t, policyName, runs[0].PolicyID)
 }
 
 func TestRunStore_UpdateRun(t *testing.T) {
@@ -157,6 +159,14 @@ func TestRunStore_GetAllPoliciesWithRuns(t *testing.T) {
 	assert.Len(t, allRuns, 2)
 	assert.Len(t, allRuns[policy1], 2)
 	assert.Len(t, allRuns[policy2], 1)
+
+	// Verify PolicyID is set correctly for each run
+	for _, run := range allRuns[policy1] {
+		assert.Equal(t, policy1, run.PolicyID)
+	}
+	for _, run := range allRuns[policy2] {
+		assert.Equal(t, policy2, run.PolicyID)
+	}
 }
 
 func TestRunStore_GetRunsForPolicy_Empty(t *testing.T) {

--- a/snmp-discovery/policy/job.go
+++ b/snmp-discovery/policy/job.go
@@ -22,6 +22,7 @@ const (
 // Job represents a single job execution
 type Job struct {
 	ID          string    `json:"id"`
+	PolicyID    string    `json:"policy_id"`
 	Status      JobStatus `json:"status"`
 	Reason      string    `json:"reason,omitempty"`
 	EntityCount int       `json:"entity_count"`
@@ -52,6 +53,7 @@ func (js *JobStore) CreateJob(policyName string) *Job {
 	now := time.Now()
 	job := &Job{
 		ID:        uuid.New().String(),
+		PolicyID:  policyName,
 		Status:    JobStatusRunning,
 		CreatedAt: now,
 		UpdatedAt: now,


### PR DESCRIPTION
This pull request adds a new `PolicyID` field to both the `Run` and `Job` structs in the network and SNMP discovery modules, ensuring that each run or job is explicitly associated with its policy. The changes also update the creation logic and tests to verify the correct assignment of the `PolicyID`.

**Policy association enhancements:**

* Added a `PolicyID` field to the `Run` struct in `network-discovery/policy/run.go` and ensured it is set when creating a new run. [[1]](diffhunk://#diff-a7e698932e1486403dc7afdcaa4163f7194e6551f7869155f9b1c9e47f7840aaR25) [[2]](diffhunk://#diff-a7e698932e1486403dc7afdcaa4163f7194e6551f7869155f9b1c9e47f7840aaR56)
* Added a `PolicyID` field to the `Job` struct in `snmp-discovery/policy/job.go` and ensured it is set when creating a new job. [[1]](diffhunk://#diff-89307355d838038577ea5012793278fd858f59db0b20e9ffb0d0f6d318d25aa8R25) [[2]](diffhunk://#diff-89307355d838038577ea5012793278fd858f59db0b20e9ffb0d0f6d318d25aa8R56)

**Test updates:**

* Updated tests in `network-discovery/policy/run_test.go` to assert that the `PolicyID` is correctly set for runs, including in scenarios with multiple policies and runs. [[1]](diffhunk://#diff-4578cad8acb43a99d68676e0138f157a2a9e92db170554422b4700a9016c9f9eR22) [[2]](diffhunk://#diff-4578cad8acb43a99d68676e0138f157a2a9e92db170554422b4700a9016c9f9eR34) [[3]](diffhunk://#diff-4578cad8acb43a99d68676e0138f157a2a9e92db170554422b4700a9016c9f9eR162-R169)