### PR TITLE
feat: add subinterface support for SNMP

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -123,17 +123,18 @@ If the referenced environment variable is not set, the service will exit with an
 
 ### Interface Type Pattern Matching
 
-SNMP discovery supports flexible interface type detection through a five-tier priority system that intelligently combines SNMP protocol data with pattern matching:
+SNMP discovery supports flexible interface type detection through a six-tier priority system that intelligently combines SNMP protocol data with pattern matching:
 
 #### Priority System
 
-1. **User-defined patterns** (highest priority) - Your custom pattern rules
+0. **Subinterface detection** (highest priority - structural) - Automatic detection of logical interfaces
+1. **User-defined patterns** - Your custom pattern rules
 2. **SNMP ifType mapping** - Protocol-specific intelligence from SNMP data
 3. **Built-in patterns** - 46 vendor-agnostic patterns included by default
 4. **Speed-based detection** - Automatic detection for Ethernet interfaces based on speed
 5. **Default fallback** - Configured `if_type` or "other"
 
-This priority order ensures that user intent always wins, while still leveraging SNMP protocol data and providing intelligent fallbacks.
+This priority order ensures that structural relationships (subinterfaces) are always detected first, followed by user intent, while still leveraging SNMP protocol data and providing intelligent fallbacks.
 
 #### Configuration
 
@@ -216,6 +217,7 @@ defaults:
 
 For each interface, the system evaluates in order:
 
