### PR TITLE
fix: pin wheel>=0.46.2 to address CVE-2026-24049

### DIFF
--- a/device-discovery/pyproject.toml
+++ b/device-discovery/pyproject.toml
@@ -58,7 +58,7 @@ package-data = {"device_discovery" = ["**/*", "policy/**"]}
 exclude-package-data = {device_discovery = ["tests/*"]}
 
 [build-system]
-requires = ["setuptools>=43.0.0", "wheel"]
+requires = ["setuptools>=43.0.0", "wheel>=0.46.2"]
 build-backend = "setuptools.build_meta"
 
 

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -57,7 +57,7 @@ package-data = {"worker" = ["**/*", "policy/**"]}
 exclude-package-data = {worker = ["tests/*"]}
 
 [build-system]
-requires = ["setuptools>=43.0.0", "wheel"]
+requires = ["setuptools>=43.0.0", "wheel>=0.46.2"]
 build-backend = "setuptools.build_meta"
 
 


### PR DESCRIPTION
## Summary

Pins the `wheel` build dependency to `>=0.46.2` in both `device-discovery` and `worker` packages. The previous unpinned requirement resolved to `0.45.1` which is vulnerable to privilege escalation via malicious wheel archives (CVE-2026-24049, HIGH).

## Changes

- `device-discovery/pyproject.toml`: `wheel` → `wheel>=0.46.2` in `[build-system].requires`
- `worker/pyproject.toml`: `wheel` → `wheel>=0.46.2` in `[build-system].requires`

## Test plan

- [ ] Existing tests pass (no functional change — just a version floor on a build dependency)
