### PR TITLE
feat: SNMP override defaults

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -154,6 +154,54 @@ policies:
         community: "public"
 ```
 
+### Per-Target Override Defaults
+
+SNMP discovery supports per-target default overrides, allowing you to customize site, role, tags, and other entity defaults for individual targets while maintaining policy-wide defaults as fallbacks.
+
+#### Example Configuration
+
+```yaml
+policies:
+  multi_site:
+    config:
+      defaults:
+        site: "New York"
+        role: "switch"
+        tags: ["snmp", "network"]
+    scope:
+      targets:
+        # Uses policy defaults
+        - host: "192.168.1.1"
+
+        # Override site and role for this target
+        - host: "192.168.1.2"
+          override_defaults:
+            site: "New York/DC-A"
+            role: "router"
+            tags: ["core", "production"]
+
+        # Override nested defaults
+        - host: "192.168.1.3"
+          override_defaults:
+            site: "Boston"
+            device:
+              description: "Core Router"
+            interface:
+              if_type: "1000base-t"
+            ip_address:
+              role: "loopback"
+
+        # Works with IP ranges - all IPs inherit the override
+        - host: "192.168.2.0/24"
+          override_defaults:
+            site: "Chicago"
+            role: "access-switch"
+
+      authentication:
+        protocol_version: "SNMPv2c"
+        community: "public"
+```
+
 ### Interface Type Pattern Matching
 
 SNMP discovery supports flexible interface type detection through a six-tier priority system that intelligently combines SNMP protocol data with pattern matching:

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -17,9 +17,10 @@ type Scope struct {
 
 // Target represents a target host to crawl
 type Target struct {
-	Host           string          `yaml:"host"`
-	Port           uint16          `yaml:"port" default:"161"`
-	Authentication *Authentication `yaml:"authentication,omitempty"`
+	Host             string          `yaml:"host"`
+	Port             uint16          `yaml:"port" default:"161"`
+	Authentication   *Authentication `yaml:"authentication,omitempty"`
+	OverrideDefaults *Defaults       `yaml:"override_defaults,omitempty"`
 }
 
 // Authentication represents the authentication credentials for a target host
@@ -74,6 +75,80 @@ type Defaults struct {
 	Interface         InterfaceDefaults  `yaml:"interface,omitempty"`
 	Device            DeviceDefaults     `yaml:"device,omitempty"`
 	InterfacePatterns []InterfacePattern `yaml:"interface_patterns,omitempty"`
+}
+
+// MergeDefaults merges target-level override defaults with policy-level defaults
+// Target overrides take precedence over policy defaults for non-zero values
+func MergeDefaults(policyDefaults, overrideDefaults *Defaults) *Defaults {
+	if overrideDefaults == nil {
+		return policyDefaults
+	}
+
+	// Create a copy of policy defaults
+	merged := *policyDefaults
+
+	// Override top-level fields if set in override
+	if overrideDefaults.Site != "" {
+		merged.Site = overrideDefaults.Site
+	}
+	if overrideDefaults.Location != "" {
+		merged.Location = overrideDefaults.Location
+	}
+	if overrideDefaults.Role != "" {
+		merged.Role = overrideDefaults.Role
+	}
+	if len(overrideDefaults.Tags) > 0 {
+		merged.Tags = overrideDefaults.Tags
+	}
+
+	// Merge IPAddress defaults
+	if overrideDefaults.IPAddress.Description != "" {
+		merged.IPAddress.Description = overrideDefaults.IPAddress.Description
+	}
+	if len(overrideDefaults.IPAddress.Tags) > 0 {
+		merged.IPAddress.Tags = overrideDefaults.IPAddress.Tags
+	}
+	if overrideDefaults.IPAddress.Comments != "" {
+		merged.IPAddress.Comments = overrideDefaults.IPAddress.Comments
+	}
+	if overrideDefaults.IPAddress.Role != "" {
+		merged.IPAddress.Role = overrideDefaults.IPAddress.Role
+	}
+	if overrideDefaults.IPAddress.Tenant != "" {
+		merged.IPAddress.Tenant = overrideDefaults.IPAddress.Tenant
+	}
+	if overrideDefaults.IPAddress.Vrf != "" {
+		merged.IPAddress.Vrf = overrideDefaults.IPAddress.Vrf
+	}
+
+	// Merge Interface defaults
+	if overrideDefaults.Interface.Description != "" {
+		merged.Interface.Description = overrideDefaults.Interface.Description
+	}
+	if len(overrideDefaults.Interface.Tags) > 0 {
+		merged.Interface.Tags = overrideDefaults.Interface.Tags
+	}
+	if overrideDefaults.Interface.Type != "" {
+		merged.Interface.Type = overrideDefaults.Interface.Type
+	}
+
+	// Merge Device defaults
+	if overrideDefaults.Device.Description != "" {
+		merged.Device.Description = overrideDefaults.Device.Description
+	}
+	if len(overrideDefaults.Device.Tags) > 0 {
+		merged.Device.Tags = overrideDefaults.Device.Tags
+	}
+	if overrideDefaults.Device.Comments != "" {
+		merged.Device.Comments = overrideDefaults.Device.Comments
+	}
+
+	// Override InterfacePatterns if provided
+	if len(overrideDefaults.InterfacePatterns) > 0 {
+		merged.InterfacePatterns = overrideDefaults.InterfacePatterns
+	}
+
+	return &merged
 }
 
 // PolicyConfig represents the configuration of a policy

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -120,9 +120,9 @@ func TestMergeDefaults(t *testing.T) {
 		assert.Equal(t, "loopback", result.IPAddress.Role)
 		assert.Equal(t, "override-tenant", result.IPAddress.Tenant)
 		assert.Equal(t, []string{"override"}, result.IPAddress.Tags)
-		assert.Equal(t, "default-vrf", result.IPAddress.Vrf)             // Not overridden
-		assert.Equal(t, "Policy IP", result.IPAddress.Description)       // Not overridden
-		assert.Equal(t, "Policy Comments", result.IPAddress.Comments)    // Not overridden
+		assert.Equal(t, "default-vrf", result.IPAddress.Vrf)          // Not overridden
+		assert.Equal(t, "Policy IP", result.IPAddress.Description)    // Not overridden
+		assert.Equal(t, "Policy Comments", result.IPAddress.Comments) // Not overridden
 	})
 
 	t.Run("Override InterfacePatterns replaces entire array", func(t *testing.T) {
@@ -207,7 +207,7 @@ func TestMergeDefaults(t *testing.T) {
 		}
 
 		overrideDefaults := &Defaults{
-			Site: "",      // Empty string should not override
+			Site: "",       // Empty string should not override
 			Role: "router", // Non-empty should override
 		}
 
@@ -226,7 +226,7 @@ func TestMergeDefaults(t *testing.T) {
 		}
 
 		overrideDefaults := &Defaults{
-			Tags:              []string{}, // Empty array should not override
+			Tags:              []string{},           // Empty array should not override
 			InterfacePatterns: []InterfacePattern{}, // Empty array should not override
 		}
 

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -1,0 +1,237 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMergeDefaults(t *testing.T) {
+	t.Run("Nil override returns policy defaults", func(t *testing.T) {
+		policyDefaults := &Defaults{
+			Site:     "Default Site",
+			Role:     "switch",
+			Location: "Default Location",
+			Tags:     []string{"default"},
+		}
+
+		result := MergeDefaults(policyDefaults, nil)
+		assert.Equal(t, policyDefaults, result)
+	})
+
+	t.Run("Override top-level fields", func(t *testing.T) {
+		policyDefaults := &Defaults{
+			Site:     "Default Site",
+			Role:     "switch",
+			Location: "Default Location",
+			Tags:     []string{"default"},
+		}
+
+		overrideDefaults := &Defaults{
+			Site: "Override Site",
+			Role: "router",
+		}
+
+		result := MergeDefaults(policyDefaults, overrideDefaults)
+		assert.Equal(t, "Override Site", result.Site)
+		assert.Equal(t, "router", result.Role)
+		assert.Equal(t, "Default Location", result.Location) // Not overridden
+		assert.Equal(t, []string{"default"}, result.Tags)    // Not overridden
+	})
+
+	t.Run("Override tags replaces entire array", func(t *testing.T) {
+		policyDefaults := &Defaults{
+			Tags: []string{"default", "policy"},
+		}
+
+		overrideDefaults := &Defaults{
+			Tags: []string{"override", "target"},
+		}
+
+		result := MergeDefaults(policyDefaults, overrideDefaults)
+		assert.Equal(t, []string{"override", "target"}, result.Tags)
+	})
+
+	t.Run("Override nested Device fields", func(t *testing.T) {
+		policyDefaults := &Defaults{
+			Device: DeviceDefaults{
+				Description: "Policy Device",
+				Tags:        []string{"policy"},
+				Comments:    "Policy Comments",
+			},
+		}
+
+		overrideDefaults := &Defaults{
+			Device: DeviceDefaults{
+				Description: "Override Device",
+				Tags:        []string{"override"},
+			},
+		}
+
+		result := MergeDefaults(policyDefaults, overrideDefaults)
+		assert.Equal(t, "Override Device", result.Device.Description)
+		assert.Equal(t, []string{"override"}, result.Device.Tags)
+		assert.Equal(t, "Policy Comments", result.Device.Comments) // Not overridden
+	})
+
+	t.Run("Override nested Interface fields", func(t *testing.T) {
+		policyDefaults := &Defaults{
+			Interface: InterfaceDefaults{
+				Type:        "other",
+				Description: "Policy Interface",
+				Tags:        []string{"policy"},
+			},
+		}
+
+		overrideDefaults := &Defaults{
+			Interface: InterfaceDefaults{
+				Type: "1000base-t",
+				Tags: []string{"override"},
+			},
+		}
+
+		result := MergeDefaults(policyDefaults, overrideDefaults)
+		assert.Equal(t, "1000base-t", result.Interface.Type)
+		assert.Equal(t, []string{"override"}, result.Interface.Tags)
+		assert.Equal(t, "Policy Interface", result.Interface.Description) // Not overridden
+	})
+
+	t.Run("Override nested IPAddress fields", func(t *testing.T) {
+		policyDefaults := &Defaults{
+			IPAddress: IPAddressDefaults{
+				Role:        "anycast",
+				Tenant:      "default-tenant",
+				Vrf:         "default-vrf",
+				Description: "Policy IP",
+				Tags:        []string{"policy"},
+				Comments:    "Policy Comments",
+			},
+		}
+
+		overrideDefaults := &Defaults{
+			IPAddress: IPAddressDefaults{
+				Role:   "loopback",
+				Tenant: "override-tenant",
+				Tags:   []string{"override"},
+			},
+		}
+
+		result := MergeDefaults(policyDefaults, overrideDefaults)
+		assert.Equal(t, "loopback", result.IPAddress.Role)
+		assert.Equal(t, "override-tenant", result.IPAddress.Tenant)
+		assert.Equal(t, []string{"override"}, result.IPAddress.Tags)
+		assert.Equal(t, "default-vrf", result.IPAddress.Vrf)             // Not overridden
+		assert.Equal(t, "Policy IP", result.IPAddress.Description)       // Not overridden
+		assert.Equal(t, "Policy Comments", result.IPAddress.Comments)    // Not overridden
+	})
+
+	t.Run("Override InterfacePatterns replaces entire array", func(t *testing.T) {
+		policyDefaults := &Defaults{
+			InterfacePatterns: []InterfacePattern{
+				{Match: "^Eth", Type: "1000base-t"},
+			},
+		}
+
+		overrideDefaults := &Defaults{
+			InterfacePatterns: []InterfacePattern{
+				{Match: "^GigabitEthernet", Type: "10gbase-x-sfpp"},
+				{Match: "^TenGigabitEthernet", Type: "25gbase-x-sfp28"},
+			},
+		}
+
+		result := MergeDefaults(policyDefaults, overrideDefaults)
+		assert.Len(t, result.InterfacePatterns, 2)
+		assert.Equal(t, "^GigabitEthernet", result.InterfacePatterns[0].Match)
+		assert.Equal(t, "10gbase-x-sfpp", result.InterfacePatterns[0].Type)
+		assert.Equal(t, "^TenGigabitEthernet", result.InterfacePatterns[1].Match)
+		assert.Equal(t, "25gbase-x-sfp28", result.InterfacePatterns[1].Type)
+	})
+
+	t.Run("Complex merge with multiple levels", func(t *testing.T) {
+		policyDefaults := &Defaults{
+			Site:     "Default Site",
+			Role:     "switch",
+			Location: "Default Location",
+			Tags:     []string{"default", "policy"},
+			Device: DeviceDefaults{
+				Description: "Policy Device",
+				Tags:        []string{"policy-device"},
+			},
+			Interface: InterfaceDefaults{
+				Type:        "other",
+				Description: "Policy Interface",
+			},
+			IPAddress: IPAddressDefaults{
+				Role:   "anycast",
+				Tenant: "default-tenant",
+			},
+			InterfacePatterns: []InterfacePattern{
+				{Match: "^Eth", Type: "1000base-t"},
+			},
+		}
+
+		overrideDefaults := &Defaults{
+			Site: "Override Site",
+			Role: "router",
+			Device: DeviceDefaults{
+				Description: "Override Device",
+			},
+			IPAddress: IPAddressDefaults{
+				Tenant: "override-tenant",
+			},
+		}
+
+		result := MergeDefaults(policyDefaults, overrideDefaults)
+
+		// Check overridden fields
+		assert.Equal(t, "Override Site", result.Site)
+		assert.Equal(t, "router", result.Role)
+		assert.Equal(t, "Override Device", result.Device.Description)
+		assert.Equal(t, "override-tenant", result.IPAddress.Tenant)
+
+		// Check non-overridden fields retain policy defaults
+		assert.Equal(t, "Default Location", result.Location)
+		assert.Equal(t, []string{"default", "policy"}, result.Tags)
+		assert.Equal(t, []string{"policy-device"}, result.Device.Tags)
+		assert.Equal(t, "other", result.Interface.Type)
+		assert.Equal(t, "Policy Interface", result.Interface.Description)
+		assert.Equal(t, "anycast", result.IPAddress.Role)
+		assert.Len(t, result.InterfacePatterns, 1)
+	})
+
+	t.Run("Empty string fields in override should not override policy defaults", func(t *testing.T) {
+		policyDefaults := &Defaults{
+			Site:     "Default Site",
+			Role:     "switch",
+			Location: "Default Location",
+		}
+
+		overrideDefaults := &Defaults{
+			Site: "",      // Empty string should not override
+			Role: "router", // Non-empty should override
+		}
+
+		result := MergeDefaults(policyDefaults, overrideDefaults)
+		assert.Equal(t, "Default Site", result.Site) // Should retain policy default
+		assert.Equal(t, "router", result.Role)       // Should be overridden
+		assert.Equal(t, "Default Location", result.Location)
+	})
+
+	t.Run("Empty array in override should not override policy defaults", func(t *testing.T) {
+		policyDefaults := &Defaults{
+			Tags: []string{"default", "policy"},
+			InterfacePatterns: []InterfacePattern{
+				{Match: "^Eth", Type: "1000base-t"},
+			},
+		}
+
+		overrideDefaults := &Defaults{
+			Tags:              []string{}, // Empty array should not override
+			InterfacePatterns: []InterfacePattern{}, // Empty array should not override
+		}
+
+		result := MergeDefaults(policyDefaults, overrideDefaults)
+		assert.Equal(t, []string{"default", "policy"}, result.Tags)
+		assert.Len(t, result.InterfacePatterns, 1)
+	})
+}

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -990,3 +990,288 @@ devices:
 	err = manager.StopPolicy("test-policy-with-devices")
 	assert.NoError(t, err)
 }
+
+func TestManagerParsePoliciesWithOverrideDefaults(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+	manager, err := policy.NewManager(context.Background(), logger, nil, nil)
+	assert.NoError(t, err)
+
+	t.Run("Valid Per-Target Override Defaults - Basic", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              defaults:
+                site: "New York"
+                role: "switch"
+                tags: ["network", "snmp"]
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  port: 161
+                  override_defaults:
+                    site: "New York/DC-A"
+                    role: "router"
+                    tags: ["core", "production"]
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		assert.NotNil(t, policies["policy1"].Scope.Targets[0].OverrideDefaults)
+		assert.Equal(t, "New York/DC-A", policies["policy1"].Scope.Targets[0].OverrideDefaults.Site)
+		assert.Equal(t, "router", policies["policy1"].Scope.Targets[0].OverrideDefaults.Role)
+		assert.Equal(t, []string{"core", "production"}, policies["policy1"].Scope.Targets[0].OverrideDefaults.Tags)
+		// Verify policy defaults unchanged
+		assert.Equal(t, "New York", policies["policy1"].Config.Defaults.Site)
+		assert.Equal(t, "switch", policies["policy1"].Config.Defaults.Role)
+	})
+
+	t.Run("Valid Per-Target Override Defaults - Nested Structures", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              defaults:
+                site: "Default Site"
+                role: "switch"
+                device:
+                  description: "Policy Device"
+                  tags: ["policy"]
+                interface:
+                  if_type: "other"
+                  tags: ["policy-interface"]
+                ip_address:
+                  role: "anycast"
+                  tenant: "default-tenant"
+                  vrf: "default-vrf"
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  override_defaults:
+                    site: "Override Site"
+                    device:
+                      description: "Overridden Device"
+                      tags: ["overridden"]
+                    interface:
+                      if_type: "1000base-t"
+                      tags: ["override-interface"]
+                    ip_address:
+                      role: "loopback"
+                      tenant: "override-tenant"
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		overrides := policies["policy1"].Scope.Targets[0].OverrideDefaults
+		assert.NotNil(t, overrides)
+		assert.Equal(t, "Override Site", overrides.Site)
+		assert.Equal(t, "Overridden Device", overrides.Device.Description)
+		assert.Equal(t, []string{"overridden"}, overrides.Device.Tags)
+		assert.Equal(t, "1000base-t", overrides.Interface.Type)
+		assert.Equal(t, []string{"override-interface"}, overrides.Interface.Tags)
+		assert.Equal(t, "loopback", overrides.IPAddress.Role)
+		assert.Equal(t, "override-tenant", overrides.IPAddress.Tenant)
+	})
+
+	t.Run("Mixed Configuration - Some Targets with Overrides", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              defaults:
+                site: "Default Site"
+                role: "switch"
+                tags: ["default"]
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  override_defaults:
+                    site: "Override Site"
+                    role: "router"
+                - host: 192.168.1.2
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		assert.NotNil(t, policies["policy1"].Scope.Targets[0].OverrideDefaults)
+		assert.Nil(t, policies["policy1"].Scope.Targets[1].OverrideDefaults)
+		assert.Equal(t, "Override Site", policies["policy1"].Scope.Targets[0].OverrideDefaults.Site)
+		assert.Equal(t, "Default Site", policies["policy1"].Config.Defaults.Site)
+	})
+
+	t.Run("Partial Override - Only Some Fields", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              defaults:
+                site: "Default Site"
+                role: "switch"
+                location: "Default Location"
+                tags: ["default"]
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  override_defaults:
+                    role: "router"
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		overrides := policies["policy1"].Scope.Targets[0].OverrideDefaults
+		assert.NotNil(t, overrides)
+		assert.Equal(t, "router", overrides.Role)
+		// Other fields should be empty in override (will be merged at runtime)
+		assert.Equal(t, "", overrides.Site)
+		assert.Equal(t, "", overrides.Location)
+	})
+
+	t.Run("Interface Patterns Override", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              defaults:
+                site: "Default Site"
+                interface_patterns:
+                  - match: "^Eth"
+                    type: "1000base-t"
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  override_defaults:
+                    interface_patterns:
+                      - match: "^GigabitEthernet"
+                        type: "10gbase-x-sfpp"
+                      - match: "^TenGigabitEthernet"
+                        type: "25gbase-x-sfp28"
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		overrides := policies["policy1"].Scope.Targets[0].OverrideDefaults
+		assert.NotNil(t, overrides)
+		assert.Len(t, overrides.InterfacePatterns, 2)
+		assert.Equal(t, "^GigabitEthernet", overrides.InterfacePatterns[0].Match)
+		assert.Equal(t, "10gbase-x-sfpp", overrides.InterfacePatterns[0].Type)
+		assert.Equal(t, "^TenGigabitEthernet", overrides.InterfacePatterns[1].Match)
+		assert.Equal(t, "25gbase-x-sfp28", overrides.InterfacePatterns[1].Type)
+	})
+
+	t.Run("Empty Override Defaults - Uses Policy Defaults", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              defaults:
+                site: "Default Site"
+                role: "switch"
+            scope:
+              targets:
+                - host: 192.168.1.1
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		assert.Nil(t, policies["policy1"].Scope.Targets[0].OverrideDefaults)
+		assert.Equal(t, "Default Site", policies["policy1"].Config.Defaults.Site)
+		assert.Equal(t, "switch", policies["policy1"].Config.Defaults.Role)
+	})
+
+	t.Run("Multiple Targets with Different Overrides", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              defaults:
+                site: "Default Site"
+                role: "switch"
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  override_defaults:
+                    site: "Site A"
+                    role: "router"
+                - host: 192.168.1.2
+                  override_defaults:
+                    site: "Site B"
+                    role: "firewall"
+                - host: 192.168.1.3
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		assert.Equal(t, "Site A", policies["policy1"].Scope.Targets[0].OverrideDefaults.Site)
+		assert.Equal(t, "router", policies["policy1"].Scope.Targets[0].OverrideDefaults.Role)
+		assert.Equal(t, "Site B", policies["policy1"].Scope.Targets[1].OverrideDefaults.Site)
+		assert.Equal(t, "firewall", policies["policy1"].Scope.Targets[1].OverrideDefaults.Role)
+		assert.Nil(t, policies["policy1"].Scope.Targets[2].OverrideDefaults)
+	})
+
+	t.Run("Override Defaults with Per-Target Auth", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              defaults:
+                site: "Default Site"
+                role: "switch"
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  authentication:
+                    protocol_version: SNMPv3
+                    security_level: authPriv
+                    username: target-user
+                    auth_protocol: SHA
+                    auth_passphrase: auth-pass
+                    priv_protocol: AES
+                    priv_passphrase: priv-pass
+                  override_defaults:
+                    site: "Override Site"
+                    role: "router"
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+       `)
+
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		assert.Contains(t, policies, "policy1")
+		target := policies["policy1"].Scope.Targets[0]
+		assert.NotNil(t, target.Authentication)
+		assert.Equal(t, "SNMPv3", target.Authentication.ProtocolVersion)
+		assert.Equal(t, "target-user", target.Authentication.Username)
+		assert.NotNil(t, target.OverrideDefaults)
+		assert.Equal(t, "Override Site", target.OverrideDefaults.Site)
+		assert.Equal(t, "router", target.OverrideDefaults.Role)
+	})
+}

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -195,6 +195,18 @@ func (r *Runner) resolveTargetAuthentication(target config.Target) *config.Authe
 	return &r.scope.Authentication
 }
 
