### PR TITLE
chore: use timestamp utc unixnano in run store for every backend

### DIFF
--- a/device-discovery/device_discovery/policy/models.py
+++ b/device-discovery/device_discovery/policy/models.py
@@ -3,8 +3,8 @@
 """Device Discovery Policy Models."""
 
 import re
+import time
 import uuid
-from datetime import datetime
 from enum import Enum
 from typing import Any
 
@@ -234,8 +234,8 @@ class Run(BaseModel):
     reason: str = ""
     entity_count: int = 0
     metadata: dict[str, str] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=lambda: datetime.now())
-    updated_at: datetime = Field(default_factory=lambda: datetime.now())
+    created_at: int = Field(default_factory=time.time_ns)
+    updated_at: int = Field(default_factory=time.time_ns)
 
 
 class PolicyStatus(BaseModel):

--- a/device-discovery/device_discovery/policy/run.py
+++ b/device-discovery/device_discovery/policy/run.py
@@ -4,7 +4,7 @@
 
 import ipaddress
 import threading
-from datetime import datetime
+import time
 
 from device_discovery.policy.models import Run, RunStatus
 
@@ -154,7 +154,7 @@ class RunStore:
                 if run.id == run_id:
                     run.status = status
                     run.entity_count = entity_count
-                    run.updated_at = datetime.now()
+                    run.updated_at = time.time_ns()
 
                     if error:
                         run.reason = str(error)

--- a/device-discovery/tests/policy/test_manager.py
+++ b/device-discovery/tests/policy/test_manager.py
@@ -167,13 +167,13 @@ def test_get_policy_statuses_active_policy_with_runs(policy_manager):
         policy_id="policy1",
         status=RunStatus.COMPLETED,
         entity_count=10,
-        created_at=datetime(2026, 1, 27, 10, 0, 0),
+        created_at=int(datetime(2026, 1, 27, 10, 0, 0).timestamp() * 1e9),
     )
     run2 = Run(
         policy_id="policy1",
         status=RunStatus.RUNNING,
         entity_count=0,
-        created_at=datetime(2026, 1, 27, 11, 0, 0),
+        created_at=int(datetime(2026, 1, 27, 11, 0, 0).timestamp() * 1e9),
     )
 
     # Mock the run store to return runs (sorted newest first)
@@ -225,13 +225,13 @@ def test_get_policy_statuses_historical_policy_no_active_runner(policy_manager):
         policy_id="old_policy",
         status=RunStatus.COMPLETED,
         entity_count=5,
-        created_at=datetime(2026, 1, 26, 10, 0, 0),
+        created_at=int(datetime(2026, 1, 26, 10, 0, 0).timestamp() * 1e9),
     )
     run2 = Run(
         policy_id="old_policy",
         status=RunStatus.FAILED,
         reason="Connection timeout",
-        created_at=datetime(2026, 1, 27, 10, 0, 0),
+        created_at=int(datetime(2026, 1, 27, 10, 0, 0).timestamp() * 1e9),
     )
 
     # Mock the run store to return runs (sorted newest first)
@@ -266,19 +266,19 @@ def test_get_policy_statuses_mixed_active_and_historical(policy_manager):
         policy_id="active_policy",
         status=RunStatus.COMPLETED,
         entity_count=15,
-        created_at=datetime(2026, 1, 27, 12, 0, 0),
+        created_at=int(datetime(2026, 1, 27, 12, 0, 0).timestamp() * 1e9),
     )
     historical_run1 = Run(
         policy_id="historical_policy",
         status=RunStatus.COMPLETED,
         entity_count=8,
-        created_at=datetime(2026, 1, 26, 10, 0, 0),
+        created_at=int(datetime(2026, 1, 26, 10, 0, 0).timestamp() * 1e9),
     )
     historical_run2 = Run(
         policy_id="historical_policy",
         status=RunStatus.COMPLETED,
         entity_count=12,
-        created_at=datetime(2026, 1, 27, 9, 0, 0),
+        created_at=int(datetime(2026, 1, 27, 9, 0, 0).timestamp() * 1e9),
     )
 
     # Mock the run store
