### PR TITLE
feat: add run store to worker backend

### DIFF
--- a/worker/tests/policy/test_manager.py
+++ b/worker/tests/policy/test_manager.py
@@ -37,7 +37,9 @@ def test_start_policy(policy_manager, sample_policy):
         policy_manager.start_policy("policy1", sample_policy)
 
         # Check that PolicyRunner.setup was called with correct arguments
-        mock_runner.setup.assert_called_once_with("policy1", None, sample_policy)
+        mock_runner.setup.assert_called_once_with(
+            "policy1", None, sample_policy, policy_manager.run_store
+        )
 
         # Ensure the policy runner was added to the manager's runners
         assert "policy1" in policy_manager.runners

--- a/worker/tests/policy/test_run.py
+++ b/worker/tests/policy/test_run.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""NetBox Labs - Worker Run Store Unit Tests."""
+
+import threading
+import time
+from datetime import datetime
+
+import pytest
+
+from worker.policy.run import MAX_RUNS_PER_POLICY, Run, RunStatus, RunStore
+
+
+@pytest.fixture
+def run_store():
+    """Fixture to create a RunStore instance."""
+    return RunStore()
+
+
+def test_create_run_basic(run_store):
+    """Test creating a basic run."""
+    policy_name = "test-policy"
+
+    run = run_store.create_run(policy_name)
+
+    # Verify run properties
+    assert run.id is not None
+    assert run.policy_id == policy_name
+    assert run.status == RunStatus.RUNNING
+    assert run.reason == ""
+    assert run.entity_count == 0
+    assert run.metadata == {}
+    assert isinstance(run.created_at, datetime)
+    assert isinstance(run.updated_at, datetime)
+    # created_at and updated_at should be very close (within 1 second)
+    time_diff = abs((run.updated_at - run.created_at).total_seconds())
+    assert time_diff < 1
+
+    # Verify run is stored
+    runs = run_store.get_runs_for_policy(policy_name)
+    assert len(runs) == 1
+    assert runs[0].id == run.id
+    assert runs[0].policy_id == policy_name
+
+
+def test_create_run_with_metadata(run_store):
+    """Test creating a run with metadata."""
+    policy_name = "test-policy"
+    metadata = {
+        "name": "test_backend",
+        "app_name": "test_app",
+        "app_version": "1.0.0",
+    }
+
+    run = run_store.create_run(policy_name, metadata=metadata)
+
+    # Verify metadata is stored
+    assert run.metadata == metadata
+
+    # Verify run is stored with metadata
+    runs = run_store.get_runs_for_policy(policy_name)
+    assert len(runs) == 1
+    assert runs[0].metadata == metadata
+
+
+def test_update_run_to_completed(run_store):
+    """Test updating a run to completed status."""
+    policy_name = "test-policy"
+
+    run = run_store.create_run(policy_name)
+    run_id = run.id
+
+    # Update to completed
+    entity_count = 5
+    run_store.update_run(
+        policy_name=policy_name,
+        run_id=run_id,
+        status=RunStatus.COMPLETED,
+        error=None,
+        entity_count=entity_count,
+    )
+
+    runs = run_store.get_runs_for_policy(policy_name)
+    assert len(runs) == 1
+    assert runs[0].status == RunStatus.COMPLETED
+    assert runs[0].reason == ""
+    assert runs[0].entity_count == entity_count
+    assert runs[0].updated_at > runs[0].created_at
+
+
+def test_update_run_to_failed(run_store):
+    """Test updating a run to failed status with error."""
+    policy_name = "test-policy"
+
+    run = run_store.create_run(policy_name)
+    run_id = run.id
+
+    # Update to failed with error
+    test_error = Exception("test error")
+    entity_count = 10
+    run_store.update_run(
+        policy_name=policy_name,
+        run_id=run_id,
+        status=RunStatus.FAILED,
+        error=test_error,
+        entity_count=entity_count,
+    )
+
+    runs = run_store.get_runs_for_policy(policy_name)
+    assert len(runs) == 1
+    assert runs[0].status == RunStatus.FAILED
+    assert runs[0].reason == str(test_error)
+    assert runs[0].entity_count == entity_count
+
+
+def test_max_runs_per_policy(run_store):
+    """Test that only the last MAX_RUNS_PER_POLICY runs are retained per policy."""
+    policy_name = "test-policy"
+
+    # Create 7 runs (more than MAX_RUNS_PER_POLICY which is 5)
+    run_ids = []
+    for i in range(7):
+        run = run_store.create_run(policy_name)
+        run_ids.append(run.id)
+        time.sleep(0.01)  # Small delay to ensure different timestamps
+
+    # Verify only last 5 runs are retained
+    runs = run_store.get_runs_for_policy(policy_name)
+    assert len(runs) == MAX_RUNS_PER_POLICY
+
+    # Verify the last 5 runs are the ones retained (sorted newest first)
+    expected_ids = run_ids[2:]  # Last 5 runs
+    expected_ids.reverse()  # Newest first
+    actual_ids = [run.id for run in runs]
+    assert actual_ids == expected_ids
+
+
+def test_multiple_policies(run_store):
+    """Test storing runs for multiple policies."""
+    policy1 = "policy-1"
+    policy2 = "policy-2"
+
+    # Create runs for policy 1
+    run_store.create_run(policy1)
+    run_store.create_run(policy1)
+
+    # Create run for policy 2
+    run_store.create_run(policy2)
+
+    # Verify runs are stored separately
+    runs1 = run_store.get_runs_for_policy(policy1)
+    runs2 = run_store.get_runs_for_policy(policy2)
+
+    assert len(runs1) == 2
+    assert len(runs2) == 1
+    assert all(run.policy_id == policy1 for run in runs1)
+    assert all(run.policy_id == policy2 for run in runs2)
+
+
+def test_get_all_policies_with_runs(run_store):
+    """Test getting all policies with their runs."""
+    policy1 = "policy-1"
+    policy2 = "policy-2"
+
+    # Create runs for multiple policies
+    run_store.create_run(policy1)
+    run_store.create_run(policy1)
+    run_store.create_run(policy2)
+
+    all_runs = run_store.get_all_policies_with_runs()
+
+    assert len(all_runs) == 2
+    assert len(all_runs[policy1]) == 2
+    assert len(all_runs[policy2]) == 1
+
+    # Verify policy_id is set correctly for each run
+    for run in all_runs[policy1]:
+        assert run.policy_id == policy1
+    for run in all_runs[policy2]:
+        assert run.policy_id == policy2
+
+
+def test_get_runs_for_policy_empty(run_store):
+    """Test getting runs for a non-existent policy."""
+    runs = run_store.get_runs_for_policy("non-existent-policy")
+    assert runs == []
+
+
+def test_update_run_non_existent(run_store):
+    """Test updating a non-existent run does not cause errors."""
+    # Should not panic or raise an error
+    run_store.update_run(
+        policy_name="non-existent-policy",
+        run_id="non-existent-id",
+        status=RunStatus.FAILED,
+        error=Exception("test"),
+        entity_count=0,
+    )
+
+    # Verify no runs were created
+    runs = run_store.get_runs_for_policy("non-existent-policy")
+    assert runs == []
+
+
+def test_run_deep_copy(run_store):
+    """Test that runs are deep copied to prevent race conditions."""
+    policy_name = "test-policy"
+    metadata = {"key": "value"}
+
+    run = run_store.create_run(policy_name, metadata=metadata)
+
+    # Modify the returned run
+    run.status = RunStatus.COMPLETED
+    run.metadata["key"] = "modified"
+
+    # Verify stored run is unchanged
+    stored_runs = run_store.get_runs_for_policy(policy_name)
+    assert stored_runs[0].status == RunStatus.RUNNING
+    assert stored_runs[0].metadata["key"] == "value"
+
+
+def test_runs_sorted_newest_first(run_store):
+    """Test that runs are returned sorted by created_at descending (newest first)."""
+    policy_name = "test-policy"
+
+    # Create multiple runs with delays
+    runs_created = []
+    for i in range(3):
+        run = run_store.create_run(policy_name)
+        runs_created.append(run)
+        time.sleep(0.01)  # Ensure different timestamps
+
+    # Get runs
+    runs = run_store.get_runs_for_policy(policy_name)
+
+    # Verify they are in reverse order (newest first)
+    assert len(runs) == 3
+    assert runs[0].id == runs_created[2].id
+    assert runs[1].id == runs_created[1].id
+    assert runs[2].id == runs_created[0].id
+
+
+def test_concurrency_create_runs(run_store):
+    """Test concurrent run creation is thread-safe."""
+    policy_name = "test-policy"
+    num_threads = 10
+    runs_per_thread = 5
+
+    def create_runs():
+        for _ in range(runs_per_thread):
+            run_store.create_run(policy_name)
+
+    threads = []
+    for _ in range(num_threads):
+        thread = threading.Thread(target=create_runs)
+        threads.append(thread)
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    # Verify we have at most MAX_RUNS_PER_POLICY runs
+    runs = run_store.get_runs_for_policy(policy_name)
+    assert len(runs) <= MAX_RUNS_PER_POLICY
+
+
+def test_concurrency_update_runs(run_store):
+    """Test concurrent run updates are thread-safe."""
+    policy_name = "test-policy"
+    run = run_store.create_run(policy_name)
+    run_id = run.id
+
+    num_threads = 10
+    entity_count = 3
+
+    def update_run():
+        run_store.update_run(
+            policy_name=policy_name,
+            run_id=run_id,
+            status=RunStatus.COMPLETED,
+            error=None,
+            entity_count=entity_count,
+        )
+
+    threads = []
+    for _ in range(num_threads):
+        thread = threading.Thread(target=update_run)
+        threads.append(thread)
+        thread.start()
+
+    for thread in threads:
+        thread.join()
+
+    # Verify run was updated
+    runs = run_store.get_runs_for_policy(policy_name)
+    assert len(runs) == 1
+    assert runs[0].id == run_id
+    assert runs[0].status == RunStatus.COMPLETED
+    assert runs[0].entity_count == entity_count

--- a/worker/tests/policy/test_run.py
+++ b/worker/tests/policy/test_run.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 import pytest
 
-from worker.policy.run import MAX_RUNS_PER_POLICY, Run, RunStatus, RunStore
+from worker.policy.run import MAX_RUNS_PER_POLICY, RunStatus, RunStore
 
 
 @pytest.fixture

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -10,6 +10,7 @@ from netboxlabs.diode.sdk.diode.v1 import ingester_pb2
 
 from worker.backend import Backend
 from worker.models import Config, DiodeConfig, Metadata, Policy, Status
+from worker.policy.run import RunStore
 from worker.policy.runner import PolicyRunner
 
 
@@ -41,6 +42,13 @@ def sample_diode_config():
         prefix="test",
     )
 
+
+@pytest.fixture
+def mock_run_store():
+    """Fixture for a mock RunStore."""
+    return MagicMock(spec=RunStore)
+
+
 @pytest.fixture
 def sample_diode_dry_run_config():
     """Fixture for a sample DiodeConfig object."""
@@ -50,6 +58,7 @@ def sample_diode_dry_run_config():
         dry_run=True,
         dry_run_output_dir="/tmp/dry_run",
     )
+
 
 @pytest.fixture
 def mock_load_class():
@@ -84,6 +93,7 @@ def mock_diode_otlp_client():
         mock_diode_otlp_client.return_value = mock_instance
         yield mock_diode_otlp_client
 
+
 @pytest.fixture
 def mock_diode_dry_run_client():
     """Fixture to mock the DiodeDryRunClient constructor."""
@@ -112,13 +122,16 @@ def test_setup_policy_runner_with_cron(
     sample_diode_config,
     mock_load_class,
     mock_diode_client,
+    mock_run_store,
 ):
     """Test setting up the PolicyRunner with a cron schedule."""
     with patch.object(policy_runner.scheduler, "start") as mock_start, patch.object(
         policy_runner.scheduler, "add_job"
     ) as mock_add_job:
 
-        policy_runner.setup("policy1", sample_diode_config, sample_policy)
+        policy_runner.setup(
+            "policy1", sample_diode_config, sample_policy, mock_run_store
+        )
 
         # Ensure scheduler starts and job is added
         mock_start.assert_called_once()
@@ -134,6 +147,7 @@ def test_setup_policy_runner_with_one_time_run(
     sample_policy,
     mock_load_class,
     mock_diode_client,
+    mock_run_store,
 ):
     """Test setting up the PolicyRunner with a one-time schedule."""
     one_time_config = Config(package="custom")
@@ -141,7 +155,9 @@ def test_setup_policy_runner_with_one_time_run(
         policy_runner.scheduler, "add_job"
     ) as mock_add_job:
         sample_policy.config = one_time_config
-        policy_runner.setup("policy1", sample_diode_config, sample_policy)
+        policy_runner.setup(
+            "policy1", sample_diode_config, sample_policy, mock_run_store
+        )
 
         # Verify that DateTrigger is used for one-time scheduling
         trigger = mock_add_job.call_args[1]["trigger"]
@@ -158,13 +174,14 @@ def test_setup_policy_runner_uses_otlp_client(
     mock_load_class,
     mock_diode_client,
     mock_diode_otlp_client,
+    mock_run_store,
 ):
     """Ensure setup falls back to DiodeOTLPClient when credentials are missing."""
     otlp_config = DiodeConfig(target="http://localhost:8080", prefix="test-prefix")
     with patch.object(policy_runner.scheduler, "start") as mock_start, patch.object(
         policy_runner.scheduler, "add_job"
     ) as mock_add_job:
-        policy_runner.setup("policy1", otlp_config, sample_policy)
+        policy_runner.setup("policy1", otlp_config, sample_policy, mock_run_store)
 
         mock_start.assert_called_once()
         mock_add_job.assert_called_once()
@@ -173,19 +190,23 @@ def test_setup_policy_runner_uses_otlp_client(
     assert not mock_diode_client.called
     mock_diode_otlp_client.assert_called_once()
 
+
 def test_setup_policy_runner_dry_run(
     policy_runner,
     sample_diode_dry_run_config,
     sample_policy,
     mock_load_class,
     mock_diode_dry_run_client,
+    mock_run_store,
 ):
     """Test setting up the PolicyRunner with dry run configuration."""
     with patch.object(policy_runner.scheduler, "start") as mock_start, patch.object(
         policy_runner.scheduler, "add_job"
     ) as mock_add_job:
 
-        policy_runner.setup("policy1", sample_diode_dry_run_config, sample_policy)
+        policy_runner.setup(
+            "policy1", sample_diode_dry_run_config, sample_policy, mock_run_store
+        )
 
         # Ensure scheduler starts and job is added
         mock_start.assert_called_once()
@@ -194,9 +215,13 @@ def test_setup_policy_runner_dry_run(
         mock_diode_dry_run_client.assert_called_once()
         assert policy_runner.status == Status.RUNNING
 
-def test_run_success(policy_runner, sample_policy, mock_diode_client, mock_backend):
+
+def test_run_success(
+    policy_runner, sample_policy, mock_diode_client, mock_backend, mock_run_store
+):
     """Test the run function for a successful execution."""
     policy_runner.name = "test_policy"
+    policy_runner.run_store = mock_run_store
 
     # Create mock entities
     entities = []
@@ -216,18 +241,19 @@ def test_run_success(policy_runner, sample_policy, mock_diode_client, mock_backe
     # Should call ingest once for the single chunk
     mock_diode_client.ingest.assert_called_once()
     # Check that entities were passed correctly
-    call_args = mock_diode_client.ingest.call_args[1]['entities']
+    call_args = mock_diode_client.ingest.call_args[1]["entities"]
     assert len(call_args) == 3
 
 
 def test_run_passes_metadata_to_ingest(
-    policy_runner, sample_policy, mock_diode_client, mock_backend
+    policy_runner, sample_policy, mock_diode_client, mock_backend, mock_run_store
 ):
     """Ensure run forwards policy/backend metadata to the Diode client."""
     policy_runner.name = "policy-meta"
     policy_runner.metadata = Metadata(
         name="custom_backend", app_name="custom", app_version="0.1"
     )
+    policy_runner.run_store = mock_run_store
 
     entity = ingester_pb2.Entity()
     entity.device.name = "device-1"
@@ -249,9 +275,11 @@ def test_run_ingestion_errors(
     mock_diode_client,
     mock_backend,
     caplog,
+    mock_run_store,
 ):
     """Test the run function when ingestion has errors."""
     policy_runner.name = "test_policy"
+    policy_runner.run_store = mock_run_store
 
     # Create mock entities
     entities = []
@@ -286,9 +314,11 @@ def test_run_backend_exception(
     mock_diode_client,
     mock_backend,
     caplog,
+    mock_run_store,
 ):
     """Test the run function when an exception is raised by the backend."""
     policy_runner.name = "test_policy"
+    policy_runner.run_store = mock_run_store
 
     # Simulate backend throwing an exception
     mock_backend.run.side_effect = Exception("Backend error")
@@ -314,7 +344,7 @@ def test_stop_policy_runner(policy_runner):
 
 
 def test_metrics_during_policy_lifecycle(
-    policy_runner, sample_policy, mock_diode_client, mock_backend
+    policy_runner, sample_policy, mock_diode_client, mock_backend, mock_run_store
 ):
     """Test that metrics are properly updated during the policy lifecycle."""
     # Create mock metrics
@@ -339,6 +369,7 @@ def test_metrics_during_policy_lifecycle(
         app_name="test_app",
         app_version="1.0",
     )
+    policy_runner.run_store = mock_run_store
 
     # Create mock entities
     entities = []
@@ -381,7 +412,7 @@ def test_metrics_during_policy_lifecycle(
 
 
 def test_metrics_during_failed_discovery(
-    policy_runner, sample_policy, mock_diode_client, mock_backend
+    policy_runner, sample_policy, mock_diode_client, mock_backend, mock_run_store
 ):
     """Test that metrics are properly updated when discovery fails."""
     mock_backend_execution_failure = MagicMock()
@@ -398,6 +429,7 @@ def test_metrics_during_failed_discovery(
         app_name="test_app",
         app_version="1.0",
     )
+    policy_runner.run_store = mock_run_store
 
     def mock_get_metric(name):
         return mock_metrics.get(name)
@@ -427,9 +459,12 @@ def test_metrics_during_failed_discovery(
         assert latency_kwargs["backend"] == "my_backend"
 
 
-def test_run_with_small_entities_no_chunking(policy_runner, sample_policy, mock_diode_client, mock_backend):
+def test_run_with_small_entities_no_chunking(
+    policy_runner, sample_policy, mock_diode_client, mock_backend, mock_run_store
+):
     """Test the run function with small entities that don't require chunking."""
     policy_runner.name = "test_policy"