+0. **Check for subinterface**: If the interface name contains `.` or `:` separators, classify as "virtual" immediately (see [Subinterface Detection](#subinterface-detection))
 1. **Check user patterns**: If any user pattern matches, use that type immediately
 2. **Check SNMP ifType**: If SNMP reports a known interface type (e.g., LAG, virtual), use it
    - For Ethernet interfaces, if speed is available, use speed-based detection
@@ -224,6 +226,71 @@ For each interface, the system evaluates in order:
 5. **Use default**: Fall back to `defaults.interface.if_type` or "other"
 
 This ensures maximum flexibility while maintaining intelligent defaults.
+
+### Subinterface Detection
+
+SNMP discovery automatically detects and handles subinterfaces (also known as logical interfaces, VLAN interfaces, or sub-interfaces) across all major network vendors.
+
+#### How It Works
+
+Subinterfaces are identified by the presence of specific separators in the interface name:
+- **Dot (`.`)** separator - Common for Cisco, Juniper, Arista, Nokia
+- **Colon (`:`)** separator - Legacy Juniper style
+
+When a subinterface is detected:
+1. **Type is set to "virtual"** - Regardless of SNMP ifType or speed
+2. **Parent interface is tracked** - The parent-child relationship is maintained
+3. **Works across all vendors** - No vendor-specific configuration needed
+
+#### Supported Formats
+
+**Cisco IOS/IOS-XE:**
+```
+GigabitEthernet0/0.100      → Parent: GigabitEthernet0/0
+TenGigabitEthernet1/1/1.200 → Parent: TenGigabitEthernet1/1/1
+Port-channel1.100           → Parent: Port-channel1
+```
+
+**Juniper JunOS:**
+```
+ge-0/0/0.0    → Parent: ge-0/0/0
+xe-1/2/3.100  → Parent: xe-1/2/3
+ae0.100       → Parent: ae0
+ge-0/0/0:0    → Parent: ge-0/0/0  (legacy colon style)
+```
+
+**Arista EOS:**
+```
+Ethernet1/1.100 → Parent: Ethernet1/1
+```
+
+**Nokia SROS:**
+```
+1/1/1.100 → Parent: 1/1/1
+```
+
+**Generic/Linux:**
+```
+eth0.100   → Parent: eth0
+eth0:1     → Parent: eth0  (legacy alias style)
+```
+
+#### Priority System
+
+Subinterface detection operates at **Tier 0** (highest priority) in the interface type resolution system:
+
+0. **Subinterface detection** ← Always evaluated first
+1. User-defined patterns
+2. SNMP ifType mapping
+3. Built-in patterns
+4. Speed-based detection
+5. Default fallback
+
+This means subinterfaces **always** receive the "virtual" type, even if:
+- SNMP reports a different ifType
+- A user pattern would match the interface name
+- Speed-based detection would assign a different type
+
 
 ### Device Model Lookup
 The `lookup_extensions_dir` specifies a directory containing device data YAML files that map SNMP device OIDs to human-readable device names. This allows snmp-discovery to provide meaningful device identification instead of raw OID values. This only needs to be set if additional or modified files are being provided instead of the ones that are included with orb-discovery and orb-agent.

--- a/snmp-discovery/mapping/interface_types.go
+++ b/snmp-discovery/mapping/interface_types.go
@@ -1,5 +1,27 @@
 package mapping
 
+import "strings"
+
+// ExtractParentInterfaceName returns the parent interface name if the supplied name
+// represents a subinterface, or an empty string if it's not a subinterface.
+// Subinterfaces are identified by the presence of dot (.) or colon (:) separators.
+// Examples: "eth0.100" -> "eth0", "GigabitEthernet0/0.100" -> "GigabitEthernet0/0",
+// "ge-0/0/0:0" -> "ge-0/0/0", "eth0" -> ""
+func ExtractParentInterfaceName(interfaceName string) string {
+	separators := []string{".", ":"}
+	for _, separator := range separators {
+		if idx := strings.LastIndex(interfaceName, separator); idx > 0 {
+			parent := interfaceName[:idx]
+			child := interfaceName[idx+1:]
+			// Both parent and child parts must be non-empty
+			if parent != "" && child != "" {
+				return parent
+			}
+		}
+	}
+	return ""
+}
+
 // InterfaceTypeMap maps SNMP ifType integer values to NetBox interface type strings
 var InterfaceTypeMap = map[string]string{
 	// Virtual Interfaces
@@ -206,8 +228,9 @@ func getEthernetInterfaceType(speed *int64) string {
 	return ""
 }
 
-// ResolveInterfaceType determines interface type using 5-tier priority system:
-// 1. User-defined patterns (highest priority)
+// ResolveInterfaceType determines interface type using 6-tier priority system:
+// 0. Subinterface detection (highest priority - structural)
+// 1. User-defined patterns
 // 2. SNMP ifType mapping
 // 3. Built-in patterns
 // 4. Speed-based detection (for Ethernet)
@@ -220,7 +243,13 @@ func ResolveInterfaceType(
 	patternMatcher *PatternMatcher,
 	userPatternCount int,
 ) string {
-	// Tier 1: User-defined patterns (highest priority)
+	// Tier 0: Subinterface detection (highest priority - structural)
+	// Subinterfaces are always virtual regardless of other attributes
+	if ExtractParentInterfaceName(interfaceName) != "" {
+		return "virtual"
+	}
+
+	// Tier 1: User-defined patterns (highest priority for non-subinterfaces)
 	if patternMatcher != nil && userPatternCount > 0 {
 		if matchedType := patternMatcher.MatchInterfaceType(interfaceName, userPatternCount); matchedType != "" {
 			return matchedType

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -60,16 +60,7 @@ func NewEntityRegistry(logger *slog.Logger) *EntityRegistry {
 	}
 }
 
-// GetEntity returns an entity from the EntityRegistry if it exists, or nil if it doesn't
-func (r *EntityRegistry) GetEntity(entityType EntityType, index ObjectIDIndex) diode.Entity {
-	if r.entities[entityType] == nil {
-		return nil
-	}
-	return r.entities[entityType][index]
-}
-
 // GetInterfaceByName searches for an interface entity by its name field
-// This is less efficient than GetEntity but necessary for parent interface resolution
 func (r *EntityRegistry) GetInterfaceByName(interfaceName string) *diode.Interface {
 	if r.entities[InterfaceEntityType] == nil {
 		return nil

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -60,6 +60,84 @@ func NewEntityRegistry(logger *slog.Logger) *EntityRegistry {
 	}
 }
 
+// GetEntity returns an entity from the EntityRegistry if it exists, or nil if it doesn't
+func (r *EntityRegistry) GetEntity(entityType EntityType, index ObjectIDIndex) diode.Entity {
+	if r.entities[entityType] == nil {
+		return nil
+	}
+	return r.entities[entityType][index]
+}
+
+// GetInterfaceByName searches for an interface entity by its name field
+// This is less efficient than GetEntity but necessary for parent interface resolution
+func (r *EntityRegistry) GetInterfaceByName(interfaceName string) *diode.Interface {
+	if r.entities[InterfaceEntityType] == nil {
+		return nil
+	}
+
+	// Search through all interface entities to find one with matching name
+	for _, entity := range r.entities[InterfaceEntityType] {
+		if iface, ok := entity.(*diode.Interface); ok {
+			if iface.Name != nil && *iface.Name == interfaceName {
+				return iface
+			}
+		}
+	}
+	return nil
+}
+
+// ResolveSubinterfaceParents resolves parent interface relationships for all subinterfaces
+// This must be called after all interfaces have been discovered and mapped
+func (r *EntityRegistry) ResolveSubinterfaceParents() {
+	if r.entities[InterfaceEntityType] == nil {
+		return
+	}
+
+	r.logger.Debug("Resolving parent interfaces for subinterfaces")
+	resolvedCount := 0
+	notFoundCount := 0
+
+	// Iterate through all interfaces to find subinterfaces
+	for _, entity := range r.entities[InterfaceEntityType] {
+		iface, ok := entity.(*diode.Interface)
+		if !ok || iface.Name == nil {
+			continue
+		}
+
+		// Check if this is a subinterface
+		parentName := ExtractParentInterfaceName(*iface.Name)
+		if parentName == "" {
+			continue // Not a subinterface
+		}
+
+		// Look up the parent interface by name
+		parent := r.GetInterfaceByName(parentName)
+		if parent != nil {
+			// Set the parent reference
+			iface.Parent = &diode.Interface{
+				Name:   parent.Name,
+				Type:   parent.Type,
+				Device: parent.Device,
+			}
+			r.logger.Debug("Resolved parent interface",
+				"subinterface", *iface.Name,
+				"parent", parentName)
+			resolvedCount++
+		} else {
+			r.logger.Debug("Parent interface not found",
+				"subinterface", *iface.Name,
+				"parent", parentName)
+			notFoundCount++
+		}
+	}
+
+	if resolvedCount > 0 {
+		r.logger.Info("Resolved subinterface parents",
+			"resolved", resolvedCount,
+			"not_found", notFoundCount)
+	}
+}
+
 // GetOrCreateEntity returns an entity from the EntityRegistry or creates a new one if it doesn't exist
 func (r *EntityRegistry) GetOrCreateEntity(entityType EntityType, index ObjectIDIndex) diode.Entity {
 	r.logger.Debug("Getting entity", "entityType", entityType, "index", index, "from", r.entities)
@@ -319,6 +397,9 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 
 	currentDevice := m.registry.GetOrCreateEntity(DeviceEntityType, CurrentDeviceIndex).(*diode.Device)
 
+	// Resolve parent interface relationships for subinterfaces now that all interfaces are discovered
+	m.registry.ResolveSubinterfaceParents()
+
 	assignedInterfaceIndices := m.getAssignedInterfaces(uniqueEntities)
 
 	// Build final entity list, excluding assigned interfaces to sending duplicates for ingestion
@@ -330,6 +411,9 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 				isAssigned = true
 			}
 			diodeInterface.Device = currentDevice
+			if diodeInterface.Parent != nil && diodeInterface.Parent.Device == nil {
+				diodeInterface.Parent.Device = currentDevice
+			}
 			if !isAssigned {
 				entities = append(entities, entity)
 			}

--- a/snmp-discovery/mapping/subinterface_test.go
+++ b/snmp-discovery/mapping/subinterface_test.go
@@ -1,0 +1,515 @@
+package mapping_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExtractParentInterfaceName(t *testing.T) {
+	tests := []struct {
+		name           string
+		interfaceName  string
+		expectedParent string
+		description    string
+	}{
+		// Dot separator tests (Cisco, Juniper, Arista, Nokia style)
+		{
+			name:           "Simple subinterface with dot",
+			interfaceName:  "eth0.100",
+			expectedParent: "eth0",
+			description:    "eth0.100 should extract parent eth0",
+		},
+		{
+			name:           "Cisco GigabitEthernet subinterface",
+			interfaceName:  "GigabitEthernet0/0.100",
+			expectedParent: "GigabitEthernet0/0",
+			description:    "GigabitEthernet0/0.100 should extract parent GigabitEthernet0/0",
+		},
+		{
+			name:           "Cisco TenGigabitEthernet subinterface",
+			interfaceName:  "TenGigabitEthernet1/1/1.200",
+			expectedParent: "TenGigabitEthernet1/1/1",
+			description:    "TenGigabitEthernet1/1/1.200 should extract parent TenGigabitEthernet1/1/1",
+		},
+		{
+			name:           "Juniper ge subinterface",
+			interfaceName:  "ge-0/0/0.0",
+			expectedParent: "ge-0/0/0",
+			description:    "ge-0/0/0.0 should extract parent ge-0/0/0",
+		},
+		{
+			name:           "Juniper xe subinterface",
+			interfaceName:  "xe-1/2/3.100",
+			expectedParent: "xe-1/2/3",
+			description:    "xe-1/2/3.100 should extract parent xe-1/2/3",
+		},
+		{
+			name:           "Juniper ae subinterface",
+			interfaceName:  "ae0.100",
+			expectedParent: "ae0",
+			description:    "ae0.100 should extract parent ae0",
+		},
+		{
+			name:           "Arista Ethernet subinterface",
+			interfaceName:  "Ethernet1/1.100",
+			expectedParent: "Ethernet1/1",
+			description:    "Ethernet1/1.100 should extract parent Ethernet1/1",
+		},
+		{
+			name:           "Nokia port subinterface",
+			interfaceName:  "1/1/1.100",
+			expectedParent: "1/1/1",
+			description:    "1/1/1.100 should extract parent 1/1/1",
+		},
+		{
+			name:           "Cisco Port-channel subinterface",
+			interfaceName:  "Port-channel1.100",
+			expectedParent: "Port-channel1",
+			description:    "Port-channel1.100 should extract parent Port-channel1",
+		},
+		{
+			name:           "Multiple dot separators",
+			interfaceName:  "eth0.100.200",
+			expectedParent: "eth0.100",
+			description:    "eth0.100.200 should extract rightmost parent eth0.100",
+		},
+
+		// Colon separator tests (Juniper style, legacy)
+		{
+			name:           "Juniper colon style subinterface",
+			interfaceName:  "ge-0/0/0:0",
+			expectedParent: "ge-0/0/0",
+			description:    "ge-0/0/0:0 should extract parent ge-0/0/0",
+		},
+		{
+			name:           "Simple colon subinterface",
+			interfaceName:  "eth0:1",
+			expectedParent: "eth0",
+			description:    "eth0:1 should extract parent eth0",
+		},
+		{
+			name:           "Multiple colon separators",
+			interfaceName:  "eth0:1:2",
+			expectedParent: "eth0:1",
+			description:    "eth0:1:2 should extract rightmost parent eth0:1",
+		},
+
+		// Non-subinterface tests (should return empty string)
+		{
+			name:           "Physical interface without separator",
+			interfaceName:  "eth0",
+			expectedParent: "",
+			description:    "eth0 should return empty string (not a subinterface)",
+		},
+		{
+			name:           "GigabitEthernet without subinterface",
+			interfaceName:  "GigabitEthernet0/0/1",
+			expectedParent: "",
+			description:    "GigabitEthernet0/0/1 should return empty string (slashes are not separators)",
+		},
+		{
+			name:           "Juniper physical interface",
+			interfaceName:  "ge-0/0/0",
+			expectedParent: "",
+			description:    "ge-0/0/0 should return empty string (not a subinterface)",
+		},
+		{
+			name:           "Management interface",
+			interfaceName:  "mgmt0",
+			expectedParent: "",
+			description:    "mgmt0 should return empty string (not a subinterface)",
+		},
+		{
+			name:           "Loopback interface",
+			interfaceName:  "Loopback0",
+			expectedParent: "",
+			description:    "Loopback0 should return empty string (not a subinterface)",
+		},
+		{
+			name:           "VLAN interface",
+			interfaceName:  "Vlan100",
+			expectedParent: "",
+			description:    "Vlan100 should return empty string (not a subinterface)",
+		},
+
+		// Edge cases
+		{
+			name:           "Empty interface name",
+			interfaceName:  "",
+			expectedParent: "",
+			description:    "Empty string should return empty string",
+		},
+		{
+			name:           "Dot at beginning",
+			interfaceName:  ".100",
+			expectedParent: "",
+			description:    ".100 should return empty string (no parent part)",
+		},
+		{
+			name:           "Dot at end",
+			interfaceName:  "eth0.",
+			expectedParent: "",
+			description:    "eth0. should return empty string (no child part)",
+		},
+		{
+			name:           "Colon at beginning",
+			interfaceName:  ":100",
+			expectedParent: "",
+			description:    ":100 should return empty string (no parent part)",
+		},
+		{
+			name:           "Colon at end",
+			interfaceName:  "eth0:",
+			expectedParent: "",
+			description:    "eth0: should return empty string (no child part)",
+		},
+		{
+			name:           "Single dot",
+			interfaceName:  ".",
+			expectedParent: "",
+			description:    ". should return empty string",
+		},
+		{
+			name:           "Single colon",
+			interfaceName:  ":",
+			expectedParent: "",
+			description:    ": should return empty string",
+		},
+		{
+			name:           "Mixed separators dot then colon",
+			interfaceName:  "eth0.100:1",
+			expectedParent: "eth0",
+			description:    "eth0.100:1 should extract parent eth0 (dot has priority)",
+		},
+		{
+			name:           "Mixed separators colon then dot",
+			interfaceName:  "eth0:1.100",
+			expectedParent: "eth0:1",
+			description:    "eth0:1.100 should extract parent eth0:1 (dot found first)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapping.ExtractParentInterfaceName(tt.interfaceName)
+			assert.Equal(t, tt.expectedParent, result, tt.description)
+		})
+	}
+}
+
+func TestResolveInterfaceType_Subinterfaces(t *testing.T) {
+	tests := []struct {
+		name                 string
+		interfaceName        string
+		ifType               string
+		speed                *int64
+		defaultInterfaceType string
+		expectedType         string
+		description          string
+	}{
+		// Subinterfaces should always return "virtual" (Tier 0 - highest priority)
+		{
+			name:                 "Simple subinterface with dot",
+			interfaceName:        "eth0.100",
+			ifType:               "6", // ethernetCsmacd
+			speed:                int64Ptr(1000000),
+			defaultInterfaceType: "",
+			expectedType:         "virtual",
+			description:          "eth0.100 should be virtual regardless of ifType or speed",
+		},
+		{
+			name:                 "Cisco subinterface with gigabit speed",
+			interfaceName:        "GigabitEthernet0/0.100",
+			ifType:               "6", // ethernetCsmacd
+			speed:                int64Ptr(1000000),
+			defaultInterfaceType: "",
+			expectedType:         "virtual",
+			description:          "GigabitEthernet0/0.100 should be virtual even with gigabit speed",
+		},
+		{
+			name:                 "Juniper subinterface with colon",
+			interfaceName:        "ge-0/0/0:0",
+			ifType:               "6",
+			speed:                int64Ptr(1000000),
+			defaultInterfaceType: "",
+			expectedType:         "virtual",
+			description:          "ge-0/0/0:0 should be virtual with colon separator",
+		},
+		{
+			name:                 "Subinterface with LAG ifType",
+			interfaceName:        "Port-channel1.100",
+			ifType:               "161", // ieee8023adLag
+			speed:                nil,
+			defaultInterfaceType: "",
+			expectedType:         "virtual",
+			description:          "Port-channel1.100 should be virtual, not lag",
+		},
+		{
+			name:                 "Subinterface with tunnel ifType",
+			interfaceName:        "Tunnel0.100",
+			ifType:               "131", // tunnel
+			speed:                nil,
+			defaultInterfaceType: "",
+			expectedType:         "virtual",
+			description:          "Tunnel0.100 should be virtual",
+		},
+		{
+			name:                 "Subinterface with custom default",
+			interfaceName:        "eth0.100",
+			ifType:               "6",
+			speed:                nil,
+			defaultInterfaceType: "custom-type",
+			expectedType:         "virtual",
+			description:          "eth0.100 should be virtual, ignoring custom default",
+		},
+		{
+			name:                 "Multiple level subinterface",
+			interfaceName:        "eth0.100.200",
+			ifType:               "6",
+			speed:                int64Ptr(10000000),
+			defaultInterfaceType: "",
+			expectedType:         "virtual",
+			description:          "eth0.100.200 should be virtual (multi-level subinterface)",
+		},
+
+		// Non-subinterfaces should follow normal resolution rules
+		{
+			name:                 "Physical interface with ethernet type",
+			interfaceName:        "eth0",
+			ifType:               "6",
+			speed:                int64Ptr(1000000),
+			defaultInterfaceType: "",
+			expectedType:         "1000base-t",
+			description:          "eth0 should resolve to 1000base-t based on speed",
+		},
+		{
+			name:                 "Physical GigabitEthernet",
+			interfaceName:        "GigabitEthernet0/0/1",
+			ifType:               "6",
+			speed:                int64Ptr(1000000),
+			defaultInterfaceType: "",
+			expectedType:         "1000base-t",
+			description:          "GigabitEthernet0/0/1 should resolve based on speed (slashes are OK)",
+		},
+		{
+			name:                 "Loopback interface",
+			interfaceName:        "Loopback0",
+			ifType:               "24", // softwareLoopback
+			speed:                nil,
+			defaultInterfaceType: "",
+			expectedType:         "virtual",
+			description:          "Loopback0 should be virtual based on ifType (not subinterface detection)",
+		},
+		{
+			name:                 "VLAN interface without dot",
+			interfaceName:        "Vlan100",
+			ifType:               "136", // l3ipvlan
+			speed:                nil,
+			defaultInterfaceType: "",
+			expectedType:         "virtual",
+			description:          "Vlan100 should be virtual based on ifType (not subinterface detection)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := mapping.ResolveInterfaceType(
+				tt.interfaceName,
+				tt.ifType,
+				tt.speed,
+				tt.defaultInterfaceType,
+				nil, // patternMatcher
+				0,   // userPatternCount
+			)
+			assert.Equal(t, tt.expectedType, result, tt.description)
+		})
+	}
+}
+
+func TestGetInterfaceByName(t *testing.T) {
+	// This test verifies the GetInterfaceByName method works correctly
+	// which is critical for parent interface resolution
+	logger := slog.Default()
+	registry := mapping.NewEntityRegistry(logger)
+
+	// Create some test interfaces with realistic SNMP indices
+	eth0Name := "eth0"
+	eth0Type := "1000base-t"
+	eth0 := registry.GetOrCreateEntity(mapping.InterfaceEntityType, mapping.ObjectIDIndex("100"))
+	if iface, ok := eth0.(*diode.Interface); ok {
+		iface.Name = &eth0Name
+		iface.Type = &eth0Type
+	}
+
+	eth0Sub100Name := "eth0.100"
+	eth0Sub100Type := "virtual"
+	eth0Sub100 := registry.GetOrCreateEntity(mapping.InterfaceEntityType, mapping.ObjectIDIndex("200"))
+	if iface, ok := eth0Sub100.(*diode.Interface); ok {
+		iface.Name = &eth0Sub100Name
+		iface.Type = &eth0Sub100Type
+	}
+
+	ge000Name := "ge-0/0/0"
+	ge000Type := "1000base-t"
+	ge000 := registry.GetOrCreateEntity(mapping.InterfaceEntityType, mapping.ObjectIDIndex("300"))
+	if iface, ok := ge000.(*diode.Interface); ok {
+		iface.Name = &ge000Name
+		iface.Type = &ge000Type
+	}
+
+	tests := []struct {
+		name         string
+		searchName   string
+		shouldFind   bool
+		expectedType string
+		description  string
+	}{
+		{
+			name:         "Find eth0 by name",
+			searchName:   "eth0",
+			shouldFind:   true,
+			expectedType: "1000base-t",
+			description:  "Should find eth0 interface",
+		},
+		{
+			name:         "Find eth0.100 by name",
+			searchName:   "eth0.100",
+			shouldFind:   true,
+			expectedType: "virtual",
+			description:  "Should find eth0.100 subinterface",
+		},
+		{
+			name:         "Find ge-0/0/0 by name",
+			searchName:   "ge-0/0/0",
+			shouldFind:   true,
+			expectedType: "1000base-t",
+			description:  "Should find Juniper interface",
+		},
+		{
+			name:        "Non-existent interface",
+			searchName:  "eth1",
+			shouldFind:  false,
+			description: "Should not find non-existent interface",
+		},
+		{
+			name:        "Empty string",
+			searchName:  "",
+			shouldFind:  false,
+			description: "Should not find with empty string",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := registry.GetInterfaceByName(tt.searchName)
+			if tt.shouldFind {
+				assert.NotNil(t, result, tt.description)
+				if result != nil {
+					assert.NotNil(t, result.Name, "Interface name should not be nil")
+					assert.Equal(t, tt.searchName, *result.Name, "Interface name should match")
+					assert.NotNil(t, result.Type, "Interface type should not be nil")
+					assert.Equal(t, tt.expectedType, *result.Type, "Interface type should match")
+				}
+			} else {
+				assert.Nil(t, result, tt.description)
+			}
+		})
+	}
+}
+
+func TestResolveSubinterfaceParents(t *testing.T) {
+	// This test verifies that parent resolution works correctly
+	// even when subinterfaces are discovered before their parent interfaces
+	logger := slog.Default()
+	registry := mapping.NewEntityRegistry(logger)
+
+	// Simulate the common case where subinterface is discovered BEFORE parent
+	// (This is the issue we're solving with post-processing)
+
+	// 1. Create subinterface FIRST (as would happen with some SNMP discoveries)
+	subName := "GigabitEthernet0/0.100"
+	subType := "virtual"
+	subInterface := registry.GetOrCreateEntity(mapping.InterfaceEntityType, mapping.ObjectIDIndex("200"))
+	if iface, ok := subInterface.(*diode.Interface); ok {
+		iface.Name = &subName
+		iface.Type = &subType
+	}
+
+	// 2. Create another subinterface (also before parent)
+	sub2Name := "GigabitEthernet0/0.200"
+	sub2Type := "virtual"
+	sub2Interface := registry.GetOrCreateEntity(mapping.InterfaceEntityType, mapping.ObjectIDIndex("300"))
+	if iface, ok := sub2Interface.(*diode.Interface); ok {
+		iface.Name = &sub2Name
+		iface.Type = &sub2Type
+	}
+
+	// 3. Create parent interface LAST (as would happen in real discovery)
+	parentName := "GigabitEthernet0/0"
+	parentType := "1000base-t"
+	parentInterface := registry.GetOrCreateEntity(mapping.InterfaceEntityType, mapping.ObjectIDIndex("100"))
+	if iface, ok := parentInterface.(*diode.Interface); ok {
+		iface.Name = &parentName
+		iface.Type = &parentType
+	}
+
+	// 4. Create a Juniper subinterface with colon separator
+	juniperSubName := "ge-0/0/0:0"
+	juniperSubType := "virtual"
+	juniperSubInterface := registry.GetOrCreateEntity(mapping.InterfaceEntityType, mapping.ObjectIDIndex("400"))
+	if iface, ok := juniperSubInterface.(*diode.Interface); ok {
+		iface.Name = &juniperSubName
+		iface.Type = &juniperSubType
+	}
+
+	// 5. Create Juniper parent
+	juniperParentName := "ge-0/0/0"
+	juniperParentType := "1000base-t"
+	juniperParent := registry.GetOrCreateEntity(mapping.InterfaceEntityType, mapping.ObjectIDIndex("500"))
+	if iface, ok := juniperParent.(*diode.Interface); ok {
+		iface.Name = &juniperParentName
+		iface.Type = &juniperParentType
+	}
+
+	// 6. Create an orphan subinterface (parent doesn't exist)
+	orphanName := "eth1.100"
+	orphanType := "virtual"
+	orphanInterface := registry.GetOrCreateEntity(mapping.InterfaceEntityType, mapping.ObjectIDIndex("600"))
+	if iface, ok := orphanInterface.(*diode.Interface); ok {
+		iface.Name = &orphanName
+		iface.Type = &orphanType
+	}
+
+	// At this point, no parent references should be set yet
+	sub := subInterface.(*diode.Interface)
+	assert.Nil(t, sub.Parent, "Parent should be nil before resolution")
+
+	// Now call the post-processing method
+	registry.ResolveSubinterfaceParents()
+
+	// Verify all subinterfaces now have correct parent references
+	sub = subInterface.(*diode.Interface)
+	assert.NotNil(t, sub.Parent, "Parent should be resolved after post-processing")
+	assert.Equal(t, parentName, *sub.Parent.Name)
+	assert.Equal(t, parentType, *sub.Parent.Type)
+
+	sub2 := sub2Interface.(*diode.Interface)
+	assert.NotNil(t, sub2.Parent, "Second subinterface should also have parent")
+	assert.Equal(t, parentName, *sub2.Parent.Name)
+
+	juniperSub := juniperSubInterface.(*diode.Interface)
+	assert.NotNil(t, juniperSub.Parent, "Juniper subinterface should have parent")
+	assert.Equal(t, juniperParentName, *juniperSub.Parent.Name)
+
+	// Orphan should have no parent (parent wasn't discovered)
+	orphan := orphanInterface.(*diode.Interface)
+	assert.Nil(t, orphan.Parent, "Orphan subinterface should have no parent")
+
+	// Physical interfaces should have no parent
+	parent := parentInterface.(*diode.Interface)
+	assert.Nil(t, parent.Parent, "Physical interface should have no parent")
+}


### PR DESCRIPTION
This pull request introduces automatic subinterface detection and parent-child relationship mapping for network interfaces in SNMP discovery. The changes add a new highest-priority tier for subinterface detection, ensuring logical interfaces are always classified as "virtual" and their parent interfaces are tracked. Documentation and code are updated to reflect this new behavior, improving accuracy and vendor compatibility.

**Subinterface detection and parent mapping:**

* Added `ExtractParentInterfaceName` function in `interface_types.go` to identify parent interfaces for subinterfaces based on dot (`.`) or colon (`:`) separators in interface names.
* Implemented `ResolveSubinterfaceParents` in `mapping.go` to set parent references for subinterfaces after all interfaces are discovered, and updated entity mapping logic to assign device references to parents. [[1]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40R63-R140) [[2]](diffhunk://#diff-d7a22e45bf57694858d78e02f49647273808985efb2e13283f857b6e4f1efd40R414-R416)

**Priority system and interface type resolution:**

* Updated the interface type resolution logic in `interface_types.go` to use a six-tier priority system, with subinterface detection as tier 0 (highest priority), ensuring subinterfaces are always classified as "virtual". [[1]](diffhunk://#diff-336574a932e727b8a71ed372b0a2f0723b4f2f3bb3cdf50f9ece13b0c5ab64bfL209-R233) [[2]](diffhunk://#diff-336574a932e727b8a71ed372b0a2f0723b4f2f3bb3cdf50f9ece13b0c5ab64bfL223-R252)

**Documentation updates:**

* Revised `README.md` to describe the new six-tier priority system, explain subinterface detection, and provide examples for major vendors. [[1]](diffhunk://#diff-fbffef8cc46e9659ab7585122a69d863e94f180f7fe48ea221791f0320e58779L126-R137) [[2]](diffhunk://#diff-fbffef8cc46e9659ab7585122a69d863e94f180f7fe48ea221791f0320e58779R220) [[3]](diffhunk://#diff-fbffef8cc46e9659ab7585122a69d863e94f180f7fe48ea221791f0320e58779R230-R294)

**Entity registry enhancements:**

* Added methods to `EntityRegistry` in `mapping.go` for retrieving interfaces by name and resolving parent relationships, supporting the new subinterface logic.

**Integration in entity mapping:**

* Updated `MapObjectIDsToEntity` in `mapping.go` to invoke parent resolution after interface discovery, ensuring correct parent-child relationships before ingestion.