### PR TITLE
OBS-2298: Per-entity run_id metadata across discovery backends

### DIFF
--- a/device-discovery/device_discovery/client.py
+++ b/device-discovery/device_discovery/client.py
@@ -14,6 +14,7 @@ from netboxlabs.diode.sdk import (
     estimate_message_size,
 )
 
+from device_discovery.entity_metadata import apply_run_id_to_entities
 from device_discovery.translate import translate_data
 from device_discovery.version import version_semver
 
@@ -106,7 +107,12 @@ class Client:
                     app_version=APP_VERSION,
                 )
 
-    def ingest(self, metadata: dict[str, Any] | None, data: dict):
+    def ingest(
+        self,
+        metadata: dict[str, Any] | None,
+        data: dict,
+        run_id: str | None = None,
+    ):
         """
         Ingest data using the Diode client after translating it.
 
@@ -114,6 +120,7 @@ class Client:
         ----
             metadata (dict[str, Any] | None): Metadata to attach to the ingestion request.
             data (dict): The data to be ingested.
+            run_id (str | None): Discovery run ID for ingest and per-entity metadata.
 
         Raises:
         ------
@@ -125,10 +132,18 @@ class Client:
 
         with self._lock:
             translated_entities = translate_data(data)
-            request_metadata = metadata or {}
+            entities_list = (
+                translated_entities
+                if isinstance(translated_entities, list)
+                else list(translated_entities)
+            )
+            if run_id is not None:
+                apply_run_id_to_entities(entities_list, run_id)
 
-            # Convert to list for size estimation and chunking
-            entities_list = list(translated_entities)
+            request_metadata = dict(metadata or {})
+            if run_id is not None:
+                request_metadata["run_id"] = str(run_id)
+
             entity_count = len(entities_list)
 
             hostname = request_metadata.get("hostname") or "unknown-host"

--- a/device-discovery/device_discovery/entity_metadata.py
+++ b/device-discovery/device_discovery/entity_metadata.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+# Copyright 2024 NetBox Labs Inc
+"""Attach discovery run_id to per-entity Diode metadata (protobuf Struct).
+
+Duplicated from worker/worker/entity_metadata.py — keep in sync when changing logic.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def apply_run_id_to_entities(entities: Iterable, run_id: str | object) -> None:
+    """
+    Merge ``run_id`` into the ``metadata`` google.protobuf.Struct on each
+    ``ingester_pb2.Entity``'s populated inner message.
+    """
+    rid = str(run_id)
+    for ent in entities:
+        which = getattr(ent, "WhichOneof", None)
+        if not callable(which):
+            continue
+        field = which("entity")
+        if not field:
+            continue
+        inner = getattr(ent, field)
+        inner.metadata.update({"run_id": rid})

--- a/device-discovery/device_discovery/entity_metadata.py
+++ b/device-discovery/device_discovery/entity_metadata.py
@@ -1,19 +1,21 @@
 #!/usr/bin/env python
 # Copyright 2024 NetBox Labs Inc
-"""Attach discovery run_id to per-entity Diode metadata (protobuf Struct).
+"""
+Attach discovery run_id to per-entity Diode metadata (protobuf Struct).
 
 Duplicated from worker/worker/entity_metadata.py — keep in sync when changing logic.
 """
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 
 def apply_run_id_to_entities(entities: Iterable, run_id: str | object) -> None:
     """
-    Merge ``run_id`` into the ``metadata`` google.protobuf.Struct on each
-    ``ingester_pb2.Entity``'s populated inner message.
+    Merge ``run_id`` into the ``metadata`` Struct for each inner protobuf entity.
+
+    Mirrors snmp-discovery ``annotateEntitiesWithRunID`` for the Python SDK.
     """
     rid = str(run_id)
     for ent in entities:

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -160,7 +160,11 @@ class PolicyRunner:
         return True
 
     def _collect_device_data(
-        self, scope: Napalm, sanitized_hostname: str, config: Config
+        self,
+        scope: Napalm,
+        sanitized_hostname: str,
+        config: Config,
+        run_id: str,
     ):
         """
         Connect to device and collect data.
