### PR TITLE
chore: skip if interface mtu and speed is zero in SNMP discovery

### DIFF
--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -291,6 +291,10 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 						m.logger.Warn("Error converting speed to int", "error", err, "value", value.Value)
 						continue
 					}
+					if speed == 0 {
+						m.logger.Debug("Speed is zero, skipping", "value", value.Value)
+						continue
+					}
 					bitsPerSecond := int64(speed)
 					kiloBitsPerSecond := bitsPerSecond / 1000
 					// Check if speed is within valid range (1 to 2147483647 inclusive)
@@ -308,6 +312,10 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					mtu, err := strconv.ParseInt(value.Value, 10, 64)
 					if err != nil {
 						m.logger.Warn("Error converting mtu to int64", "error", err, "value", value.Value)
+						continue
+					}
+					if mtu == 0 {
+						m.logger.Debug("mtu is zero, skipping", "value", value.Value)
 						continue
 					}
 					// Check if MTU is within valid range (1 to 2147483647 inclusive) and not overflowing int32

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -16,7 +16,7 @@ import (
 
 // Interface speed constants
 const (
-	minInterfaceSpeed = 1
+	minInterfaceSpeed = 0
 	maxInterfaceSpeed = 2147483647
 )
 
@@ -289,10 +289,6 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					speed, err := strconv.Atoi(value.Value)
 					if err != nil {
 						m.logger.Warn("Error converting speed to int", "error", err, "value", value.Value)
-						continue
-					}
-					if speed == 0 {
-						m.logger.Debug("Speed is zero, skipping", "value", value.Value)
 						continue
 					}
 					bitsPerSecond := int64(speed)

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -1306,7 +1306,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 	}
 }
 
-func TestInterfaceMapper_Map_SkipsZeroSpeedAndMtu(t *testing.T) {
+func TestInterfaceMapper_Map_ZeroSpeedAndMtu(t *testing.T) {
 	logger := slog.Default()
 
 	tests := []struct {
@@ -1316,7 +1316,7 @@ func TestInterfaceMapper_Map_SkipsZeroSpeedAndMtu(t *testing.T) {
 		assertFn     func(t *testing.T, iface *diode.Interface)
 	}{
 		{
-			name: "speed value of zero is ignored",
+			name: "speed value of zero is accepted",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.2.2.1.2.1": {
 					OID:    "1.3.6.1.2.1.2.2.1.2.1",
@@ -1352,7 +1352,8 @@ func TestInterfaceMapper_Map_SkipsZeroSpeedAndMtu(t *testing.T) {
 			},
 			assertFn: func(t *testing.T, iface *diode.Interface) {
 				assert.Equal(t, mapping.StringPtr("eth0"), iface.Name)
-				assert.Nil(t, iface.Speed)
+				zero := int64(0)
+				assert.Equal(t, &zero, iface.Speed)
 			},
 		},
 		{

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -1306,6 +1306,110 @@ func TestInterfaceMapper_Map(t *testing.T) {
 	}
 }
 
+func TestInterfaceMapper_Map_SkipsZeroSpeedAndMtu(t *testing.T) {
+	logger := slog.Default()
+
+	tests := []struct {
+		name         string
+		values       map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
+		mappingEntry *mapping.Entry
+		assertFn     func(t *testing.T, iface *diode.Interface)
+	}{
+		{
+			name: "speed value of zero is ignored",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.5.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.5.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.5",
+					Value:  "0",
+					Type:   mapping.Integer,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.5",
+						Entity: "interface",
+						Field:  "speed",
+					},
+				},
+			},
+			assertFn: func(t *testing.T, iface *diode.Interface) {
+				assert.Equal(t, mapping.StringPtr("eth0"), iface.Name)
+				assert.Nil(t, iface.Speed)
+			},
+		},
+		{
+			name: "mtu value of zero is ignored",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.2.2.1.4.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.4.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.4",
+					Value:  "0",
+					Type:   mapping.Integer,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.4",
+						Entity: "interface",
+						Field:  "mtu",
+					},
+				},
+			},
+			assertFn: func(t *testing.T, iface *diode.Interface) {
+				assert.Equal(t, mapping.StringPtr("eth0"), iface.Name)
+				assert.Nil(t, iface.Mtu)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := mapping.NewEntityRegistry(logger)
+			mapper := mapping.NewInterfaceMapper(logger)
+			entity := mapper.Map(tt.values, tt.mappingEntry, registry, nil)
+			assert.NotNil(t, entity)
+			iface, ok := entity.(*diode.Interface)
+			assert.True(t, ok)
+			tt.assertFn(t, iface)
+		})
+	}
+}
+
 func TestInterfaceMapper_FormatMACAddress(t *testing.T) {
 	logger := slog.Default()
 	mapper := mapping.NewInterfaceMapper(logger)


### PR DESCRIPTION
This pull request updates the interface mapping logic to better handle zero values for interface speed and MTU. The main changes ensure that a speed of zero is now considered valid, while an MTU of zero is ignored. Additional tests have been added to verify this behavior.

**Interface speed and MTU handling:**

* Changed the minimum allowed value for `minInterfaceSpeed` from `1` to `0` in `mappers.go`, allowing interface speed to be zero.
* Updated the interface mapping logic to skip MTU values of zero, logging a debug message when this occurs.

**Testing improvements:**

* Added a new test `TestInterfaceMapper_Map_ZeroSpeedAndMtu` in `mappers_test.go` to verify that zero speed is accepted and zero MTU is ignored.