### PR TITLE
feat: add metadata do run store in network discovery

### DIFF
--- a/network-discovery/policy/run.go
+++ b/network-discovery/policy/run.go
@@ -1,6 +1,7 @@
 package policy
 
 import (
+	"encoding/json"
 	"sync"
 	"time"
 
@@ -21,13 +22,14 @@ const (
 
 // Run represents a single run execution
 type Run struct {
-	ID          string    `json:"id"`
-	PolicyID    string    `json:"policy_id"`
-	Status      RunStatus `json:"status"`
-	Reason      string    `json:"reason,omitempty"`
-	EntityCount int       `json:"entity_count"`
-	CreatedAt   time.Time `json:"created_at"`
-	UpdatedAt   time.Time `json:"updated_at"`
+	ID          string            `json:"id"`
+	PolicyID    string            `json:"policy_id"`
+	Status      RunStatus         `json:"status"`
+	Reason      string            `json:"reason,omitempty"`
+	EntityCount int               `json:"entity_count"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	UpdatedAt   time.Time         `json:"updated_at"`
 }
 
 // RunStore manages runs in memory
@@ -46,15 +48,26 @@ func NewRunStore() *RunStore {
 }
 
 // CreateRun creates a new run for the given policy and returns it
-func (rs *RunStore) CreateRun(policyName string) *Run {
+func (rs *RunStore) CreateRun(policyName string, targets []string) *Run {
 	rs.mu.Lock()
 	defer rs.mu.Unlock()
 
 	now := time.Now()
+
+	// Create metadata with targets
+	metadata := make(map[string]string)
+	if len(targets) > 0 {
+		targetsJSON, err := json.Marshal(targets)
+		if err == nil {
+			metadata["targets"] = string(targetsJSON)
+		}
+	}
+
 	run := &Run{
 		ID:        uuid.New().String(),
 		PolicyID:  policyName,
 		Status:    RunStatusRunning,
+		Metadata:  metadata,
 		CreatedAt: now,
 		UpdatedAt: now,
 	}

--- a/network-discovery/policy/run.go
+++ b/network-discovery/policy/run.go
@@ -54,11 +54,12 @@ func (rs *RunStore) CreateRun(policyName string, targets []string) *Run {
 
 	now := time.Now()
 
-	// Create metadata with targets
-	metadata := make(map[string]string)
+	// Create metadata with targets if provided
+	var metadata map[string]string
 	if len(targets) > 0 {
 		targetsJSON, err := json.Marshal(targets)
 		if err == nil {
+			metadata = make(map[string]string)
 			metadata["targets"] = string(targetsJSON)
 		}
 	}

--- a/network-discovery/policy/run_test.go
+++ b/network-discovery/policy/run_test.go
@@ -1,6 +1,7 @@
 package policy_test
 
 import (
+	"encoding/json"
 	"errors"
 	"sync"
 	"testing"
@@ -198,12 +199,14 @@ func TestRunStore_CreateRun_WithTargets(t *testing.T) {
 	assert.NotEmpty(t, run.Metadata)
 	assert.Contains(t, run.Metadata, "targets")
 
-	// Verify targets JSON is valid and matches input
+	// Verify targets JSON is valid by unmarshaling it
 	targetsJSON := run.Metadata["targets"]
 	assert.NotEmpty(t, targetsJSON)
-	assert.Contains(t, targetsJSON, "192.168.1.0/24")
-	assert.Contains(t, targetsJSON, "10.0.0.1")
-	assert.Contains(t, targetsJSON, "172.16.0.0/16")
+
+	var unmarshaledTargets []string
+	err := json.Unmarshal([]byte(targetsJSON), &unmarshaledTargets)
+	require.NoError(t, err, "targets JSON should be valid and unmarshalable")
+	assert.Equal(t, targets, unmarshaledTargets, "unmarshaled targets should match original targets")
 
 	// Verify run is stored
 	runs := store.GetRunsForPolicy(policyName)
@@ -217,6 +220,22 @@ func TestRunStore_CreateRun_WithEmptyTargets(t *testing.T) {
 
 	run := store.CreateRun(policyName, []string{})
 
-	// Verify metadata is empty when no targets provided
-	assert.Empty(t, run.Metadata)
+	// Verify metadata is nil (not empty map) when no targets provided
+	// This ensures proper omitempty behavior in JSON serialization
+	assert.Nil(t, run.Metadata)
+}
+
+func TestRunStore_CreateRun_WithNilTargets(t *testing.T) {
+	store := policy.NewRunStore()
+	policyName := "test-policy"
+
+	run := store.CreateRun(policyName, nil)
+
+	// Verify metadata is nil when nil targets provided
+	assert.Nil(t, run.Metadata)
+
+	// Verify JSON serialization omits metadata field
+	jsonData, err := json.Marshal(run)
+	require.NoError(t, err)
+	assert.NotContains(t, string(jsonData), "metadata", "metadata field should be omitted from JSON when nil")
 }

--- a/network-discovery/policy/run_test.go
+++ b/network-discovery/policy/run_test.go
@@ -15,7 +15,7 @@ func TestRunStore_CreateRun(t *testing.T) {
 	store := policy.NewRunStore()
 	policyName := "test-policy"
 
-	run := store.CreateRun(policyName)
+	run := store.CreateRun(policyName, []string{})
 
 	// Verify run properties
 	assert.NotEmpty(t, run.ID)
@@ -38,7 +38,7 @@ func TestRunStore_UpdateRun(t *testing.T) {
 	store := policy.NewRunStore()
 	policyName := "test-policy"
 
-	run := store.CreateRun(policyName)
+	run := store.CreateRun(policyName, []string{})
 	runID := run.ID
 
 	// Update to completed
@@ -71,7 +71,7 @@ func TestRunStore_MaxFiveRuns(t *testing.T) {
 	// Create 7 runs
 	var runIDs []string
 	for i := 0; i < 7; i++ {
-		run := store.CreateRun(policyName)
+		run := store.CreateRun(policyName, []string{})
 		runIDs = append(runIDs, run.ID)
 		time.Sleep(10 * time.Millisecond) // Small delay to ensure different timestamps
 	}
@@ -103,7 +103,7 @@ func TestRunStore_Concurrency(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < runsPerGoroutine; j++ {
-				store.CreateRun(policyName)
+				store.CreateRun(policyName, []string{})
 			}
 		}()
 	}
@@ -150,9 +150,9 @@ func TestRunStore_GetAllPoliciesWithRuns(t *testing.T) {
 	policy1 := "policy-1"
 	policy2 := "policy-2"
 
-	store.CreateRun(policy1)
-	store.CreateRun(policy1)
-	store.CreateRun(policy2)
+	store.CreateRun(policy1, []string{})
+	store.CreateRun(policy1, []string{})
+	store.CreateRun(policy2, []string{})
 
 	allRuns := store.GetAllPoliciesWithRuns()
 
@@ -185,4 +185,38 @@ func TestRunStore_UpdateRun_NonExistent(t *testing.T) {
 	// Verify no runs were created
 	runs := store.GetRunsForPolicy("non-existent-policy")
 	assert.Empty(t, runs)
+}
+
+func TestRunStore_CreateRun_WithTargets(t *testing.T) {
+	store := policy.NewRunStore()
+	policyName := "test-policy"
+	targets := []string{"192.168.1.0/24", "10.0.0.1", "172.16.0.0/16"}
+
+	run := store.CreateRun(policyName, targets)
+
+	// Verify targets are stored in metadata
+	assert.NotEmpty(t, run.Metadata)
+	assert.Contains(t, run.Metadata, "targets")
+
+	// Verify targets JSON is valid and matches input
+	targetsJSON := run.Metadata["targets"]
+	assert.NotEmpty(t, targetsJSON)
+	assert.Contains(t, targetsJSON, "192.168.1.0/24")
+	assert.Contains(t, targetsJSON, "10.0.0.1")
+	assert.Contains(t, targetsJSON, "172.16.0.0/16")
+
+	// Verify run is stored
+	runs := store.GetRunsForPolicy(policyName)
+	require.Len(t, runs, 1)
+	assert.Equal(t, run.Metadata["targets"], runs[0].Metadata["targets"])
+}
+
+func TestRunStore_CreateRun_WithEmptyTargets(t *testing.T) {
+	store := policy.NewRunStore()
+	policyName := "test-policy"
+
+	run := store.CreateRun(policyName, []string{})
+
+	// Verify metadata is empty when no targets provided
+	assert.Empty(t, run.Metadata)
 }

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -133,7 +133,7 @@ func (r *Runner) run() {
 	policyName := r.ctx.Value(policyKey).(string)
 
 	// Create run at start
-	run := r.runStore.CreateRun(policyName)
+	run := r.runStore.CreateRun(policyName, r.scope.Targets)
 
 	if rMetric := metrics.GetPolicyExecutions(); rMetric != nil {
 		rMetric.Add(r.ctx, 1,


### PR DESCRIPTION
This pull request enhances the `Run` and `RunStore` logic in the network discovery policy module to support storing and retrieving target metadata for each run. The changes add a new `Metadata` field to the `Run` struct, update the `CreateRun` method to accept a list of targets, and ensure this information is properly serialized and tested.

**Enhancements to run metadata and creation:**

* Added a `Metadata` field (as a `map[string]string`) to the `Run` struct to store additional information, such as targets, for each run.
* Updated the `CreateRun` method in `RunStore` to accept a `targets` parameter, serialize it as JSON, and store it in the run's metadata if provided.
* Modified the `Runner` to pass the current scope's targets to `CreateRun`, ensuring that run metadata includes the relevant targets.

**Testing improvements:**

* Updated all existing tests to use the new `CreateRun` signature with the `targets` argument. [[1]](diffhunk://#diff-4578cad8acb43a99d68676e0138f157a2a9e92db170554422b4700a9016c9f9eL18-R18) [[2]](diffhunk://#diff-4578cad8acb43a99d68676e0138f157a2a9e92db170554422b4700a9016c9f9eL41-R41) [[3]](diffhunk://#diff-4578cad8acb43a99d68676e0138f157a2a9e92db170554422b4700a9016c9f9eL74-R74) [[4]](diffhunk://#diff-4578cad8acb43a99d68676e0138f157a2a9e92db170554422b4700a9016c9f9eL106-R106) [[5]](diffhunk://#diff-4578cad8acb43a99d68676e0138f157a2a9e92db170554422b4700a9016c9f9eL153-R155)
* Added new tests to verify that targets are correctly stored in the run metadata and that metadata is empty when no targets are provided.

**Dependency update:**

* Imported the `encoding/json` package to support serialization of the targets list into metadata.