### PR TITLE
feat: add container scanning for network-discovery and snmp-discovery

### DIFF
--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -16,6 +16,8 @@ jobs:
     with:
       image_ref: "docker.io/netboxlabs/${{ matrix.service }}:latest"
     permissions:
+      actions: read
       contents: read
       id-token: write
+      security-events: write
     secrets: inherit

--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -8,16 +8,82 @@ on:
 jobs:
   rescan:
     name: Rescan ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
         service: [network-discovery, snmp-discovery]
-    uses: netboxlabs/internal-workflows/.github/workflows/reusable-container-rescan.yml@develop
-    with:
-      image_ref: "docker.io/netboxlabs/${{ matrix.service }}:latest"
-    permissions:
-      actions: read
-      contents: read
-      id-token: write
-      security-events: write
-    secrets: inherit
+    env:
+      TRIVY_DISABLE_VEX_NOTICE: "true"
+
+    steps:
+      - name: Pull image
+        env:
+          SERVICE: ${{ matrix.service }}
+        run: docker pull "docker.io/netboxlabs/${SERVICE}:latest"
+
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: docker.io/netboxlabs/${{ matrix.service }}:latest
+          format: json
+          output: trivy-output.json
+          vuln-type: os,library
+          scanners: vuln,secret
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          ignore-unfixed: true
+          exit-code: "0"
+
+      - name: Build rescan summary
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          SERVICE: ${{ matrix.service }}
+        with:
+          script: |
+            const fs = require('fs');
+            const service = process.env.SERVICE;
+            const data = JSON.parse(fs.readFileSync('trivy-output.json', 'utf8'));
+            const vulns = (data.Results || []).flatMap(r =>
+              (r.Vulnerabilities || []).map(v => ({ ...v, target: r.Target }))
+            );
+
+            const SEVERITY_LABEL = {
+              CRITICAL: '🔴 **CRITICAL**',
+              HIGH: '🟠 **HIGH**',
+              MEDIUM: '🟡 MEDIUM',
+              LOW: '⚪ LOW'
+            };
+
+            let summary = `### Rescan Complete — ${service}\n\n`;
+            summary += `**Image:** \`docker.io/netboxlabs/${service}:latest\`\n`;
+            summary += `**Scanned at:** ${new Date().toISOString().replace('T', ' ').split('.')[0]} UTC\n\n`;
+
+            if (vulns.length === 0) {
+              summary += '_No vulnerabilities found._\n';
+            } else {
+              summary += `| Library | CVE | Severity | Installed | Fixed | Title |\n`;
+              summary += `|---|---|---|---|---|---|\n`;
+              for (const v of vulns) {
+                const title = (v.Title || '').replace(/\|/g, '\\|').substring(0, 80);
+                const cve = v.PrimaryURL ? `[${v.VulnerabilityID}](${v.PrimaryURL})` : v.VulnerabilityID;
+                summary += `| ${v.PkgName} | ${cve} | ${SEVERITY_LABEL[v.Severity] || v.Severity} | ${v.InstalledVersion} | ${v.FixedVersion || 'N/A'} | ${title} |\n`;
+              }
+            }
+
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, summary);
+
+      - name: Convert scan results to SARIF
+        if: "!cancelled()"
+        run: trivy convert --format sarif --output trivy-results.sarif trivy-output.json
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: "!cancelled()"
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        with:
+          sarif_file: trivy-results.sarif
+          category: ${{ matrix.service }}-rescan

--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -1,0 +1,21 @@
+name: Scheduled Container Rescan
+
+on:
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 06:00 UTC
+  workflow_dispatch:
+
+jobs:
+  rescan:
+    name: Rescan ${{ matrix.service }}
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [network-discovery, snmp-discovery]
+    uses: netboxlabs/internal-workflows/.github/workflows/reusable-container-rescan.yml@develop
+    with:
+      image_ref: "docker.io/netboxlabs/${{ matrix.service }}:latest"
+    permissions:
+      contents: read
+      id-token: write
+    secrets: inherit

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -18,11 +18,15 @@ env:
   GO_VERSION: '1.25'
 
 jobs:
