### PR TITLE
chore: update diode sdk version in network discovery

### DIFF
--- a/network-discovery/go.mod
+++ b/network-discovery/go.mod
@@ -6,7 +6,8 @@ require (
 	github.com/Ullaakut/nmap/v3 v3.0.4
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-co-op/gocron/v2 v2.14.0
-	github.com/netboxlabs/diode-sdk-go v1.6.0
+	github.com/google/uuid v1.6.0
+	github.com/netboxlabs/diode-sdk-go v1.6.1
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0
@@ -31,7 +32,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-playground/validator/v10 v10.23.0 // indirect
 	github.com/goccy/go-json v0.10.4 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/jonboulle/clockwork v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/network-discovery/go.sum
+++ b/network-discovery/go.sum
@@ -69,8 +69,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/netboxlabs/diode-sdk-go v1.6.0 h1:Fkcidz201Sm4BPV/PAMK/Yxqe+qeZk+zm8Fgpr7LcW0=
-github.com/netboxlabs/diode-sdk-go v1.6.0/go.mod h1:Y93A5nsK/sz6wsgwiMytZgek01Yl50wzYQjZKFZfdkQ=
+github.com/netboxlabs/diode-sdk-go v1.6.1 h1:j4rPr1eRNZG5lgPAekopeok+ygijUM3ksNGeRyJexsE=
+github.com/netboxlabs/diode-sdk-go v1.6.1/go.mod h1:Y93A5nsK/sz6wsgwiMytZgek01Yl50wzYQjZKFZfdkQ=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
This pull request updates dependencies in the `network-discovery/go.mod` file to keep them current and improve compatibility. The most important changes are:

Dependency updates:

* Upgraded `github.com/netboxlabs/diode-sdk-go` from version 1.6.0 to 1.6.1, ensuring the latest bug fixes and features are included.
* Added a direct dependency on `github.com/google/uuid` version 1.6.0, while removing it from the list of indirect dependencies, which clarifies its usage in the project. [[1]](diffhunk://#diff-622e1b493a8288886b8db66d986869ea28f51acd15da599c7949de15c561b09cL9-R10) [[2]](diffhunk://#diff-622e1b493a8288886b8db66d986869ea28f51acd15da599c7949de15c561b09cL34)