### PR TITLE
feat: add interface type match based on interface name for SNMP

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -58,6 +58,13 @@ policies:
         device:
           description: "SNMP discovered device"
           comments: "Automatically discovered via SNMP"
+        interface_patterns:  # (Optional) Custom interface type patterns
+          - match: "^mgmt-"
+            type: "1000base-t"
+          - match: "^uplink-"
+            type: "100gbase-x-qsfp28"
+          - match: "^Po\\d+"
+            type: "lag"
       lookup_extensions_dir: "/opt/orb/snmp-extensions" # (Optional) Specifies an override for the directory containing device data yaml files (see below). Defaults to `/etc/snmp-discovery/lookup-extensions
     scope:
       targets:
@@ -113,6 +120,110 @@ If the referenced environment variable is not set, the service will exit with an
         priv_protocol: "AES" 
         priv_passphrase: "secure-priv-pass"
 ```
+
+### Interface Type Pattern Matching
+
+SNMP discovery supports flexible interface type detection through a five-tier priority system that intelligently combines SNMP protocol data with pattern matching:
+
+#### Priority System
+
+1. **User-defined patterns** (highest priority) - Your custom pattern rules
+2. **SNMP ifType mapping** - Protocol-specific intelligence from SNMP data
+3. **Built-in patterns** - 46 vendor-agnostic patterns included by default
+4. **Speed-based detection** - Automatic detection for Ethernet interfaces based on speed
+5. **Default fallback** - Configured `if_type` or "other"
+
+This priority order ensures that user intent always wins, while still leveraging SNMP protocol data and providing intelligent fallbacks.
+
+#### Configuration
+
+Interface patterns are defined at the `defaults` level (not under `defaults.interface`). Patterns use Go regex syntax (RE2):
+
+```yaml
+defaults:
+  interface:
+    if_type: "other"  # Fallback type for unmatched interfaces
+  interface_patterns:  # At defaults level
+    - match: "^mgmt-"
+      type: "1000base-t"
+    - match: "^uplink-"
+      type: "100gbase-x-qsfp28"
+    - match: "^Po\\d+"
+      type: "lag"
+```
+
+#### Pattern Rules
+
+- **User patterns always win**: Your patterns override even SNMP ifType data
+- **Most specific match wins**: Within each priority tier, the longest matching pattern is used
+- **Case-sensitive**: Patterns are matched case-sensitively
+- **Regex syntax**: Uses Go's RE2 regex engine (see [syntax reference](https://github.com/google/re2/wiki/Syntax))
+- **Invalid patterns**: Will cause the policy to fail at load time with a clear error message
+
+#### Built-in Patterns
+
+The following vendor patterns are included automatically and cover 80-90% of common deployments:
+
+**Cisco IOS/IOS-XE:**
+- `HundredGig*`, `FortyGig*`, `TenGig*`, `GigabitEthernet*`, `FastEthernet*`
+- `TwentyFiveGig*`, `FiveGig*`, `TwoGig*`
+
+**Juniper JunOS:**
+- `ge-*`, `xe-*`, `et-*` (Gigabit, 10G, 40G/100G Ethernet)
+- `ae*`, `lo*` (Aggregated Ethernet, Loopback)
+
+**Cross-Vendor:**
+- LAG: `Port-channel*`, `Bundle-Ether*`, `ae*`
+- Virtual: `Loopback*`, `Vlan*`, `Tunnel*`, `irb`
+- Management: `Management*`, `mgmt*`, `fxp*`, `em*`
+
+**Linux/Cumulus:**
+- `eth*`, `ens*`, `enp*`, `swp*`
+
+See [interface_patterns.go](mapping/interface_patterns.go) for the complete list.
+
+#### Examples
+
+**Override management interface detection:**
+```yaml
+defaults:
+  interface_patterns:
+    - match: "^mgmt-eth"
+      type: "1000base-t"
+```
+
+**Identify uplink interfaces:**
+```yaml
+defaults:
+  interface_patterns:
+    - match: "^(uplink|trunk)-"
+      type: "100gbase-x-qsfp28"
+```
+
+**Custom naming convention:**
+```yaml
+defaults:
+  interface_patterns:
+    - match: "^CORE-"
+      type: "100gbase-x-qsfp28"
+    - match: "^ACCESS-"
+      type: "1000base-t"
+    - match: "^MGMT-"
+      type: "1000base-t"
+```
+
+#### How It Works
+
+For each interface, the system evaluates in order:
+
+1. **Check user patterns**: If any user pattern matches, use that type immediately
+2. **Check SNMP ifType**: If SNMP reports a known interface type (e.g., LAG, virtual), use it
+   - For Ethernet interfaces, if speed is available, use speed-based detection
+3. **Check built-in patterns**: Fall back to vendor patterns if no SNMP match
+4. **Use speed if Ethernet**: For unknown Ethernet types, infer from interface speed
+5. **Use default**: Fall back to `defaults.interface.if_type` or "other"
+
+This ensures maximum flexibility while maintaining intelligent defaults.
 
 ### Device Model Lookup
 The `lookup_extensions_dir` specifies a directory containing device data YAML files that map SNMP device OIDs to human-readable device names. This allows snmp-discovery to provide meaningful device identification instead of raw OID values. This only needs to be set if additional or modified files are being provided instead of the ones that are included with orb-discovery and orb-agent.

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -50,6 +50,12 @@ type InterfaceDefaults struct {
 	Type        string   `yaml:"if_type,omitempty"`
 }
 
+// InterfacePattern represents a regex pattern for interface type matching
+type InterfacePattern struct {
+	Match string `yaml:"match"` // Regex pattern for interface name
+	Type  string `yaml:"type"`  // NetBox interface type to assign
+}
+
 // DeviceDefaults represents default values for a specific entity type
 type DeviceDefaults struct {
 	Description string   `yaml:"description,omitempty"`
@@ -59,13 +65,14 @@ type DeviceDefaults struct {
 
 // Defaults represents the supported default values for a policy
 type Defaults struct {
-	Tags      []string          `yaml:"tags,omitempty"`
-	Site      string            `yaml:"site,omitempty"`
-	Location  string            `yaml:"location,omitempty"`
-	Role      string            `yaml:"role,omitempty"`
-	IPAddress IPAddressDefaults `yaml:"ip_address,omitempty"`
-	Interface InterfaceDefaults `yaml:"interface,omitempty"`
-	Device    DeviceDefaults    `yaml:"device,omitempty"`
+	Tags              []string           `yaml:"tags,omitempty"`
+	Site              string             `yaml:"site,omitempty"`
+	Location          string             `yaml:"location,omitempty"`
+	Role              string             `yaml:"role,omitempty"`
+	IPAddress         IPAddressDefaults  `yaml:"ip_address,omitempty"`
+	Interface         InterfaceDefaults  `yaml:"interface,omitempty"`
+	Device            DeviceDefaults     `yaml:"device,omitempty"`
+	InterfacePatterns []InterfacePattern `yaml:"interface_patterns,omitempty"`
 }
 
 // PolicyConfig represents the configuration of a policy

--- a/snmp-discovery/mapping/interface_patterns.go
+++ b/snmp-discovery/mapping/interface_patterns.go
@@ -1,0 +1,55 @@
+package mapping
+
+import "github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+
+// DefaultInterfacePatterns provides vendor-agnostic interface type detection
+// Covers 80-90% of common deployments across major vendors
+// Ordered by specificity (most specific first within each vendor)
+var DefaultInterfacePatterns = []config.InterfacePattern{
+	// Cisco IOS/IOS-XE - High-Speed Interfaces
+	{Match: `^(HundredGig|Hu)\S+`, Type: "100gbase-x-qsfp28"},
+	{Match: `^(FortyGig|Fo)\S+`, Type: "40gbase-x-qsfpp"},
+	{Match: `^(TwentyFiveGig|Twe)\S+`, Type: "25gbase-x-sfp28"},
+	{Match: `^(TenGig|Te)\S+`, Type: "10gbase-x-sfpp"},
+	{Match: `^(FiveGig|Fi)\S+`, Type: "5gbase-t"},
+	{Match: `^(TwoGig|Tw)\S+`, Type: "2.5gbase-t"},
+
+	// Cisco IOS/IOS-XE - Standard Interfaces
+	{Match: `^(GigabitEthernet|Gi)\d+`, Type: "1000base-t"},
+	{Match: `^(FastEthernet|Fa)\d+`, Type: "100base-tx"},
+
+	// Juniper JunOS - Physical Interfaces
+	{Match: `^et-\d+/\d+/\d+`, Type: "40gbase-x-qsfpp"}, // Can be 40G or 100G
+	{Match: `^xe-\d+/\d+/\d+`, Type: "10gbase-x-sfpp"},
+	{Match: `^ge-\d+/\d+/\d+`, Type: "1000base-t"},
+
+	// Nokia SR OS
+	{Match: `^ethernet-\d+/\d+`, Type: "1000base-t"},
+
+	// LAG/Port-Channel (Cross-vendor)
+	{Match: `^(Port-channel|port-channel|Po)\d+`, Type: "lag"},
+	{Match: `^ae\d+`, Type: "lag"},           // Juniper
+	{Match: `^Bundle-Ether\d+`, Type: "lag"}, // Cisco IOS-XR
+
+	// Loopback Interfaces (Virtual)
+	{Match: `^Loopback\d+`, Type: "virtual"}, // Cisco/Arista
+	{Match: `^lo\d*$`, Type: "virtual"},      // Juniper/Linux
+
+	// VLAN/SVI Interfaces (Virtual)
+	{Match: `^Vlan\d+`, Type: "virtual"},   // Cisco/Arista
+	{Match: `^vlan\.\d+`, Type: "virtual"}, // Juniper
+	{Match: `^irb$`, Type: "virtual"},      // Juniper IRB
+
+	// Tunnel Interfaces (Virtual)
+	{Match: `^Tunnel\d+`, Type: "virtual"}, // Cisco
+
+	// Management Interfaces
+	{Match: `^(Management|mgmt)\d+`, Type: "1000base-t"}, // Cisco/Arista
+	{Match: `^(fxp|em)\d+`, Type: "1000base-t"},          // Juniper
+
+	// Cumulus Linux Switch Ports
+	{Match: `^swp\d+`, Type: "1000base-t"},
+
+	// Generic Linux Ethernet
+	{Match: `^(eth|ens|enp)\d+`, Type: "1000base-t"},
+}

--- a/snmp-discovery/mapping/interface_resolver_test.go
+++ b/snmp-discovery/mapping/interface_resolver_test.go
@@ -1,0 +1,272 @@
+// Copyright 2024 NetBox Labs Inc
+package mapping
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestResolveInterfaceType_Priority tests the 5-tier priority system
+func TestResolveInterfaceType_Priority(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("Tier 1: User pattern overrides all", func(t *testing.T) {
+		// User says all GigabitEthernet should be 100gbase-x (unusual but valid)
+		userPatterns := []config.InterfacePattern{
+			{Match: `^GigabitEthernet\d+`, Type: "100gbase-x-qsfp28"},
+		}
+		merged := MergePatterns(userPatterns, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		speed := int64(1000000) // 1 Gbps in Kbps
+		// ifType "117" = gigabitEthernet, speed says 1Gbps, built-in pattern says 1000base-t
+		// But user pattern should override all
+		result := ResolveInterfaceType(
+			"GigabitEthernet0/1",
+			"117", // SNMP ifType for gigabitEthernet
+			&speed,
+			"other", // Default
+			matcher,
+			1, // 1 user pattern
+		)
+		assert.Equal(t, "100gbase-x-qsfp28", result, "User pattern should override SNMP ifType, speed, and built-in")
+	})
+
+	t.Run("Tier 2: SNMP ifType beats built-in pattern", func(t *testing.T) {
+		// No user patterns, only built-ins
+		merged := MergePatterns(nil, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		// Interface name matches built-in pattern for "lag"
+		// But SNMP ifType says it's virtual
+		result := ResolveInterfaceType(
+			"Port-channel1",
+			"24", // SNMP ifType for softwareLoopback (virtual)
+			nil,
+			"other",
+			matcher,
+			0,
+		)
+		assert.Equal(t, "virtual", result, "SNMP ifType should beat built-in pattern")
+	})
+
+	t.Run("Tier 2: Speed-based detection for Ethernet", func(t *testing.T) {
+		merged := MergePatterns(nil, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		speed := int64(10000000) // 10 Gbps in Kbps
+		// ifType is ethernet, speed indicates 10G
+		result := ResolveInterfaceType(
+			"UnknownEthernetInterface",
+			"6", // SNMP ifType for ethernetCsmacd
+			&speed,
+			"other",
+			matcher,
+			0,
+		)
+		assert.Equal(t, "10gbase-t", result, "Speed-based detection should work for Ethernet")
+	})
+
+	t.Run("Tier 3: Built-in pattern fallback", func(t *testing.T) {
+		// No user patterns, only built-ins
+		merged := MergePatterns(nil, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		// Interface name matches built-in, SNMP ifType unknown
+		result := ResolveInterfaceType(
+			"TenGigabitEthernet0/1",
+			"999", // Unknown SNMP ifType
+			nil,
+			"other",
+			matcher,
+			0,
+		)
+		assert.Equal(t, "10gbase-x-sfpp", result, "Built-in pattern should be used as fallback")
+	})
+
+	t.Run("Tier 5: Default fallback", func(t *testing.T) {
+		// No matches anywhere, should use default
+		result := ResolveInterfaceType(
+			"CompletelyUnknownInterface",
+			"9999", // Unknown SNMP ifType
+			nil,
+			"custom-default",
+			nil, // No pattern matcher
+			0,
+		)
+		assert.Equal(t, "custom-default", result, "Should use default when nothing matches")
+	})
+
+	t.Run("Tier 5: Final fallback to 'other'", func(t *testing.T) {
+		// No matches anywhere, no default specified
+		result := ResolveInterfaceType(
+			"CompletelyUnknownInterface",
+			"9999",
+			nil,
+			"", // No default
+			nil,
+			0,
+		)
+		assert.Equal(t, "other", result, "Should fallback to 'other' when no default")
+	})
+}
+
+func TestResolveInterfaceType_EdgeCases(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("Empty interface name skips pattern matching", func(t *testing.T) {
+		userPatterns := []config.InterfacePattern{
+			{Match: `.*`, Type: "should-not-match"},
+		}
+		merged := MergePatterns(userPatterns, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		// Empty name with known SNMP ifType
+		result := ResolveInterfaceType(
+			"",
+			"161", // ieee8023adLag
+			nil,
+			"other",
+			matcher,
+			1,
+		)
+		assert.Equal(t, "lag", result, "Should use SNMP ifType when name is empty")
+	})
+
+	t.Run("Nil pattern matcher", func(t *testing.T) {
+		// No pattern matcher, should skip to SNMP ifType
+		result := ResolveInterfaceType(
+			"GigabitEthernet0/1",
+			"117", // gigabitEthernet
+			nil,
+			"other",
+			nil, // No matcher
+			0,
+		)
+		// No speed, so InterfaceTypeMap lookup happens but gigabitEthernet (117) is not in the map
+		// So it should fall through to default
+		assert.Equal(t, "other", result, "Should fallback when no pattern matcher")
+	})
+
+	t.Run("Zero speed value", func(t *testing.T) {
+		merged := MergePatterns(nil, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		speed := int64(0)
+		result := ResolveInterfaceType(
+			"eth0",
+			"6", // ethernetCsmacd
+			&speed,
+			"other",
+			matcher,
+			0,
+		)
+		// Zero speed shouldn't trigger speed-based detection
+		// Should use built-in pattern for eth0
+		assert.Equal(t, "1000base-t", result, "Should use built-in pattern when speed is 0")
+	})
+
+	t.Run("Nil speed pointer", func(t *testing.T) {
+		merged := MergePatterns(nil, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		result := ResolveInterfaceType(
+			"TenGigabitEthernet0/1",
+			"6", // ethernetCsmacd
+			nil, // No speed
+			"other",
+			matcher,
+			0,
+		)
+		// No speed-based detection, but built-in pattern should match
+		assert.Equal(t, "10gbase-x-sfpp", result, "Should use built-in pattern when speed is nil")
+	})
+}
+
+func TestResolveInterfaceType_RealWorldScenarios(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("Cisco switch with custom mgmt pattern", func(t *testing.T) {
+		// User wants to override management interface detection
+		userPatterns := []config.InterfacePattern{
+			{Match: `^mgmt-`, Type: "1000base-t"},
+		}
+		merged := MergePatterns(userPatterns, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		result := ResolveInterfaceType(
+			"mgmt-eth0",
+			"6",
+			nil,
+			"other",
+			matcher,
+			1,
+		)
+		assert.Equal(t, "1000base-t", result)
+	})
+
+	t.Run("Juniper interface with SNMP speed", func(t *testing.T) {
+		merged := MergePatterns(nil, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		speed := int64(10000000) // 10G
+		result := ResolveInterfaceType(
+			"xe-0/0/0",
+			"6", // ethernetCsmacd
+			&speed,
+			"other",
+			matcher,
+			0,
+		)
+		// Speed-based detection (Tier 2) beats built-in pattern (Tier 3)
+		assert.Equal(t, "10gbase-t", result)
+	})
+
+	t.Run("LAG interface from SNMP ifType", func(t *testing.T) {
+		merged := MergePatterns(nil, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		result := ResolveInterfaceType(
+			"Bundle-Ether100",
+			"161", // ieee8023adLag
+			nil,
+			"other",
+			matcher,
+			0,
+		)
+		// SNMP ifType (Tier 2) should match before built-in pattern (Tier 3)
+		assert.Equal(t, "lag", result)
+	})
+}
+
+func TestGetNetboxType_BackwardCompatibility(t *testing.T) {
+	t.Run("GetNetboxType wraps ResolveInterfaceType", func(t *testing.T) {
+		speed := int64(1000000) // 1G
+		result := GetNetboxType("6", "other", &speed)
+		// Should use speed-based detection
+		assert.Equal(t, "1000base-t", result)
+	})
+
+	t.Run("GetNetboxType with SNMP ifType map", func(t *testing.T) {
+		result := GetNetboxType("161", "other", nil) // ieee8023adLag
+		assert.Equal(t, "lag", result)
+	})
+
+	t.Run("GetNetboxType with default fallback", func(t *testing.T) {
+		result := GetNetboxType("9999", "custom-default", nil)
+		assert.Equal(t, "custom-default", result)
+	})
+}

--- a/snmp-discovery/mapping/interface_types.go
+++ b/snmp-discovery/mapping/interface_types.go
@@ -206,8 +206,28 @@ func getEthernetInterfaceType(speed *int64) string {
 	return ""
 }
 
-// GetNetboxType maps an SNMP ifType integer to a NetBox interface type
-func GetNetboxType(ifType, defaultInterfaceType string, speed *int64) string {
+// ResolveInterfaceType determines interface type using 5-tier priority system:
+// 1. User-defined patterns (highest priority)
+// 2. SNMP ifType mapping
+// 3. Built-in patterns
+// 4. Speed-based detection (for Ethernet)
+// 5. Default fallback
+func ResolveInterfaceType(
+	interfaceName string,
+	ifType string,
+	speed *int64,
+	defaultInterfaceType string,
+	patternMatcher *PatternMatcher,
+	userPatternCount int,
+) string {
+	// Tier 1: User-defined patterns (highest priority)
+	if patternMatcher != nil && userPatternCount > 0 {
+		if matchedType := patternMatcher.MatchInterfaceType(interfaceName, userPatternCount); matchedType != "" {
+			return matchedType
+		}
+	}
+
+	// Tier 2: SNMP ifType mapping (protocol-specific intelligence)
 	if isEthernetInterfaceType(ifType) {
 		if speed != nil && *speed > 0 {
 			if eType := getEthernetInterfaceType(speed); eType != "" {
@@ -218,8 +238,30 @@ func GetNetboxType(ifType, defaultInterfaceType string, speed *int64) string {
 	if netboxType, found := InterfaceTypeMap[ifType]; found {
 		return netboxType
 	}
+
+	// Tier 3: Built-in patterns (vendor defaults)
+	if patternMatcher != nil {
+		// Match only built-in patterns by passing empty string to check all patterns after user patterns
+		allPatterns := patternMatcher.compiledPatterns
+		if len(allPatterns) > userPatternCount {
+			builtinPatterns := allPatterns[userPatternCount:]
+			if matchedType := patternMatcher.findBestMatch(interfaceName, builtinPatterns); matchedType != "" {
+				return matchedType
+			}
+		}
+	}
+
+	// Tier 4: Speed-based detection (already checked in Tier 2 for Ethernet)
+
+	// Tier 5: Default fallback
 	if defaultInterfaceType != "" {
 		return defaultInterfaceType
 	}
 	return "other"
+}
+
+// GetNetboxType maps an SNMP ifType integer to a NetBox interface type
+// Maintained for backward compatibility - wraps ResolveInterfaceType
+func GetNetboxType(ifType, defaultInterfaceType string, speed *int64) string {
+	return ResolveInterfaceType("", ifType, speed, defaultInterfaceType, nil, 0)
 }

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -193,14 +193,32 @@ func maskToPrefixSize(maskStr string) (int, error) {
 
 // InterfaceMapper is a struct that maps interfaces to entities
 type InterfaceMapper struct {
-	logger *slog.Logger
+	logger           *slog.Logger
+	patternMatcher   *PatternMatcher
+	userPatternCount int
 }
 
 // NewInterfaceMapper creates a new InterfaceMapper
-func NewInterfaceMapper(logger *slog.Logger) *InterfaceMapper {
-	return &InterfaceMapper{
-		logger: logger,
+func NewInterfaceMapper(logger *slog.Logger, patterns []config.InterfacePattern) (*InterfaceMapper, error) {
+	var patternMatcher *PatternMatcher
+	var userPatternCount int
+
+	if len(patterns) > 0 {
+		userPatternCount = len(patterns)
+		mergedPatterns := MergePatterns(patterns, true)
+
+		var err error
+		patternMatcher, err = NewPatternMatcher(mergedPatterns, logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create pattern matcher: %w", err)
+		}
 	}
+
+	return &InterfaceMapper{
+		logger:           logger,
+		patternMatcher:   patternMatcher,
+		userPatternCount: userPatternCount,
+	}, nil
 }
 
 // applyDefaults applies default values to an interface entity
@@ -278,7 +296,20 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					if defaults != nil && defaults.Interface.Type != "" {
 						defaultType = defaults.Interface.Type
 					}
-					interfaceType := GetNetboxType(value.Value, defaultType, interfaceEntity.Speed)
+
+					var interfaceName string
+					if interfaceEntity.Name != nil {
+						interfaceName = *interfaceEntity.Name
+					}
+
+					interfaceType := ResolveInterfaceType(
+						interfaceName,
+						value.Value,
+						interfaceEntity.Speed,
+						defaultType,
+						m.patternMatcher,
+						m.userPatternCount,
+					)
 					interfaceEntity.Type = &interfaceType
 					fieldFound = true
 				case "speed":

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -201,12 +201,13 @@ type InterfaceMapper struct {
 // NewInterfaceMapper creates a new InterfaceMapper
 func NewInterfaceMapper(logger *slog.Logger, patterns []config.InterfacePattern) (*InterfaceMapper, error) {
 	var patternMatcher *PatternMatcher
-	var userPatternCount int
+	userPatternCount := len(patterns)
 
-	if len(patterns) > 0 {
-		userPatternCount = len(patterns)
-		mergedPatterns := MergePatterns(patterns, true)
+	// Always merge patterns to include built-in defaults
+	mergedPatterns := MergePatterns(patterns, true)
 
+	// Create pattern matcher if we have any patterns (user or built-in)
+	if len(mergedPatterns) > 0 {
 		var err error
 		patternMatcher, err = NewPatternMatcher(mergedPatterns, logger)
 		if err != nil {
@@ -267,6 +268,8 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	interfaceEntity := entityRegistry.GetOrCreateEntity(InterfaceEntityType, getIndex(values)).(*diode.Interface)
 
 	fieldFound := false
+	var snmpIfType string // Store SNMP ifType for final type resolution
+
 	valueKeys := make([]ObjectIDIndex, 0, len(values))
 	for objectID := range values {
 		valueKeys = append(valueKeys, objectID)
@@ -292,25 +295,9 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					interfaceEntity.Description = &description
 					fieldFound = true
 				case "type":
-					defaultType := ""
-					if defaults != nil && defaults.Interface.Type != "" {
-						defaultType = defaults.Interface.Type
-					}
-
-					var interfaceName string
-					if interfaceEntity.Name != nil {
-						interfaceName = *interfaceEntity.Name
-					}
-
-					interfaceType := ResolveInterfaceType(
-						interfaceName,
-						value.Value,
-						interfaceEntity.Speed,
-						defaultType,
-						m.patternMatcher,
-						m.userPatternCount,
-					)
-					interfaceEntity.Type = &interfaceType
+					// Store SNMP ifType but defer type resolution until after all fields are processed
+					// This ensures name and speed are available for pattern matching
+					snmpIfType = value.Value
 					fieldFound = true
 				case "speed":
 					if value.Value == "" {
@@ -399,6 +386,30 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				}
 			}
 		}
+	}
+
+	// Resolve interface type after all fields are collected
+	// This ensures name and speed are available for pattern matching
+	if snmpIfType != "" {
+		var interfaceName string
+		if interfaceEntity.Name != nil {
+			interfaceName = *interfaceEntity.Name
+		}
+
+		defaultType := ""
+		if defaults != nil && defaults.Interface.Type != "" {
+			defaultType = defaults.Interface.Type
+		}
+
+		interfaceType := ResolveInterfaceType(
+			interfaceName,
+			snmpIfType,
+			interfaceEntity.Speed,
+			defaultType,
+			m.patternMatcher,
+			m.userPatternCount,
+		)
+		interfaceEntity.Type = &interfaceType
 	}
 
 	// Apply defaults if available

--- a/snmp-discovery/mapping/mappers_deferred_type_test.go
+++ b/snmp-discovery/mapping/mappers_deferred_type_test.go
@@ -1,0 +1,260 @@
+package mapping
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInterfaceMapper_DeferredTypeResolution(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("Pattern matching with name processed after type", func(t *testing.T) {
+		// Create mapper with user patterns
+		userPatterns := []config.InterfacePattern{
+			{Match: `^GigabitEthernet\d+`, Type: "custom-gigabit"},
+		}
+		mapper, err := NewInterfaceMapper(logger, userPatterns)
+		assert.NoError(t, err)
+
+		// Simulate SNMP data where type OID comes before name OID
+		// This is common in real SNMP walks due to numeric OID ordering
+		values := map[ObjectIDIndex]*ObjectIDValue{
+			"1.3.6.1.2.1.2.2.1.2.1": { // name (processed later due to reverse sort)
+				OID:    "1.3.6.1.2.1.2.2.1.2.1",
+				Index:  "1",
+				Parent: "1.3.6.1.2.1.2.2.1.2",
+				Value:  "GigabitEthernet0/1",
+				Type:   OctetString,
+			},
+			"1.3.6.1.2.1.2.2.1.3.1": { // type (processed first due to reverse sort)
+				OID:    "1.3.6.1.2.1.2.2.1.3.1",
+				Index:  "1",
+				Parent: "1.3.6.1.2.1.2.2.1.3",
+				Value:  "6", // ethernetCsmacd
+				Type:   Integer,
+			},
+		}
+
+		mappingEntry := &Entry{
+			OID:    "1.3.6.1.2.1.2.2.1",
+			Entity: "interface",
+			Field:  "_id",
+			MappingEntries: []Entry{
+				{
+					OID:    "1.3.6.1.2.1.2.2.1.2",
+					Entity: "interface",
+					Field:  "name",
+				},
+				{
+					OID:    "1.3.6.1.2.1.2.2.1.3",
+					Entity: "interface",
+					Field:  "type",
+				},
+			},
+		}
+
+		registry := NewEntityRegistry(logger)
+		defaults := &config.Defaults{
+			Interface: config.InterfaceDefaults{
+				Type: "other",
+			},
+		}
+
+		result := mapper.Map(values, mappingEntry, registry, defaults)
+		iface, ok := result.(*diode.Interface)
+		assert.True(t, ok)
+		assert.NotNil(t, iface)
+		assert.NotNil(t, iface.Name)
+		assert.Equal(t, "GigabitEthernet0/1", *iface.Name)
+		assert.NotNil(t, iface.Type)
+		// Should use user pattern match via deferred type resolution
+		assert.Equal(t, "custom-gigabit", *iface.Type, "Should use user pattern with deferred type resolution")
+	})
+
+	t.Run("Pattern matching with name processed before type", func(t *testing.T) {
+		// Create mapper with user patterns
+		userPatterns := []config.InterfacePattern{
+			{Match: `^TenGigabitEthernet\d+`, Type: "custom-tengig"},
+		}
+		mapper, err := NewInterfaceMapper(logger, userPatterns)
+		assert.NoError(t, err)
+
+		// Simulate SNMP data where name OID comes before type OID
+		values := map[ObjectIDIndex]*ObjectIDValue{
+			"1.3.6.1.2.1.2.2.1.1.1": { // some field before name
+				OID:    "1.3.6.1.2.1.2.2.1.1.1",
+				Index:  "1",
+				Parent: "1.3.6.1.2.1.2.2.1.1",
+				Value:  "1",
+				Type:   Integer,
+			},
+			"1.3.6.1.2.1.2.2.1.2.1": { // name
+				OID:    "1.3.6.1.2.1.2.2.1.2.1",
+				Index:  "1",
+				Parent: "1.3.6.1.2.1.2.2.1.2",
+				Value:  "TenGigabitEthernet0/1",
+				Type:   OctetString,
+			},
+			"1.3.6.1.2.1.2.2.1.3.1": { // type
+				OID:    "1.3.6.1.2.1.2.2.1.3.1",
+				Index:  "1",
+				Parent: "1.3.6.1.2.1.2.2.1.3",
+				Value:  "6", // ethernetCsmacd
+				Type:   Integer,
+			},
+		}
+
+		mappingEntry := &Entry{
+			OID:    "1.3.6.1.2.1.2.2.1",
+			Entity: "interface",
+			Field:  "_id",
+			MappingEntries: []Entry{
+				{
+					OID:    "1.3.6.1.2.1.2.2.1.2",
+					Entity: "interface",
+					Field:  "name",
+				},
+				{
+					OID:    "1.3.6.1.2.1.2.2.1.3",
+					Entity: "interface",
+					Field:  "type",
+				},
+			},
+		}
+
+		registry := NewEntityRegistry(logger)
+		defaults := &config.Defaults{
+			Interface: config.InterfaceDefaults{
+				Type: "other",
+			},
+		}
+
+		result := mapper.Map(values, mappingEntry, registry, defaults)
+		iface, ok := result.(*diode.Interface)
+		assert.True(t, ok)
+		assert.NotNil(t, iface)
+		assert.NotNil(t, iface.Name)
+		assert.Equal(t, "TenGigabitEthernet0/1", *iface.Name)
+		assert.NotNil(t, iface.Type)
+		// Should use user pattern match via deferred type resolution
+		assert.Equal(t, "custom-tengig", *iface.Type, "Should use user pattern with deferred type resolution")
+	})
+
+	t.Run("Built-in pattern matching with deferred resolution", func(t *testing.T) {
+		// Create mapper with no user patterns, only built-ins
+		mapper, err := NewInterfaceMapper(logger, nil)
+		assert.NoError(t, err)
+
+		values := map[ObjectIDIndex]*ObjectIDValue{
+			"1.3.6.1.2.1.2.2.1.2.1": { // name
+				OID:    "1.3.6.1.2.1.2.2.1.2.1",
+				Index:  "1",
+				Parent: "1.3.6.1.2.1.2.2.1.2",
+				Value:  "Port-channel1",
+				Type:   OctetString,
+			},
+			"1.3.6.1.2.1.2.2.1.3.1": { // type
+				OID:    "1.3.6.1.2.1.2.2.1.3.1",
+				Index:  "1",
+				Parent: "1.3.6.1.2.1.2.2.1.3",
+				Value:  "999", // Unknown ifType
+				Type:   Integer,
+			},
+		}
+
+		mappingEntry := &Entry{
+			OID:    "1.3.6.1.2.1.2.2.1",
+			Entity: "interface",
+			Field:  "_id",
+			MappingEntries: []Entry{
+				{
+					OID:    "1.3.6.1.2.1.2.2.1.2",
+					Entity: "interface",
+					Field:  "name",
+				},
+				{
+					OID:    "1.3.6.1.2.1.2.2.1.3",
+					Entity: "interface",
+					Field:  "type",
+				},
+			},
+		}
+
+		registry := NewEntityRegistry(logger)
+		defaults := &config.Defaults{
+			Interface: config.InterfaceDefaults{
+				Type: "other",
+			},
+		}
+
+		result := mapper.Map(values, mappingEntry, registry, defaults)
+		iface, ok := result.(*diode.Interface)
+		assert.True(t, ok)
+		assert.NotNil(t, iface)
+		assert.NotNil(t, iface.Type)
+		// Should use built-in pattern for Port-channel
+		assert.Equal(t, "lag", *iface.Type, "Should use built-in pattern match via deferred type resolution")
+	})
+
+	t.Run("Deferred resolution with no pattern matcher", func(t *testing.T) {
+		// Create mapper without patterns
+		mapper, err := NewInterfaceMapper(logger, nil)
+		assert.NoError(t, err)
+		// Clear pattern matcher to simulate old behavior
+		mapper.patternMatcher = nil
+
+		values := map[ObjectIDIndex]*ObjectIDValue{
+			"1.3.6.1.2.1.2.2.1.2.1": { // name
+				OID:    "1.3.6.1.2.1.2.2.1.2.1",
+				Index:  "1",
+				Parent: "1.3.6.1.2.1.2.2.1.2",
+				Value:  "GigabitEthernet0/1",
+				Type:   OctetString,
+			},
+			"1.3.6.1.2.1.2.2.1.3.1": { // type
+				OID:    "1.3.6.1.2.1.2.2.1.3.1",
+				Index:  "1",
+				Parent: "1.3.6.1.2.1.2.2.1.3",
+				Value:  "161", // ieee8023adLag
+				Type:   Integer,
+			},
+		}
+
+		mappingEntry := &Entry{
+			OID:    "1.3.6.1.2.1.2.2.1",
+			Entity: "interface",
+			Field:  "_id",
+			MappingEntries: []Entry{
+				{
+					OID:    "1.3.6.1.2.1.2.2.1.2",
+					Entity: "interface",
+					Field:  "name",
+				},
+				{
+					OID:    "1.3.6.1.2.1.2.2.1.3",
+					Entity: "interface",
+					Field:  "type",
+				},
+			},
+		}
+
+		registry := NewEntityRegistry(logger)
+		defaults := &config.Defaults{
+			Interface: config.InterfaceDefaults{
+				Type: "other",
+			},
+		}
+
+		result := mapper.Map(values, mappingEntry, registry, defaults)
+		iface, ok := result.(*diode.Interface)
+		assert.True(t, ok)
+		assert.NotNil(t, iface)
+		assert.NotNil(t, iface.Type)
+		// Should use SNMP ifType mapping with deferred resolution
+		assert.Equal(t, "lag", *iface.Type, "Should use SNMP ifType when no pattern matcher")
+	})
+}

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -1332,7 +1332,8 @@ func TestInterfaceMapper_Map(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := slog.Default()
 			registry := mapping.NewEntityRegistry(logger)
-			mapper := mapping.NewInterfaceMapper(logger)
+			mapper, err := mapping.NewInterfaceMapper(logger, nil)
+			assert.NoError(t, err)
 			entity := mapper.Map(tt.values, tt.mappingEntry, registry, tt.defaults)
 
 			if tt.expectError {
@@ -1509,7 +1510,8 @@ func TestInterfaceMapper_Map_ZeroSpeedAndMtu(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			registry := mapping.NewEntityRegistry(logger)
-			mapper := mapping.NewInterfaceMapper(logger)
+			mapper, err := mapping.NewInterfaceMapper(logger, nil)
+			assert.NoError(t, err)
 			entity := mapper.Map(tt.values, tt.mappingEntry, registry, nil)
 			assert.NotNil(t, entity)
 			iface, ok := entity.(*diode.Interface)
@@ -1587,7 +1589,8 @@ func TestInterfaceMapper_Map_HighSpeed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			registry := mapping.NewEntityRegistry(logger)
-			mapper := mapping.NewInterfaceMapper(logger)
+			mapper, err := mapping.NewInterfaceMapper(logger, nil)
+			assert.NoError(t, err)
 			entity := mapper.Map(tt.values, tt.mappingEntry, registry, nil)
 			assert.NotNil(t, entity)
 			iface, ok := entity.(*diode.Interface)
@@ -1599,7 +1602,8 @@ func TestInterfaceMapper_Map_HighSpeed(t *testing.T) {
 
 func TestInterfaceMapper_FormatMACAddress(t *testing.T) {
 	logger := slog.Default()
-	mapper := mapping.NewInterfaceMapper(logger)
+	mapper, err := mapping.NewInterfaceMapper(logger, nil)
+	assert.NoError(t, err)
 
 	tests := []struct {
 		name        string

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -156,14 +156,25 @@ type Config struct {
 }
 
 // NewConfig creates a new Config
-func NewConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturers data.ManufacturerRetriever, deviceLookup data.DeviceRetriever) *Config {
+func NewConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturers data.ManufacturerRetriever,
+	deviceLookup data.DeviceRetriever, defaults *config.Defaults,
+) (*Config, error) {
+	// Create InterfaceMapper with pattern support
+	var interfacePatterns []config.InterfacePattern
+	if defaults != nil {
+		interfacePatterns = defaults.InterfacePatterns
+	}
+
+	interfaceMapper, err := NewInterfaceMapper(logger, interfacePatterns)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create interface mapper: %w", err)
+	}
+
 	entityMappers := map[string]orbToEntityMapper{
 		"ipAddress": &IPAddressMapper{
 			logger: logger,
 		},
-		"interface": &InterfaceMapper{
-			logger: logger,
-		},
+		"interface": interfaceMapper,
 		"device": &DeviceMapper{
 			logger:        logger,
 			manufacturers: manufacturers,
@@ -181,7 +192,7 @@ func NewConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturer
 	}
 	return &Config{
 		mapping: mapping,
-	}
+	}, nil
 }
 
 // NewObjectIDMapper creates a new ObjectIDMapper

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -341,7 +341,8 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mappingConfig := mapping.NewConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{})
+			mappingConfig, err := mapping.NewConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+			assert.NoError(t, err)
 			mapper := mapping.NewObjectIDMapper(mappingConfig, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &config.Defaults{
 				Interface: config.InterfaceDefaults{
 					Type: "other",
@@ -404,7 +405,8 @@ func TestObjectIDs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			mappingConfig := mapping.NewConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{})
+			mappingConfig, err := mapping.NewConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+			assert.NoError(t, err)
 			objectIDs := mappingConfig.ObjectIDs()
 
 			assert.Equal(t, tt.expectedOIDs, objectIDs)
@@ -599,7 +601,8 @@ func TestIPAddressIdentifierSizeInheritance(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
-			mappingConfig := mapping.NewConfig(tt.mapping, logger, &FakeManufacturers{}, &FakeDeviceLookup{})
+			mappingConfig, err := mapping.NewConfig(tt.mapping, logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+			assert.NoError(t, err)
 			objectIDMapper := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{})
 
 			entities := objectIDMapper.MapObjectIDsToEntity(tt.objectIDs)
@@ -693,7 +696,8 @@ func TestObjectIDsMethodWithIdentifierSizeInheritance(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
-			mappingConfig := mapping.NewConfig(tt.mapping, logger, &FakeManufacturers{}, &FakeDeviceLookup{})
+			mappingConfig, err := mapping.NewConfig(tt.mapping, logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+			assert.NoError(t, err)
 			objectIDs := mappingConfig.ObjectIDs()
 
 			for expectedOID, expectedSize := range tt.expectedOIDs {

--- a/snmp-discovery/mapping/pattern_matcher.go
+++ b/snmp-discovery/mapping/pattern_matcher.go
@@ -1,0 +1,114 @@
+// Copyright 2024 NetBox Labs Inc
+package mapping
+
+import (
+	"fmt"
+	"log/slog"
+	"regexp"
+
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+)
+
+// CompiledPattern wraps a pattern with its pre-compiled regex
+type CompiledPattern struct {
+	Pattern *regexp.Regexp
+	Type    string
+}
+
+// PatternMatcher handles interface name pattern matching with caching
+type PatternMatcher struct {
+	compiledPatterns []CompiledPattern
+	logger           *slog.Logger
+}
+
+// NewPatternMatcher creates a PatternMatcher with pre-compiled patterns
+func NewPatternMatcher(patterns []config.InterfacePattern, logger *slog.Logger) (*PatternMatcher, error) {
+	compiled := make([]CompiledPattern, 0, len(patterns))
+
+	for i, pattern := range patterns {
+		regex, err := regexp.Compile(pattern.Match)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile pattern %d ('%s'): %w", i, pattern.Match, err)
+		}
+		compiled = append(compiled, CompiledPattern{
+			Pattern: regex,
+			Type:    pattern.Type,
+		})
+	}
+
+	return &PatternMatcher{
+		compiledPatterns: compiled,
+		logger:           logger,
+	}, nil
+}
+
+// MatchInterfaceType matches interface name against patterns with priority-aware logic
+// Returns matched type or empty string if no match
+func (pm *PatternMatcher) MatchInterfaceType(interfaceName string, userPatternCount int) string {
+	if len(pm.compiledPatterns) == 0 {
+		return ""
+	}
+
+	// Separate user patterns from built-in patterns
+	userPatterns := pm.compiledPatterns[:userPatternCount]
+	builtinPatterns := pm.compiledPatterns[userPatternCount:]
+
+	// Priority 1: Check user patterns first
+	if len(userPatterns) > 0 {
+		if matchedType := pm.findBestMatch(interfaceName, userPatterns); matchedType != "" {
+			pm.logger.Debug("Matched interface with user pattern",
+				"interface", interfaceName,
+				"type", matchedType)
+			return matchedType
+		}
+	}
+
+	// Priority 2: Check built-in patterns only if no user pattern matched
+	if matchedType := pm.findBestMatch(interfaceName, builtinPatterns); matchedType != "" {
+		pm.logger.Debug("Matched interface with built-in pattern",
+			"interface", interfaceName,
+			"type", matchedType)
+		return matchedType
+	}
+
+	return ""
+}
+
+// findBestMatch finds the most specific (longest) match in a pattern list
+func (pm *PatternMatcher) findBestMatch(interfaceName string, patterns []CompiledPattern) string {
+	bestMatchLength := 0
+	bestMatchType := ""
+
+	for _, compiled := range patterns {
+		match := compiled.Pattern.FindString(interfaceName)
+		if match != "" {
+			matchLength := len(match)
+			if matchLength > bestMatchLength {
+				bestMatchLength = matchLength
+				bestMatchType = compiled.Type
+			}
+		}
+	}
+
+	return bestMatchType
+}
+
+// MergePatterns merges user patterns with built-in defaults
+// User patterns always come first (highest priority)
+func MergePatterns(userPatterns []config.InterfacePattern, includeDefaults bool) []config.InterfacePattern {
+	if !includeDefaults {
+		return userPatterns
+	}
+
+	merged := make([]config.InterfacePattern, 0, len(userPatterns)+len(DefaultInterfacePatterns))
+
+	// User patterns first (highest priority)
+	if len(userPatterns) > 0 {
+		merged = append(merged, userPatterns...)
+	}
+
+	// Built-in patterns as fallback
+	merged = append(merged, DefaultInterfacePatterns...)
+
+	return merged
+}

--- a/snmp-discovery/mapping/pattern_matcher.go
+++ b/snmp-discovery/mapping/pattern_matcher.go
@@ -1,4 +1,3 @@
-// Copyright 2024 NetBox Labs Inc
 package mapping
 
 import (

--- a/snmp-discovery/mapping/pattern_matcher_test.go
+++ b/snmp-discovery/mapping/pattern_matcher_test.go
@@ -1,0 +1,256 @@
+// Copyright 2024 NetBox Labs Inc
+package mapping
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPatternMatcher(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("Valid patterns compile successfully", func(t *testing.T) {
+		patterns := []config.InterfacePattern{
+			{Match: `^Gi\d+`, Type: "1000base-t"},
+			{Match: `^Te\d+`, Type: "10gbase-x-sfpp"},
+		}
+		matcher, err := NewPatternMatcher(patterns, logger)
+		assert.NoError(t, err)
+		assert.NotNil(t, matcher)
+		assert.Equal(t, 2, len(matcher.compiledPatterns))
+	})
+
+	t.Run("Invalid regex returns error", func(t *testing.T) {
+		patterns := []config.InterfacePattern{
+			{Match: `^Gi\d+`, Type: "1000base-t"},
+			{Match: `[invalid(`, Type: "10gbase-x-sfpp"}, // Invalid regex
+		}
+		matcher, err := NewPatternMatcher(patterns, logger)
+		assert.Error(t, err)
+		assert.Nil(t, matcher)
+		assert.Contains(t, err.Error(), "failed to compile pattern 1")
+	})
+
+	t.Run("Empty patterns creates empty matcher", func(t *testing.T) {
+		patterns := []config.InterfacePattern{}
+		matcher, err := NewPatternMatcher(patterns, logger)
+		assert.NoError(t, err)
+		assert.NotNil(t, matcher)
+		assert.Equal(t, 0, len(matcher.compiledPatterns))
+	})
+}
+
+func TestPatternMatcher_MatchInterfaceType(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("User pattern overrides built-in pattern", func(t *testing.T) {
+		// User wants all GigabitEthernet to be 10gbase-t instead of default 1000base-t
+		userPatterns := []config.InterfacePattern{
+			{Match: `^GigabitEthernet\d+`, Type: "10gbase-t"},
+		}
+		merged := MergePatterns(userPatterns, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		matchedType := matcher.MatchInterfaceType("GigabitEthernet0/1", 1)
+		assert.Equal(t, "10gbase-t", matchedType, "User pattern should override built-in")
+	})
+
+	t.Run("Built-in pattern matches when no user pattern", func(t *testing.T) {
+		merged := MergePatterns(nil, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		matchedType := matcher.MatchInterfaceType("GigabitEthernet0/1", 0)
+		assert.Equal(t, "1000base-t", matchedType, "Built-in pattern should match")
+	})
+
+	t.Run("Most specific match wins within user patterns", func(t *testing.T) {
+		userPatterns := []config.InterfacePattern{
+			{Match: `^Gi`, Type: "1000base-t"},                    // Less specific
+			{Match: `^GigabitEthernet\d+/\d+`, Type: "10gbase-t"}, // More specific
+		}
+		merged := MergePatterns(userPatterns, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		matchedType := matcher.MatchInterfaceType("GigabitEthernet0/1", 2)
+		assert.Equal(t, "10gbase-t", matchedType, "More specific pattern should win")
+	})
+
+	t.Run("Most specific match wins within built-in patterns", func(t *testing.T) {
+		merged := MergePatterns(nil, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		// TenGig pattern is more specific than Te pattern in built-ins
+		matchedType := matcher.MatchInterfaceType("TenGigabitEthernet0/1", 0)
+		assert.Equal(t, "10gbase-x-sfpp", matchedType, "Built-in most specific should win")
+	})
+
+	t.Run("No match returns empty string", func(t *testing.T) {
+		userPatterns := []config.InterfacePattern{
+			{Match: `^Gi\d+`, Type: "1000base-t"},
+		}
+		merged := MergePatterns(userPatterns, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		matchedType := matcher.MatchInterfaceType("UnknownInterface", 1)
+		assert.Equal(t, "", matchedType, "No match should return empty string")
+	})
+
+	t.Run("Empty interface name returns empty string", func(t *testing.T) {
+		merged := MergePatterns(nil, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		matchedType := matcher.MatchInterfaceType("", 0)
+		assert.Equal(t, "", matchedType)
+	})
+
+	t.Run("Case sensitive matching", func(t *testing.T) {
+		userPatterns := []config.InterfacePattern{
+			{Match: `^Gi\d+`, Type: "1000base-t"},
+		}
+		merged := MergePatterns(userPatterns, true)
+		matcher, err := NewPatternMatcher(merged, logger)
+		assert.NoError(t, err)
+
+		// Should not match lowercase
+		matchedType := matcher.MatchInterfaceType("gi0/1", 1)
+		assert.Equal(t, "", matchedType, "Pattern matching should be case sensitive")
+
+		// Should match uppercase
+		matchedType = matcher.MatchInterfaceType("Gi0/1", 1)
+		assert.Equal(t, "1000base-t", matchedType)
+	})
+}
+
+func TestPatternMatcher_findBestMatch(t *testing.T) {
+	logger := slog.Default()
+
+	t.Run("Longer match wins", func(t *testing.T) {
+		patterns := []config.InterfacePattern{
+			{Match: `^Gi`, Type: "type1"},
+			{Match: `^GigabitEthernet`, Type: "type2"},
+		}
+		matcher, err := NewPatternMatcher(patterns, logger)
+		assert.NoError(t, err)
+
+		matchedType := matcher.findBestMatch("GigabitEthernet0/1", matcher.compiledPatterns)
+		assert.Equal(t, "type2", matchedType, "Longer match should win")
+	})
+
+	t.Run("Empty patterns returns empty string", func(t *testing.T) {
+		patterns := []config.InterfacePattern{}
+		matcher, err := NewPatternMatcher(patterns, logger)
+		assert.NoError(t, err)
+
+		matchedType := matcher.findBestMatch("GigabitEthernet0/1", matcher.compiledPatterns)
+		assert.Equal(t, "", matchedType)
+	})
+}
+
+func TestMergePatterns(t *testing.T) {
+	t.Run("Merge user patterns with defaults", func(t *testing.T) {
+		userPatterns := []config.InterfacePattern{
+			{Match: `^custom-`, Type: "custom-type"},
+		}
+		merged := MergePatterns(userPatterns, true)
+
+		// User patterns should come first
+		assert.Greater(t, len(merged), 1, "Should have user + built-in patterns")
+		assert.Equal(t, "^custom-", merged[0].Match, "User pattern should be first")
+
+		// Built-in patterns should follow
+		hasBuiltin := false
+		for i := 1; i < len(merged); i++ {
+			if merged[i].Match == `^(HundredGig|Hu)\S+` {
+				hasBuiltin = true
+				break
+			}
+		}
+		assert.True(t, hasBuiltin, "Built-in patterns should be included")
+	})
+
+	t.Run("User patterns only when includeDefaults is false", func(t *testing.T) {
+		userPatterns := []config.InterfacePattern{
+			{Match: `^custom-`, Type: "custom-type"},
+		}
+		merged := MergePatterns(userPatterns, false)
+
+		assert.Equal(t, 1, len(merged), "Should only have user patterns")
+		assert.Equal(t, "^custom-", merged[0].Match)
+	})
+
+	t.Run("Empty user patterns with defaults", func(t *testing.T) {
+		merged := MergePatterns(nil, true)
+
+		assert.Greater(t, len(merged), 0, "Should have built-in patterns")
+		// First pattern should be a built-in
+		assert.Equal(t, `^(HundredGig|Hu)\S+`, merged[0].Match)
+	})
+
+	t.Run("Empty user patterns without defaults", func(t *testing.T) {
+		merged := MergePatterns(nil, false)
+
+		assert.Equal(t, 0, len(merged), "Should have no patterns")
+	})
+}
+
+func TestBuiltInPatterns(t *testing.T) {
+	logger := slog.Default()
+
+	// Create matcher with only built-in patterns
+	matcher, err := NewPatternMatcher(DefaultInterfacePatterns, logger)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name          string
+		interfaceName string
+		expectedType  string
+	}{
+		// Cisco IOS/IOS-XE
+		{"Cisco HundredGig", "HundredGigE0/1/0", "100gbase-x-qsfp28"},
+		{"Cisco FortyGig", "FortyGigabitEthernet0/1", "40gbase-x-qsfpp"},
+		{"Cisco TenGig", "TenGigabitEthernet0/1", "10gbase-x-sfpp"},
+		{"Cisco GigabitEthernet", "GigabitEthernet0/1", "1000base-t"},
+		{"Cisco FastEthernet", "FastEthernet0/1", "100base-tx"},
+
+		// Juniper
+		{"Juniper et", "et-0/0/0", "40gbase-x-qsfpp"},
+		{"Juniper xe", "xe-0/0/0", "10gbase-x-sfpp"},
+		{"Juniper ge", "ge-0/0/0", "1000base-t"},
+
+		// LAG
+		{"Cisco Port-channel", "Port-channel1", "lag"},
+		{"Juniper ae", "ae0", "lag"},
+		{"Cisco IOS-XR Bundle", "Bundle-Ether100", "lag"},
+
+		// Virtual
+		{"Loopback", "Loopback0", "virtual"},
+		{"VLAN", "Vlan100", "virtual"},
+		{"Tunnel", "Tunnel0", "virtual"},
+
+		// Management
+		{"Management", "Management0", "1000base-t"},
+		{"Juniper fxp", "fxp0", "1000base-t"},
+
+		// Linux
+		{"Linux eth", "eth0", "1000base-t"},
+		{"Linux ens", "ens33", "1000base-t"},
+		{"Cumulus swp", "swp1", "1000base-t"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matchedType := matcher.findBestMatch(tt.interfaceName, matcher.compiledPatterns)
+			assert.Equal(t, tt.expectedType, matchedType,
+				"Pattern should match %s to %s", tt.interfaceName, tt.expectedType)
+		})
+	}
+}

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -271,7 +271,11 @@ func (r *Runner) logEntitiesForIngestion(entities []diode.Entity) {
 }
 
 func (r *Runner) queryTarget(target config.Target) []diode.Entity {
-	mappingConfig := mapping.NewConfig(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup)
+	mappingConfig, err := mapping.NewConfig(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup, &r.config.Defaults)
+	if err != nil {
+		r.logger.Error("Error creating mapping config", "error", err)
+		return make([]diode.Entity, 0)
+	}
 	objectIDs := mappingConfig.ObjectIDs()
 	r.logger.Info("Querying target", "target", target, "objectCount", len(objectIDs))
 


### PR DESCRIPTION
This pull request enhances the mapping of Ethernet interface types and improves handling of interface speeds in SNMP discovery. It introduces detailed support for various Ethernet speeds up to 800Gbps, adds logic to prefer `highSpeed` over `speed` when available, and strengthens input validation for speed and MTU values. The test suite is expanded to cover new speed types, edge cases, and error scenarios.

### Ethernet speed mapping improvements
* The `getEthernetInterfaceType` function in `interface_types.go` now supports granular mapping for Ethernet speeds from 10Mbps up to 800Gbps, returning more precise NetBox types for each speed tier.
* Test cases in `interface_types_test.go` are updated and expanded to verify correct mapping for all supported speeds, including new types (e.g., 2.5gbase-t, 5gbase-t, 40gbase-x-qsfpp, 50gbase-x-sfp56, 100gbase-x-qsfp28, 200gbase-x-qsfp56, 400gbase-x-qsfpdd, 800gbase-x-qsfpdd). Edge cases for missing or excessive speeds are also covered. [[1]](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acL218-R219) [[2]](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acR238-R245) [[3]](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acR262-R307) [[4]](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acL290-R331) [[5]](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acL306-R347) [[6]](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acR1078-R1092)

### Interface speed and highSpeed handling
* The interface mapping logic in `mappers.go` now checks and prefers `highSpeed` SNMP values over `speed`, and ensures only valid (non-negative, within range) values are set. Negative and out-of-range speeds are ignored.
* New and updated tests in `mappers_test.go` verify correct precedence of `highSpeed` over `speed`, proper handling of invalid/negative values, and edge cases for both speed and MTU. [[1]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L596-R664) [[2]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R1427-R1466) [[3]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130R1522-R1599) [[4]](diffhunk://#diff-683ef3f3451d82e76a861bc708a56f8b84a3cdaec883501f378724e5c3b93130L796-R864)

### Policy and configuration updates
* The SNMP mapping policy in `mapping.yaml` is updated to include the `highSpeed` OID for interface entities, ensuring it is available for mapping.

### Input validation and logging
* Improved validation and logging for speed and MTU values in `mappers.go`, including checks for negative and out-of-range values, and more descriptive warnings/debug messages.

---

If you have questions about how the new speed mapping works or want to understand the logic for preferring `highSpeed`, let me know!