### PR TITLE
bump timeout and default speed, fixes #270

### DIFF
--- a/network-discovery/README.md
+++ b/network-discovery/README.md
@@ -46,7 +46,7 @@ policies:
   network_1:
     config:
       schedule: "* * * * *" #Cron expression
-      timeout: 5 #default 2 minutes
+      timeout: 10 #default 5 minutes
     scope:
       targets: [192.168.1.0/24] # REQUIRED param
       fast_mode: True # -F 
@@ -73,12 +73,12 @@ build/network-discovery --diode-target grpc://192.168.31.114:8080/diode  --diode
 ```
 
 ### ⚠️ Warning
-Be **AWARE** that executing a policy with only targets defined is equivalent to running `nmap <targets>`, which in turn is the same as executing `nmap -sS -p1-1000 --open -T3 <target>`:
+Be **AWARE** that executing a policy with only targets defined is equivalent to running `nmap <targets>`, which in turn is the same as executing `nmap -sS -p1-1000 --open -T4 <target>`:
 
 - `-sS` → SYN scan (stealth scan, requires root privileges)
 - `-p1-1000` → Scans the top 1000 most common ports
 - `--open` → Only shows open ports
-- `-T3` → Uses the default timing template (T3 is the standard speed)
+- `-T4` → Uses the agressive timing template
 
 ### Docker Image
 device-discovery can be build and run using docker:

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -25,7 +25,7 @@ type contextKey string
 // Define the policy key
 const (
 	policyKey      contextKey = "policy"
-	defaultTimeout            = 2 * time.Minute
+	defaultTimeout            = 5 * time.Minute
 )
 
 // targetInfo stores information about each target
@@ -181,6 +181,9 @@ func (r *Runner) run() {
 
 	if r.scope.Timing != nil {
 		options = append(options, nmap.WithTimingTemplate(nmap.Timing(*r.scope.Timing)))
+	} else {
+		// Default to -T4 (aggressive) timing template
+		options = append(options, nmap.WithTimingTemplate(nmap.Timing(4)))
 	}
 
 	if r.scope.TopPorts != nil {


### PR DESCRIPTION
increases the network-discovery default timeout from 2 minutes to 5, and the default speed from -T3 to -T4