### PR TITLE
feat: add snmp port scan to define active hosts

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -61,8 +61,8 @@ policies:
       lookup_extensions_dir: "/opt/orb/snmp-extensions" # (Optional) Specifies an override for the directory containing device data yaml files (see below). Defaults to `/etc/snmp-discovery/lookup-extensions
     scope:
       targets:
-        - host: "192.168.1.1"
-        - host: "192.168.1.254"
+        - host: "192.168.1.1/24" #subnet support
+        - host: "192.168.2.1-20" # range support
         - host: "10.0.0.1"
           port: 162  # Non-standard SNMP port
       authentication:

--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -61,7 +61,7 @@ policies:
       lookup_extensions_dir: "/opt/orb/snmp-extensions" # (Optional) Specifies an override for the directory containing device data yaml files (see below). Defaults to `/etc/snmp-discovery/lookup-extensions
     scope:
       targets:
-        - host: "192.168.1.1/24" #subnet support
+        - host: "192.168.1.1/24" # subnet support
         - host: "192.168.2.1-20" # range support
         - host: "10.0.0.1"
           port: 162  # Non-standard SNMP port

--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -40,6 +40,7 @@ policies:
       schedule: "0 */6 * * *" # Cron expression - every 6 hours
       timeout: 300 # Timeout for policy in seconds (default 2 minutes)
       snmp_timeout: 300 # Timeout for SNMP operations in seconds (default 5 seconds)
+      snmp_probe_timeout: 1 # Timeout for SNMP probe operations in seconds (default 1 second)
       retries: 3 # Number of retries
       defaults:
         tags: ["snmp-discovery", "orb"]

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -74,6 +74,7 @@ type PolicyConfig struct {
 	Defaults            Defaults `yaml:"defaults"`
 	Timeout             int      `yaml:"timeout"`
 	SNMPTimeout         int      `yaml:"snmp_timeout"`
+	SNMPProbeTimeout    int      `yaml:"snmp_probe_timeout"`
 	Retries             int      `yaml:"retries"`
 	LookupExtensionsDir string   `yaml:"lookup_extensions_dir,omitempty"`
 }

--- a/snmp-discovery/go.mod
+++ b/snmp-discovery/go.mod
@@ -5,8 +5,9 @@ go 1.24.6
 require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-co-op/gocron/v2 v2.14.0
+	github.com/google/uuid v1.6.0
 	github.com/gosnmp/gosnmp v1.39.0
-	github.com/netboxlabs/diode-sdk-go v1.6.0
+	github.com/netboxlabs/diode-sdk-go v1.6.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0
@@ -31,7 +32,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.23.0 // indirect
 	github.com/goccy/go-json v0.10.4 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/snmp-discovery/go.sum
