### PR TITLE
feat: add debug argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 
 .cursor/
 .cursor.md
+
+CLAUDE.md
+.DS_Store

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -72,6 +72,7 @@ def mock_load_class():
     """
     with patch("worker.policy.runner.load_class") as mock_load:
         mock_backend_class = MagicMock(spec=Backend)
+        mock_backend_class.__name__ = "MockBackend"
         mock_load.return_value = mock_backend_class
         yield mock_load
 

--- a/worker/tests/test_main.py
+++ b/worker/tests/test_main.py
@@ -182,3 +182,53 @@ def test_resolve_env_var_returns_original(monkeypatch):
     monkeypatch.delenv("NOT_DEFINED", raising=False)
     assert resolve_env_var("plain-value") == "plain-value"
     assert resolve_env_var("${NOT_DEFINED}") == "${NOT_DEFINED}"
+
+
+def test_main_with_debug_flag(mock_parse_args, mock_uvicorn_run, mock_diode_client):
+    """Test main with --debug flag sets application log level to DEBUG."""
+    mock_parse_args.return_value.debug = True
+    mock_parse_args.return_value.dry_run = False
+    mock_parse_args.return_value.diode_target = "localhost:8081"
+    mock_parse_args.return_value.diode_client_id = "test-id"
+    mock_parse_args.return_value.diode_client_secret = "test-secret"
+    mock_parse_args.return_value.diode_app_name_prefix = None
+    mock_parse_args.return_value.dry_run_output_dir = None
+    mock_parse_args.return_value.host = "0.0.0.0"
+    mock_parse_args.return_value.port = 8071
+    mock_parse_args.return_value.otel_endpoint = None
+
+    import logging
+    with patch.object(sys, "exit", side_effect=Exception("Test Exit")):
+        try:
+            main()
+        except Exception as e:
+            assert str(e) == "Test Exit"
+
+    # Verify system log level is DEBUG
+    root_logger = logging.getLogger()
+    assert root_logger.level == logging.DEBUG
+
+
+def test_main_without_debug_flag(mock_parse_args, mock_uvicorn_run, mock_diode_client):
+    """Test main without --debug flag - application uses INFO, uvicorn stays at INFO."""
+    mock_parse_args.return_value.debug = False
+    mock_parse_args.return_value.dry_run = False
+    mock_parse_args.return_value.diode_target = "localhost:8081"
+    mock_parse_args.return_value.diode_client_id = "test-id"
+    mock_parse_args.return_value.diode_client_secret = "test-secret"
+    mock_parse_args.return_value.diode_app_name_prefix = None
+    mock_parse_args.return_value.dry_run_output_dir = None
+    mock_parse_args.return_value.host = "0.0.0.0"
+    mock_parse_args.return_value.port = 8071
+    mock_parse_args.return_value.otel_endpoint = None
+
+    import logging
+    with patch.object(sys, "exit", side_effect=Exception("Test Exit")):
+        try:
+            main()
+        except Exception as e:
+            assert str(e) == "Test Exit"
+
+    # Verify system log level is INFO
+    root_logger = logging.getLogger()
+    assert root_logger.level == logging.INFO

--- a/worker/tests/test_main.py
+++ b/worker/tests/test_main.py
@@ -196,6 +196,7 @@ def test_main_with_debug_flag(mock_parse_args, mock_uvicorn_run, mock_diode_clie
     mock_parse_args.return_value.host = "0.0.0.0"
     mock_parse_args.return_value.port = 8071
     mock_parse_args.return_value.otel_endpoint = None
+    mock_parse_args.return_value.otel_export_period = None
 
     import logging
     with patch.object(sys, "exit", side_effect=Exception("Test Exit")):
@@ -221,6 +222,7 @@ def test_main_without_debug_flag(mock_parse_args, mock_uvicorn_run, mock_diode_c
     mock_parse_args.return_value.host = "0.0.0.0"
     mock_parse_args.return_value.port = 8071
     mock_parse_args.return_value.otel_endpoint = None
+    mock_parse_args.return_value.otel_export_period = None
 
     import logging
     with patch.object(sys, "exit", side_effect=Exception("Test Exit")):

--- a/worker/worker/main.py
+++ b/worker/worker/main.py
@@ -3,6 +3,7 @@
 """Orb Worker entry point."""
 
 import argparse
+import logging
 import os
 import sys
 
@@ -129,8 +130,26 @@ def main():
         required=False,
     )
 
+    parser.add_argument(
+        "--debug",
+        help="Enable debug logging",
+        action="store_true",
+        required=False,
+    )
+
     try:
         args = parser.parse_args()
+
+        log_level = logging.DEBUG if args.debug else logging.INFO
+        logging.basicConfig(
+            level=log_level,
+            format='%(levelname)s: %(name)s: %(message)s',
+            force=True,
+        )
+        logger = logging.getLogger(__name__)
+        if args.debug:
+            logger.debug("Debug logging enabled")
+
         if not args.dry_run:
             missing = [
                 name

--- a/worker/worker/metrics.py
+++ b/worker/worker/metrics.py
@@ -14,8 +14,6 @@ from opentelemetry.sdk.metrics.export import (
 
 from worker.version import version_semver
 
-# Set up logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Global variables to store the provider and meter

--- a/worker/worker/policy/manager.py
+++ b/worker/worker/policy/manager.py
@@ -11,8 +11,6 @@ from worker.models import DiodeConfig, Policy, PolicyRequest
 from worker.policy.run import RunStore
 from worker.policy.runner import PolicyRunner
 
-# Set up logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -78,6 +76,7 @@ class PolicyManager:
             raise ValueError(f"policy '{name}' already exists")
 
         runner = PolicyRunner()
+        logger.debug(f"Starting policy '{name}' with package: {policy.config.package}")
         runner.setup(name, self.config, policy, self.run_store)
         self.loaded_modules.add(policy.config.package)
         self.runners[name] = runner

--- a/worker/worker/policy/manager.py
+++ b/worker/worker/policy/manager.py
@@ -76,7 +76,6 @@ class PolicyManager:
             raise ValueError(f"policy '{name}' already exists")
 
         runner = PolicyRunner()
-        logger.debug(f"Starting policy '{name}' with package: {policy.config.package}")
         runner.setup(name, self.config, policy, self.run_store)
         self.loaded_modules.add(policy.config.package)
         self.runners[name] = runner

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -22,8 +22,6 @@ from worker.metrics import get_metric
 from worker.models import DiodeConfig, Policy, Status
 from worker.policy.run import RunStatus, RunStore
 
-# Set up logging
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -57,8 +55,12 @@ class PolicyRunner:
         policy.config.package = policy.config.package.replace("\r\n", "").replace(
             "\n", ""
         )
+
+        # Debug logging for backend loading
+        logger.debug(f"Loading backend class: {policy.config.package}")
         backend_class = load_class(policy.config.package)
         backend = backend_class()
+        logger.debug(f"Backend class loaded successfully: {backend_class.__name__}")
 
         metadata = backend.setup()
         app_name = (
@@ -153,8 +155,12 @@ class PolicyRunner:
         exec_start_time = time.perf_counter()
         entity_count = 0
         try:
+            logger.debug(f"Policy {self.name}: Starting backend execution")
             entities = backend.run(self.name, policy)
+            elapsed = time.perf_counter() - exec_start_time
+            logger.debug(f"Policy {self.name}: Backend execution completed in {elapsed:.3f} seconds")
             entity_count = len(entities)
+
             metadata = {
                 "policy_name": self.name,
                 "worker_backend": self.metadata.name,


### PR DESCRIPTION
## description
Add optional debug flag that sets the root logger level to DEBUG.

## testing
- added unit tests
- tested locally

## notes
- unit tests were failing due to mock missing dunder field __name__
- relate to [orb-agent #275](https://github.com/netboxlabs/orb-agent/pull/275)