### PR TITLE
fix: avoid creating interfaces with 00:00:00:00:00:00 MAC address value

### DIFF
--- a/snmp-discovery/go.mod
+++ b/snmp-discovery/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/go-co-op/gocron/v2 v2.14.0
 	github.com/google/uuid v1.6.0
 	github.com/gosnmp/gosnmp v1.39.0
-	github.com/netboxlabs/diode-sdk-go v1.6.2
+	github.com/netboxlabs/diode-sdk-go v1.7.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0

--- a/snmp-discovery/go.sum
+++ b/snmp-discovery/go.sum
@@ -70,10 +70,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/netboxlabs/diode-sdk-go v1.6.1 h1:j4rPr1eRNZG5lgPAekopeok+ygijUM3ksNGeRyJexsE=
-github.com/netboxlabs/diode-sdk-go v1.6.1/go.mod h1:Y93A5nsK/sz6wsgwiMytZgek01Yl50wzYQjZKFZfdkQ=
-github.com/netboxlabs/diode-sdk-go v1.6.2 h1:UoXQSRt2Eh4kcqYtpB6ChXXadK16pd/QaZ4ji5qhK/M=
-github.com/netboxlabs/diode-sdk-go v1.6.2/go.mod h1:Y93A5nsK/sz6wsgwiMytZgek01Yl50wzYQjZKFZfdkQ=
+github.com/netboxlabs/diode-sdk-go v1.7.0 h1:PEfczyJCWJ8CJEb13HqiNfIluJEW/2D50CHqOd4Oub8=
+github.com/netboxlabs/diode-sdk-go v1.7.0/go.mod h1:Y93A5nsK/sz6wsgwiMytZgek01Yl50wzYQjZKFZfdkQ=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -352,7 +352,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				case "macAddress":
 					macAddress, err := m.FormatMACAddress(value.Value)
 					if err != nil {
-						m.logger.Warn("Error formatting mac address", "error", err, "value", value.Value)
+						m.logger.Debug("Error formatting mac address", "error", err, "value", value.Value)
 						continue
 					}
 					interfaceEntity.PrimaryMacAddress = &diode.MACAddress{
@@ -391,6 +391,18 @@ func (m *InterfaceMapper) FormatMACAddress(input string) (string, error) {
 	// Check for correct MAC address length
 	if len(bytes) != 6 {
 		return "", fmt.Errorf("invalid MAC address length: got %d bytes", len(bytes))
+	}
+
+	// Check if MAC address is all zeros (00:00:00:00:00:00)
+	allZeros := true
+	for _, b := range bytes {
+		if b != 0 {
+			allZeros = false
+			break
+		}
+	}
+	if allZeros {
+		return "", fmt.Errorf("invalid MAC address: 00:00:00:00:00:00 is not a valid hardware address")
 	}
 
 	// Format to colon-separated hex string

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -1631,6 +1631,12 @@ func TestInterfaceMapper_FormatMACAddress(t *testing.T) {
 			expected:    "",
 			expectError: true,
 		},
+		{
+			name:        "invalid all zeros MAC address (00:00:00:00:00:00)",
+			input:       "\x00\x00\x00\x00\x00\x00",
+			expected:    "",
+			expectError: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -310,7 +310,7 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 
 	assignedInterfaceIndices := m.getAssignedInterfaces(uniqueEntities)
 
-	// Build final entity list, excluding assigned interfaces to sending duplcates for ingestion
+	// Build final entity list, excluding assigned interfaces to sending duplicates for ingestion
 	entities := make([]diode.Entity, 0, len(uniqueEntities))
 	for entity := range uniqueEntities {
 		if diodeInterface, ok := entity.(*diode.Interface); ok {

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -74,14 +74,12 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 			},
 			expected: []diode.Entity{
 				&diode.Interface{
-					Speed: &[]int64{1000000}[0],
-					Name:  diode.String("GigabitEthernet1/0/1"),
-					PrimaryMacAddress: &diode.MACAddress{
-						MacAddress: &[]string{"00:00:00:00:00:00"}[0],
-					},
-					Enabled: &[]bool{true}[0],
-					Type:    diode.String("other"),
-					Device:  &diode.Device{},
+					Speed:             &[]int64{1000000}[0],
+					Name:              diode.String("GigabitEthernet1/0/1"),
+					PrimaryMacAddress: nil, // all-zeros MAC address should be ignored
+					Enabled:           &[]bool{true}[0],
+					Type:              diode.String("other"),
+					Device:            &diode.Device{},
 				},
 				&diode.Interface{
 					Speed: &[]int64{1000000}[0],
@@ -153,14 +151,12 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 			},
 			expected: []diode.Entity{
 				&diode.Interface{
-					Speed: &[]int64{1000000}[0],
-					Name:  diode.String("GigabitEthernet1/0/1"),
-					PrimaryMacAddress: &diode.MACAddress{
-						MacAddress: diode.String("00:00:00:00:00:00"),
-					},
-					Enabled: &[]bool{true}[0],
-					Type:    diode.String("other"),
-					Device:  &diode.Device{},
+					Speed:             &[]int64{1000000}[0],
+					Name:              diode.String("GigabitEthernet1/0/1"),
+					PrimaryMacAddress: nil, // all-zeros MAC address should be ignored
+					Enabled:           &[]bool{true}[0],
+					Type:              diode.String("other"),
+					Device:            &diode.Device{},
 				},
 				&diode.IPAddress{
 					Address: diode.String("192.168.1.2/32"),


### PR DESCRIPTION
This pull request improves the handling of MAC addresses in the SNMP discovery mapping logic, specifically by rejecting all-zeros MAC addresses as invalid. It also updates relevant tests to reflect this behavior and makes a minor dependency update. The most important changes are as follows:

### MAC address validation improvements

* Updated the `FormatMACAddress` function in `mappers.go` to detect and reject all-zeros MAC addresses (`00:00:00:00:00:00`) as invalid, returning an error if encountered.
* Changed logging in `InterfaceMapper.Map` to use debug level instead of warn level when an invalid MAC address is encountered, reducing noise for expected validation failures.

### Test updates

* Added a test case to `TestInterfaceMapper_FormatMACAddress` in `mappers_test.go` to ensure all-zeros MAC addresses are rejected.
* Updated expected results in `TestMapObjectIDsToEntity` in `mapping_test.go` so that interfaces with all-zeros MAC addresses have `PrimaryMacAddress` set to `nil`, reflecting the new validation logic. [[1]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L79-R79) [[2]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L158-R156)

### Dependency update

* Bumped `github.com/netboxlabs/diode-sdk-go` dependency from version 1.6.2 to 1.7.0 in `go.mod`.

### Minor fix

* Fixed a typo in a comment in `mapping.go` ("duplcates" to "duplicates").