### PR TITLE
fix: entity_count always returns 1 for device-discovery runs

### DIFF
--- a/device-discovery/device_discovery/client.py
+++ b/device-discovery/device_discovery/client.py
@@ -188,3 +188,5 @@ class Client:
                 logger.info(
                     f"Hostname {hostname}: Successfully ingested {entity_count} entities"
                 )
+
+            return entity_count

--- a/device-discovery/device_discovery/client.py
+++ b/device-discovery/device_discovery/client.py
@@ -112,7 +112,7 @@ class Client:
         metadata: dict[str, Any] | None,
         data: dict,
         run_id: str | None = None,
-    ):
+    ) -> int:
         """
         Ingest data using the Diode client after translating it.
 
@@ -121,6 +121,10 @@ class Client:
             metadata (dict[str, Any] | None): Metadata to attach to the ingestion request.
             data (dict): The data to be ingested.
             run_id (str | None): Discovery run ID for ingest and per-entity metadata.
+
+        Returns:
+        -------
+            int: Number of entities ingested.
 
         Raises:
         ------

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -397,7 +397,7 @@ class PolicyRunner:
                 discovery_attempts.add(1, {"policy": self.name})
 
             # Collect data from device
-            self._collect_device_data(scope, sanitized_hostname, config, run.id)
+            entity_count = self._collect_device_data(scope, sanitized_hostname, config, run.id)
 
             # UPDATE RUN ON SUCCESS
             self.run_store.update_run(
@@ -406,7 +406,7 @@ class PolicyRunner:
                 run_id=run.id,
                 status=RunStatus.COMPLETED,
                 error=None,
-                entity_count=1,
+                entity_count=entity_count,
             )
 
             # Record total discovery duration
@@ -510,7 +510,7 @@ class PolicyRunner:
                 discovery_attempts.add(1, {"policy": self.name})
 
             # Collect data from device
-            self._collect_device_data(scope, sanitized_hostname, config, run.id)
+            entity_count = self._collect_device_data(scope, sanitized_hostname, config, run.id)
 
             # UPDATE RUN ON SUCCESS
             self.run_store.update_run(
@@ -519,7 +519,7 @@ class PolicyRunner:
                 run_id=run.id,
                 status=RunStatus.COMPLETED,
                 error=None,
-                entity_count=1,
+                entity_count=entity_count,
             )
 
             # Record total discovery duration

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -206,6 +206,10 @@ class PolicyRunner:
             config: Configuration data containing site information.
             run_id: Run identifier for ingest and per-entity metadata.
 
+        Returns
+        -------
+            int: Number of entities ingested.
+
         """
         np_driver = get_network_driver(scope.driver)
         logger.info(
@@ -260,10 +264,11 @@ class PolicyRunner:
                     f"Policy {self.name}, Hostname {sanitized_hostname}: Error getting VLANs: {e}. Continuing without VLAN data."
                 )
             metadata = {"policy_name": self.name, "hostname": sanitized_hostname}
-            Client().ingest(metadata, data, run_id=run_id)
+            entity_count = Client().ingest(metadata, data, run_id=run_id)
             discovery_success = get_metric("discovery_success")
             if discovery_success:
                 discovery_success.add(1, {"policy": self.name})
