### PR TITLE
chore: standardize structured log attributes across snmp-discovery and network-discovery

### DIFF
--- a/network-discovery/cmd/main.go
+++ b/network-discovery/cmd/main.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"log/slog"
 	"os"
 	"os/signal"
 	"strings"
@@ -92,7 +91,7 @@ func main() {
 			diode.WithClientSecret(resolveEnv(*diodeClientSecret)),
 		)
 	} else {
-		logger.Debug("Initializing OTLP client")
+		logger.Debug("initializing OTLP client")
 		client, err = diode.NewOTLPClient(
 			resolveEnv(*diodeTarget),
 			producerName,
@@ -111,7 +110,7 @@ func main() {
 			logger.Error("failed to setup metrics export", "error", err)
 			os.Exit(1)
 		}
-		logger.Info("Metrics export configured", slog.String("endpoint", *otelEndpoint), slog.Int("period_seconds", *otelExportPeriod))
+		logger.Info("metrics export configured", "endpoint", *otelEndpoint, "period_seconds", *otelExportPeriod)
 	}
 
 	policyManager := policy.NewManager(ctx, logger, client)

--- a/network-discovery/metrics/metrics.go
+++ b/network-discovery/metrics/metrics.go
@@ -65,7 +65,7 @@ func GetCounter(name string, description string) metric.Int64Counter {
 	// Create the counter (error handling omitted for brevity)
 	c, err := meter.Int64Counter(name, metric.WithDescription(description))
 	if err != nil {
-		logger.Error("Error creating counter", "name", name, "error", err)
+		logger.Error("error creating counter", "name", name, "error", err)
 		return nil
 	}
 	counterCache[name] = c
@@ -85,7 +85,7 @@ func GetUpDownCounter(name string, description string) metric.Int64UpDownCounter
 	}
 	c, err := meter.Int64UpDownCounter(name, metric.WithDescription(description))
 	if err != nil {
-		logger.Error("Error creating updown counter", "name", name, "error", err)
+		logger.Error("error creating updown counter", "name", name, "error", err)
 		return nil
 	}
 	upDownCounterCache[name] = c
@@ -105,7 +105,7 @@ func GetHistogram(name string, description string) metric.Float64Histogram {
 	}
 	h, err := meter.Float64Histogram(name, metric.WithDescription(description))
 	if err != nil {
-		logger.Error("Error creating histogram", "name", name, "error", err)
+		logger.Error("error creating histogram", "name", name, "error", err)
 		return nil
 	}
 	histogramCache[name] = h
@@ -125,7 +125,7 @@ func GetGauge(name string, description string) metric.Int64Gauge {
 	}
 	g, err := meter.Int64Gauge(name, metric.WithDescription(description))
 	if err != nil {
-		logger.Error("Error creating gauge", "name", name, "error", err)
+		logger.Error("error creating gauge", "name", name, "error", err)
 		return nil
 	}
 	gaugeCache[name] = g

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -236,8 +236,8 @@ func (r *Runner) run() {
 						hasOtherScans = true
 					}
 				} else {
-					r.logger.Warn("Skipping additional TCP scan due to conflict", "skipped_scan", scanType,
-						"selected_scan", selectedTCPScan, slog.String("policy", policyName))
+					r.logger.Warn("skipping additional TCP scan due to conflict", "skipped_scan", scanType,
+						"selected_scan", selectedTCPScan, "policy", policyName)
 				}
 			} else if fn, exists := privilegedScans[scanType]; exists {
 				options = append(options, fn())
@@ -256,8 +256,8 @@ func (r *Runner) run() {
 
 	if r.scope.PingScan != nil && *r.scope.PingScan {
 		if hasOtherScans || selectedTCPScan != "" {
-			r.logger.Warn("Skipping ping scan because it is not valid with any other scan types",
-				slog.String("policy", policyName))
+			r.logger.Warn("skipping ping scan because it is not valid with any other scan types",
+				"policy", policyName)
 		} else {
 			options = append(options, nmap.WithPingScan())
 		}
@@ -268,7 +268,7 @@ func (r *Runner) run() {
 
 	scanner, err := nmap.NewScanner(ctx, options...)
 	if err != nil {
-		r.logger.Error("error creating scanner", slog.Any("error", err), slog.String("policy", policyName))
+		r.logger.Error("error creating scanner", "error", err, "policy", policyName)
 		r.runStore.UpdateRun(policyName, run.ID, RunStatusFailed, err, 0)
 		if rMetric := metrics.GetDiscoveryFailure(); rMetric != nil {
 			rMetric.Add(r.ctx, 1,
@@ -279,20 +279,20 @@ func (r *Runner) run() {
 		}
 		return
 	}
-	r.logger.Info("running scanner", slog.Any("targets", r.scope.Targets), slog.String("policy", policyName))
+	r.logger.Info("running scanner", "targets", r.scope.Targets, "policy", policyName)
 	result, warnings, err := scanner.Run()
 	if len(*warnings) > 0 {
-		r.logger.Warn("run finished with warnings", slog.String("warnings", fmt.Sprintf("%v", *warnings)))
+		r.logger.Warn("run finished with warnings", "warnings", fmt.Sprintf("%v", *warnings))
 	}
 	if err != nil {
 		if errors.Is(ctx.Err(), context.DeadlineExceeded) || errors.Is(err, context.DeadlineExceeded) {
 			r.logger.Warn("nmap scan timed out; consider increasing policy timeout",
-				slog.Duration("timeout", r.timeout),
-				slog.String("policy", policyName),
+				"timeout", r.timeout,
+				"policy", policyName,
 			)
 			err = fmt.Errorf("nmap scan timed out after %s: %w", r.timeout, err)
 		}
-		r.logger.Error("error running scanner", slog.Any("error", err), slog.String("policy", policyName))
+		r.logger.Error("error running scanner", "error", err, "policy", policyName)
 		r.runStore.UpdateRun(policyName, run.ID, RunStatusFailed, err, 0)
 		if rMetric := metrics.GetDiscoveryFailure(); rMetric != nil {
 			rMetric.Add(r.ctx, 1,
@@ -322,13 +322,13 @@ func (r *Runner) run() {
 
 	entities := make([]diode.Entity, 0, len(result.Hosts))
 	if len(result.Hosts) == 0 {
-		r.logger.Warn("discovery complete: no hosts found", slog.Any("targets", r.scope.Targets),
-			slog.String("policy", policyName))
+		r.logger.Warn("discovery complete: no hosts found", "targets", r.scope.Targets,
+			"policy", policyName)
 		// Update run status to completed even if no hosts found
 		r.runStore.UpdateRun(policyName, run.ID, RunStatusCompleted, nil, 0)
 		return
 	}
-	r.logger.Info("discovery complete", slog.Int("hosts_found", len(result.Hosts)), slog.String("policy", policyName))
+	r.logger.Info("discovery complete", "hosts_found", len(result.Hosts), "policy", policyName)
 
 	// Track discovered hosts
 	processedEntries := make(map[string]bool)
@@ -339,15 +339,15 @@ func (r *Runner) run() {
 	}
 
 	for _, host := range result.Hosts {
-		r.logger.Debug("processing host", slog.Any("host_address", host.Addresses), slog.Any("host_ports", host.Ports),
-			slog.Any("host_hostnames", host.Hostnames), slog.String("policy", policyName))
+		r.logger.Debug("processing host", "host_address", host.Addresses, "host_ports", host.Ports,
+			"host_hostnames", host.Hostnames, "policy", policyName)
 		if len(host.Addresses) == 0 {
 			continue
 		}
 
 		addr := host.Addresses[0].Addr
 		if _, exists := processedEntries[addr]; exists {
-			r.logger.Info("skipping already processed IP address", slog.String("ip_address", addr), slog.String("policy", policyName))
+			r.logger.Info("skipping already processed IP address", "ip_address", addr, "policy", policyName)
 			continue
 		}
 
@@ -431,7 +431,7 @@ func (r *Runner) run() {
 			}
 			data, err := json.Marshal(&metadata)
 			if err != nil {
-				r.logger.Error("error marshalling metadata", slog.Any("error", err), slog.String("policy", policyName))
+				r.logger.Error("error marshalling metadata", "error", err, "policy", policyName)
 			} else {
 				ip.Comments = diode.String(string(data))
 			}
@@ -445,14 +445,14 @@ func (r *Runner) run() {
 		"run_id":      run.ID,
 	}))
 	if err != nil {
-		r.logger.Error("error ingesting entities", slog.Any("error", err), slog.String("policy", policyName))
+		r.logger.Error("error ingesting entities", "error", err, "policy", policyName, "entity_count", len(entities))
 		r.runStore.UpdateRun(policyName, run.ID, RunStatusFailed, err, len(entities))
 	} else if resp != nil && resp.Errors != nil {
 		ingestErr := fmt.Errorf("ingestion errors: %v", resp.Errors)
-		r.logger.Error("error ingesting entities", slog.Any("error", resp.Errors), slog.String("policy", policyName))
+		r.logger.Error("error ingesting entities", "error", resp.Errors, "policy", policyName, "entity_count", len(entities))
 		r.runStore.UpdateRun(policyName, run.ID, RunStatusFailed, ingestErr, len(entities))
 	} else {
-		r.logger.Info("entities ingested successfully", slog.String("policy", policyName))
+		r.logger.Info("entities ingested successfully", "policy", policyName, "entity_count", len(entities))
 		r.runStore.UpdateRun(policyName, run.ID, RunStatusCompleted, nil, len(entities))
 	}
 }

--- a/snmp-discovery/cmd/main.go
+++ b/snmp-discovery/cmd/main.go
@@ -79,7 +79,7 @@ func main() {
 			diode.WithClientSecret(env.ResolveEnvOrExit(*diodeClientSecret)),
 		)
 	} else {
-		logger.Debug("Initializing OTLP client")
+		logger.Debug("initializing OTLP client")
 		client, err = diode.NewOTLPClient(
 			env.ResolveEnvOrExit(*diodeTarget),
 			producerName,
@@ -98,12 +98,12 @@ func main() {
 			logger.Error("failed to setup metrics export", "error", err)
 			os.Exit(1)
 		}
-		logger.Info("Metrics export configured", "endpoint", *otelEndpoint, "period_seconds", *otelExportPeriod)
+		logger.Info("metrics export configured", "endpoint", *otelEndpoint, "period_seconds", *otelExportPeriod)
 	}
 
 	manufacturers, err := data.NewManufacturerLookup()
 	if err != nil {
-		logger.Error("Failed to load manufacturer lookup", "error", err)
+		logger.Error("failed to load manufacturer lookup", "error", err)
 		os.Exit(1)
 	}
 

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -96,7 +96,7 @@ func (m *IPAddressMapper) applyDefaults(entity *diode.IPAddress, defaults *confi
 
 // Map maps IP addresses to entities
 func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults) diode.Entity {
-	m.logger.Debug("Mapping values to ipAddress entity", "values", values, "mappingEntry", mappingEntry)
+	m.logger.Debug("mapping values to ipAddress entity", "values", values, "mapping_entry", mappingEntry)
 	ipAddress := diode.IPAddress{}
 
 	fieldFound := false
@@ -109,7 +109,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 		if value.Index != "" {
 			if ip := net.ParseIP(string(value.Index)); ip != nil && ip.To4() != nil {
 				extractedIP = ip.String()
-				m.logger.Debug("Extracted IP address", "field", field, "ip", extractedIP)
+				m.logger.Debug("extracted IP address", "field", field, "ip", extractedIP)
 			}
 		}
 	}
@@ -122,7 +122,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 		if value.Value != "" {
 			if ip := net.ParseIP(value.Value); ip != nil && ip.To4() != nil {
 				extractedIP = ip.String()
-				m.logger.Debug("Extracted IP address", "field", field, "ip", extractedIP)
+				m.logger.Debug("extracted IP address", "field", field, "ip", extractedIP)
 				return true
 			}
 		}
@@ -136,13 +136,13 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	}
 
 	for objectID, value := range values {
-		m.logger.Debug("Mapping value to ipAddress entity", "objectID", objectID, "value", value)
+		m.logger.Debug("mapping value to ipAddress entity", "object_id", objectID, "value", value)
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(propertyMappingEntry.OID) {
 				switch propertyMappingEntry.Field {
 				case "address":
 					if !extractIPFromValueOrIndex(value, propertyMappingEntry.Field) {
-						m.logger.Warn("Could not extract valid IP address from any field")
+						m.logger.Warn("could not extract valid IP address from any field")
 						continue
 					}
 					if ipAddress.Address != nil && strings.HasPrefix(*ipAddress.Address, "/") {
@@ -157,7 +157,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					extractIPFromIndex(value, propertyMappingEntry.Field)
 					prefixLength, err := maskToPrefixSize(value.Value)
 					if err != nil {
-						m.logger.Warn("Error converting mask to prefix size", "error", err, "value", value.Value)
+						m.logger.Warn("error converting mask to prefix size", "error", err, "value", value.Value)
 						continue
 					}
 					if ipAddress.Address == nil || *ipAddress.Address == "" {
@@ -185,7 +185,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					if propertyMappingEntry.Relationship != (config.Relationship{}) {
 						linkedEntity := entityRegistry.GetOrCreateEntity(EntityType(propertyMappingEntry.Relationship.Type), ObjectIDIndex(value.Value))
 						if linkedEntity == nil {
-							m.logger.Warn("No linked entity found while mapping assigned object", "relationship", propertyMappingEntry.Relationship)
+							m.logger.Warn("no linked entity found while mapping assigned object", "relationship", propertyMappingEntry.Relationship)
 							continue
 						}
 						// Handle relationship mapping
@@ -195,7 +195,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 						}
 					}
 				default:
-					m.logger.Warn("Unknown field", "field", mappingEntry.Field)
+					m.logger.Warn("unknown field", "field", mappingEntry.Field)
 				}
 			}
 		}
@@ -204,7 +204,7 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	// Validate the final IP/CIDR before storage
 	if ipAddress.Address != nil && *ipAddress.Address != "" {
 		if !ValidateIPv4CIDR(*ipAddress.Address) {
-			m.logger.Warn("Invalid IP/CIDR format, skipping",
+			m.logger.Warn("invalid IP/CIDR format, skipping",
 				"address", *ipAddress.Address)
 			return &diode.IPAddress{} // Empty entity won't be added
 		}
@@ -213,9 +213,9 @@ func (m *IPAddressMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	if fieldFound {
 		m.applyDefaults(&ipAddress, defaults)
 		if ipAddress.Address != nil {
-			m.logger.Debug("Successfully mapped IP address", "address", *ipAddress.Address)
+			m.logger.Debug("successfully mapped IP address", "address", *ipAddress.Address)
 		} else {
-			m.logger.Debug("Successfully mapped IP address (address field empty)")
+			m.logger.Debug("successfully mapped IP address (address field empty)")
 		}
 	}
 
@@ -341,7 +341,7 @@ func (m *InterfaceMapper) applyDefaults(entity *diode.Interface, defaults *confi
 
 // Map maps interfaces to entities
 func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults) diode.Entity {
-	m.logger.Debug("Mapping values to interface entity", "values", values, "mappingEntry", mappingEntry)
+	m.logger.Debug("mapping values to interface entity", "values", values, "mapping_entry", mappingEntry)
 	interfaceEntity := entityRegistry.GetOrCreateEntity(InterfaceEntityType, getIndex(values)).(*diode.Interface)
 
 	fieldFound := false
@@ -359,7 +359,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 		value := values[objectID]
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(propertyMappingEntry.OID) {
-				m.logger.Debug("Mapping value to interface entity with mapper", "objectID", objectID, "value", value)
+				m.logger.Debug("mapping value to interface entity with mapper", "object_id", objectID, "value", value)
 				switch propertyMappingEntry.Field {
 				case "name":
 					interfaceEntity.Name = &value.Value
@@ -378,44 +378,44 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					fieldFound = true
 				case "speed":
 					if value.Value == "" {
-						m.logger.Debug("Speed is empty", "value", value.Value)
+						m.logger.Debug("speed is empty", "value", value.Value)
 						continue
 					}
 					speed, err := strconv.Atoi(value.Value)
 					if err != nil {
-						m.logger.Warn("Error converting speed to int", "error", err, "value", value.Value)
+						m.logger.Warn("error converting speed to int", "error", err, "value", value.Value)
 						continue
 					}
 					bitsPerSecond := int64(speed)
 					kiloBitsPerSecond := bitsPerSecond / 1000
 					// Check if speed is within valid range (0 to 2147483647 inclusive)
 					if kiloBitsPerSecond < minInterfaceSpeed || kiloBitsPerSecond > maxInterfaceSpeed {
-						m.logger.Warn("Interface speed is outside valid range (0-2147483647)", "speed", speed, "value",
-							value.Value, "mappingID", propertyMappingEntry.OID, "interfaceIndex", objectID)
+						m.logger.Warn("interface speed is outside valid range (0-2147483647)", "speed", speed, "value",
+							value.Value, "mapping_id", propertyMappingEntry.OID, "interface_index", objectID)
 						continue
 					}
 					if interfaceEntity.Speed != nil && *interfaceEntity.Speed > 0 {
-						m.logger.Debug("Interface speed already set, skipping", "existingSpeed", *interfaceEntity.Speed,
-							"newSpeed", kiloBitsPerSecond, "interfaceIndex", objectID)
+						m.logger.Debug("interface speed already set, skipping", "existing_speed", *interfaceEntity.Speed,
+							"new_speed", kiloBitsPerSecond, "interface_index", objectID)
 						continue
 					}
 					interfaceEntity.Speed = &kiloBitsPerSecond
 					fieldFound = true
 				case "highSpeed":
 					if value.Value == "" {
-						m.logger.Debug("highSpeed is empty", "value", value.Value)
+						m.logger.Debug("high_speed is empty", "value", value.Value)
 						continue
 					}
 					highSpeed, err := strconv.Atoi(value.Value)
 					if err != nil {
-						m.logger.Warn("Error converting highSpeed to int", "error", err, "value", value.Value)
+						m.logger.Warn("error converting high_speed to int", "error", err, "value", value.Value)
 						continue
 					}
 					speedMbps := int64(highSpeed)
 					// Check if highSpeed is within valid range (0 to 2147483647 inclusive)
 					if speedMbps < minInterfaceSpeed || speedMbps > maxInterfaceSpeed {
-						m.logger.Warn("Interface highSpeed is outside valid range (0-2147483647)", "highSpeed",
-							highSpeed, "value", value.Value, "mappingID", propertyMappingEntry.OID, "interfaceIndex", objectID)
+						m.logger.Warn("interface high_speed is outside valid range (0-2147483647)", "highSpeed",
+							highSpeed, "value", value.Value, "mapping_id", propertyMappingEntry.OID, "interface_index", objectID)
 						continue
 					}
 					kiloBitsPerSecond := speedMbps * 1000
@@ -428,7 +428,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					}
 					mtu, err := strconv.ParseInt(value.Value, 10, 64)
 					if err != nil {
-						m.logger.Warn("Error converting mtu to int64", "error", err, "value", value.Value)
+						m.logger.Warn("error converting mtu to int64", "error", err, "value", value.Value)
 						continue
 					}
 					if mtu == 0 {
@@ -437,8 +437,8 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					}
 					// Check if MTU is within valid range (1 to 2147483647 inclusive) and not overflowing int32
 					if mtu < minInterfaceMTU || mtu > maxInterfaceMTU {
-						m.logger.Warn("Interface MTU is outside valid range (1-2147483647) or overflows int32", "mtu", mtu,
-							"value", value.Value, "mappingID", propertyMappingEntry.OID, "interfaceIndex", objectID)
+						m.logger.Warn("interface MTU is outside valid range (1-2147483647) or overflows int32", "mtu", mtu,
+							"value", value.Value, "mapping_id", propertyMappingEntry.OID, "interface_index", objectID)
 						continue
 					}
 					mtu64 := mtu
@@ -447,7 +447,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				case "macAddress":
 					macAddress, err := m.FormatMACAddress(value.Value)
 					if err != nil {
-						m.logger.Debug("Error formatting mac address", "error", err, "value", value.Value)
+						m.logger.Debug("error formatting mac address", "error", err, "value", value.Value)
 						continue
 					}
 					interfaceEntity.PrimaryMacAddress = &diode.MACAddress{
@@ -459,7 +459,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					interfaceEntity.Enabled = &enabled
 					fieldFound = true
 				default:
-					m.logger.Warn("Unknown field", "field", propertyMappingEntry.Field)
+					m.logger.Warn("unknown field", "field", propertyMappingEntry.Field)
 				}
 			}
 		}
@@ -493,9 +493,9 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	if fieldFound {
 		m.applyDefaults(interfaceEntity, defaults)
 		if interfaceEntity.Name != nil {
-			m.logger.Debug("Successfully mapped interface", "name", *interfaceEntity.Name)
+			m.logger.Debug("successfully mapped interface", "name", *interfaceEntity.Name)
 		} else {
-			m.logger.Debug("Successfully mapped interface (name field empty)")
+			m.logger.Debug("successfully mapped interface (name field empty)")
 		}
 	}
 
@@ -531,7 +531,7 @@ func (m *InterfaceMapper) FormatMACAddress(input string) (string, error) {
 	}
 
 	output := strings.Join(parts, ":")
-	m.logger.Debug("Formatted mac address", "input", input, "output", output)
+	m.logger.Debug("formatted mac address", "input", input, "output", output)
 	return output, nil
 }
 
@@ -621,14 +621,14 @@ func NewDeviceMapper(manufacturers data.ManufacturerRetriever, deviceLookup data
 
 // Map maps devices to entities
 func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry *Entry, entityRegistry *EntityRegistry, defaults *config.Defaults) diode.Entity {
-	m.logger.Debug("Mapping values to device entity", "values", values, "mappingEntry", mappingEntry)
+	m.logger.Debug("mapping values to device entity", "values", values, "mapping_entry", mappingEntry)
 	deviceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), CurrentDeviceIndex).(*diode.Device)
 
 	fieldFound := false
 	for objectID, value := range values {
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(propertyMappingEntry.OID) {
-				m.logger.Debug("Mapping value to device entity with mapper", "objectID", objectID, "value", value, "mappingEntry", propertyMappingEntry)
+				m.logger.Debug("mapping value to device entity with mapper", "object_id", objectID, "value", value, "mapping_entry", propertyMappingEntry)
 				switch propertyMappingEntry.Field {
 				case "name":
 					deviceEntity.Name = &value.Value
@@ -643,12 +643,12 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 				case "platform":
 					manufacturerID, err := m.getManufacturerID(value.Value)
 					if err != nil {
-						m.logger.Warn("Error getting device IDs", "error", err, "value", value.Value)
+						m.logger.Warn("error getting device IDs", "error", err, "value", value.Value)
 						continue
 					}
 					manufacturer, err := m.manufacturers.GetManufacturer(manufacturerID)
 					if err != nil {
-						m.logger.Warn("Error getting manufacturer", "error", err, "manufacturerID", manufacturerID)
+						m.logger.Warn("error getting manufacturer", "error", err, "manufacturer_id", manufacturerID)
 						manufacturer = value.Value
 					}
 
@@ -664,7 +664,7 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 
 					deviceModel, err := m.deviceLookup.GetDevice(value.Value)
 					if err != nil {
-						m.logger.Warn("Error getting device model falling back to OID", "error", err, "deviceOID", value.Value)
+						m.logger.Warn("error getting device model falling back to OID", "error", err, "device_oid", value.Value)
 						deviceModel = value.Value
 					}
 					deviceEntity.DeviceType = &diode.DeviceType{
@@ -673,7 +673,7 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 					}
 					fieldFound = true
 				default:
-					m.logger.Warn("Unknown field", "field", propertyMappingEntry.Field)
+					m.logger.Warn("unknown field", "field", propertyMappingEntry.Field)
 				}
 			}
 		}
@@ -683,9 +683,9 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 	if fieldFound {
 		m.applyDefaults(deviceEntity, defaults)
 		if deviceEntity.Name != nil {
-			m.logger.Debug("Successfully mapped device", "name", *deviceEntity.Name)
+			m.logger.Debug("successfully mapped device", "name", *deviceEntity.Name)
 		} else {
-			m.logger.Debug("Successfully mapped device (name field empty)")
+			m.logger.Debug("successfully mapped device (name field empty)")
 		}
 	}
 

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -84,7 +84,7 @@ func (r *EntityRegistry) ResolveSubinterfaceParents() {
 		return
 	}
 
-	r.logger.Debug("Resolving parent interfaces for subinterfaces")
+	r.logger.Debug("resolving parent interfaces for subinterfaces")
 	resolvedCount := 0
 	notFoundCount := 0
 
@@ -110,12 +110,12 @@ func (r *EntityRegistry) ResolveSubinterfaceParents() {
 				Type:   parent.Type,
 				Device: parent.Device,
 			}
-			r.logger.Debug("Resolved parent interface",
+			r.logger.Debug("resolved parent interface",
 				"subinterface", *iface.Name,
 				"parent", parentName)
 			resolvedCount++
 		} else {
-			r.logger.Debug("Parent interface not found",
+			r.logger.Debug("parent interface not found",
 				"subinterface", *iface.Name,
 				"parent", parentName)
 			notFoundCount++
@@ -123,7 +123,7 @@ func (r *EntityRegistry) ResolveSubinterfaceParents() {
 	}
 
 	if resolvedCount > 0 {
-		r.logger.Info("Resolved subinterface parents",
+		r.logger.Info("resolved subinterface parents",
 			"resolved", resolvedCount,
 			"not_found", notFoundCount)
 	}
@@ -131,15 +131,15 @@ func (r *EntityRegistry) ResolveSubinterfaceParents() {
 
 // GetOrCreateEntity returns an entity from the EntityRegistry or creates a new one if it doesn't exist
 func (r *EntityRegistry) GetOrCreateEntity(entityType EntityType, index ObjectIDIndex) diode.Entity {
-	r.logger.Debug("Getting entity", "entityType", entityType, "index", index, "from", r.entities)
+	r.logger.Debug("getting entity", "entity_type", entityType, "index", index, "from", r.entities)
 	if r.entities[entityType] == nil {
 		r.entities[entityType] = make(map[ObjectIDIndex]diode.Entity)
 	}
 	if r.entities[entityType][index] == nil {
 		entity, err := createEntity(entityType)
-		r.logger.Debug("Entity not found, creating", "entityType", entityType, "index", index, "entity", entity)
+		r.logger.Debug("entity not found, creating", "entity_type", entityType, "index", index, "entity", entity)
 		if err != nil {
-			r.logger.Warn("Error creating entity", "error", err, "entityType", entityType, "index", index)
+			r.logger.Warn("error creating entity", "error", err, "entity_type", entityType, "index", index)
 			return nil
 		}
 		r.entities[entityType][index] = entity
@@ -204,16 +204,16 @@ type Entry struct {
 
 // MapToEntity maps a value to an entity
 func (m *Entry) MapToEntity(pdus map[ObjectIDIndex]*ObjectIDValue, entityRegistry *EntityRegistry, defaults *config.Defaults, logger *slog.Logger) diode.Entity {
-	logger.Debug("Mapping value to entity", "entity", m.Entity, "value", pdus)
+	logger.Debug("mapping value to entity", "entity", m.Entity, "value", pdus)
 
 	if m.Mapper == nil {
-		logger.Warn("No mapper found for entity. Ignoring.", "entity", m.Entity)
+		logger.Warn("no mapper found for entity, ignoring", "entity", m.Entity)
 		return nil
 	}
 	entity := m.Mapper.Map(pdus, m, entityRegistry, defaults)
-	logger.Debug("Entity returned from mapper", "entity", entity)
+	logger.Debug("entity returned from mapper", "entity", entity)
 	if entity == nil {
-		logger.Warn("No entity returned from mapper. Ignoring.", "entity", m.Entity)
+		logger.Warn("no entity returned from mapper, ignoring", "entity", m.Entity)
 		return nil
 	}
 	return entity
@@ -252,7 +252,7 @@ func NewConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturer
 	}
 	mapping := make(map[string]*Entry)
 	for _, m := range mappings {
-		logger.Debug("Adding mapping", "oid", m.OID, "entity", m.Entity, "field", m.Field, "relationship", m.Relationship)
+		logger.Debug("adding mapping", "oid", m.OID, "entity", m.Entity, "field", m.Field, "relationship", m.Relationship)
 		Entry := newMappingEntry(m, logger, entityMappers)
 		if Entry == nil {
 			continue
@@ -288,7 +288,7 @@ func getIndex(values map[ObjectIDIndex]*ObjectIDValue) ObjectIDIndex {
 func newMappingEntry(m config.MappingEntry, logger *slog.Logger, entityMappers map[string]orbToEntityMapper) *Entry {
 	mapper := entityMappers[m.Entity]
 	if mapper == nil {
-		logger.Warn("No mapper found for entity. Ignoring.", "entity", m.Entity)
+		logger.Warn("no mapper found for entity, ignoring", "entity", m.Entity)
 		return nil
 	}
 	return &Entry{
@@ -305,7 +305,7 @@ func newMappingEntry(m config.MappingEntry, logger *slog.Logger, entityMappers m
 func newChildMappingEntries(configMappingEntries []config.MappingEntry, logger *slog.Logger, parentIdentifierSize int) []Entry {
 	childMappingEntries := make([]Entry, 0, len(configMappingEntries))
 	for _, m := range configMappingEntries {
-		logger.Debug("Adding child mapping entry", "oid", m.OID, "entity", m.Entity, "field", m.Field, "relationship", m.Relationship)
+		logger.Debug("adding child mapping entry", "oid", m.OID, "entity", m.Entity, "field", m.Field, "relationship", m.Relationship)
 
 		// Use child's IdentifierSize if specified, otherwise inherit from parent
 		identifierSize := m.IdentifierSize
@@ -376,10 +376,10 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 	objectIDIndexMap := m.groupByObjectIDIndex(objectIDs)
 	uniqueEntities := make(map[diode.Entity]bool)
 	for index, value := range objectIDIndexMap {
-		m.logger.Debug("Mapping objectIDIndex", "objectIDIndex", index, "values", value.Values)
+		m.logger.Debug("mapping object ID index", "object_id_index", index, "values", value.Values)
 		entry, err := m.mappingConfig.getMappingEntry(value.Index)
 		if err != nil {
-			m.logger.Warn("Error finding mapping entry", "error", err, "objectID", value.Index)
+			m.logger.Warn("error finding mapping entry", "error", err, "object_id", value.Index)
 			continue
 		}
 		newEntity := entry.MapToEntity(value.Values, m.registry, m.defaults, m.logger)
@@ -434,7 +434,7 @@ func (m *ObjectIDMapper) groupByObjectIDIndex(objectIDs ObjectIDValueMap) map[Ob
 	for objectID, value := range objectIDs {
 		objectIDValue, err := newObjectIDValue(objectID, value)
 		if err != nil {
-			m.logger.Warn("Error creating objectIDValue", "error", err, "objectID", objectID)
+			m.logger.Warn("error creating object ID value", "error", err, "object_id", objectID)
 			continue
 		}
 

--- a/snmp-discovery/mapping/pattern_matcher.go
+++ b/snmp-discovery/mapping/pattern_matcher.go
@@ -55,7 +55,7 @@ func (pm *PatternMatcher) MatchInterfaceType(interfaceName string, userPatternCo
 	// Priority 1: Check user patterns first
 	if len(userPatterns) > 0 {
 		if matchedType := pm.findBestMatch(interfaceName, userPatterns); matchedType != "" {
-			pm.logger.Debug("Matched interface with user pattern",
+			pm.logger.Debug("matched interface with user pattern",
 				"interface", interfaceName,
 				"type", matchedType)
 			return matchedType
@@ -64,7 +64,7 @@ func (pm *PatternMatcher) MatchInterfaceType(interfaceName string, userPatternCo
 
 	// Priority 2: Check built-in patterns only if no user pattern matched
 	if matchedType := pm.findBestMatch(interfaceName, builtinPatterns); matchedType != "" {
-		pm.logger.Debug("Matched interface with built-in pattern",
+		pm.logger.Debug("matched interface with built-in pattern",
 			"interface", interfaceName,
 			"type", matchedType)
 		return matchedType

--- a/snmp-discovery/metrics/metrics.go
+++ b/snmp-discovery/metrics/metrics.go
@@ -65,7 +65,7 @@ func GetCounter(name string, description string) metric.Int64Counter {
 	// Create the counter (error handling omitted for brevity)
 	c, err := meter.Int64Counter(name, metric.WithDescription(description))
 	if err != nil {
-		logger.Error("Error creating counter", "name", name, "error", err)
+		logger.Error("error creating counter", "name", name, "error", err)
 		return nil
 	}
 	counterCache[name] = c
@@ -85,7 +85,7 @@ func GetUpDownCounter(name string, description string) metric.Int64UpDownCounter
 	}
 	c, err := meter.Int64UpDownCounter(name, metric.WithDescription(description))
 	if err != nil {
-		logger.Error("Error creating updown counter", "name", name, "error", err)
+		logger.Error("error creating updown counter", "name", name, "error", err)
 		return nil
 	}
 	upDownCounterCache[name] = c
@@ -105,7 +105,7 @@ func GetHistogram(name string, description string) metric.Float64Histogram {
 	}
 	h, err := meter.Float64Histogram(name, metric.WithDescription(description))
 	if err != nil {
-		logger.Error("Error creating histogram", "name", name, "error", err)
+		logger.Error("error creating histogram", "name", name, "error", err)
 		return nil
 	}
 	histogramCache[name] = h
@@ -125,7 +125,7 @@ func GetGauge(name string, description string) metric.Int64Gauge {
 	}
 	g, err := meter.Int64Gauge(name, metric.WithDescription(description))
 	if err != nil {
-		logger.Error("Error creating gauge", "name", name, "error", err)
+		logger.Error("error creating gauge", "name", name, "error", err)
 		return nil
 	}
 	gaugeCache[name] = g

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -39,7 +39,7 @@ type Manager struct {
 func NewManager(ctx context.Context, logger *slog.Logger, client diode.Client, manufacturers data.ManufacturerRetriever) (*Manager, error) {
 	mappingConfig, err := loadMappingConfig()
 	if err != nil {
-		logger.Error("Failed to load mapping config", "error", err)
+		logger.Error("failed to load mapping config", "error", err)
 		return nil, err
 	}
 
@@ -210,7 +210,7 @@ func (m *Manager) HasPolicy(name string) bool {
 
 // StartPolicy starts the policy
 func (m *Manager) StartPolicy(name string, policy config.Policy) error {
-	m.logger.Debug("Starting policy", "policy", policy)
+	m.logger.Debug("starting policy", "policy", policy)
 	if len(policy.Scope.Targets) == 0 {
 		return fmt.Errorf("%s : no targets found in the policy", name)
 	}
@@ -219,9 +219,9 @@ func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 		// Load device lookup extensions
 		deviceLookup, err := data.LoadDeviceLookupExtensions(policy.Config.LookupExtensionsDir)
 		if err != nil {
-			m.logger.Warn("Failed to load device lookup extensions", "error", err, "directory", policy.Config.LookupExtensionsDir)
+			m.logger.Warn("failed to load device lookup extensions", "error", err, "directory", policy.Config.LookupExtensionsDir)
 		} else {
-			m.logger.Info("Loaded device lookup extensions", "directory", policy.Config.LookupExtensionsDir)
+			m.logger.Info("loaded device lookup extensions", "directory", policy.Config.LookupExtensionsDir)
 		}
 
 		// Create logger-aware ClientFactory wrapper

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -138,7 +138,7 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 	// Create run for the scan operation (includes port)
 	scanRun := r.runStore.CreateRun(policyName, originalTarget, port, "")
 
-	r.logger.Info("Starting SNMP probe scan", "policy", policyName, "target", originalTarget, "targetCount", len(targets))
+	r.logger.Info("starting SNMP probe scan", "policy", policyName, "target", originalTarget, "target_count", len(targets))
 	workerCount := min(256, len(targets))
 
 	ctx, cancel := context.WithTimeout(r.ctx, r.timeout)
@@ -184,7 +184,7 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 
 	// Check if context was canceled or timed out
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		r.logger.Warn("SNMP probe scan interrupted", "policy", policyName, "error", ctxErr, "responsiveTargetCount", len(responsive))
+		r.logger.Warn("SNMP probe scan interrupted", "policy", policyName, "error", ctxErr, "responsive_target_count", len(responsive))
 		r.runStore.UpdateRun(policyName, originalTarget, port, scanRun.ID, RunStatusFailed, ctxErr, len(responsive))
 		return
 	}
@@ -210,18 +210,18 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 
 	// Update scan run status
 	r.runStore.UpdateRun(policyName, originalTarget, port, scanRun.ID, RunStatusCompleted, nil, len(responsive))
-	r.logger.Info("SNMP probe scan complete", "policy", policyName, "responsiveTargetCount", len(responsive))
+	r.logger.Info("SNMP probe scan complete", "policy", policyName, "responsive_target_count", len(responsive))
 }
 
 // resolveTargetAuthentication returns the authentication to use for a target
 // Uses target-level auth if available, otherwise falls back to policy-level auth
 func (r *Runner) resolveTargetAuthentication(target config.Target) *config.Authentication {
 	if target.Authentication != nil {
-		r.logger.Debug("Using target-level authentication", "host", target.Host)
+		r.logger.Debug("using target-level authentication", "host", target.Host)
 		return target.Authentication
 	}
 
-	r.logger.Debug("Using policy-level authentication (fallback)", "host", target.Host)
+	r.logger.Debug("using policy-level authentication (fallback)", "host", target.Host)
 	return &r.scope.Authentication
 }
 
@@ -229,11 +229,11 @@ func (r *Runner) resolveTargetAuthentication(target config.Target) *config.Authe
 // Merges target-level override defaults with policy-level defaults
 func (r *Runner) resolveTargetDefaults(target config.Target) *config.Defaults {
 	if target.OverrideDefaults != nil {
-		r.logger.Debug("Merging target-level override defaults", "host", target.Host)
+		r.logger.Debug("merging target-level override defaults", "host", target.Host)
 		return config.MergeDefaults(&r.config.Defaults, target.OverrideDefaults)
 	}
 
-	r.logger.Debug("Using policy-level defaults", "host", target.Host)
+	r.logger.Debug("using policy-level defaults", "host", target.Host)
 	return &r.config.Defaults
 }
 
@@ -304,10 +304,10 @@ func (r *Runner) runWithMetadata(target config.Target, parentTarget string) {
 		r.runStore.UpdateRun(policyName, targetHost, targetPort, run.ID, RunStatusFailed, err, 0)
 		return
 	}
-	r.logger.Info("SNMP crawl complete", "host", target.Host, "policy", policyName, "entityCount", len(entities))
+	r.logger.Info("SNMP crawl complete", "host", target.Host, "policy", policyName, "entity_count", len(entities))
 
 	if len(entities) == 0 {
-		r.logger.Info("No entities to ingest", "host", target.Host, "policy", policyName)
+		r.logger.Info("no entities to ingest", "host", target.Host, "policy", policyName)
 		// Update run status to completed even if no entities
 		r.runStore.UpdateRun(policyName, targetHost, targetPort, run.ID, RunStatusCompleted, nil, 0)
 		return
@@ -320,21 +320,21 @@ func (r *Runner) runWithMetadata(target config.Target, parentTarget string) {
 		"run_id":      run.ID,
 	}))
 	if err != nil {
-		r.logger.Error("error ingesting entities", "host", target.Host, "error", err, "policy", policyName)
+		r.logger.Error("error ingesting entities", "host", target.Host, "error", err, "policy", policyName, "entity_count", len(entities))
 		r.runStore.UpdateRun(policyName, targetHost, targetPort, run.ID, RunStatusFailed, err, len(entities))
 	} else if resp != nil && resp.Errors != nil {
 		ingestErr := fmt.Errorf("ingestion errors: %v", resp.Errors)
-		r.logger.Error("error ingesting entities", "host", target.Host, "error", resp.Errors, "policy", policyName)
+		r.logger.Error("error ingesting entities", "host", target.Host, "error", resp.Errors, "policy", policyName, "entity_count", len(entities))
 		r.runStore.UpdateRun(policyName, targetHost, targetPort, run.ID, RunStatusFailed, ingestErr, len(entities))
 	} else {
-		r.logger.Info("entities ingested successfully", "host", target.Host, "policy", policyName)
+		r.logger.Info("entities ingested successfully", "host", target.Host, "policy", policyName, "entity_count", len(entities))
 		r.runStore.UpdateRun(policyName, targetHost, targetPort, run.ID, RunStatusCompleted, nil, len(entities))
 	}
 }
 
 func (r *Runner) logEntitiesForIngestion(entities []diode.Entity) {
 	for _, entity := range entities {
-		r.logger.Debug("Entity for ingestion", "entity", entity.ConvertToProtoMessage())
+		r.logger.Debug("entity for ingestion", "entity", entity.ConvertToProtoMessage())
 	}
 }
 
@@ -347,11 +347,11 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 
 	mappingConfig, err := mapping.NewConfig(r.mappingConfig.Entries, r.logger, r.manufacturers, r.deviceLookup, targetDefaults)
 	if err != nil {
-		r.logger.Error("Error creating mapping config", "error", err)
+		r.logger.Error("error creating mapping config", "error", err)
 		return nil, err
 	}
 	objectIDs := mappingConfig.ObjectIDs()
-	r.logger.Info("Querying target", "host", target.Host, "port", target.Port, "objectCount", len(objectIDs))
+	r.logger.Info("querying target", "host", target.Host, "port", target.Port, "object_count", len(objectIDs))
 
 	mapper := mapping.NewObjectIDMapper(mappingConfig, r.logger, targetDefaults)
 	policyName := r.ctx.Value(policyKey).(string)
@@ -395,7 +395,7 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 		return nil, ctx.Err()
 	case res := <-resultCh:
 		if res.err != nil {
-			r.logger.Warn("Error crawling host", "host", target.Host, "error", res.err)
+			r.logger.Warn("error crawling host", "host", target.Host, "error", res.err)
 			if rMetric := metrics.GetDiscoveryFailure(); rMetric != nil {
 				rMetric.Add(r.ctx, 1,
 					metric.WithAttributes(
@@ -442,7 +442,7 @@ func (r *Runner) expandTargetRanges(configuredTargets []config.Target) []expande
 		originalHost := target.Host // Preserve original target string
 		ips, err := targets.Expand(target.Host)
 		if err != nil {
-			r.logger.Warn("Error expanding target host", "host", target.Host, "error", err)
+			r.logger.Warn("error expanding target host", "host", target.Host, "error", err)
 			continue
 		}
 
@@ -465,7 +465,7 @@ func (r *Runner) expandTargetRanges(configuredTargets []config.Target) []expande
 
 // Start starts the policy runner
 func (r *Runner) Start() {
-	r.logger.Info("Starting policy runner", "policy", r.ctx.Value(policyKey))
+	r.logger.Info("starting policy runner", "policy", r.ctx.Value(policyKey))
 	r.scheduler.Start()
 }
 

--- a/snmp-discovery/server/server.go
+++ b/snmp-discovery/server/server.go
@@ -171,11 +171,11 @@ func (s *Server) createPolicy(c *gin.Context) {
 		return
 	}
 
-	s.logger.Info("Received policies", "policyCount", len(policies))
+	s.logger.Info("received policies", "policy_count", len(policies))
 
 	rPolicies := []string{}
 	for name, policy := range policies {
-		s.logger.Debug("Starting policy", "policy", policy)
+		s.logger.Debug("starting policy", "policy", policy)
 		if s.manager.HasPolicy(name) {
 			for _, p := range rPolicies {
 				if err = s.manager.StopPolicy(p); err != nil {

--- a/snmp-discovery/snmp/snmp.go
+++ b/snmp-discovery/snmp/snmp.go
@@ -53,7 +53,7 @@ func NewHost(host string, port uint16, retries int, timeout time.Duration, authe
 
 // Walk walks the SNMP host
 func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) {
-	s.logger.Info("Scanning", "host", s.address)
+	s.logger.Info("scanning", "host", s.address)
 
 	snmpClient, err := s.ClientFactory(s.address, s.port, s.retries, s.timeout, s.authentication, s.logger)
 	if err != nil {
@@ -61,13 +61,13 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 	}
 	defer func() {
 		if err := snmpClient.Close(); err != nil {
-			s.logger.Warn("Error closing SNMP connection", "host", s.address, "error", err)
+			s.logger.Warn("error closing SNMP connection", "host", s.address, "error", err)
 		}
 	}()
 
 	err = snmpClient.Connect()
 	if err != nil {
-		s.logger.Warn("Could not connect to host", "host", s.address, "error", err)
+		s.logger.Warn("could not connect to host", "host", s.address, "error", err)
 		return nil, err
 	}
 
@@ -75,18 +75,18 @@ func (s *Host) Walk(objectIDs map[string]int) (mapping.ObjectIDValueMap, error) 
 	for objectID, identifierSize := range objectIDs {
 		pdu, err := snmpClient.Walk(objectID, identifierSize)
 		if err != nil {
-			s.logger.Warn("Error walking ObjectID", "objectID", objectID, "error", err)
+			s.logger.Warn("error walking object ID", "object_id", objectID, "error", err)
 			return nil, err
 		}
 		for k, value := range pdu {
-			s.logger.Debug("Mapping PDU", "objectID", k, "value", value, "ValueType", reflect.TypeOf(value.Value))
+			s.logger.Debug("mapping PDU", "object_id", k, "value", value, "value_type", reflect.TypeOf(value.Value))
 			value, err := MapPDU(value)
 			if err != nil {
-				s.logger.Warn("Error mapping PDU", "objectID", k, "error", err)
+				s.logger.Warn("error mapping PDU", "object_id", k, "error", err)
 				continue
 			}
 			output[k] = value
-			s.logger.Debug("Mapped PDU", "objectID", k, "value", value)
+			s.logger.Debug("mapped PDU", "object_id", k, "value", value)
 		}
 	}
 
@@ -124,7 +124,7 @@ func MapPDU(pdu PDU) (mapping.Value, error) {
 			value = fmt.Sprintf("%d", val)
 		}
 	default:
-		slog.Warn("Unhandled SNMP type", "name", pdu.Name, "type", pdu.Type)
+		slog.Warn("unhandled SNMP type", "name", pdu.Name, "type", pdu.Type)
 		return mapping.Value{}, fmt.Errorf("unhandled SNMP type: %s", pdu.Type)
 	}
 	return mapping.Value{


### PR DESCRIPTION
Align log attribute keys and message style with OpenTelemetry Semantic Conventions and the diode project conventions:

- Rename camelCase keys to snake_case (e.g. entityCount → entity_count, objectID → object_id, responsiveTargetCount → responsive_target_count)
- Replace slog.String()/slog.Int()/slog.Any() constructors with bare key-value pairs throughout network-discovery
- Lowercase all log message text (e.g. "Starting SNMP probe scan" → "starting SNMP probe scan", "Error creating counter" → "error creating counter")
- Remove now-unused log/slog import from network-discovery/cmd/main.go