### PR TITLE
fix: snmp ip address extraction and mapping

### DIFF
--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -100,42 +100,88 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	ipAddress := diode.IPAddress{}
 
 	fieldFound := false
-	// for each value in the map, map it to the ip address entity
+	var extractedIP string // Store the IP address extracted from any field
+
+	extractIPFromIndex := func(value *ObjectIDValue, field string) {
+		if extractedIP != "" {
+			return
+		}
+		if value.Index != "" {
+			if ip := net.ParseIP(string(value.Index)); ip != nil && ip.To4() != nil {
+				extractedIP = ip.String()
+				m.logger.Debug("Extracted IP address", "field", field, "ip", extractedIP)
+			}
+		}
+	}
+
+	extractIPFromValueOrIndex := func(value *ObjectIDValue, field string) bool {
+		if extractedIP != "" {
+			return true // Already extracted
+		}
+		// Try to extract from value field first
+		if value.Value != "" {
+			if ip := net.ParseIP(value.Value); ip != nil && ip.To4() != nil {
+				extractedIP = ip.String()
+				m.logger.Debug("Extracted IP address", "field", field, "ip", extractedIP)
+				return true
+			}
+		}
+		// Fall back to extracting from index
+		extractIPFromIndex(value, field)
+		return extractedIP != ""
+	}
+
+	setOrUpdateAddress := func(newAddress string) {
+		ipAddress.Address = &newAddress
+	}
+
 	for objectID, value := range values {
 		m.logger.Debug("Mapping value to ipAddress entity", "objectID", objectID, "value", value)
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(propertyMappingEntry.OID) {
 				switch propertyMappingEntry.Field {
 				case "address":
+					if !extractIPFromValueOrIndex(value, propertyMappingEntry.Field) {
+						m.logger.Warn("Could not extract valid IP address from any field")
+						continue
+					}
 					if ipAddress.Address != nil && strings.HasPrefix(*ipAddress.Address, "/") {
-						x := fmt.Sprintf("%s%s", string(value.Index), *ipAddress.Address)
-						ipAddress.Address = &x
+						// Prefix was processed first, prepend IP
+						setOrUpdateAddress(fmt.Sprintf("%s%s", extractedIP, *ipAddress.Address))
 					} else if ipAddress.Address == nil || *ipAddress.Address == "" {
-						x := fmt.Sprintf("%s/32", value.Index)
-						ipAddress.Address = &x
+						// No prefix yet, set IP with default /32
+						setOrUpdateAddress(fmt.Sprintf("%s/32", extractedIP))
 					}
 					fieldFound = true
-				case "address_prefixSize":
+				case "addressPrefixSize":
+					extractIPFromIndex(value, propertyMappingEntry.Field)
 					prefixLength, err := maskToPrefixSize(value.Value)
 					if err != nil {
 						m.logger.Warn("Error converting mask to prefix size", "error", err, "value", value.Value)
 						continue
 					}
 					if ipAddress.Address == nil || *ipAddress.Address == "" {
-						x := fmt.Sprintf("/%d", prefixLength)
-						ipAddress.Address = &x
+						// No address set yet
+						if extractedIP != "" {
+							// Use extracted IP with the prefix
+							setOrUpdateAddress(fmt.Sprintf("%s/%d", extractedIP, prefixLength))
+						} else {
+							// No IP available, store just the prefix (will be rejected by validation)
+							setOrUpdateAddress(fmt.Sprintf("/%d", prefixLength))
+						}
+						fieldFound = true
 					} else {
+						// Address already set, update the prefix
 						prefixParts := strings.Split(*ipAddress.Address, "/")
 						if len(prefixParts) >= 1 {
-							x := fmt.Sprintf("%s/%d", prefixParts[0], prefixLength)
-							ipAddress.Address = &x
+							setOrUpdateAddress(fmt.Sprintf("%s/%d", prefixParts[0], prefixLength))
 						} else {
-							x := fmt.Sprintf("%s/%d", *ipAddress.Address, prefixLength)
-							ipAddress.Address = &x
+							setOrUpdateAddress(fmt.Sprintf("%s/%d", *ipAddress.Address, prefixLength))
 						}
+						fieldFound = true
 					}
-					fieldFound = true
-				case "assigned_object":
+				case "assignedObject":
+					extractIPFromIndex(value, propertyMappingEntry.Field)
 					if propertyMappingEntry.Relationship != (config.Relationship{}) {
 						linkedEntity := entityRegistry.GetOrCreateEntity(EntityType(propertyMappingEntry.Relationship.Type), ObjectIDIndex(value.Value))
 						if linkedEntity == nil {
@@ -152,6 +198,15 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					m.logger.Warn("Unknown field", "field", mappingEntry.Field)
 				}
 			}
+		}
+	}
+
+	// Validate the final IP/CIDR before storage
+	if ipAddress.Address != nil && *ipAddress.Address != "" {
+		if !ValidateIPv4CIDR(*ipAddress.Address) {
+			m.logger.Warn("Invalid IP/CIDR format, skipping",
+				"address", *ipAddress.Address)
+			return &diode.IPAddress{} // Empty entity won't be added
 		}
 	}
 
@@ -189,6 +244,28 @@ func maskToPrefixSize(maskStr string) (int, error) {
 	ones, _ := mask.Size()
 
 	return ones, nil
+}
+
+// ValidateIPv4CIDR validates an IPv4 address in CIDR notation (e.g., "192.168.1.1/24").
+// Returns true if the format is valid, false otherwise.
+func ValidateIPv4CIDR(cidr string) bool {
+	ip, ipNet, err := net.ParseCIDR(cidr)
+	if err != nil {
+		return false
+	}
+
+	// Verify it's IPv4 (not IPv6)
+	if ip.To4() == nil {
+		return false
+	}
+
+	// Verify prefix is in valid range (0-32 for IPv4)
+	ones, bits := ipNet.Mask.Size()
+	if bits != 32 || ones < 0 || ones > 32 {
+		return false
+	}
+
+	return true
 }
 
 // InterfaceMapper is a struct that maps interfaces to entities

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -229,7 +229,7 @@ func TestIPAddressMapper_Map(t *testing.T) {
 					{
 						OID:    "1.3.6.1.2.1.4.20.1.2",
 						Entity: "ipAddress",
-						Field:  "assigned_object",
+						Field:  "assignedObject",
 						Relationship: config.Relationship{
 							Type: "interface",
 						},
@@ -2431,7 +2431,7 @@ func TestMaskToPrefixSize(t *testing.T) {
 					{
 						OID:    "test",
 						Entity: "ipAddress",
-						Field:  "address_prefixSize",
+						Field:  "addressPrefixSize",
 					},
 				},
 			}
@@ -2439,22 +2439,13 @@ func TestMaskToPrefixSize(t *testing.T) {
 			entityRegistry := mapping.NewEntityRegistry(slog.Default())
 			result := mapper.Map(values, mappingEntry, entityRegistry, nil)
 
-			if tt.expectError {
-				// For error cases, we expect the function to skip the invalid mask
-				// and return an entity with no address set (since no valid fields were found)
-				assert.NotNil(t, result)
-				ipAddress, ok := result.(*diode.IPAddress)
-				assert.True(t, ok)
-				// The address should be nil since the invalid mask was skipped
-				assert.Nil(t, ipAddress.Address)
-			} else {
-				// For valid cases, we expect the function to work correctly
-				assert.NotNil(t, result)
-				ipAddress, ok := result.(*diode.IPAddress)
-				assert.True(t, ok)
-				// The address should be just the prefix since there's no address field
-				assert.Equal(t, fmt.Sprintf("/%d", tt.expected), *ipAddress.Address)
-			}
+			// All cases with prefix-only (no IP address) should result in nil address
+			// because validation now requires a complete IP/CIDR format
+			assert.NotNil(t, result)
+			ipAddress, ok := result.(*diode.IPAddress)
+			assert.True(t, ok)
+			// The address should be nil since prefix-only is not a valid IP/CIDR
+			assert.Nil(t, ipAddress.Address)
 		})
 	}
 }
