### PR TITLE
ci: remove JFrog Artifactory publishing

### DIFF
--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -21,7 +21,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write
 
 jobs:
   get-next-version:
@@ -145,22 +144,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Setup JFrog CLI
-        id: setup-jfrog-cli
-        uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
-        env:
-          JF_URL: https://netboxlabs.jfrog.io
-          JF_PROJECT: obs
-        with:
-          oidc-provider-name: github-ci
-
-      - name: Login to JFrog Artifactory
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3
-        with:
-          registry: netboxlabs.jfrog.io
-          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
-          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
-
       - name: Set build info
         run: |
           echo $BUILD_COMMIT > ./network-discovery/version/BUILD_COMMIT.txt
@@ -178,8 +161,6 @@ jobs:
           tags: |
             netboxlabs/network-discovery:latest
             netboxlabs/network-discovery:${{ env.BUILD_VERSION }}
-            netboxlabs.jfrog.io/obs-builds/network-discovery:latest
-            netboxlabs.jfrog.io/obs-builds/network-discovery:${{ env.BUILD_VERSION }}
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
 

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -21,7 +21,6 @@ permissions:
   contents: write
   issues: write
   pull-requests: write
-  id-token: write
 
 jobs:
   get-next-version:
@@ -145,22 +144,6 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Setup JFrog CLI
-        id: setup-jfrog-cli
-        uses: jfrog/setup-jfrog-cli@ff5cb544114ffc152db9cea1cd3d5978d5074946 # v4.5.11
-        env:
-          JF_URL: https://netboxlabs.jfrog.io
-          JF_PROJECT: obs
-        with:
-          oidc-provider-name: github-ci
-
-      - name: Login to JFrog Artifactory
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3
-        with:
-          registry: netboxlabs.jfrog.io
-          username: ${{ steps.setup-jfrog-cli.outputs.oidc-user }}
-          password: ${{ steps.setup-jfrog-cli.outputs.oidc-token }}
-
       - name: Set build info
         run: |
           echo $BUILD_COMMIT > ./snmp-discovery/version/BUILD_COMMIT.txt
@@ -178,8 +161,6 @@ jobs:
           tags: |
             netboxlabs/snmp-discovery:latest
             netboxlabs/snmp-discovery:${{ env.BUILD_VERSION }}
-            netboxlabs.jfrog.io/obs-builds/snmp-discovery:latest
-            netboxlabs.jfrog.io/obs-builds/snmp-discovery:${{ env.BUILD_VERSION }}
           build-args: |
             GO_VERSION=${{ env.GO_VERSION }}
 


### PR DESCRIPTION
## Summary
- Remove unused Artifactory setup, login, and image tags from `network-discovery-release.yaml` and `snmp-discovery-release.yaml`
- Images continue to be published to Docker Hub

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Confirm images push to Docker Hub on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)