@@ -170,6 +174,7 @@ class PolicyRunner:
             scope: Scope data for the device.
             sanitized_hostname: Sanitized hostname for logging.
             config: Configuration data containing site information.
+            run_id: Run identifier for ingest and per-entity metadata.
 
         """
         np_driver = get_network_driver(scope.driver)
@@ -224,7 +229,7 @@ class PolicyRunner:
                     f"Policy {self.name}, Hostname {sanitized_hostname}: Error getting VLANs: {e}. Continuing without VLAN data."
                 )
             metadata = {"policy_name": self.name, "hostname": sanitized_hostname}
-            Client().ingest(metadata, data)
+            Client().ingest(metadata, data, run_id=run_id)
             discovery_success = get_metric("discovery_success")
             if discovery_success:
                 discovery_success.add(1, {"policy": self.name})
@@ -355,7 +360,7 @@ class PolicyRunner:
                 discovery_attempts.add(1, {"policy": self.name})
 
             # Collect data from device
-            self._collect_device_data(scope, sanitized_hostname, config)
+            self._collect_device_data(scope, sanitized_hostname, config, run.id)
 
             # UPDATE RUN ON SUCCESS
             self.run_store.update_run(
@@ -467,7 +472,7 @@ class PolicyRunner:
                 discovery_attempts.add(1, {"policy": self.name})
 
             # Collect data from device
-            self._collect_device_data(scope, sanitized_hostname, config)
+            self._collect_device_data(scope, sanitized_hostname, config, run.id)
 
             # UPDATE RUN ON SUCCESS
             self.run_store.update_run(

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -205,10 +205,13 @@ def test_run_device_with_discovered_driver(
         mock_discover.assert_called_once_with(sample_scopes[0])
         mock_ingest.assert_called_once()
         metadata_arg, data = mock_ingest.call_args[0]
+        kwargs = mock_ingest.call_args[1]
         assert metadata_arg == {
             "policy_name": policy_runner.name,
             "hostname": sample_scopes[0].hostname,
         }
+        run = run_store.get_runs_for_policy(policy_runner.name)[0]
+        assert kwargs["run_id"] == run.id
         assert data["driver"] == "ios"
         assert data["device"] == {"model": "SampleModel"}
         assert data["interface"] == {"eth0": "up"}

--- a/device-discovery/tests/test_client.py
+++ b/device-discovery/tests/test_client.py
@@ -127,6 +127,26 @@ def test_ingest_success(mock_diode_client_class, sample_data, sample_metadata):
         )
 
 
+def test_ingest_includes_run_id_in_request_and_entities(
+    mock_diode_client_class, sample_data, sample_metadata
+):
+    """run_id is added to ingest metadata and each entity's metadata Struct."""
+    client = Client()
+    client.init_client(
+        prefix="", target="https://example.com", client_id="abc", client_secret="def"
+    )
+    mock_diode_instance = mock_diode_client_class.return_value
+    mock_diode_instance.ingest.return_value.errors = []
+    with patch(
+        "device_discovery.client.translate_data",
+        return_value=translate_data(sample_data),
+    ):
+        client.ingest(sample_metadata, sample_data, run_id="run-xyz")
+    kwargs = mock_diode_instance.ingest.call_args[1]
+    assert kwargs["metadata"]["run_id"] == "run-xyz"
+    assert kwargs["entities"][0].device.metadata["run_id"] == "run-xyz"
+
+
 def test_ingest_failure(mock_diode_client_class, sample_data, sample_metadata):
     """Test data ingestion with errors raises RuntimeError."""
     client = Client()