@@ -2471,7 +2462,7 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 		expectError    bool
 	}{
 		{
-			name: "address_prefixSize with existing address",
+			name: "addressPrefixSize with existing address",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
 					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
@@ -2501,7 +2492,7 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 					{
 						OID:    "1.3.6.1.2.1.4.20.1.3",
 						Entity: "ipAddress",
-						Field:  "address_prefixSize",
+						Field:  "addressPrefixSize",
 					},
 				},
 			},
@@ -2512,7 +2503,7 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "address_prefixSize without existing address",
+			name: "addressPrefixSize without existing address - now extracts IP from index",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.4.20.1.3.192.168.1.1": {
 					OID:    "1.3.6.1.2.1.4.20.1.3.192.168.1.1",
@@ -2530,18 +2521,18 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 					{
 						OID:    "1.3.6.1.2.1.4.20.1.3",
 						Entity: "ipAddress",
-						Field:  "address_prefixSize",
+						Field:  "addressPrefixSize",
 					},
 				},
 			},
 			defaults: nil,
 			expectedEntity: &diode.IPAddress{
-				Address: mapping.StringPtr("/24"),
+				Address: mapping.StringPtr("192.168.1.1/24"), // Now extracts IP from index
 			},
 			expectError: false,
 		},
 		{
-			name: "address_prefixSize with address that already has prefix",
+			name: "addressPrefixSize with address that already has prefix",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
 					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
@@ -2571,7 +2562,7 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 					{
 						OID:    "1.3.6.1.2.1.4.20.1.3",
 						Entity: "ipAddress",
-						Field:  "address_prefixSize",
+						Field:  "addressPrefixSize",
 					},
 				},
 			},