+    policy_runner.run_store = mock_run_store
 
     # Create mock entities
     entities = []
@@ -442,20 +477,30 @@ def test_run_with_small_entities_no_chunking(policy_runner, sample_policy, mock_
     mock_diode_client.ingest.return_value.errors = []
 
     # Mock estimate_message_size to return small size (under 3.0 MB)
-    with patch("worker.policy.runner.estimate_message_size", return_value=1024 * 1024):  # 1MB
+    with patch(
+        "worker.policy.runner.estimate_message_size", return_value=1024 * 1024
+    ):  # 1MB
         policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Should call ingest once (no chunking)
     mock_diode_client.ingest.assert_called_once()
 
     # Verify all entities were passed in single call
-    call_args = mock_diode_client.ingest.call_args[1]['entities']
+    call_args = mock_diode_client.ingest.call_args[1]["entities"]
     assert len(call_args) == 5
 
 
-def test_run_with_multiple_chunks(policy_runner, sample_policy, mock_diode_client, mock_backend, caplog):
+def test_run_with_multiple_chunks(
+    policy_runner,
+    sample_policy,
+    mock_diode_client,
+    mock_backend,
+    caplog,
+    mock_run_store,
+):
     """Test the run function with entities that require multiple chunks."""
     policy_runner.name = "test_policy"
+    policy_runner.run_store = mock_run_store
 
     # Create many mock entities to trigger chunking
     entities = []
@@ -468,8 +513,12 @@ def test_run_with_multiple_chunks(policy_runner, sample_policy, mock_diode_clien
     mock_diode_client.ingest.return_value.errors = []
 
     # Mock estimate_message_size to return large size (over 3.0 MB) and create_message_chunks
-    with patch("worker.policy.runner.estimate_message_size", return_value=5 * 1024 * 1024), \
-         patch("worker.policy.runner.create_message_chunks", return_value=[entities[:5], entities[5:]]) as mock_chunks:
+    with patch(
+        "worker.policy.runner.estimate_message_size", return_value=5 * 1024 * 1024
+    ), patch(
+        "worker.policy.runner.create_message_chunks",
+        return_value=[entities[:5], entities[5:]],
+    ) as mock_chunks:
 
         with caplog.at_level("INFO"):
             policy_runner.run(mock_diode_client, mock_backend, sample_policy)
@@ -484,9 +533,17 @@ def test_run_with_multiple_chunks(policy_runner, sample_policy, mock_diode_clien
         assert "Successfully ingested 10 entities in 2 chunks" in caplog.text
 
 
-def test_run_chunk_ingestion_error(policy_runner, sample_policy, mock_diode_client, mock_backend, caplog):
+def test_run_chunk_ingestion_error(
+    policy_runner,
+    sample_policy,
+    mock_diode_client,
+    mock_backend,
+    caplog,
+    mock_run_store,
+):
     """Test the run function when a chunk ingestion fails."""
     policy_runner.name = "test_policy"
+    policy_runner.run_store = mock_run_store
 
     # Create mock entities
     entities = []
@@ -505,8 +562,12 @@ def test_run_chunk_ingestion_error(policy_runner, sample_policy, mock_diode_clie
     mock_diode_client.ingest.side_effect = responses
 
     # Mock large size to trigger chunking and create_message_chunks
-    with patch("worker.policy.runner.estimate_message_size", return_value=5 * 1024 * 1024), \
-         patch("worker.policy.runner.create_message_chunks", return_value=[entities[:3], entities[3:]]):
+    with patch(
+        "worker.policy.runner.estimate_message_size", return_value=5 * 1024 * 1024
+    ), patch(
+        "worker.policy.runner.create_message_chunks",
+        return_value=[entities[:3], entities[3:]],
+    ):
 
         with caplog.at_level("ERROR"):
             policy_runner.run(mock_diode_client, mock_backend, sample_policy)

--- a/worker/worker/policy/manager.py
+++ b/worker/worker/policy/manager.py
@@ -8,6 +8,7 @@ import os
 import yaml
 
 from worker.models import DiodeConfig, Policy, PolicyRequest
+from worker.policy.run import RunStore
 from worker.policy.runner import PolicyRunner
 
 # Set up logging
@@ -46,6 +47,7 @@ class PolicyManager:
         self.runners = dict[str, PolicyRunner]()
         self.config = None
         self.loaded_modules = set()
+        self.run_store = RunStore()
 
     def get_loaded_modules(self):
         """Return the loaded modules."""
@@ -76,7 +78,7 @@ class PolicyManager:
             raise ValueError(f"policy '{name}' already exists")
 
         runner = PolicyRunner()
-        runner.setup(name, self.config, policy)
+        runner.setup(name, self.config, policy, self.run_store)
         self.loaded_modules.add(policy.config.package)
         self.runners[name] = runner
 

--- a/worker/worker/policy/run.py
+++ b/worker/worker/policy/run.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""Worker Run Store."""
+
+import threading
+import uuid
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel, Field
+
+
+class RunStatus(str, Enum):
+    """Run status enumeration."""
+
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class Run(BaseModel):
+    """Model for a single run execution."""
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    policy_id: str
+    status: RunStatus
+    reason: str = ""
+    entity_count: int = 0
+    metadata: dict[str, str] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=lambda: datetime.now())
+    updated_at: datetime = Field(default_factory=lambda: datetime.now())
+
+
+# Maximum number of runs to keep per policy
+MAX_RUNS_PER_POLICY = 5
+
+
+class RunStore:
+    """
+    Thread-safe store for managing policy run history.
+
+    Tracks up to MAX_RUNS_PER_POLICY runs per policy.
+    Uses a dictionary: policy_name -> list of runs.
+    """
+
+    def __init__(self):
+        """Initialize the RunStore with thread-safe storage."""
+        self._lock = threading.RLock()
+        self._runs: dict[str, list[Run]] = {}
+
+    def _copy_run(self, run: Run) -> Run:
+        """
+        Create deep copy of run to prevent race conditions.
+
+        Args:
+        ----
+            run: Run object to copy.
+
+        Returns:
+        -------
+            Run: Deep copy of the run.
+
+        """
+        return run.model_copy(deep=True)
+
+    def create_run(
+        self, policy_name: str, metadata: dict[str, str] | None = None
+    ) -> Run:
+        """
+        Create a new run for the given policy.
+
+        Args:
+        ----
+            policy_name: Name of the policy.
+            metadata: Optional metadata to attach to the run (e.g., app_name, app_version).
+
+        Returns:
+        -------
+            Run: The created Run object (deep copy).
+
+        """
+        with self._lock:
+            # Create run with running status
+            run = Run(
+                policy_id=policy_name,
+                status=RunStatus.RUNNING,
+                metadata=metadata or {},
+            )
+
+            # Initialize list if needed
+            if policy_name not in self._runs:
+                self._runs[policy_name] = []
+
+            # Add run to the policy's run list
+            runs = self._runs[policy_name]
+            runs.append(run)
+
+            # Keep only the last MAX_RUNS_PER_POLICY runs
+            if len(runs) > MAX_RUNS_PER_POLICY:
+                runs[:] = runs[-MAX_RUNS_PER_POLICY:]
+
+            return self._copy_run(run)
+
+    def update_run(
+        self,
+        policy_name: str,
+        run_id: str,
+        status: RunStatus,
+        error: Exception | None,
+        entity_count: int,
+    ) -> None:
+        """
+        Update an existing run's status.
+
+        Args:
+        ----
+            policy_name: Name of the policy.
+            run_id: Run ID to update.
+            status: New status.
+            error: Error if failed, None otherwise.
+            entity_count: Number of entities discovered.
+
+        """
+        with self._lock:
+            if policy_name not in self._runs:
+                return
+
+            runs = self._runs[policy_name]
+            for run in runs:
+                if run.id == run_id:
+                    run.status = status
+                    run.entity_count = entity_count
+                    run.updated_at = datetime.now()
+
+                    if error:
+                        run.reason = str(error)
+                    else:
+                        run.reason = ""  # Clear reason when no error
+
+                    return
+
+    def get_runs_for_policy(self, policy_name: str) -> list[Run]:
+        """
+        Get all runs for a specific policy.
+
+        Args:
+        ----
+            policy_name: Name of the policy.
+
+        Returns:
+        -------
+            List[Run]: List of runs sorted by created_at descending (deep copies).
+
+        """
+        with self._lock:
+            if policy_name not in self._runs:
+                return []
+
+            runs = self._runs[policy_name]
+            result = [self._copy_run(run) for run in runs]
+
+            # Sort newest first
+            result.sort(key=lambda r: r.created_at, reverse=True)
+
+            return result
+
+    def get_all_policies_with_runs(self) -> dict[str, list[Run]]:
+        """
+        Get all policies with their runs.
+
+        Returns
+        -------
+            Dict[str, List[Run]]: Dict mapping policy name to list of runs (deep copies).
+
+        """
+        with self._lock:
+            result = {}
+
+            for policy_name, runs in self._runs.items():
+                # Copy runs
+                runs_copy = [self._copy_run(run) for run in runs]
+
+                # Sort newest first
+                runs_copy.sort(key=lambda r: r.created_at, reverse=True)
+
+                result[policy_name] = runs_copy
+
+            return result

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -20,6 +20,7 @@ from netboxlabs.diode.sdk import (
 from worker.backend import Backend, load_class
 from worker.metrics import get_metric
 from worker.models import DiodeConfig, Policy, Status
+from worker.policy.run import RunStatus, RunStore
 
 # Set up logging
 logging.basicConfig(level=logging.INFO)
@@ -36,8 +37,11 @@ class PolicyRunner:
         self.policy = None
         self.status = Status.NEW
         self.scheduler = BackgroundScheduler()
+        self.run_store = None
 
-    def setup(self, name: str, diode_config: DiodeConfig, policy: Policy):
+    def setup(
+        self, name: str, diode_config: DiodeConfig, policy: Policy, run_store: RunStore
+    ):
         """
         Set up the policy runner.
 
@@ -46,6 +50,7 @@ class PolicyRunner:
             name: Policy name.
             diode_config: Diode configuration data.
             policy: Policy configuration data.
+            run_store: RunStore instance for tracking runs.
 
         """
         self.name = name.replace("\r\n", "").replace("\n", "")
@@ -87,6 +92,7 @@ class PolicyRunner:
 
         self.metadata = metadata
         self.policy = policy
+        self.run_store = run_store
 
         self.scheduler.start()
 
@@ -133,9 +139,22 @@ class PolicyRunner:
         if policy_executions:
             policy_executions.add(1, {"policy": self.name})
 
+        # CREATE RUN AT START with metadata from backend setup
+        run_metadata = {
+            "name": self.metadata.name,
+            "app_name": self.metadata.app_name,
+            "app_version": self.metadata.app_version,
+        }
+        run = self.run_store.create_run(
+            policy_name=self.name,
+            metadata=run_metadata,
+        )
+
         exec_start_time = time.perf_counter()
+        entity_count = 0
         try:
             entities = backend.run(self.name, policy)
+            entity_count = len(entities)
             metadata = {
                 "policy_name": self.name,
                 "worker_backend": self.metadata.name,
@@ -149,16 +168,24 @@ class PolicyRunner:
                 for chunk in chunks:
                     response = client.ingest(entities=chunk, metadata=metadata)
                     if response.errors:
-                        raise RuntimeError(
-                            f"Chunk ingestion failed: {response.errors}"
-                        )
+                        raise RuntimeError(f"Chunk ingestion failed: {response.errors}")
             else:
                 response = client.ingest(entities=entities, metadata=metadata)
                 if response.errors:
                     raise RuntimeError(f"Entities ingestion failed: {response.errors}")
             logger.info(
-                f"Policy {self.name}: Successfully ingested {len(entities)} entities in {chunk_num} chunks"
+                f"Policy {self.name}: Successfully ingested {entity_count} entities in {chunk_num} chunks"
             )
+
+            # UPDATE RUN ON SUCCESS
+            self.run_store.update_run(
+                policy_name=self.name,
+                run_id=run.id,
+                status=RunStatus.COMPLETED,
+                error=None,
+                entity_count=entity_count,
+            )
+
             run_success = get_metric("backend_execution_success")
             if run_success:
                 run_success.add(
@@ -172,6 +199,16 @@ class PolicyRunner:
                 )
         except Exception as e:
             logger.error(f"Policy {self.name}: {e}")
+
+            # UPDATE RUN ON FAILURE
+            self.run_store.update_run(
+                policy_name=self.name,
+                run_id=run.id,
+                status=RunStatus.FAILED,
+                error=e,
+                entity_count=entity_count,
+            )
+
             run_failure = get_metric("backend_execution_failure")
             if run_failure:
                 run_failure.add(


### PR DESCRIPTION
This pull request updates the policy management and runner test infrastructure to support passing a `RunStore` instance throughout the policy lifecycle. The main changes ensure that `RunStore` is initialized in `PolicyManager`, passed to `PolicyRunner.setup`, and made available in all relevant test cases. This enables more robust testing and future extensibility for tracking policy runs.

**Policy management and runner integration:**

* `PolicyManager` now initializes a `RunStore` instance and passes it to each `PolicyRunner` during setup, ensuring consistent run tracking across all policies. [[1]](diffhunk://#diff-a9fc052d6dc03d7c0b255e9079f560d3767935adc86ac43e60cb9f033404be75R11) [[2]](diffhunk://#diff-a9fc052d6dc03d7c0b255e9079f560d3767935adc86ac43e60cb9f033404be75R50) [[3]](diffhunk://#diff-a9fc052d6dc03d7c0b255e9079f560d3767935adc86ac43e60cb9f033404be75L79-R81)
* `PolicyRunner.setup` and all related test calls have been updated to accept and use the `run_store` parameter, reflecting the new interface. [[1]](diffhunk://#diff-1a7788aca7065180e3b939777776453d5a9d752b0e28c32168dcf27bb9727fd8L40-R42) [[2]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R125-R134) [[3]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R150-R160) [[4]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R177-R184) [[5]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R193-R209)

**Test infrastructure improvements:**

* Added a `mock_run_store` pytest fixture and updated all relevant test cases in `test_runner.py` to use it, ensuring that `PolicyRunner` is always tested with a `run_store` instance. [[1]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R45-R51) [[2]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L197-R224) [[3]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L219-R256) [[4]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R278-R282) [[5]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R317-R321) [[6]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L317-R347) [[7]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R372) [[8]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L384-R415) [[9]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R432) [[10]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L430-R467) [[11]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L445-R503) [[12]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L487-R546) [[13]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L508-R570)

**Minor code and formatting cleanups:**

* Improved patching and argument formatting in several test cases for clarity and consistency. [[1]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L445-R503) [[2]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L471-R521) [[3]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51L508-R570)
* Minor whitespace and import adjustments for readability. [[1]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R13) [[2]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R62) [[3]](diffhunk://#diff-f6ad41627bb040e8e4b7e13d214a73c2bd73b5da5f9882ec7bfe9b1c83c63a51R96)