--- a/network-discovery/policy/entity_run_metadata.go
+++ b/network-discovery/policy/entity_run_metadata.go
@@ -1,0 +1,86 @@
+package policy
+
+import (
+	"unsafe"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+)
+
+// annotateEntitiesWithRunID sets per-entity Diode metadata key "run_id" on each entity
+// in the batch and on nested Device, Interface, and IPAddress references.
+func annotateEntitiesWithRunID(entities []diode.Entity, runID string) {
+	seen := make(map[unsafe.Pointer]struct{})
+	for _, e := range entities {
+		switch v := e.(type) {
+		case *diode.Device:
+			annotateDevice(v, runID, seen)
+		case *diode.Interface:
+			annotateInterface(v, runID, seen)
+		case *diode.IPAddress:
+			annotateIPAddress(v, runID, seen)
+		}
+	}
+}
+
+func mergeRunID(md *diode.Metadata, runID string) {
+	if md == nil {
+		return
+	}
+	if *md == nil {
+		*md = make(diode.Metadata)
+	}
+	(*md)["run_id"] = runID
+}
+
+func annotateDevice(d *diode.Device, runID string, seen map[unsafe.Pointer]struct{}) {
+	if d == nil {
+		return
+	}
+	p := unsafe.Pointer(d)
+	if _, ok := seen[p]; ok {
+		return
+	}
+	seen[p] = struct{}{}
+	mergeRunID(&d.Metadata, runID)
+}
+
+func annotateInterface(iface *diode.Interface, runID string, seen map[unsafe.Pointer]struct{}) {
+	if iface == nil {
+		return
+	}
+	p := unsafe.Pointer(iface)
+	if _, ok := seen[p]; ok {
+		return
+	}
+	seen[p] = struct{}{}
+	mergeRunID(&iface.Metadata, runID)
+	annotateDevice(iface.Device, runID, seen)
+	annotateInterface(iface.Parent, runID, seen)
+	annotateInterface(iface.Bridge, runID, seen)
+	annotateInterface(iface.Lag, runID, seen)
+}
+
+func annotateIPAddress(ip *diode.IPAddress, runID string, seen map[unsafe.Pointer]struct{}) {
+	if ip == nil {
+		return
+	}
+	p := unsafe.Pointer(ip)
+	if _, ok := seen[p]; ok {
+		return
+	}
+	seen[p] = struct{}{}
+	mergeRunID(&ip.Metadata, runID)
+	if ip.AssignedObject != nil {
+		switch a := ip.AssignedObject.(type) {
+		case *diode.Interface:
+			annotateInterface(a, runID, seen)
+		case *diode.FHRPGroup:
+			mergeRunID(&a.Metadata, runID)
+		case *diode.VMInterface:
+			mergeRunID(&a.Metadata, runID)
+		}
+	}
+	if ip.NatInside != nil {
+		annotateIPAddress(ip.NatInside, runID, seen)
+	}
+}

--- a/network-discovery/policy/entity_run_metadata_test.go
+++ b/network-discovery/policy/entity_run_metadata_test.go
@@ -1,0 +1,16 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnnotateEntitiesWithRunID_ipAddress(t *testing.T) {
+	ip := &diode.IPAddress{Address: diode.String("192.0.2.1/32")}
+	annotateEntitiesWithRunID([]diode.Entity{ip}, "run-net-1")
+	require.Contains(t, ip.Metadata, "run_id")
+	assert.Equal(t, "run-net-1", ip.Metadata["run_id"])
+}

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -440,6 +440,8 @@ func (r *Runner) run() {
 		entities = append(entities, ip)
 	}
 
