### PR TITLE
fix: rename invalid interface type in snmp discovery

### DIFF
--- a/snmp-discovery/mapping/interface_types.go
+++ b/snmp-discovery/mapping/interface_types.go
@@ -175,7 +175,7 @@ func getEthernetInterfaceType(speed *int64) string {
 
 	// 10 Mbps Ethernet
 	if speedMbps <= 10 {
-		return "10base-t"
+		return "other"
 	}
 	// 100 Mbps FastEthernet
 	if speedMbps <= 100 {

--- a/snmp-discovery/mapping/interface_types_test.go
+++ b/snmp-discovery/mapping/interface_types_test.go
@@ -215,8 +215,8 @@ var tests = []struct {
 		name:                 "ethernetCsmacd 10Mbps",
 		ifType:               "6",
 		defaultInterfaceType: "",
-		expectedNetboxType:   "10base-t",
-		description:          "ethernetCsmacd with 10Mbps should map to 10base-t",
+		expectedNetboxType:   "other",
+		description:          "ethernetCsmacd with 10Mbps should map to other",
 		speed:                int64Ptr(10000),
 	},
 	{
@@ -303,8 +303,8 @@ var tests = []struct {
 		name:                 "ethernetCsmacd 1Mbps",
 		ifType:               "6",
 		defaultInterfaceType: "",
-		expectedNetboxType:   "10base-t",
-		description:          "ethernetCsmacd with 1Mbps should map to 10base-t",
+		expectedNetboxType:   "other",
+		description:          "ethernetCsmacd with 1Mbps should map to other",
 		speed:                int64Ptr(1000),
 	},
 	{

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -593,7 +593,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			defaults: nil,
 			expectedEntity: &diode.Interface{
 				Speed: int64Ptr(10000),
-				Type:  mapping.StringPtr("10base-t"),
+				Type:  mapping.StringPtr("other"),
 			},
 			expectError: false,
 		},


### PR DESCRIPTION
This pull request updates the mapping logic for low-speed Ethernet interfaces, changing their classification from `"10base-t"` to `"other"`. The changes ensure that interfaces with speeds of 10 Mbps or lower are now consistently mapped to `"other"` instead of `"10base-t"` across the codebase and related tests.

Mapping logic update:

* Changed the return value in `getEthernetInterfaceType` for speeds of 10 Mbps or lower from `"10base-t"` to `"other"` in `interface_types.go`.

Test updates for new mapping:

* Updated test cases in `interface_types_test.go` to expect `"other"` for 10 Mbps and 1 Mbps Ethernet speeds, including descriptions. [[1]](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acL218-R219) [[2]](diffhunk://#diff-4db9e97486ea67d0446039deeff38aa2db961ed6e81d973c370f255927a922acL306-R307)
* Modified the expected interface type in `mappers_test.go` for a 10 Mbps Ethernet interface from `"10base-t"` to `"other"`.