@@ -329,7 +329,7 @@ def test_get_policy_statuses_multiple_active_policies(policy_manager):
         policy_id="policy1",
         status=RunStatus.FAILED,
         reason="Network error",
-        created_at=datetime(2026, 1, 27, 10, 0, 0),
+        created_at=int(datetime(2026, 1, 27, 10, 0, 0).timestamp() * 1e9),
     )
 
     # Mock the run store
@@ -371,13 +371,13 @@ def test_get_policy_statuses_prefer_running_status(policy_manager):
         policy_id="policy1",
         status=RunStatus.RUNNING,
         entity_count=0,
-        created_at=datetime(2026, 1, 27, 10, 0, 0),
+        created_at=int(datetime(2026, 1, 27, 10, 0, 0).timestamp() * 1e9),
     )
     run2 = Run(
         policy_id="policy1",
         status=RunStatus.COMPLETED,
         entity_count=15,
-        created_at=datetime(2026, 1, 27, 11, 0, 0),  # Latest run
+        created_at=int(datetime(2026, 1, 27, 11, 0, 0).timestamp() * 1e9),  # Latest run
     )
 
     # Mock the run store to return runs (sorted newest first)

--- a/device-discovery/tests/test_server.py
+++ b/device-discovery/tests/test_server.py
@@ -423,8 +423,8 @@ def test_read_status_with_policies(mock_version_semver):
         policy_id="test_policy",
         status=RunStatus.COMPLETED,
         entity_count=10,