+	annotateEntitiesWithRunID(entities, run.ID)
+
 	resp, err := r.client.Ingest(r.ctx, entities, diode.WithIngestMetadata(diode.Metadata{
 		"policy_name": policyName,
 		"run_id":      run.ID,

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -432,7 +432,10 @@ func TestRunnerWithNetworkMask(t *testing.T) {
 		ingestCalled <- true
 		entities := args.Get(1).([]diode.Entity)
 		assert.NotEmpty(t, entities, "Entities should not be empty when scanning a network with a mask")
-		assert.Contains(t, *entities[0].(*diode.IPAddress).Address, "/28", "The scanned entity should reflect the network mask")
+		ip0 := entities[0].(*diode.IPAddress)
+		assert.Contains(t, *ip0.Address, "/28", "The scanned entity should reflect the network mask")
+		rid, ok := ip0.Metadata["run_id"].(string)
+		assert.True(t, ok && rid != "", "per-entity metadata should include run_id")
 	}).Return(&diodepb.IngestResponse{}, nil)
 
 	// Start the process

--- a/snmp-discovery/policy/entity_run_metadata.go
+++ b/snmp-discovery/policy/entity_run_metadata.go
@@ -1,0 +1,86 @@
+package policy
+
+import (
+	"unsafe"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+)
+
+// annotateEntitiesWithRunID sets per-entity Diode metadata key "run_id" on each entity
+// in the batch and on nested Device, Interface, and IPAddress references.
+func annotateEntitiesWithRunID(entities []diode.Entity, runID string) {
+	seen := make(map[unsafe.Pointer]struct{})
+	for _, e := range entities {
+		switch v := e.(type) {
+		case *diode.Device:
+			annotateDevice(v, runID, seen)
+		case *diode.Interface:
+			annotateInterface(v, runID, seen)
+		case *diode.IPAddress:
+			annotateIPAddress(v, runID, seen)
+		}
+	}
+}
+
+func mergeRunID(md *diode.Metadata, runID string) {
+	if md == nil {
+		return
+	}
+	if *md == nil {
+		*md = make(diode.Metadata)
+	}
+	(*md)["run_id"] = runID
+}
+
+func annotateDevice(d *diode.Device, runID string, seen map[unsafe.Pointer]struct{}) {
+	if d == nil {
+		return
+	}
+	p := unsafe.Pointer(d)
+	if _, ok := seen[p]; ok {
+		return
+	}
+	seen[p] = struct{}{}
+	mergeRunID(&d.Metadata, runID)
+}
+
+func annotateInterface(iface *diode.Interface, runID string, seen map[unsafe.Pointer]struct{}) {
+	if iface == nil {
+		return
+	}
+	p := unsafe.Pointer(iface)
+	if _, ok := seen[p]; ok {
+		return
+	}
+	seen[p] = struct{}{}
+	mergeRunID(&iface.Metadata, runID)
+	annotateDevice(iface.Device, runID, seen)
+	annotateInterface(iface.Parent, runID, seen)
+	annotateInterface(iface.Bridge, runID, seen)
+	annotateInterface(iface.Lag, runID, seen)
+}
+
+func annotateIPAddress(ip *diode.IPAddress, runID string, seen map[unsafe.Pointer]struct{}) {
+	if ip == nil {
+		return
+	}
+	p := unsafe.Pointer(ip)
+	if _, ok := seen[p]; ok {
+		return
+	}
+	seen[p] = struct{}{}
+	mergeRunID(&ip.Metadata, runID)
+	if ip.AssignedObject != nil {
+		switch a := ip.AssignedObject.(type) {
+		case *diode.Interface:
+			annotateInterface(a, runID, seen)
+		case *diode.FHRPGroup:
+			mergeRunID(&a.Metadata, runID)
+		case *diode.VMInterface:
+			mergeRunID(&a.Metadata, runID)
+		}
+	}
+	if ip.NatInside != nil {
+		annotateIPAddress(ip.NatInside, runID, seen)
+	}
+}

--- a/snmp-discovery/policy/entity_run_metadata_test.go
+++ b/snmp-discovery/policy/entity_run_metadata_test.go
@@ -1,0 +1,54 @@
+package policy
+
+import (
+	"testing"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAnnotateEntitiesWithRunID_device(t *testing.T) {
+	dev := &diode.Device{Name: diode.String("r1")}
+	entities := []diode.Entity{dev}
+	annotateEntitiesWithRunID(entities, "run-abc")
+	require.Contains(t, dev.Metadata, "run_id")
+	assert.Equal(t, "run-abc", dev.Metadata["run_id"])
+}
+
+func TestAnnotateEntitiesWithRunID_interfaceNestedDevice(t *testing.T) {
+	dev := &diode.Device{Name: diode.String("core")}
+	iface := &diode.Interface{
+		Name:   diode.String("eth0"),
+		Device: dev,
+	}
+	entities := []diode.Entity{iface}
+	annotateEntitiesWithRunID(entities, "run-xyz")
+	require.Contains(t, iface.Metadata, "run_id")
+	assert.Equal(t, "run-xyz", iface.Metadata["run_id"])
+	require.Contains(t, dev.Metadata, "run_id")
+	assert.Equal(t, "run-xyz", dev.Metadata["run_id"])
+}
+
+func TestAnnotateEntitiesWithRunID_ipAssignedToInterface(t *testing.T) {
+	dev := &diode.Device{Name: diode.String("d")}
+	iface := &diode.Interface{Name: diode.String("gi0"), Device: dev}
+	ip := &diode.IPAddress{
+		Address:        diode.String("10.0.0.1/32"),
+		AssignedObject: iface,
+	}
+	entities := []diode.Entity{ip}
+	annotateEntitiesWithRunID(entities, "run-ip")
+	require.Contains(t, ip.Metadata, "run_id")
+	require.Contains(t, iface.Metadata, "run_id")
+	require.Contains(t, dev.Metadata, "run_id")
+}
+
+func TestAnnotateEntitiesWithRunID_sharedDeviceVisitedOnce(t *testing.T) {
+	dev := &diode.Device{Name: diode.String("shared")}
+	if1 := &diode.Interface{Name: diode.String("a"), Device: dev}
+	if2 := &diode.Interface{Name: diode.String("b"), Device: dev}
+	entities := []diode.Entity{if1, if2}
+	annotateEntitiesWithRunID(entities, "run-shared")
+	assert.Equal(t, "run-shared", dev.Metadata["run_id"])
+}

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -314,6 +314,7 @@ func (r *Runner) runWithMetadata(target config.Target, parentTarget string) {
 	}
 
 	r.logEntitiesForIngestion(entities)
+	annotateEntitiesWithRunID(entities, run.ID)
 
 	resp, err := r.client.Ingest(r.ctx, entities, diode.WithIngestMetadata(diode.Metadata{
 		"policy_name": policyName,

--- a/snmp-discovery/policy/runner_test.go
+++ b/snmp-discovery/policy/runner_test.go
@@ -358,25 +358,29 @@ func TestRunnerIngestCalledWithCorrectValues(t *testing.T) {
 	// Use a channel to signal that Ingest was called
 	ingestCalled := make(chan bool, 1)
 
-	expectedEntities := []diode.Entity{
-		&diode.Interface{
-			Device:      &diode.Device{},
-			Name:        diode.String("GigabitEthernet1/0/1"),
-			Description: diode.String("Interface Default"),
-			Tags: []*diode.Tag{
-				{Name: diode.String("interface")},
-				{Name: diode.String("default")},
-				{Name: diode.String("test")},
-				{Name: diode.String("snmp")},
-			},
-			Type: diode.String("virtual"),
-		},
-	}
-
-	mockClient.On("Ingest", mock.Anything, expectedEntities).Run(func(args mock.Arguments) {
+	mockClient.On("Ingest", mock.Anything, mock.MatchedBy(func(entities []diode.Entity) bool {
+		if len(entities) != 1 {
+			return false
+		}
+		iface, ok := entities[0].(*diode.Interface)
+		if !ok {
+			return false
+		}
+		rid, ok := iface.Metadata["run_id"].(string)
+		if !ok || rid == "" {
+			return false
+		}
+		if iface.Device == nil {
+			return false
+		}
+		drid, ok := iface.Device.Metadata["run_id"].(string)
+		return ok && drid == rid
+	})).Run(func(args mock.Arguments) {
 		ingestCalled <- true
 		entities := args.Get(1).([]diode.Entity)
-		assert.Equal(t, expectedEntities, entities, "Ingest should be called with the correct entities")
+		iface := entities[0].(*diode.Interface)
+		assert.Equal(t, "GigabitEthernet1/0/1", *iface.Name)
+		assert.Equal(t, "virtual", *iface.Type)
 	}).Return(&diodepb.IngestResponse{}, nil)
 
 	// Start the process

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -46,7 +46,11 @@ def sample_diode_config():
 @pytest.fixture
 def mock_run_store():
     """Fixture for a mock RunStore."""
-    return MagicMock(spec=RunStore)
+    store = MagicMock(spec=RunStore)
+    run = MagicMock()
+    run.id = "11111111-1111-1111-1111-111111111111"
+    store.create_run.return_value = run
+    return store
 
 
 @pytest.fixture
@@ -267,7 +271,17 @@ def test_run_passes_metadata_to_ingest(
     assert kwargs["metadata"] == {
         "policy_name": "policy-meta",
         "worker_backend": "custom_backend",
+        "run_id": "11111111-1111-1111-1111-111111111111",
     }
+    ingested = kwargs["entities"][0]
+    assert ingested.device.metadata["run_id"] == "11111111-1111-1111-1111-111111111111"
+
+
+def test_apply_run_id_to_entities_skips_non_protobuf_entries():
+    """apply_run_id_to_entities ignores non-Entity entries (e.g. test doubles)."""
+    from worker.entity_metadata import apply_run_id_to_entities
+
+    apply_run_id_to_entities(["not-an-entity"], "run-id")
 
 
 def test_run_ingestion_errors(

--- a/worker/worker/entity_metadata.py
+++ b/worker/worker/entity_metadata.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# Copyright 2025 NetBox Labs Inc
+"""Attach discovery run_id to per-entity Diode metadata (protobuf Struct)."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+
+def apply_run_id_to_entities(entities: Iterable, run_id: str | object) -> None:
+    """
+    Merge ``run_id`` into the ``metadata`` google.protobuf.Struct on each
+    ``ingester_pb2.Entity``'s populated inner message.
+
+    Mirrors snmp-discovery ``annotateEntitiesWithRunID`` for the Python SDK.
+    """
+    rid = str(run_id)
+    for ent in entities:
+        which = getattr(ent, "WhichOneof", None)
+        if not callable(which):
+            continue
+        field = which("entity")
+        if not field:
+            continue
+        inner = getattr(ent, field)
+        inner.metadata.update({"run_id": rid})

--- a/worker/worker/entity_metadata.py
+++ b/worker/worker/entity_metadata.py
@@ -4,13 +4,12 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from collections.abc import Iterable
 
 
 def apply_run_id_to_entities(entities: Iterable, run_id: str | object) -> None:
     """
-    Merge ``run_id`` into the ``metadata`` google.protobuf.Struct on each
-    ``ingester_pb2.Entity``'s populated inner message.
+    Merge ``run_id`` into the ``metadata`` Struct for each inner protobuf entity.
 
     Mirrors snmp-discovery ``annotateEntitiesWithRunID`` for the Python SDK.
     """

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -18,6 +18,7 @@ from netboxlabs.diode.sdk import (
 )
 
 from worker.backend import Backend, load_class
+from worker.entity_metadata import apply_run_id_to_entities
 from worker.metrics import get_metric
 from worker.models import DiodeConfig, Policy, Status
 from worker.policy.run import RunStatus, RunStore
@@ -156,14 +157,17 @@ class PolicyRunner:
         entity_count = 0
         try:
             logger.debug(f"Policy {self.name}: Starting backend execution")
-            entities = backend.run(self.name, policy)
+            entities = list(backend.run(self.name, policy))
             elapsed = time.perf_counter() - exec_start_time
             logger.debug(f"Policy {self.name}: Backend execution completed in {elapsed:.3f} seconds")
             entity_count = len(entities)
 
+            apply_run_id_to_entities(entities, run.id)
+
             metadata = {
                 "policy_name": self.name,
                 "worker_backend": self.metadata.name,
+                "run_id": run.id,
             }
             chunk_num = 1
             size_bytes = estimate_message_size(entities)


### PR DESCRIPTION
## Summary

Sets `run_id` on each Diode entity's **per-entity** `Metadata` / protobuf `metadata` Struct (in addition to ingest-level metadata where applicable) for snmp-discovery, network-discovery, orb worker, and device-discovery.

## Commits

1. **snmp-discovery** — Annotate Device, Interface, IPAddress (with nested walk) before `Ingest`; tests.
2. **network-discovery** — Same helper pattern for IP entities; tests.
3. **worker** — `apply_run_id_to_entities`, ingest metadata `run_id`; tests.
4. **device-discovery** — `Client.ingest(..., run_id=)`, runner plumbing; tests.

## Testing

- `go test ./...` in `snmp-discovery` and `network-discovery`
- `pytest` in `worker` and `device-discovery` (with dev dependencies)


Made with [Cursor](https://cursor.com)