@@ -2582,7 +2573,7 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "address_prefixSize with address that has no prefix",
+			name: "addressPrefixSize with address that has no prefix",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
 					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
@@ -2612,7 +2603,7 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 					{
 						OID:    "1.3.6.1.2.1.4.20.1.3",
 						Entity: "ipAddress",
-						Field:  "address_prefixSize",
+						Field:  "addressPrefixSize",
 					},
 				},
 			},
@@ -2623,7 +2614,7 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "address_prefixSize with invalid mask - should skip",
+			name: "addressPrefixSize with invalid mask - should skip",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
 					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
@@ -2653,7 +2644,7 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 					{
 						OID:    "1.3.6.1.2.1.4.20.1.3",
 						Entity: "ipAddress",
-						Field:  "address_prefixSize",
+						Field:  "addressPrefixSize",
 					},
 				},
 			},
@@ -2664,7 +2655,7 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "address_prefixSize with different subnet masks",
+			name: "addressPrefixSize with different subnet masks",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.4.20.1.1.10.0.0.1": {
 					OID:    "1.3.6.1.2.1.4.20.1.1.10.0.0.1",
@@ -2694,7 +2685,7 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 					{
 						OID:    "1.3.6.1.2.1.4.20.1.3",
 						Entity: "ipAddress",
-						Field:  "address_prefixSize",
+						Field:  "addressPrefixSize",
 					},
 				},
 			},
@@ -2705,7 +2696,7 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "address_prefixSize with /30 subnet",
+			name: "addressPrefixSize with /30 subnet",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.4.20.1.1.172.16.1.1": {
 					OID:    "1.3.6.1.2.1.4.20.1.1.172.16.1.1",
@@ -2735,7 +2726,7 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 					{
 						OID:    "1.3.6.1.2.1.4.20.1.3",
 						Entity: "ipAddress",
-						Field:  "address_prefixSize",
+						Field:  "addressPrefixSize",
 					},
 				},
 			},