+++ b/snmp-discovery/go.sum
@@ -70,8 +70,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/netboxlabs/diode-sdk-go v1.6.0 h1:Fkcidz201Sm4BPV/PAMK/Yxqe+qeZk+zm8Fgpr7LcW0=
-github.com/netboxlabs/diode-sdk-go v1.6.0/go.mod h1:Y93A5nsK/sz6wsgwiMytZgek01Yl50wzYQjZKFZfdkQ=
+github.com/netboxlabs/diode-sdk-go v1.6.1 h1:j4rPr1eRNZG5lgPAekopeok+ygijUM3ksNGeRyJexsE=
+github.com/netboxlabs/diode-sdk-go v1.6.1/go.mod h1:Y93A5nsK/sz6wsgwiMytZgek01Yl50wzYQjZKFZfdkQ=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -119,10 +119,6 @@ func (m *Manager) applyDefaults(policy *config.Policy) {
 	if policy.Config.Defaults.Site == "" {
 		policy.Config.Defaults.Site = "undefined"
 	}
-
-	if policy.Config.Defaults.Location == "" {
-		policy.Config.Defaults.Location = "undefined"
-	}
 }
 
 // validatePolicy validates the policy

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -590,31 +590,6 @@ func TestManagerApplyDefaults_Location(t *testing.T) {
 	manager, err := policy.NewManager(context.Background(), logger, nil, nil)
 	assert.NoError(t, err)
 
-	t.Run("Empty Location gets set to undefined", func(t *testing.T) {
-		yamlData := []byte(`
-        policies:
-          policy1:
-            config:
-              defaults:
-                role: "existing-role"
-                site: "existing-site"
-                # location is intentionally omitted (empty)
-            scope:
-              targets:
-                - host: 192.168.1.1
-              authentication:
-                protocol_version: SNMPv2c
-                community: public
-       `)
-
-		policies, err := manager.ParsePolicies(yamlData)
-		assert.NoError(t, err)
-		assert.Contains(t, policies, "policy1")
-		assert.Equal(t, "undefined", policies["policy1"].Config.Defaults.Location)
-		assert.Equal(t, "existing-role", policies["policy1"].Config.Defaults.Role)
-		assert.Equal(t, "existing-site", policies["policy1"].Config.Defaults.Site)
-	})
-
 	t.Run("Existing Location value is preserved", func(t *testing.T) {
 		yamlData := []byte(`
         policies:
@@ -640,39 +615,14 @@ func TestManagerApplyDefaults_Location(t *testing.T) {
 		assert.Equal(t, "custom-site", policies["policy1"].Config.Defaults.Site)
 	})
 
-	t.Run("Empty string Location gets default value", func(t *testing.T) {
-		yamlData := []byte(`
-        policies:
-          policy1:
-            config:
-              defaults:
-                role: "existing-role"
-                site: "existing-site"
-                location: ""
-            scope:
-              targets:
-                - host: 192.168.1.1
-              authentication:
-                protocol_version: SNMPv2c
-                community: public
-       `)
-
-		policies, err := manager.ParsePolicies(yamlData)
-		assert.NoError(t, err)
-		assert.Contains(t, policies, "policy1")
-		assert.Equal(t, "undefined", policies["policy1"].Config.Defaults.Location)
-		assert.Equal(t, "existing-role", policies["policy1"].Config.Defaults.Role)
-		assert.Equal(t, "existing-site", policies["policy1"].Config.Defaults.Site)
-	})
-
-	t.Run("All defaults (Role, Site, Location) empty get default values", func(t *testing.T) {
+	t.Run("All defaults (Role, Site) empty get default values", func(t *testing.T) {
 		yamlData := []byte(`
         policies:
           policy1:
             config:
               defaults:
                 comments: "test"
-                # role, site, and location are intentionally omitted (empty)
+                # role and site are intentionally omitted (empty)
             scope:
               targets:
                 - host: 192.168.1.1
@@ -686,10 +636,9 @@ func TestManagerApplyDefaults_Location(t *testing.T) {
 		assert.Contains(t, policies, "policy1")
 		assert.Equal(t, "undefined", policies["policy1"].Config.Defaults.Role)
 		assert.Equal(t, "undefined", policies["policy1"].Config.Defaults.Site)
-		assert.Equal(t, "undefined", policies["policy1"].Config.Defaults.Location)
 	})
 
-	t.Run("All defaults (Role, Site, Location) as empty strings get default values", func(t *testing.T) {
+	t.Run("All defaults (Role, Site) as empty strings get default values", func(t *testing.T) {
 		yamlData := []byte(`
         policies:
           policy1:
@@ -711,7 +660,6 @@ func TestManagerApplyDefaults_Location(t *testing.T) {
 		assert.Contains(t, policies, "policy1")
 		assert.Equal(t, "undefined", policies["policy1"].Config.Defaults.Role)
 		assert.Equal(t, "undefined", policies["policy1"].Config.Defaults.Site)
-		assert.Equal(t, "undefined", policies["policy1"].Config.Defaults.Location)
 	})
 }
 

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"sync"
 	"time"
 
 	"github.com/go-co-op/gocron/v2"
@@ -23,9 +24,10 @@ type contextKey string
 
 // Define the policy key
 const (
-	policyKey          contextKey = "policy"
-	defaultTimeout                = 2 * time.Minute
-	defaultSNMPTimeout            = 5 * time.Second
+	policyKey           contextKey = "policy"
+	defaultTimeout                 = 2 * time.Minute
+	defaultSNMPTimeout             = 5 * time.Second
+	defaultSNMPProbeOID            = "1.3.6.1.2.1.1" // SNMPv2-MIB::system
 )
 
 // Runner represents the policy runner
@@ -78,22 +80,124 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 
 	expandedTargets := runner.expandTargetRanges(runner.scope.Targets)
 
-	for _, target := range expandedTargets {
-		task := gocron.NewTask(runner.run, target)
-		if policy.Config.Schedule != nil {
-			_, err = runner.scheduler.NewJob(gocron.CronJob(*policy.Config.Schedule, false), task,
-				gocron.WithSingletonMode(gocron.LimitModeReschedule))
-		} else {
-			_, err = runner.scheduler.NewJob(gocron.OneTimeJob(
-				gocron.OneTimeJobStartDateTime(time.Now().Add(1*time.Second))), task,
-				gocron.WithSingletonMode(gocron.LimitModeReschedule))
+	for _, targets := range expandedTargets {
+		if len(targets) == 1 {
+			// Create scan task for single target
+			task := gocron.NewTask(runner.run, targets[0])
+			if policy.Config.Schedule != nil {
+				_, err = runner.scheduler.NewJob(gocron.CronJob(*policy.Config.Schedule, false), task,
+					gocron.WithSingletonMode(gocron.LimitModeReschedule))
+			} else {
+				_, err = runner.scheduler.NewJob(gocron.OneTimeJob(
+					gocron.OneTimeJobStartDateTime(time.Now().Add(1*time.Second))), task,
+					gocron.WithSingletonMode(gocron.LimitModeReschedule))
+			}
+			if err != nil {
+				return nil, err
+			}
+			runner.tasks = append(runner.tasks, task)
+			continue
 		}
+		// Create scan task for multiple targets
+		task := gocron.NewTask(runner.runScan, targets)
+		_, err = runner.scheduler.NewJob(gocron.OneTimeJob(
+			gocron.OneTimeJobStartDateTime(time.Now().Add(1*time.Second))), task,
+			gocron.WithSingletonMode(gocron.LimitModeReschedule))
 		if err != nil {
 			return nil, err
 		}
 		runner.tasks = append(runner.tasks, task)
 	}
 	return runner, nil
+}
+
+func (r *Runner) runScan(targets []config.Target) {
+	policyName := r.ctx.Value(policyKey).(string)
+	r.logger.Info("Starting SNMP probe scan", "policy", policyName, "targetCount", len(targets))
+	workerCount := min(256, len(targets))
+
+	ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
+	defer cancel()
+
+	targetCh := make(chan config.Target)
+	resultsCh := make(chan config.Target, workerCount)
+
+	var wg sync.WaitGroup
+	wg.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer wg.Done()
+			for target := range targetCh {
+				if r.probeTarget(ctx, target) {
+					resultsCh <- target
+				}
+			}
+		}()
+	}
+
+	go func() {
+		defer close(targetCh)
+		for _, target := range targets {
+			select {
+			case <-ctx.Done():
+				return
+			case targetCh <- target:
+			}
+		}
+	}()
+
+	go func() {
+		wg.Wait()
+		close(resultsCh)
+	}()
+
+	var responsive []config.Target
+	for target := range resultsCh {
+		responsive = append(responsive, target)
+		r.logger.Debug("SNMP probe succeeded", "host", target.Host, "port", target.Port, "policy", policyName)
+	}
+	var err error
+	for _, target := range responsive {
+		task := gocron.NewTask(r.run, target)
+		if r.config.Schedule != nil {
+			_, err = r.scheduler.NewJob(gocron.CronJob(*r.config.Schedule, false), task,
+				gocron.WithSingletonMode(gocron.LimitModeReschedule))
+		} else {
+			_, err = r.scheduler.NewJob(gocron.OneTimeJob(
+				gocron.OneTimeJobStartDateTime(time.Now().Add(1*time.Second))), task,
+				gocron.WithSingletonMode(gocron.LimitModeReschedule))
+		}
+		if err != nil {
+			r.logger.Error("failed to schedule crawl task for responsive target",
+				"host", target.Host, "policy", policyName, "error", err)
+			continue
+		}
+		r.tasks = append(r.tasks, task)
+	}
+	r.logger.Info("SNMP probe scan complete", "policy", policyName, "responsiveTargetCount", len(responsive))
+}
+
+func (r *Runner) probeTarget(ctx context.Context, target config.Target) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	default:
+	}
+
+	snmpClient, err := r.ClientFactory(target.Host, target.Port, 0, 1*time.Second, &r.scope.Authentication, r.logger)
+	if err != nil {
+		return false
+	}
+	defer func() {
+		_ = snmpClient.Close()
+	}()
+
+	if err := snmpClient.Connect(); err != nil {
+		return false
+	}
+
+	_, err = snmpClient.Walk(defaultSNMPProbeOID, 0)
+	return err == nil
 }
 
 // run runs the policy
@@ -126,10 +230,10 @@ func (r *Runner) run(target config.Target) {
 	defer cancel()
 
 	entities := r.queryTarget(target)
-	r.logger.Info("SNMP crawl complete", "policy", policyName, "entityCount", len(entities))
+	r.logger.Info("SNMP crawl complete", "host", target.Host, "policy", policyName, "entityCount", len(entities))
 
 	if len(entities) == 0 {
-		r.logger.Info("No entities to ingest", "policy", policyName)
+		r.logger.Info("No entities to ingest", "host", target.Host, "policy", policyName)
 		// Update job status to completed even if no entities
 		r.jobStore.UpdateJob(policyName, job.ID, JobStatusCompleted, nil, 0)
 		return
@@ -142,14 +246,14 @@ func (r *Runner) run(target config.Target) {
 		"job_id":      job.ID,
 	}))
 	if err != nil {
-		r.logger.Error("error ingesting entities", "error", err, "policy", policyName)
+		r.logger.Error("error ingesting entities", "host", target.Host, "error", err, "policy", policyName)
 		r.jobStore.UpdateJob(policyName, job.ID, JobStatusFailed, err, len(entities))
 	} else if resp != nil && resp.Errors != nil {
 		ingestErr := fmt.Errorf("ingestion errors: %v", resp.Errors)
-		r.logger.Error("error ingesting entities", "error", resp.Errors, "policy", policyName)
+		r.logger.Error("error ingesting entities", "host", target.Host, "error", resp.Errors, "policy", policyName)
 		r.jobStore.UpdateJob(policyName, job.ID, JobStatusFailed, ingestErr, len(entities))
 	} else {
-		r.logger.Info("entities ingested successfully", "policy", policyName)
+		r.logger.Info("entities ingested successfully", "host", target.Host, "policy", policyName)
 		r.jobStore.UpdateJob(policyName, job.ID, JobStatusCompleted, nil, len(entities))
 	}
 }
@@ -222,22 +326,22 @@ func (r *Runner) queryTarget(target config.Target) []diode.Entity {
 	return entities
 }
 
-func (r *Runner) expandTargetRanges(configuredTargets []config.Target) []config.Target {
-	var expandedTargets []config.Target
+func (r *Runner) expandTargetRanges(configuredTargets []config.Target) [][]config.Target {
+	expandedMatrix := make([][]config.Target, 0, len(configuredTargets))
 	for _, target := range configuredTargets {
 		ips, err := targets.Expand(target.Host)
 		if err != nil {
 			r.logger.Warn("Error expanding target host", "host", target.Host, "error", err)
 			continue
 		}
-		for _, ip := range ips {
-			expandedTargets = append(expandedTargets, config.Target{
-				Host: ip,
-				Port: target.Port,
-			})
+
+		expandedTargets := make([]config.Target, len(ips))
+		for i := range ips {
+			expandedTargets[i] = config.Target{Host: ips[i], Port: target.Port}
 		}
+		expandedMatrix = append(expandedMatrix, expandedTargets)
 	}
-	return expandedTargets
+	return expandedMatrix
 }
 
 // Start starts the policy runner

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -24,28 +24,30 @@ type contextKey string
 
 // Define the policy key
 const (
-	policyKey           contextKey = "policy"
-	defaultTimeout                 = 2 * time.Minute
-	defaultSNMPTimeout             = 5 * time.Second
-	defaultSNMPProbeOID            = "1.3.6.1.2.1.1" // SNMPv2-MIB::system
+	policyKey               contextKey = "policy"
+	defaultTimeout                     = 2 * time.Minute
+	defaultSNMPTimeout                 = 5 * time.Second
+	defaultSNMPProbeTimeout            = 1 * time.Second
+	defaultSNMPProbeOID                = "1.3.6.1.2.1.1" // SNMPv2-MIB::system
 )
 
 // Runner represents the policy runner
 type Runner struct {
-	scheduler     gocron.Scheduler
-	ctx           context.Context
-	tasks         []gocron.Task
-	client        diode.Client
-	logger        *slog.Logger
-	timeout       time.Duration
-	snmpTimeout   time.Duration
-	scope         config.Scope
-	config        config.PolicyConfig
-	ClientFactory snmp.ClientFactory
-	manufacturers data.ManufacturerRetriever
-	mappingConfig *config.Mapping
-	deviceLookup  data.DeviceRetriever
-	jobStore      *JobStore
+	scheduler        gocron.Scheduler
+	ctx              context.Context
+	tasks            []gocron.Task
+	client           diode.Client
+	logger           *slog.Logger
+	timeout          time.Duration
+	snmpTimeout      time.Duration
+	snmpProbeTimeout time.Duration
+	scope            config.Scope
+	config           config.PolicyConfig
+	ClientFactory    snmp.ClientFactory
+	manufacturers    data.ManufacturerRetriever
+	mappingConfig    *config.Mapping
+	deviceLookup     data.DeviceRetriever
+	jobStore         *JobStore
 }
 
 // NewRunner returns a new policy runner
@@ -73,6 +75,10 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	runner.snmpTimeout = time.Duration(policy.Config.SNMPTimeout) * time.Second
 	if runner.snmpTimeout == 0 {
 		runner.snmpTimeout = defaultSNMPTimeout
+	}
+	runner.snmpProbeTimeout = time.Duration(policy.Config.SNMPProbeTimeout) * time.Second
+	if runner.snmpProbeTimeout == 0 {
+		runner.snmpProbeTimeout = defaultSNMPProbeTimeout
 	}
 	runner.ctx = context.WithValue(ctx, policyKey, name)
 	runner.scope = policy.Scope
@@ -184,7 +190,7 @@ func (r *Runner) probeTarget(ctx context.Context, target config.Target) bool {
 	default:
 	}
 
-	snmpClient, err := r.ClientFactory(target.Host, target.Port, 0, 1*time.Second, &r.scope.Authentication, r.logger)
+	snmpClient, err := r.ClientFactory(target.Host, target.Port, 0, r.snmpProbeTimeout, &r.scope.Authentication, r.logger)
 	if err != nil {
 		return false
 	}

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -92,8 +92,9 @@ func TestProbeTargetSuccess(t *testing.T) {
 	var gotTimeout time.Duration
 
 	runner := &Runner{
-		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
-		scope:  config.Scope{Authentication: config.Authentication{Community: "public"}},
+		logger:           slog.New(slog.NewTextHandler(io.Discard, nil)),
+		scope:            config.Scope{Authentication: config.Authentication{Community: "public"}},
+		snmpProbeTimeout: 2 * time.Second,
 		ClientFactory: func(host string, port uint16, _ int, timeout time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
 			gotHost = host
 			gotPort = port
@@ -111,7 +112,7 @@ func TestProbeTargetSuccess(t *testing.T) {
 	assert.Equal(t, 0, walker.walkIdentifier)
 	assert.Equal(t, "127.0.0.1", gotHost)
 	assert.Equal(t, uint16(161), gotPort)
-	assert.Equal(t, 1*time.Second, gotTimeout)
+	assert.Equal(t, 2*time.Second, gotTimeout)
 }
 
 func TestProbeTargetFailurePaths(t *testing.T) {

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -172,7 +172,7 @@ func TestRunScanSchedulesResponsiveTargets(t *testing.T) {
 
 	runner := &Runner{
 		scheduler: scheduler,
-		ctx:       context.Background(),
+		ctx:       context.WithValue(context.Background(), policyKey, "test-policy"),
 		timeout:   5 * time.Second,
 		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -1,0 +1,194 @@
+package policy
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-co-op/gocron/v2"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type testWalker struct {
+	connectErr     error
+	walkErr        error
+	connectCalled  bool
+	walkCalled     bool
+	closeCalled    bool
+	walkOID        string
+	walkIdentifier int
+}
+
+func (t *testWalker) Connect() error {
+	t.connectCalled = true
+	return t.connectErr
+}
+
+func (t *testWalker) Walk(objectID string, identifierSize int) (map[string]snmp.PDU, error) {
+	t.walkCalled = true
+	t.walkOID = objectID
+	t.walkIdentifier = identifierSize
+	return nil, t.walkErr
+}
+
+func (t *testWalker) Close() error {
+	t.closeCalled = true
+	return nil
+}
+
+func TestExpandTargetRangesGroupsTargets(t *testing.T) {
+	runner := &Runner{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	configuredTargets := []config.Target{
+		{Host: "192.168.1.1-2", Port: 161},
+		{Host: "example.com", Port: 162},
+	}
+
+	expanded := runner.expandTargetRanges(configuredTargets)
+	require.Len(t, expanded, 2)
+
+	require.Len(t, expanded[0], 2)
+	assert.Equal(t, "192.168.1.1", expanded[0][0].Host)
+	assert.Equal(t, uint16(161), expanded[0][0].Port)
+	assert.Equal(t, "192.168.1.2", expanded[0][1].Host)
+	assert.Equal(t, uint16(161), expanded[0][1].Port)
+
+	require.Len(t, expanded[1], 1)
+	assert.Equal(t, "example.com", expanded[1][0].Host)
+	assert.Equal(t, uint16(162), expanded[1][0].Port)
+}
+
+func TestProbeTargetCanceledContextSkipsClientFactory(t *testing.T) {
+	var factoryCalls int32
+	runner := &Runner{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		ClientFactory: func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+			atomic.AddInt32(&factoryCalls, 1)
+			return &testWalker{}, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	ok := runner.probeTarget(ctx, config.Target{Host: "127.0.0.1", Port: 161})
+	assert.False(t, ok)
+	assert.Equal(t, int32(0), atomic.LoadInt32(&factoryCalls))
+}
+
+func TestProbeTargetSuccess(t *testing.T) {
+	walker := &testWalker{}
+	var gotHost string
+	var gotPort uint16
+	var gotTimeout time.Duration
+
+	runner := &Runner{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		scope:  config.Scope{Authentication: config.Authentication{Community: "public"}},
+		ClientFactory: func(host string, port uint16, _ int, timeout time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+			gotHost = host
+			gotPort = port
+			gotTimeout = timeout
+			return walker, nil
+		},
+	}
+
+	ok := runner.probeTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161})
+	require.True(t, ok)
+	assert.True(t, walker.connectCalled)
+	assert.True(t, walker.walkCalled)
+	assert.True(t, walker.closeCalled)
+	assert.Equal(t, defaultSNMPProbeOID, walker.walkOID)
+	assert.Equal(t, 0, walker.walkIdentifier)
+	assert.Equal(t, "127.0.0.1", gotHost)
+	assert.Equal(t, uint16(161), gotPort)
+	assert.Equal(t, 1*time.Second, gotTimeout)
+}
+
+func TestProbeTargetFailurePaths(t *testing.T) {
+	tests := []struct {
+		name       string
+		factoryErr error
+		connectErr error
+		walkErr    error
+		expectWalk bool
+	}{
+		{
+			name:       "factory error",
+			factoryErr: errors.New("factory error"),
+		},
+		{
+			name:       "connect error",
+			connectErr: errors.New("connect error"),
+		},
+		{
+			name:       "walk error",
+			walkErr:    errors.New("walk error"),
+			expectWalk: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			walker := &testWalker{
+				connectErr: tt.connectErr,
+				walkErr:    tt.walkErr,
+			}
+
+			runner := &Runner{
+				logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+				ClientFactory: func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+					if tt.factoryErr != nil {
+						return nil, tt.factoryErr
+					}
+					return walker, nil
+				},
+			}
+
+			ok := runner.probeTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161})
+			assert.False(t, ok)
+			if tt.factoryErr == nil {
+				assert.True(t, walker.connectCalled)
+				assert.Equal(t, tt.expectWalk, walker.walkCalled)
+				assert.True(t, walker.closeCalled)
+			}
+		})
+	}
+}
+
+func TestRunScanSchedulesResponsiveTargets(t *testing.T) {
+	scheduler, err := gocron.NewScheduler()
+	require.NoError(t, err)
+
+	runner := &Runner{
+		scheduler: scheduler,
+		ctx:       context.Background(),
+		timeout:   5 * time.Second,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	runner.ClientFactory = func(host string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		if host == "good-1" || host == "good-2" {
+			return &testWalker{}, nil
+		}
+		return &testWalker{walkErr: errors.New("no response")}, nil
+	}
+
+	runner.runScan([]config.Target{
+		{Host: "good-1", Port: 161},
+		{Host: "bad-1", Port: 161},
+		{Host: "good-2", Port: 161},
+	})
+
+	assert.Len(t, runner.tasks, 2)
+	assert.Len(t, runner.scheduler.Jobs(), 2)
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the SNMP policy runner, focusing on more efficient target expansion and scanning, robust SNMP probe scheduling, and enhanced test coverage. The main changes include refactoring how target ranges are expanded and processed, implementing concurrent SNMP probing for multiple targets, improving logging for better observability, and adding comprehensive unit tests for the new logic.

**Policy runner improvements:**

* Refactored the `expandTargetRanges` method in `runner.go` to return a matrix (`[][]config.Target`) grouping expanded targets by their original configuration, enabling batch processing and more flexible scheduling.
* Updated the runner initialization in `NewRunner` to schedule single-target scans as before, but now schedule batch scans for groups of targets using the new `runScan` method. [[1]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL81-R86) [[2]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdR99-R202)

**Concurrent SNMP probing and scheduling:**

* Added the `runScan` method to perform concurrent SNMP probe scans on batches of targets, using worker goroutines for efficiency. Responsive targets are then scheduled for regular crawling. Also introduced the `probeTarget` method for efficient, cancelable SNMP reachability checks.

**Logging and diagnostics:**

* Enhanced logging in the `run` method to include the target host in all log messages, improving traceability of operations and errors. [[1]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL129-R236) [[2]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL145-R256)
* Introduced a constant for the default SNMP probe OID (`defaultSNMPProbeOID`) for clarity and consistency.

**Testing and validation:**

* Added a comprehensive new test file, `runner_internal_test.go`, with unit tests for target expansion, SNMP probe logic, and the new concurrent scan scheduling, ensuring robustness of the new logic.

**Dependency updates:**

* Updated `github.com/netboxlabs/diode-sdk-go` to v1.6.1 and moved `github.com/google/uuid` from indirect to direct dependency in `go.mod`. [[1]](diffhunk://#diff-b317fe0c907478d97c235e904821194309658448be78cf050d9ada1dd275ec8fR8-R10) [[2]](diffhunk://#diff-b317fe0c907478d97c235e904821194309658448be78cf050d9ada1dd275ec8fL34)