-  build:
-    name: Build ${{ matrix.service }}
+  build-and-scan:
+    name: ${{ matrix.service }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
+      actions: read
       contents: read
+      pull-requests: write
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -33,6 +37,9 @@ jobs:
           - service: snmp-discovery
             dockerfile: snmp-discovery/docker/Dockerfile
             context: snmp-discovery
+    env:
+      TRIVY_DISABLE_VEX_NOTICE: "true"
+
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -54,35 +61,139 @@ jobs:
             GO_VERSION=${{ env.GO_VERSION }}
           tags: ${{ matrix.service }}:scan
 
-      - name: Save image
+      - name: Scan image for vulnerabilities
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: ${{ matrix.service }}:scan
+          format: json
+          output: trivy-output.json
+          vuln-type: os,library
+          scanners: vuln,secret
+          severity: CRITICAL,HIGH,MEDIUM,LOW
+          ignore-unfixed: true
+          exit-code: "0"
+          list-all-pkgs: "true"
+
+      - name: Build scan summary
+        id: scan-summary
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
           SERVICE: ${{ matrix.service }}
-        run: docker save "${SERVICE}:scan" -o image.tar
+        with:
+          script: |
+            const fs = require('fs');
+            const service = process.env.SERVICE;
+            const data = JSON.parse(fs.readFileSync('trivy-output.json', 'utf8'));
+            const vulns = (data.Results || []).flatMap(r =>
+              (r.Vulnerabilities || []).map(v => ({ ...v, target: r.Target }))
+            );
 
-      - name: Upload image artifact
+            const blockingSeverities = new Set(['CRITICAL', 'HIGH']);
+
+            const SEVERITY_LABEL = {
+              CRITICAL: '🔴 **CRITICAL**',
+              HIGH: '🟠 **HIGH**',
+              MEDIUM: '🟡 MEDIUM',
+              LOW: '⚪ LOW'
+            };
+
+            const counts = { CRITICAL: 0, HIGH: 0, MEDIUM: 0, LOW: 0 };
+            for (const v of vulns) {
+              if (counts[v.Severity] !== undefined) counts[v.Severity]++;
+            }
+
+            const hasBlocking = vulns.some(v => blockingSeverities.has(v.Severity));
+            core.setOutput('has_blocking', hasBlocking.toString());
+
+            const buildTable = (vulns) => {
+              if (vulns.length === 0) return '_No vulnerabilities found._\n';
+              let t = '| Library | CVE | Severity | Installed | Fixed | Title |\n';
+              t += '|---|---|---|---|---|---|\n';
+              for (const v of vulns) {
+                const title = (v.Title || '').replace(/\|/g, '\\|').substring(0, 80);
+                const cve = v.PrimaryURL ? `[${v.VulnerabilityID}](${v.PrimaryURL})` : v.VulnerabilityID;
+                t += `| ${v.PkgName} | ${cve} | ${SEVERITY_LABEL[v.Severity] || v.Severity} | ${v.InstalledVersion} | ${v.FixedVersion || 'N/A'} | ${title} |\n`;
+              }
+              return t;
+            };
+
+            const table = buildTable(vulns);
+            fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY,
+              `## Vulnerability Scan Results — ${service}\n\n` + table
+            );
+
+            const artifact = JSON.stringify({ table, hasBlocking, counts });
+            fs.writeFileSync('scan-result.json', artifact);
+
+      - name: Post scan results as PR comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        env:
+          SERVICE: ${{ matrix.service }}
+          COMMIT_SHA: ${{ github.sha }}
+        with:
+          script: |
+            const fs = require('fs');
+            const service = process.env.SERVICE;
+            const { table, hasBlocking } = JSON.parse(fs.readFileSync('scan-result.json', 'utf8'));
+
+            const heading = hasBlocking
+              ? `## Vulnerability Scan: Failed — ${service}`
+              : `## Vulnerability Scan: Passed — ${service}`;
+
+            const commitSha = process.env.COMMIT_SHA;
+            const marker = `<!-- trivy-scan-${service} -->`;
+            const body = `${marker}\n${heading}\n\n**Image:** \`${service}:scan\`\n\n${table}\n*Commit: ${commitSha}*`;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            });
+            const existing = comments.find(c => c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body,
+              });
+            }
+
+      - name: Fail on blocking vulnerabilities
+        if: steps.scan-summary.outputs.has_blocking == 'true'
+        env:
+          SERVICE: ${{ matrix.service }}
+        run: |
+          echo "Blocking vulnerabilities found for ${SERVICE}. Failing build."
+          exit 1
+
+      - name: Convert scan results to SBOM
+        if: "!cancelled()"
+        run: trivy convert --format cyclonedx --output sbom.cdx.json trivy-output.json
+
+      - name: Upload SBOM artifact
+        if: "!cancelled()"
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: docker-image-${{ matrix.service }}
-          path: image.tar
-          retention-days: 1
+          name: sbom-${{ matrix.service }}-${{ github.sha }}
+          path: sbom.cdx.json
+          retention-days: 90
 