@@ -2760,7 +2751,375 @@ func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {
 				assert.NotNil(t, result)
 				ipAddress, ok := result.(*diode.IPAddress)
 				assert.True(t, ok)
+				if tt.expectedEntity.Address != nil && ipAddress.Address != nil {
+					t.Logf("Expected: %s, Got: %s", *tt.expectedEntity.Address, *ipAddress.Address)
+				}
 				assert.Equal(t, tt.expectedEntity.Address, ipAddress.Address)
+			}
+		})
+	}
+}
+
+func Test_validateIPv4CIDR(t *testing.T) {
+	tests := []struct {
+		name     string
+		cidr     string
+		expected bool
+	}{
+		{
+			name:     "valid CIDR /24",
+			cidr:     "192.168.1.1/24",
+			expected: true,
+		},
+		{
+			name:     "valid CIDR /8",
+			cidr:     "10.0.0.1/8",
+			expected: true,
+		},
+		{
+			name:     "valid CIDR /32",
+			cidr:     "127.0.0.1/32",
+			expected: true,
+		},
+		{
+			name:     "valid CIDR /0",
+			cidr:     "0.0.0.0/0",
+			expected: true,
+		},
+		{
+			name:     "invalid prefix too high",
+			cidr:     "192.168.1.1/33",
+			expected: false,
+		},
+		{
+			name:     "invalid IP octet",
+			cidr:     "256.1.1.1/24",
+			expected: false,
+		},
+		{
+			name:     "invalid IP format",
+			cidr:     "999.999.999.999/24",
+			expected: false,
+		},
+		{
+			name:     "missing prefix",
+			cidr:     "192.168.1.1",
+			expected: false,
+		},
+		{
+			name:     "only prefix",
+			cidr:     "/24",
+			expected: false,
+		},
+		{
+			name:     "IPv6 CIDR (should reject)",
+			cidr:     "fe80::1/64",
+			expected: false,
+		},
+		{
+			name:     "malformed CIDR",
+			cidr:     "192.168.1.1/abc",
+			expected: false,
+		},
+		{
+			name:     "incomplete IP",
+			cidr:     "192.168.1/24",
+			expected: false,
+		},
+		{
+			name:     "too many octets",
+			cidr:     "192.168.1.1.1/24",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapping.ValidateIPv4CIDR(tt.cidr)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestIPAddressMapper_Map_ValueFieldExtraction(t *testing.T) {
+	logger := slog.Default()
+
+	tests := []struct {
+		name           string
+		values         map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
+		mappingEntry   *mapping.Entry
+		expectedEntity *diode.IPAddress
+	}{
+		{
+			name: "IP in value field with correct type",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   0x40, // IPAddress type
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address: mapping.StringPtr("192.168.1.1/32"),
+			},
+		},
+		{
+			name: "IP in value field with wrong type (OctetString)",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.10.110.18.4": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.10.110.18.4",
+					Index:  "10.110.18.4",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "10.110.18.4",
+					Type:   0x04, // OctetString type
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address: mapping.StringPtr("10.110.18.4/32"),
+			},
+		},
+		{
+			name: "fallback to index when value is invalid",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.10.0.0.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.10.0.0.1",
+					Index:  "10.0.0.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "invalid.ip",
+					Type:   0x40,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address: mapping.StringPtr("10.0.0.1/32"),
+			},
+		},
+		{
+			name: "value field IP with netmask",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   0x40,
+				},
+				"1.3.6.1.2.1.4.20.1.3.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.3.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.3",
+					Value:  "255.255.255.0",
+					Type:   0x40,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.3",
+						Entity: "ipAddress",
+						Field:  "addressPrefixSize",
+					},
+				},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address: mapping.StringPtr("192.168.1.1/24"),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapper := mapping.NewIPAddressMapper(logger)
+			entityRegistry := mapping.NewEntityRegistry(logger)
+
+			result := mapper.Map(tt.values, tt.mappingEntry, entityRegistry, nil)
+
+			assert.NotNil(t, result)
+			ipAddress, ok := result.(*diode.IPAddress)
+			assert.True(t, ok)
+			assert.Equal(t, tt.expectedEntity.Address, ipAddress.Address)
+		})
+	}
+}
+
+func TestIPAddressMapper_Map_InvalidCases(t *testing.T) {
+	logger := slog.Default()
+
+	tests := []struct {
+		name            string
+		values          map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
+		mappingEntry    *mapping.Entry
+		expectEmpty     bool
+		expectedAddress *string
+	}{
+		{
+			name: "both value and index invalid",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.999.999.999.999": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.999.999.999.999",
+					Index:  "999.999.999.999",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "invalid",
+					Type:   0x40,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			expectEmpty: true,
+		},
+		{
+			name: "incomplete IP with only 3 octets",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1",
+					Index:  "192.168.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1",
+					Type:   0x40,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			expectEmpty: true,
+		},
+		{
+			name: "malformed IP address 256.1.1.1",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.256.1.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.256.1.1.1",
+					Index:  "256.1.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "256.1.1.1",
+					Type:   0x40,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			expectEmpty: true,
+		},
+		{
+			name: "only prefix without IP - now extracts IP from index",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.3.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.3.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.3",
+					Value:  "255.255.255.0",
+					Type:   0x40,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.3",
+						Entity: "ipAddress",
+						Field:  "addressPrefixSize",
+					},
+				},
+			},
+			expectEmpty:     false, // Changed: now extracts IP from addressPrefixSize field's index
+			expectedAddress: mapping.StringPtr("192.168.1.1/24"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mapper := mapping.NewIPAddressMapper(logger)
+			entityRegistry := mapping.NewEntityRegistry(logger)
+
+			result := mapper.Map(tt.values, tt.mappingEntry, entityRegistry, nil)
+
+			assert.NotNil(t, result)
+			ipAddress, ok := result.(*diode.IPAddress)
+			assert.True(t, ok)
+
+			if tt.expectEmpty {
+				// Empty entity should have nil or empty address
+				assert.True(t, ipAddress.Address == nil || *ipAddress.Address == "")
+			} else if tt.expectedAddress != nil {
+				// Check the expected address
+				if ipAddress.Address != nil {
+					t.Logf("Expected: %s, Got: %s", *tt.expectedAddress, *ipAddress.Address)
+				}
+				assert.Equal(t, tt.expectedAddress, ipAddress.Address)
 			}
 		})
 	}

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -252,7 +252,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 						{
 							OID:    ".1.3.6.1.2.1.4.20.1.2",
 							Entity: "ipAddress",
-							Field:  "assigned_object",
+							Field:  "assignedObject",
 							Relationship: config.Relationship{
 								Type:  "interface",
 								Field: "_id",
@@ -504,7 +504,7 @@ func TestIPAddressIdentifierSizeInheritance(t *testing.T) {
 						{
 							OID:    ".1.3.6.1.2.1.4.20.1.3",
 							Entity: "ipAddress",
-							Field:  "address_prefixSize",
+							Field:  "addressPrefixSize",
 							// No IdentifierSize specified - should inherit from parent
 						},
 					},
@@ -557,10 +557,10 @@ func TestIPAddressIdentifierSizeInheritance(t *testing.T) {
 			},
 			expected: []diode.Entity{
 				&diode.IPAddress{
-					Address: diode.String("1.2/32"), // Uses child's identifier size of 2
+					Address: nil, // Invalid IP format "1.2" is rejected by validation
 				},
 			},
-			description: "This test verifies that child mappings can override parent identifier size when explicitly specified",
+			description: "This test verifies that child mappings can override parent identifier size, but invalid IPs are still rejected",
 		},
 		{
 			name: "Zero identifier size on parent defaults correctly",
@@ -589,10 +589,10 @@ func TestIPAddressIdentifierSizeInheritance(t *testing.T) {
 			},
 			expected: []diode.Entity{
 				&diode.IPAddress{
-					Address: diode.String("/32"), // When identifier size is 0, no index is captured
+					Address: nil, // Invalid IP format (incomplete) is rejected by validation
 				},
 			},
-			description: "This test verifies behavior when parent has zero identifier size",
+			description: "This test verifies behavior when parent has zero identifier size - invalid IPs are rejected",
 		},
 	}
 