+// resolveTargetDefaults returns the defaults to use for a target
+// Merges target-level override defaults with policy-level defaults
+func (r *Runner) resolveTargetDefaults(target config.Target) *config.Defaults {
+	if target.OverrideDefaults != nil {
+		r.logger.Debug("Merging target-level override defaults", "host", target.Host)
+		return config.MergeDefaults(&r.config.Defaults, target.OverrideDefaults)
+	}
+
+	r.logger.Debug("Using policy-level defaults", "host", target.Host)
+	return &r.config.Defaults
+}
+
 func (r *Runner) probeTarget(ctx context.Context, target config.Target) bool {
 	select {
 	case <-ctx.Done():
@@ -285,7 +297,9 @@ func (r *Runner) logEntitiesForIngestion(entities []diode.Entity) {
 }
 
 func (r *Runner) queryTarget(target config.Target) []diode.Entity {
-	mappingConfig, err := mapping.NewConfig(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup, &r.config.Defaults)
+	targetDefaults := r.resolveTargetDefaults(target)
+
+	mappingConfig, err := mapping.NewConfig(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup, targetDefaults)
 	if err != nil {
 		r.logger.Error("Error creating mapping config", "error", err)
 		return make([]diode.Entity, 0)
@@ -295,7 +309,7 @@ func (r *Runner) queryTarget(target config.Target) []diode.Entity {
 
 	entities := make([]diode.Entity, 0)
 
-	mapper := mapping.NewObjectIDMapper(mappingConfig, r.logger, &r.config.Defaults)
+	mapper := mapping.NewObjectIDMapper(mappingConfig, r.logger, targetDefaults)
 	policyName := r.ctx.Value(policyKey).(string)
 	// Track discovery attempt
 	if rMetric := metrics.GetDiscoveryAttempts(); rMetric != nil {
@@ -364,9 +378,10 @@ func (r *Runner) expandTargetRanges(configuredTargets []config.Target) [][]confi
 		expandedTargets := make([]config.Target, len(ips))
 		for i := range ips {
 			expandedTargets[i] = config.Target{
-				Host:           ips[i],
-				Port:           target.Port,
-				Authentication: target.Authentication,
+				Host:             ips[i],
+				Port:             target.Port,
+				Authentication:   target.Authentication,
+				OverrideDefaults: target.OverrideDefaults,
 			}
 		}
 		expandedMatrix = append(expandedMatrix, expandedTargets)


### PR DESCRIPTION
This pull request adds support for per-target default overrides in SNMP discovery policies, allowing users to customize defaults (such as site, role, tags, and nested device/interface/ip_address settings) for individual targets while maintaining policy-wide defaults as fallbacks. The changes include updates to configuration structures, merging logic, documentation, and comprehensive tests to ensure correct behavior.

### Per-target override defaults support

* Added a new `override_defaults` field to the `Target` struct in `config.go`, enabling per-target customization of defaults in policy configuration.
* Implemented the `MergeDefaults` function in `config.go` to merge target-level overrides with policy-level defaults, ensuring that non-zero values from overrides take precedence.
* Updated the `Runner` in `runner.go` to use merged defaults when querying targets, by resolving and passing per-target defaults to mapping and entity logic. [[1]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdR198-R209) [[2]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL288-R302) [[3]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL298-R312)

### Documentation and configuration examples

* Added documentation and YAML configuration examples to `README.md` to explain how per-target default overrides work and how to use them in practice.

### Testing and validation

* Added extensive unit tests for the `MergeDefaults` function in `config_test.go`, covering top-level and nested overrides, array merging, and edge cases.
* Added integration tests to `manager_test.go` to validate parsing and handling of per-target overrides in various policy configurations, including nested structures and mixed scenarios.