### PR TITLE
fix: proper error out policy timeout for snmp discovery

### DIFF
--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -373,6 +373,9 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 		oids mapping.ObjectIDValueMap
 		err  error
 	}
+	// The buffered channel ensures the goroutine can always send its result and exit,
+	// even if we have already returned due to context cancellation. The goroutine is
+	// bounded by snmpTimeout (set on the SNMP client), so it is not a permanent leak.
 	resultCh := make(chan walkResult, 1)
 	go func() {
 		oids, err := host.Walk(objectIDs)

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -86,6 +86,9 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	if runner.snmpProbeTimeout == 0 {
 		runner.snmpProbeTimeout = defaultSNMPProbeTimeout
 	}
+	if runner.timeout <= runner.snmpTimeout {
+		return nil, fmt.Errorf("policy timeout (%s) must be greater than snmp_timeout (%s)", runner.timeout, runner.snmpTimeout)
+	}
 	runner.ctx = context.WithValue(ctx, policyKey, name)
 	runner.scope = policy.Scope
 	runner.config = policy.Config
@@ -295,7 +298,12 @@ func (r *Runner) runWithMetadata(target config.Target, parentTarget string) {
 	ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
 	defer cancel()
 
-	entities := r.queryTarget(target)
+	entities, err := r.queryTarget(ctx, target)
+	if err != nil {
+		r.logger.Error("error querying target", "host", target.Host, "error", err, "policy", policyName)
+		r.runStore.UpdateRun(policyName, targetHost, targetPort, run.ID, RunStatusFailed, err, 0)
+		return
+	}
 	r.logger.Info("SNMP crawl complete", "host", target.Host, "policy", policyName, "entityCount", len(entities))
 
 	if len(entities) == 0 {
@@ -307,7 +315,7 @@ func (r *Runner) runWithMetadata(target config.Target, parentTarget string) {
 
 	r.logEntitiesForIngestion(entities)
 
-	resp, err := r.client.Ingest(ctx, entities, diode.WithIngestMetadata(diode.Metadata{
+	resp, err := r.client.Ingest(r.ctx, entities, diode.WithIngestMetadata(diode.Metadata{
 		"policy_name": policyName,
 		"run_id":      run.ID,
 	}))
@@ -330,18 +338,20 @@ func (r *Runner) logEntitiesForIngestion(entities []diode.Entity) {
 	}
 }
 
-func (r *Runner) queryTarget(target config.Target) []diode.Entity {
+func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode.Entity, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
 	targetDefaults := r.resolveTargetDefaults(target)
 
 	mappingConfig, err := mapping.NewConfig(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup, targetDefaults)
 	if err != nil {
 		r.logger.Error("Error creating mapping config", "error", err)
-		return make([]diode.Entity, 0)
+		return nil, err
 	}
 	objectIDs := mappingConfig.ObjectIDs()
-	r.logger.Info("Querying target", "target", target, "objectCount", len(objectIDs))
-
-	entities := make([]diode.Entity, 0)
+	r.logger.Info("Querying target", "host", target.Host, "port", target.Port, "objectCount", len(objectIDs))
 
 	mapper := mapping.NewObjectIDMapper(mappingConfig, r.logger, targetDefaults)
 	policyName := r.ctx.Value(policyKey).(string)
@@ -358,19 +368,41 @@ func (r *Runner) queryTarget(target config.Target) []diode.Entity {
 	auth := r.resolveTargetAuthentication(target)
 
 	host := snmp.NewHost(target.Host, target.Port, r.config.Retries, r.snmpTimeout, auth, r.logger, r.ClientFactory)
-	oids, err := host.Walk(objectIDs)
-	if err != nil {
-		r.logger.Warn("Error crawling host", "host", target.Host, "error", err)
-		// Track failed discovery
+
+	type walkResult struct {
+		oids mapping.ObjectIDValueMap
+		err  error
+	}
+	resultCh := make(chan walkResult, 1)
+	go func() {
+		oids, err := host.Walk(objectIDs)
+		resultCh <- walkResult{oids, err}
+	}()
+
+	var oids mapping.ObjectIDValueMap
+	select {
+	case <-ctx.Done():
 		if rMetric := metrics.GetDiscoveryFailure(); rMetric != nil {
-			policyName := r.ctx.Value(policyKey).(string)
 			rMetric.Add(r.ctx, 1,
 				metric.WithAttributes(
 					attribute.String("policy", policyName),
-					attribute.String("error", err.Error()),
+					attribute.String("error", ctx.Err().Error()),
 				))
 		}
-		return entities
+		return nil, ctx.Err()
+	case res := <-resultCh:
+		if res.err != nil {
+			r.logger.Warn("Error crawling host", "host", target.Host, "error", res.err)
+			if rMetric := metrics.GetDiscoveryFailure(); rMetric != nil {
+				rMetric.Add(r.ctx, 1,
+					metric.WithAttributes(
+						attribute.String("policy", policyName),
+						attribute.String("error", res.err.Error()),
+					))
+			}
+			return nil, res.err
+		}
+		oids = res.oids
 	}
 
 	// Track successful discovery
@@ -387,6 +419,7 @@ func (r *Runner) queryTarget(target config.Target) []diode.Entity {
 				attribute.String("policy", policyName)))
 	}
 
+	entities := make([]diode.Entity, 0)
 	entitiesForTarget := mapper.MapObjectIDsToEntity(oids)
 	entities = append(entities, entitiesForTarget...)
 
@@ -397,7 +430,7 @@ func (r *Runner) queryTarget(target config.Target) []diode.Entity {
 				attribute.String("policy", policyName)))
 	}
 
-	return entities
+	return entities, nil
 }
 
 func (r *Runner) expandTargetRanges(configuredTargets []config.Target) []expandedTargetGroup {

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -16,6 +16,22 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// slowWalker blocks in Connect until done is closed, simulating a long-running SNMP operation.
+type slowWalker struct {
+	done <-chan struct{}
+}
+
+func (s *slowWalker) Connect() error {
+	<-s.done
+	return errors.New("unblocked")
+}
+
+func (s *slowWalker) Walk(_ string, _ int) (map[string]snmp.PDU, error) {
+	return nil, nil
+}
+
+func (s *slowWalker) Close() error { return nil }
+
 type testWalker struct {
 	connectErr     error
 	walkErr        error
@@ -206,4 +222,81 @@ func TestRunScanSchedulesResponsiveTargets(t *testing.T) {
 	assert.Equal(t, "192.168.1.0/24", runs[0].Metadata["target"])
 	assert.Equal(t, "161", runs[0].Metadata["port"])
 	assert.Equal(t, RunStatusCompleted, runs[0].Status)
+}
+
+func queryTargetRunner(clientFactory snmp.ClientFactory, mappingEntries []config.MappingEntry) *Runner {
+	return &Runner{
+		ctx:           context.WithValue(context.Background(), policyKey, "test-policy"),
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		mappingConfig: &config.Mapping{Entries: mappingEntries},
+		scope:         config.Scope{Authentication: config.Authentication{}},
+		snmpTimeout:   time.Second,
+		ClientFactory: clientFactory,
+	}
+}
+
+func TestQueryTargetContextAlreadyCanceled(t *testing.T) {
+	runner := queryTargetRunner(snmp.NewFakeSNMPWalker, nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	entities, err := runner.queryTarget(ctx, config.Target{Host: "127.0.0.1", Port: 161})
+	assert.Nil(t, entities)
+	assert.ErrorIs(t, err, context.Canceled)
+}
+
+func TestQueryTargetContextTimeout(t *testing.T) {
+	done := make(chan struct{})
+	defer close(done)
+
+	runner := queryTargetRunner(func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return &slowWalker{done: done}, nil
+	}, nil)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	entities, err := runner.queryTarget(ctx, config.Target{Host: "127.0.0.1", Port: 161})
+	assert.Nil(t, entities)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestQueryTargetWalkError(t *testing.T) {
+	walkErr := errors.New("snmp walk failed")
+	entries := []config.MappingEntry{
+		{
+			OID:    "iso.3.6.1.2.1.2.2.1",
+			Entity: "interface",
+			Field:  "_id",
+			MappingEntries: []config.MappingEntry{
+				{OID: "iso.3.6.1.2.1.2.2.1.2", Entity: "interface", Field: "name"},
+			},
+		},
+	}
+	runner := queryTargetRunner(func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return &testWalker{walkErr: walkErr}, nil
+	}, entries)
+
+	entities, err := runner.queryTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161})
+	assert.Nil(t, entities)
+	assert.ErrorIs(t, err, walkErr)
+}
+
+func TestQueryTargetSuccess(t *testing.T) {
+	entries := []config.MappingEntry{
+		{
+			OID:    "iso.3.6.1.2.1.2.2.1",
+			Entity: "interface",
+			Field:  "_id",
+			MappingEntries: []config.MappingEntry{
+				{OID: "iso.3.6.1.2.1.2.2.1.2", Entity: "interface", Field: "name"},
+			},
+		},
+	}
+	runner := queryTargetRunner(snmp.NewFakeSNMPWalker, entries)
+
+	entities, err := runner.queryTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161})
+	require.NoError(t, err)
+	assert.NotEmpty(t, entities)
 }

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -230,6 +230,7 @@ func queryTargetRunner(clientFactory snmp.ClientFactory, mappingEntries []config
 		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
 		mappingConfig: &config.Mapping{Entries: mappingEntries},
 		scope:         config.Scope{Authentication: config.Authentication{}},
+		config:        config.PolicyConfig{Retries: 0, Defaults: config.Defaults{}},
 		snmpTimeout:   time.Second,
 		ClientFactory: clientFactory,
 	}

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -104,6 +104,38 @@ func TestNewRunner(t *testing.T) {
 	assert.NoError(t, err, "policy.NewRunner should not return an error")
 }
 
+func TestNewRunnerTimeoutNotGreaterThanSNMPTimeout(t *testing.T) {
+	setupTestMetrics(t)
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+	mockClient := new(MockDiodeClient)
+	tests := []struct {
+		desc        string
+		timeout     int // seconds
+		snmpTimeout int // seconds
+	}{
+		{desc: "timeout equal to snmp_timeout", timeout: 5, snmpTimeout: 5},
+		{desc: "timeout less than snmp_timeout", timeout: 1, snmpTimeout: 5},
+		{desc: "timeout less than default snmp_timeout", timeout: 1, snmpTimeout: 0}, // 0 uses default 5s
+	}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			policyConfig := config.Policy{
+				Config: config.PolicyConfig{
+					Timeout:     tt.timeout,
+					SNMPTimeout: tt.snmpTimeout,
+				},
+				Scope: config.Scope{
+					Targets: []config.Target{{Host: "localhost", Port: 161}},
+				},
+			}
+			runStore := policy.NewRunStore()
+			runner, err := policy.NewRunner(context.Background(), logger, "test-policy", policyConfig, mockClient, snmp.NewFakeSNMPWalker, &config.Mapping{}, nil, nil, runStore)
+			assert.Error(t, err)
+			assert.Nil(t, runner)
+		})
+	}
+}
+
 func TestNewRunnerInvalidSchedule(t *testing.T) {
 	setupTestMetrics(t)
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))