-  scan:
-    name: Scan ${{ matrix.service }}
-    needs: build
-    strategy:
-      fail-fast: false
-      matrix:
-        service: [network-discovery, snmp-discovery]
-    uses: netboxlabs/internal-workflows/.github/workflows/reusable-container-scan.yml@develop
-    with:
-      image_ref: "${{ matrix.service }}:scan"
-      image_artifact_name: "docker-image-${{ matrix.service }}"
-      comment_marker: "<!-- trivy-scan-${{ matrix.service }} -->"
-      sarif_enabled: false
-      artifact_name_prefix: "sbom-${{ matrix.service }}"
-    permissions:
-      actions: read
-      contents: read
-      pull-requests: write
-      security-events: write
-    secrets: inherit
+      - name: Convert scan results to SARIF
+        if: "!cancelled()"
+        run: trivy convert --format sarif --output trivy-results.sarif trivy-output.json
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: "!cancelled()"
+        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        with:
+          sarif_file: trivy-results.sarif
+          category: ${{ matrix.service }}

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -1,0 +1,88 @@
+name: Container Scan
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "network-discovery/**"
+      - "snmp-discovery/**"
+      - ".github/workflows/container-scan.yaml"
+      - "!network-discovery/docker/**"
+      - "!snmp-discovery/docker/**"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: '1.25'
+
+jobs:
+  build:
+    name: Build ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: network-discovery
+            dockerfile: network-discovery/docker/Dockerfile
+            context: network-discovery
+          - service: snmp-discovery
+            dockerfile: snmp-discovery/docker/Dockerfile
+            context: snmp-discovery
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Build image
+        uses: docker/build-push-action@1dc73863535b631f98b2378be8619f83b136f4a0 # v6.17.0
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          load: true
+          push: false
+          platforms: linux/amd64
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,scope=${{ matrix.service }},mode=max
+          build-args: |
+            GO_VERSION=${{ env.GO_VERSION }}
+          tags: ${{ matrix.service }}:scan
+
+      - name: Save image
+        env:
+          SERVICE: ${{ matrix.service }}
+        run: docker save "${SERVICE}:scan" -o image.tar
+
+      - name: Upload image artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: docker-image-${{ matrix.service }}
+          path: image.tar
+          retention-days: 1
+
+  scan:
+    name: Scan ${{ matrix.service }}
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        service: [network-discovery, snmp-discovery]
+    uses: netboxlabs/internal-workflows/.github/workflows/reusable-container-scan.yml@develop
+    with:
+      image_ref: "${{ matrix.service }}:scan"
+      image_artifact_name: "docker-image-${{ matrix.service }}"
+      comment_marker: "<!-- trivy-scan-${{ matrix.service }} -->"
+      sarif_enabled: false
+      artifact_name_prefix: "sbom-${{ matrix.service }}"
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+      security-events: write
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds Trivy container vulnerability scanning for the two services that produce Docker images.

### New workflows

**`container-scan.yaml`** — PR scan workflow
- Triggered on PRs affecting `network-discovery/` or `snmp-discovery/` code
- Builds both images (single-platform linux/amd64)
- Scans via the reusable container scan workflow from `internal-workflows`
- Per-service PR comments with vulnerability tables
- Per-service CycloneDX SBOMs (90-day retention)
- Blocks on CRITICAL and HIGH

**`container-rescan.yaml`** — Daily rescan
- Runs daily at 06:00 UTC + manual dispatch
- Pulls published images from Docker Hub (`netboxlabs/network-discovery:latest`, `netboxlabs/snmp-discovery:latest`)
- No auth needed (public Docker Hub images)
- Scans via the reusable rescan workflow

### Pipeline flow

```
build (matrix: network-discovery, snmp-discovery)
  ├── Build image
  ├── Save as artifact
  └── Upload

scan (matrix, reusable workflow)
  ├── PR comment per service
  ├── Severity gate (CRITICAL,HIGH)
  └── SBOM per service
```

Note: `device-discovery` and `worker` are Python packages published to PyPI only — no Docker images to scan.

## Test plan

- [ ] PR triggers build → scan for both services
- [ ] Each service gets its own PR comment
- [ ] SBOM artifacts uploaded per service
- [ ] Rescan via `workflow_dispatch` pulls from Docker Hub and scans