### PR TITLE
fix: bump Go from 1.24.6 to 1.25.4 for network-discovery and snmp-discovery

### DIFF
--- a/.github/workflows/network-discovery-lint.yaml
+++ b/.github/workflows/network-discovery-lint.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           check-latest: true
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0

--- a/.github/workflows/network-discovery-lint.yaml
+++ b/.github/workflows/network-discovery-lint.yaml
@@ -28,6 +28,6 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0
         with:
-          version: v2.1.6
+          version: v2.11.3
           working-directory: network-discovery
           args: --config ../.github/golangci.yaml

--- a/.github/workflows/network-discovery-tests.yaml
+++ b/.github/workflows/network-discovery-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           check-latest: true
       - name: Run go build
         run: go build ./...

--- a/.github/workflows/snmp-discovery-lint.yaml
+++ b/.github/workflows/snmp-discovery-lint.yaml
@@ -28,6 +28,6 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0
         with:
-          version: v2.1.6
+          version: v2.11.3
           working-directory: snmp-discovery
           args: --config ../.github/golangci.yaml

--- a/.github/workflows/snmp-discovery-lint.yaml
+++ b/.github/workflows/snmp-discovery-lint.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           check-latest: true
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0

--- a/.github/workflows/snmp-discovery-tests.yaml
+++ b/.github/workflows/snmp-discovery-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.x'
+          go-version: '1.25.x'
           check-latest: true
       - name: Run go build
         run: go build ./...

--- a/network-discovery/go.mod
+++ b/network-discovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/orb-discovery/network-discovery
 
-go 1.24.6
+go 1.25.4
 
 require (
 	github.com/Ullaakut/nmap/v3 v3.0.4

--- a/snmp-discovery/go.mod
+++ b/snmp-discovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/orb-discovery/snmp-discovery
 
-go 1.24.6
+go 1.25.4
 
 require (
 	github.com/gin-gonic/gin v1.10.0


### PR DESCRIPTION
## Summary

- Bumps Go version from `1.24.6` to `1.25.4` in both `network-discovery` and `snmp-discovery` modules
- Fixes Go stdlib vulnerabilities embedded in the compiled binaries:
  - **CVE-2026-25679** (MEDIUM): Incorrect parsing of IPv6 host literals in `net/url`
  - **CVE-2026-27142** (MEDIUM): URLs in meta content attribute not escaped in `html/template`
  - **CVE-2026-27139** (LOW): `os.FileInfo` can escape from a `Root`

### Rebuild note

The published discovery images were last built with Go 1.24.6 and need to be rebuilt after this merge to pick up the stdlib fixes. The OTel SDK is already at v1.40.0 in source but published images still carry v1.38.0 (CVE-2026-24051, HIGH) — rebuilding will resolve that as well.

## Test plan

- [ ] `network-discovery` and `snmp-discovery` lint/test workflows pass
- [ ] After merge, trigger release builds for both discovery images