### PR DESCRIPTION
This pull request introduces significant improvements to error handling and context management in the SNMP discovery policy runner. The changes ensure that timeouts and cancellations are respected during SNMP operations, and that errors are surfaced and handled properly throughout the runner and its tests. Additionally, new tests have been added to validate these behaviors.

### Error handling and context management improvements

* Refactored the `queryTarget` method in `runner.go` to accept a `context.Context`, return errors, and handle context cancellation and timeouts during SNMP operations. This includes running SNMP walks in a goroutine, using a channel to capture results, and properly tracking failed and successful discoveries via metrics. [[1]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL333-R354) [[2]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdR371-R405) [[3]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdR422) [[4]](diffhunk://#diff-f0a20465993d1870b397eaebe9560ece5bad63ec7978b8e7c343a215ccf71ecdL400-R433)
* Updated the `runWithMetadata` method to handle errors returned from `queryTarget`, logging failures and updating run status accordingly.

### Validation enhancements

* Added a check in `NewRunner` to ensure that the policy timeout is greater than the SNMP timeout, returning an error if not.

### Testing improvements

* Added new tests in `runner_internal_test.go` to verify `queryTarget` behavior with context cancellation, timeout, SNMP walk errors, and successful execution. Introduced a `slowWalker` test helper to simulate long-running SNMP operations. [[1]](diffhunk://#diff-33c04d392e3432ddc3bb56e432a37e8629d405e3cbde0e49c854a70603f69820R19-R34) [[2]](diffhunk://#diff-33c04d392e3432ddc3bb56e432a37e8629d405e3cbde0e49c854a70603f69820R226-R302)
* Added a test in `runner_test.go` to validate that `NewRunner` returns an error when the policy timeout is not greater than the SNMP timeout.