+            return entity_count
 
     def run_scan(
         self, hostnames: list[str], trigger: BaseTrigger, scope: Napalm, config: Config

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -206,7 +206,7 @@ class PolicyRunner:
             config: Configuration data containing site information.
             run_id: Run identifier for ingest and per-entity metadata.
 
-        Returns
+        Returns:
         -------
             int: Number of entities ingested.
 

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -195,7 +195,7 @@ class PolicyRunner:
         sanitized_hostname: str,
         config: Config,
         run_id: str,
-    ):
+    ) -> int:
         """
         Connect to device and collect data.
 

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -566,3 +566,48 @@ def test_collect_device_data_returns_entity_count(policy_runner):
         result = policy_runner._collect_device_data(scope, "router1", config, "run-abc")
 
     assert result == 7
+
+
+def test_run_uses_entity_count_from_collect(policy_runner, run_store):
+    """run() passes the actual entity count (not 1) to update_run."""
+    scope = Napalm(driver="ios", hostname="router1", username="admin", password="password")
+    config = Config(defaults=Defaults(site="NY"), options=Options())
+    policy_runner.run_store = run_store
+
+    with (
+        patch.object(policy_runner, "_discover_driver", return_value=True),
+        patch.object(policy_runner, "_collect_device_data", return_value=5),
+        patch("device_discovery.policy.runner.get_metric", return_value=None),
+    ):
+        policy_runner.name = "test-policy"
+        run = run_store.create_run(policy_name="test-policy", target="router1")
+        # Patch create_run to return our known run
+        with patch.object(run_store, "create_run", return_value=run):
+            with patch.object(run_store, "update_run") as mock_update:
+                policy_runner.run("job-1", scope, config)
+
+    mock_update.assert_called_once()
+    call_kwargs = mock_update.call_args[1]
+    assert call_kwargs["entity_count"] == 5
+
+
+def test_run_with_parent_uses_entity_count_from_collect(policy_runner, run_store):
+    """run_with_parent() passes the actual entity count (not 1) to update_run."""
+    scope = Napalm(driver="ios", hostname="router1", username="admin", password="password")
+    config = Config(defaults=Defaults(site="NY"), options=Options())
+    policy_runner.run_store = run_store
+
+    with (
+        patch.object(policy_runner, "_discover_driver", return_value=True),
+        patch.object(policy_runner, "_collect_device_data", return_value=12),
+        patch("device_discovery.policy.runner.get_metric", return_value=None),
+    ):
+        policy_runner.name = "test-policy"
+        run = run_store.create_run(policy_name="test-policy", target="router1")
+        with patch.object(run_store, "create_run", return_value=run):
+            with patch.object(run_store, "update_run") as mock_update:
+                policy_runner.run_with_parent("job-1", scope, config, "192.168.1.0/24")
+
+    mock_update.assert_called_once()
+    call_kwargs = mock_update.call_args[1]
+    assert call_kwargs["entity_count"] == 12

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -537,3 +537,32 @@ def test_setup_accepts_valid_discovery_drivers():
         runner.setup("test-policy", config, scope, run_store)
     finally:
         runner.stop()
+
+
+def test_collect_device_data_returns_entity_count(policy_runner):
+    """_collect_device_data returns the number of ingested entities."""
+    scope = Napalm(
+        driver="ios",
+        hostname="router1",
+        username="admin",
+        password="password",
+    )
+    config = Config(defaults=Defaults(site="NY"))
+
+    fake_device = MagicMock()
+    fake_device.get_facts.return_value = {"hostname": "router1"}
+    fake_device.get_interfaces.return_value = {}
+    fake_device.get_interfaces_ip.return_value = {}
+    fake_device.get_vlans.return_value = {}
+    fake_device.__enter__ = MagicMock(return_value=fake_device)
+    fake_device.__exit__ = MagicMock(return_value=False)
+
+    with (
+        patch("device_discovery.policy.runner.get_network_driver", return_value=MagicMock(return_value=fake_device)),
+        patch("device_discovery.policy.runner.Client") as mock_client_cls,
+    ):
+        mock_client_cls.return_value.ingest.return_value = 7
+
+        result = policy_runner._collect_device_data(scope, "router1", config, "run-abc")
+
+    assert result == 7

--- a/device-discovery/tests/test_client.py
+++ b/device-discovery/tests/test_client.py
@@ -229,3 +229,22 @@ def test_init_client_uses_otlp_when_credentials_missing(
         app_name="prefix/device-discovery",
         app_version=mock_version_semver(),
     )
+
+
+def test_ingest_returns_entity_count(mock_diode_client_class, sample_data, sample_metadata):
+    """ingest() returns the number of entities ingested."""
+    client = Client()
+    client.init_client(
+        prefix="", target="https://example.com", client_id="abc", client_secret="def"
+    )
+    mock_diode_instance = mock_diode_client_class.return_value
+    mock_diode_instance.ingest.return_value.errors = []
+
+    with patch(
+        "device_discovery.client.translate_data",
+        return_value=translate_data(sample_data),
+    ) as mock_translate:
+        count = client.ingest(sample_metadata, sample_data)
+
+    expected = len(list(translate_data(sample_data)))
+    assert count == expected

--- a/device-discovery/tests/test_client.py
+++ b/device-discovery/tests/test_client.py
@@ -243,7 +243,7 @@ def test_ingest_returns_entity_count(mock_diode_client_class, sample_data, sampl
     with patch(
         "device_discovery.client.translate_data",
         return_value=translate_data(sample_data),
-    ) as mock_translate:
+    ):
         count = client.ingest(sample_metadata, sample_data)
 
     expected = len(list(translate_data(sample_data)))


### PR DESCRIPTION
## Summary
- `Client.ingest()` already computed `entity_count = len(entities_list)` but never returned it — added `return entity_count` and `-> int` annotation
- `_collect_device_data()` now captures and returns that value (with `-> int` annotation and `Returns` docstring)
- `run()` and `run_with_parent()` now use the returned count in `run_store.update_run()` instead of the hardcoded `1`

## Test Plan
- [ ] `pytest device-discovery/` passes (225 tests)
- [ ] Verify a discovery run against a real device reports the correct entity count (should reflect the number of translated entities, not always 1)

Closes OBS-2596

🤖 Generated with [Claude Code](https://claude.com/claude-code)