-        created_at=datetime(2026, 1, 27, 10, 0, 0),
-        updated_at=datetime(2026, 1, 27, 10, 5, 0),
+        created_at=int(datetime(2026, 1, 27, 10, 0, 0).timestamp() * 1e9),
+        updated_at=int(datetime(2026, 1, 27, 10, 5, 0).timestamp() * 1e9),
     )
     policy_status = PolicyStatus(
         name="test_policy", status="completed", runs=[run1]

--- a/network-discovery/go.mod
+++ b/network-discovery/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/gin-gonic/gin v1.10.0
 	github.com/go-co-op/gocron/v2 v2.14.0
 	github.com/google/uuid v1.6.0
-	github.com/netboxlabs/diode-sdk-go v1.6.2
+	github.com/netboxlabs/diode-sdk-go v1.7.0
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.38.0

--- a/network-discovery/go.sum
+++ b/network-discovery/go.sum
@@ -69,10 +69,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
-github.com/netboxlabs/diode-sdk-go v1.6.1 h1:j4rPr1eRNZG5lgPAekopeok+ygijUM3ksNGeRyJexsE=
-github.com/netboxlabs/diode-sdk-go v1.6.1/go.mod h1:Y93A5nsK/sz6wsgwiMytZgek01Yl50wzYQjZKFZfdkQ=
-github.com/netboxlabs/diode-sdk-go v1.6.2 h1:UoXQSRt2Eh4kcqYtpB6ChXXadK16pd/QaZ4ji5qhK/M=
-github.com/netboxlabs/diode-sdk-go v1.6.2/go.mod h1:Y93A5nsK/sz6wsgwiMytZgek01Yl50wzYQjZKFZfdkQ=
+github.com/netboxlabs/diode-sdk-go v1.7.0 h1:PEfczyJCWJ8CJEb13HqiNfIluJEW/2D50CHqOd4Oub8=
+github.com/netboxlabs/diode-sdk-go v1.7.0/go.mod h1:Y93A5nsK/sz6wsgwiMytZgek01Yl50wzYQjZKFZfdkQ=
 github.com/pelletier/go-toml/v2 v2.2.3 h1:YmeHyLY8mFWbdkNWwpr+qIL2bEqT0o95WSdkNHvL12M=
 github.com/pelletier/go-toml/v2 v2.2.3/go.mod h1:MfCQTFTvCcUyyvvwm1+G6H/jORL20Xlb6rzQu9GuUkc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/network-discovery/policy/run.go
+++ b/network-discovery/policy/run.go
@@ -28,8 +28,8 @@ type Run struct {
 	Reason      string            `json:"reason,omitempty"`
 	EntityCount int               `json:"entity_count"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
+	CreatedAt   int64             `json:"created_at"`
+	UpdatedAt   int64             `json:"updated_at"`
 }
 
 // RunStore manages runs in memory
@@ -69,8 +69,8 @@ func (rs *RunStore) CreateRun(policyName string, targets []string) *Run {
 		PolicyID:  policyName,
 		Status:    RunStatusRunning,
 		Metadata:  metadata,
-		CreatedAt: now,
-		UpdatedAt: now,
+		CreatedAt: now.UTC().UnixNano(),
+		UpdatedAt: now.UTC().UnixNano(),
 	}
 
 	// Add run to the policy's run list
@@ -96,7 +96,7 @@ func (rs *RunStore) UpdateRun(policyName, runID string, status RunStatus, err er
 		if run.ID == runID {
 			run.Status = status
 			run.EntityCount = entityCount
-			run.UpdatedAt = time.Now()
+			run.UpdatedAt = time.Now().UTC().UnixNano()
 			if err != nil {
 				run.Reason = err.Error()
 			}

--- a/network-discovery/policy/run_test.go
+++ b/network-discovery/policy/run_test.go
@@ -24,8 +24,8 @@ func TestRunStore_CreateRun(t *testing.T) {
 	assert.Equal(t, policy.RunStatusRunning, run.Status)
 	assert.Empty(t, run.Reason)
 	assert.Equal(t, 0, run.EntityCount)
-	assert.False(t, run.CreatedAt.IsZero())
-	assert.False(t, run.UpdatedAt.IsZero())
+	assert.Greater(t, run.CreatedAt, int64(0))
+	assert.Greater(t, run.UpdatedAt, int64(0))
 	assert.Equal(t, run.CreatedAt, run.UpdatedAt)
 
 	// Verify run is stored
@@ -51,7 +51,7 @@ func TestRunStore_UpdateRun(t *testing.T) {
 	assert.Equal(t, policy.RunStatusCompleted, runs[0].Status)
 	assert.Empty(t, runs[0].Reason)
 	assert.Equal(t, entityCount, runs[0].EntityCount)
-	assert.True(t, runs[0].UpdatedAt.After(runs[0].CreatedAt))
+	assert.Greater(t, runs[0].UpdatedAt, runs[0].CreatedAt)
 
 	// Update to failed with error
 	testError := errors.New("test error")

--- a/snmp-discovery/policy/run.go
+++ b/snmp-discovery/policy/run.go
@@ -31,8 +31,8 @@ type Run struct {
 	Reason      string            `json:"reason,omitempty"`
 	EntityCount int               `json:"entity_count"`
 	Metadata    map[string]string `json:"metadata,omitempty"`
-	CreatedAt   time.Time         `json:"created_at"`
-	UpdatedAt   time.Time         `json:"updated_at"`
+	CreatedAt   int64             `json:"created_at"`
+	UpdatedAt   int64             `json:"updated_at"`
 }
 
 // RunStore manages runs in memory with per-target tracking
@@ -115,8 +115,8 @@ func (rs *RunStore) CreateRun(policyName string, target string, port uint16, par
 		PolicyID:  policyName,
 		Status:    RunStatusRunning,
 		Metadata:  metadata,
-		CreatedAt: now,
-		UpdatedAt: now,
+		CreatedAt: now.UTC().UnixNano(),
+		UpdatedAt: now.UTC().UnixNano(),
 	}
 
 	// Initialize policy map if needed
@@ -155,7 +155,7 @@ func (rs *RunStore) UpdateRun(policyName, target string, port uint16, runID stri
 		if run.ID == runID {
 			run.Status = status
 			run.EntityCount = entityCount
-			run.UpdatedAt = time.Now()
+			run.UpdatedAt = time.Now().UTC().UnixNano()
 			if err != nil {
 				run.Reason = err.Error()
 			} else {
@@ -206,7 +206,7 @@ func (rs *RunStore) GetRunsForPolicy(policyName string) []*Run {
 
 	// Sort by CreatedAt descending (newest first)
 	sort.Slice(result, func(i, j int) bool {
-		return result[i].CreatedAt.After(result[j].CreatedAt)
+		return result[i].CreatedAt > result[j].CreatedAt
 	})
 
 	return result
@@ -229,7 +229,7 @@ func (rs *RunStore) GetAllPoliciesWithRuns() map[string][]*Run {
 
 		// Sort runs for consistent ordering (newest first)
 		sort.Slice(runs, func(i, j int) bool {
-			return runs[i].CreatedAt.After(runs[j].CreatedAt)
+			return runs[i].CreatedAt > runs[j].CreatedAt
 		})
 
 		result[policyName] = runs

--- a/snmp-discovery/policy/run_test.go
+++ b/snmp-discovery/policy/run_test.go
@@ -33,8 +33,8 @@ func TestRunStore_CreateRun(t *testing.T) {
 	assert.Equal(t, "161", run.Metadata["port"])
 	assert.Equal(t, parentTarget, run.Metadata["parent_target"])
 
-	assert.False(t, run.CreatedAt.IsZero())
-	assert.False(t, run.UpdatedAt.IsZero())
+	assert.Greater(t, run.CreatedAt, int64(0))
+	assert.Greater(t, run.UpdatedAt, int64(0))
 	assert.Equal(t, run.CreatedAt, run.UpdatedAt)
 
 	// Verify run is stored for target
@@ -76,7 +76,7 @@ func TestRunStore_UpdateRun(t *testing.T) {
 	assert.Equal(t, policy.RunStatusCompleted, runs[0].Status)
 	assert.Empty(t, runs[0].Reason)
 	assert.Equal(t, entityCount, runs[0].EntityCount)
-	assert.True(t, runs[0].UpdatedAt.After(runs[0].CreatedAt))
+	assert.Greater(t, runs[0].UpdatedAt, runs[0].CreatedAt)
 
 	// Update to failed with error
 	testError := errors.New("test error")
@@ -162,7 +162,7 @@ func TestRunStore_MaxThreeRunsPerTarget_MultipleTargets(t *testing.T) {
 
 	// Verify runs are sorted by CreatedAt descending (newest first)
 	for i := 0; i < len(allRuns)-1; i++ {
-		assert.True(t, allRuns[i].CreatedAt.After(allRuns[i+1].CreatedAt) || allRuns[i].CreatedAt.Equal(allRuns[i+1].CreatedAt),
+		assert.GreaterOrEqual(t, allRuns[i].CreatedAt, allRuns[i+1].CreatedAt,
 			"Runs should be sorted newest first")
 	}
 }
@@ -215,8 +215,8 @@ func TestRunStore_GetRunsForPolicy(t *testing.T) {
 	assert.Len(t, runs, 3)
 
 	// Verify runs are sorted by CreatedAt descending
-	assert.True(t, runs[0].CreatedAt.After(runs[1].CreatedAt))
-	assert.True(t, runs[1].CreatedAt.After(runs[2].CreatedAt))
+	assert.Greater(t, runs[0].CreatedAt, runs[1].CreatedAt)
+	assert.Greater(t, runs[1].CreatedAt, runs[2].CreatedAt)
 
 	// Verify each run has correct metadata
 	targets := make(map[string]bool)
@@ -354,7 +354,7 @@ func TestRunStore_GetAllPoliciesWithRuns(t *testing.T) {
 	// Verify runs are sorted within each policy
 	for _, runs := range allRuns {
 		for i := 0; i < len(runs)-1; i++ {
-			assert.True(t, runs[i].CreatedAt.After(runs[i+1].CreatedAt) || runs[i].CreatedAt.Equal(runs[i+1].CreatedAt))
+			assert.GreaterOrEqual(t, runs[i].CreatedAt, runs[i+1].CreatedAt)
 		}
 	}
 }

--- a/worker/tests/policy/test_run.py
+++ b/worker/tests/policy/test_run.py
@@ -30,11 +30,11 @@ def test_create_run_basic(run_store):
     assert run.reason == ""
     assert run.entity_count == 0
     assert run.metadata == {}
-    assert isinstance(run.created_at, datetime)
-    assert isinstance(run.updated_at, datetime)
-    # created_at and updated_at should be very close (within 1 second)
-    time_diff = abs((run.updated_at - run.created_at).total_seconds())
-    assert time_diff < 1
+    assert isinstance(run.created_at, int)
+    assert isinstance(run.updated_at, int)
+    # created_at and updated_at should be very close (within 1 second in nanoseconds)
+    time_diff_ns = abs(run.updated_at - run.created_at)
+    assert time_diff_ns < 1_000_000_000  # 1 second in nanoseconds
 
     # Verify run is stored
     runs = run_store.get_runs_for_policy(policy_name)

--- a/worker/worker/policy/run.py
+++ b/worker/worker/policy/run.py
@@ -3,8 +3,8 @@
 """Worker Run Store."""
 
 import threading
+import time
 import uuid
-from datetime import datetime
 from enum import Enum
 
 from pydantic import BaseModel, Field
@@ -27,8 +27,8 @@ class Run(BaseModel):
     reason: str = ""
     entity_count: int = 0
     metadata: dict[str, str] = Field(default_factory=dict)
-    created_at: datetime = Field(default_factory=lambda: datetime.now())
-    updated_at: datetime = Field(default_factory=lambda: datetime.now())
+    created_at: int = Field(default_factory=time.time_ns)
+    updated_at: int = Field(default_factory=time.time_ns)
 
 
 # Maximum number of runs to keep per policy
@@ -130,7 +130,7 @@ class RunStore:
                 if run.id == run_id:
                     run.status = status
                     run.entity_count = entity_count
-                    run.updated_at = datetime.now()
+                    run.updated_at = time.time_ns()
 
                     if error:
                         run.reason = str(error)


### PR DESCRIPTION
This pull request standardizes the handling of timestamps for run objects across Python and Go components by switching from `datetime` or `time.Time` objects to storing timestamps as integer nanoseconds since the Unix epoch. This change improves consistency, simplifies serialization, and aligns timestamp handling between different services. All relevant code, sorting logic, and tests have been updated to use the new integer nanosecond format.

**Core timestamp representation changes:**

* Changed the `created_at` and `updated_at` fields in Python (`Run` models in `device_discovery/policy/models.py` and `worker/worker/policy/run.py`) and Go (`Run` structs in `network-discovery/policy/run.go` and `snmp-discovery/policy/run.go`) from `datetime`/`time.Time` to integer nanoseconds. [[1]](diffhunk://#diff-6a336230783aebcdf213f14e3c6628fe4b4c705e8e65a7367e072ea77836b684L237-R238) [[2]](diffhunk://#diff-1da1de85df3821e78497f04cd85cd4419c3743aa5236aa8880cc671bf63817b4L30-R31) [[3]](diffhunk://#diff-a7e698932e1486403dc7afdcaa4163f7194e6551f7869155f9b1c9e47f7840aaL31-R32) [[4]](diffhunk://#diff-e4b72a9210cd45f24603f6fa2022c5c54494035cbc3270552b22270eed104254L34-R35)

**Timestamp assignment and update logic:**

* Updated all code paths that assign or update `created_at` and `updated_at` to use nanosecond timestamps (`time.time_ns()` in Python, `time.Now().UTC().UnixNano()` in Go). [[1]](diffhunk://#diff-816c3cc6365eaa441c6260b23181bba78cbe7d1b70d4a26b3bad474f41eb46f1L157-R157) [[2]](diffhunk://#diff-1da1de85df3821e78497f04cd85cd4419c3743aa5236aa8880cc671bf63817b4L133-R133) [[3]](diffhunk://#diff-a7e698932e1486403dc7afdcaa4163f7194e6551f7869155f9b1c9e47f7840aaL72-R73) [[4]](diffhunk://#diff-a7e698932e1486403dc7afdcaa4163f7194e6551f7869155f9b1c9e47f7840aaL99-R99) [[5]](diffhunk://#diff-e4b72a9210cd45f24603f6fa2022c5c54494035cbc3270552b22270eed104254L118-R119) [[6]](diffhunk://#diff-e4b72a9210cd45f24603f6fa2022c5c54494035cbc3270552b22270eed104254L158-R158)

**Sorting and comparison logic:**

* Modified sorting and comparison logic for runs to work with integer nanosecond timestamps instead of datetime objects, ensuring correct ordering (newest first). [[1]](diffhunk://#diff-e4b72a9210cd45f24603f6fa2022c5c54494035cbc3270552b22270eed104254L209-R209) [[2]](diffhunk://#diff-e4b72a9210cd45f24603f6fa2022c5c54494035cbc3270552b22270eed104254L232-R232) [[3]](diffhunk://#diff-2732cd360b18624fcc3df08e6a1f652a4c03c15558414ff0b01432a7479096e0L165-R165) [[4]](diffhunk://#diff-2732cd360b18624fcc3df08e6a1f652a4c03c15558414ff0b01432a7479096e0L218-R219) [[5]](diffhunk://#diff-2732cd360b18624fcc3df08e6a1f652a4c03c15558414ff0b01432a7479096e0L357-R357)

**Test updates:**

* Updated all relevant tests in Python and Go to expect and validate integer nanosecond timestamps, including type checks, comparisons, and time difference calculations. [[1]](diffhunk://#diff-732a3dc668689370d7aff52cb432fbf3e6c29daa65492b670e996a63d7a3ec9eL170-R176) [[2]](diffhunk://#diff-732a3dc668689370d7aff52cb432fbf3e6c29daa65492b670e996a63d7a3ec9eL228-R234) [[3]](diffhunk://#diff-732a3dc668689370d7aff52cb432fbf3e6c29daa65492b670e996a63d7a3ec9eL269-R281) [[4]](diffhunk://#diff-732a3dc668689370d7aff52cb432fbf3e6c29daa65492b670e996a63d7a3ec9eL332-R332) [[5]](diffhunk://#diff-732a3dc668689370d7aff52cb432fbf3e6c29daa65492b670e996a63d7a3ec9eL374-R380) [[6]](diffhunk://#diff-29a99b9020f9c648a9c4dd00030b53ad32bed8bd8babe513ba1ef291059092f7L426-R427) [[7]](diffhunk://#diff-4578cad8acb43a99d68676e0138f157a2a9e92db170554422b4700a9016c9f9eL27-R28) [[8]](diffhunk://#diff-4578cad8acb43a99d68676e0138f157a2a9e92db170554422b4700a9016c9f9eL54-R54) [[9]](diffhunk://#diff-2732cd360b18624fcc3df08e6a1f652a4c03c15558414ff0b01432a7479096e0L36-R37) [[10]](diffhunk://#diff-2732cd360b18624fcc3df08e6a1f652a4c03c15558414ff0b01432a7479096e0L79-R79) [[11]](diffhunk://#diff-2732cd360b18624fcc3df08e6a1f652a4c03c15558414ff0b01432a7479096e0L218-R219) [[12]](diffhunk://#diff-2732cd360b18624fcc3df08e6a1f652a4c03c15558414ff0b01432a7479096e0L357-R357) [[13]](diffhunk://#diff-bb24ad9775ab566856a672d86b7da7481250dac42d0ff238541d1c8f72441643L33-R37)

**Dependency and import clean-up:**

* Removed unused `datetime` imports and replaced them with `time` where appropriate, reflecting the new approach. [[1]](diffhunk://#diff-6a336230783aebcdf213f14e3c6628fe4b4c705e8e65a7367e072ea77836b684R6-L7) [[2]](diffhunk://#diff-816c3cc6365eaa441c6260b23181bba78cbe7d1b70d4a26b3bad474f41eb46f1L7-R7) [[3]](diffhunk://#diff-1da1de85df3821e78497f04cd85cd4419c3743aa5236aa8880cc671bf63817b4R6-L7)

These changes ensure that all components use a consistent, language-agnostic timestamp format, making data interchange and storage more robust.