### PR TITLE
fix: properly pass security level in snmp v3

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -181,7 +181,6 @@ Be **AWARE** that executing a policy with only targets defined will use default 
 - **Protocol Version**: v2c (if not specified)
 - **Community**: "public" (if not specified for v1/v2c)
 - **Port**: 161 (standard SNMP port, if not specified)
-- **Security Level**: noAuthNoPriv (if not specified for v3)
 
 Always ensure proper authentication is configured for production environments to avoid security risks.
 

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -227,6 +227,15 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 		if err != nil {
 			return nil, err
 		}
+		msgFlags := gosnmp.NoAuthNoPriv
+		switch authentication.SecurityLevel {
+		case "noAuthNoPriv":
+			msgFlags = gosnmp.NoAuthNoPriv
+		case "authNoPriv":
+			msgFlags = gosnmp.AuthNoPriv
+		case "authPriv":
+			msgFlags = gosnmp.AuthPriv
+		}
 		return &Client{
 			&gosnmp.GoSNMP{
 				Target:        host,
@@ -234,6 +243,7 @@ func NewClient(host string, port uint16, retries int, timeout time.Duration, aut
 				Version:       gosnmp.Version3,
 				Timeout:       timeout,
 				Retries:       retries,
+				MsgFlags:      msgFlags,
 				SecurityModel: gosnmp.UserSecurityModel,
 				Logger:        gosnmpLogger,
 				SecurityParameters: &gosnmp.UsmSecurityParameters{

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -449,6 +449,62 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewClientSecurityLevelMsgFlags(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	testCases := []struct {
+		name          string
+		securityLevel string
+		authProtocol  string
+		privProtocol  string
+		expectedFlag  gosnmp.SnmpV3MsgFlags
+	}{
+		{
+			name:          "noAuthNoPriv sets NoAuthNoPriv flags",
+			securityLevel: "noAuthNoPriv",
+			authProtocol:  "NoAuth",
+			privProtocol:  "NoPriv",
+			expectedFlag:  gosnmp.NoAuthNoPriv,
+		},
+		{
+			name:          "authNoPriv sets AuthNoPriv flags",
+			securityLevel: "authNoPriv",
+			authProtocol:  "SHA",
+			privProtocol:  "NoPriv",
+			expectedFlag:  gosnmp.AuthNoPriv,
+		},
+		{
+			name:          "authPriv sets AuthPriv flags",
+			securityLevel: "authPriv",
+			authProtocol:  "SHA",
+			privProtocol:  "AES",
+			expectedFlag:  gosnmp.AuthPriv,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			auth := &config.Authentication{
+				ProtocolVersion: snmp.ProtocolVersion3,
+				Username:        "testuser",
+				AuthProtocol:    tc.authProtocol,
+				AuthPassphrase:  "testpass",
+				PrivProtocol:    tc.privProtocol,
+				PrivPassphrase:  "testpass",
+				SecurityLevel:   tc.securityLevel,
+			}
+
+			client, err := snmp.NewClient("192.168.1.1", 161, 3, 1*time.Second, auth, logger)
+
+			assert.NoError(t, err)
+			typed, ok := client.(*snmp.Client)
+			assert.True(t, ok)
+			if ok {
+				assert.Equal(t, tc.expectedFlag, typed.GoSNMP.MsgFlags)
+			}
+		})
+	}
+}
+
 func TestMapPDU(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/snmp-discovery/snmp/snmp_test.go
+++ b/snmp-discovery/snmp/snmp_test.go
@@ -499,7 +499,7 @@ func TestNewClientSecurityLevelMsgFlags(t *testing.T) {
 			typed, ok := client.(*snmp.Client)
 			assert.True(t, ok)
 			if ok {
-				assert.Equal(t, tc.expectedFlag, typed.GoSNMP.MsgFlags)
+				assert.Equal(t, tc.expectedFlag, typed.MsgFlags)
 			}
 		})
 	}


### PR DESCRIPTION
This pull request improves SNMPv3 client configuration by ensuring that the correct message flags are set based on the specified security level. It also adds comprehensive tests to verify this behavior.

**SNMPv3 Security Level Handling:**

* Updated the `NewClient` function in `snmp/snmp.go` to correctly set the `MsgFlags` field of the SNMP client according to the provided `SecurityLevel` (supports `noAuthNoPriv`, `authNoPriv`, and `authPriv`).

**Testing Improvements:**

* Added a new test `TestNewClientSecurityLevelMsgFlags` in `snmp/snmp_test.go` to verify that the `MsgFlags` are set appropriately for each supported SNMPv3 security level.

**Documentation:**

* Removed a redundant line about the default SNMPv3 security level from the `README.md` to avoid confusion, since this is now handled in code.