### PR TITLE
chore: corrects snmp lookup extensions path in docs

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -409,7 +409,7 @@ You can create custom device lookup files for your specific hardware or to overr
 ```bash
 # Clone the repository to get device lookup files
 git clone https://github.com/netboxlabs/orb-discovery.git
-cd orb-discovery/snmp-discovery/lookup_extensions/
+cd orb-discovery/snmp-discovery/data/lookup_extensions/
 
 # Copy the files to your lookup extensions directory
 cp *.yaml /opt/orb/snmp-extensions/


### PR DESCRIPTION
Corrects the path for the snmp lookup extensions directory