@@ -646,7 +646,7 @@ func TestObjectIDsMethodWithIdentifierSizeInheritance(t *testing.T) {
 						{
 							OID:    ".1.3.6.1.2.1.4.20.1.3",
 							Entity: "ipAddress",
-							Field:  "address_prefixSize",
+							Field:  "addressPrefixSize",
 							// Should inherit IdentifierSize 4 from parent
 						},
 					},

--- a/snmp-discovery/policy/mapping.yaml
+++ b/snmp-discovery/policy/mapping.yaml
@@ -41,10 +41,10 @@ entries:
         field: "address"
       - oid: ".1.3.6.1.2.1.4.20.1.3"
         entity: "ipAddress"
-        field: "address_prefixSize"
+        field: "addressPrefixSize"
       - oid: ".1.3.6.1.2.1.4.20.1.2"
         entity: "ipAddress"
-        field: "assigned_object"
+        field: "assignedObject"
         relationship:
           type: "interface"
           field: "_id"


### PR DESCRIPTION
This pull request improves the robustness and correctness of IP address mapping in SNMP discovery by standardizing field names, adding validation for IP/CIDR formats, and updating tests and configuration accordingly. The changes ensure only valid IPv4 CIDR addresses are stored and mapped, preventing malformed data from being accepted.

**Field name standardization:**

* Standardized mapping field names from snake_case to camelCase throughout the codebase and configuration files (e.g., `address_prefixSize` → `addressPrefixSize`, `assigned_object` → `assignedObject`) to ensure consistency and prevent mapping errors. [[1]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eL103-R184) [[2]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L251-R251) [[3]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L503-R503) [[4]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L645-R645) [[5]](diffhunk://#diff-b7cede7e8e7568c61abe873dd0ab8f4f7fa2a47b9a3c047c8410b1b0fc971b38L44-R47)

**IP address extraction and validation improvements:**

* Refactored IP extraction logic in `IPAddressMapper.Map` to more reliably extract IP addresses from both value and index fields, and to handle address and prefix mapping more robustly.
* Added a `ValidateIPv4CIDR` function to ensure only valid IPv4 addresses in CIDR notation are accepted and stored. The mapper now skips invalid addresses. [[1]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR249-R270) [[2]](diffhunk://#diff-480b988f8d1afe0ad0f2780a5b6bfa716acc21e684a110065226f573af92925eR204-R212)

**Test updates:**

* Updated tests to reflect stricter validation: tests now expect `nil` addresses when invalid or incomplete IPs are encountered, ensuring the new validation logic is enforced. [[1]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L556-R559) [[2]](diffhunk://#diff-4d22060a6680c75e54fdccf5df713c74999e66c6ad12877b7b57c48cdbb51519L588-R591)

These changes improve data integrity and make the mapping process more predictable and maintainable.