### PR TITLE
fix: bump Go from 1.24 to 1.25 in Dockerfiles and release workflows

### DIFF
--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -14,7 +14,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   APP_NAME: network-discovery
 
 permissions:

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -14,7 +14,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   APP_NAME: snmp-discovery
 
 permissions:

--- a/network-discovery/docker/Dockerfile
+++ b/network-discovery/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 

--- a/snmp-discovery/docker/Dockerfile
+++ b/snmp-discovery/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 


### PR DESCRIPTION
## Summary

The `go.mod` files were bumped to Go 1.25.4 in #282 but the Dockerfiles and release workflows still referenced Go 1.24, causing release builds to fail with:

```
go.mod requires go >= 1.25.4 (running go 1.24.13; GOTOOLCHAIN=local)
```

### Files updated

- `network-discovery/docker/Dockerfile`: `GO_VERSION=1.24` → `1.25`
- `snmp-discovery/docker/Dockerfile`: `GO_VERSION=1.24` → `1.25`
- `.github/workflows/network-discovery-release.yaml`: `GO_VERSION: '1.24'` → `'1.25'`
- `.github/workflows/snmp-discovery-release.yaml`: `GO_VERSION: '1.24'` → `'1.25'`

Fixes failed release runs:
- https://github.com/netboxlabs/orb-discovery/actions/runs/23001093190
- https://github.com/netboxlabs/orb-discovery/actions/runs/23001093206

## Test plan

- [ ] PR checks pass
- [ ] After merge to develop and re-merge to release, release builds succeed
