### PR TITLE
Add @grant-nbl and @paulstuart as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jajeffries @leoparente @mfiedorowicz @MicahParks
+* @jajeffries @leoparente @mfiedorowicz @MicahParks @grant-nbl @paulstuart


### PR DESCRIPTION
Adds [@grant-nbl](https://github.com/grant-nbl) and [@paulstuart](https://github.com/paulstuart) to the default CODEOWNERS line so they are included in review requests for changes across the repository.

Made with [Cursor](https://cursor.com)