### PR TITLE
release: merge develop into release (Go version fix)

### DIFF
--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -14,7 +14,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   APP_NAME: network-discovery
 
 permissions:

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -14,7 +14,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   APP_NAME: snmp-discovery
 
 permissions:

--- a/network-discovery/docker/Dockerfile
+++ b/network-discovery/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 

--- a/snmp-discovery/docker/Dockerfile
+++ b/snmp-discovery/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.24
+ARG GO_VERSION=1.25
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 


### PR DESCRIPTION
## Summary

Merge `develop` into `release` to pick up the Go version fix in Dockerfiles and release workflows (#285).

The previous release attempt (#284) failed because the Dockerfiles and release workflows still referenced Go 1.24 while go.mod required 1.25.4. This merge includes the fix.

## Test plan

- [ ] Release workflows trigger and succeed for network-discovery and snmp-discovery