### PR TITLE
fix: populate startup config in asa_ssh and strip CRLF in asa get_interfaces

### DIFF
--- a/device-discovery/custom_napalm/asa.py
+++ b/device-discovery/custom_napalm/asa.py
@@ -292,9 +292,9 @@ class ASADriver(_napalm_base.NetworkDriver):
             raw = outputs[i] if i < len(outputs) else ""
             match_mac = re.search(r"MAC address (.{14}),", raw)
             mac = match_mac.group(1) if match_mac else ""
-            match_status = re.search(r"line protocol is (.{2,4})\n", raw)
-            is_up = match_status.group(1) == "up" if match_status else False
-            match_mtu = re.search(r"MTU (.{1,4})\n", raw)
+            match_status = re.search(r"line protocol is (.{2,4})\r?\n", raw)
+            is_up = match_status.group(1).strip() == "up" if match_status else False
+            match_mtu = re.search(r"MTU (.{1,4})\r?\n", raw)
             mtu = int(match_mtu.group(1)) if match_mtu else 0
             details[name] = {"mac_address": mac, "is_up": is_up, "mtu": mtu}
         return details

--- a/device-discovery/custom_napalm/asa_ssh.py
+++ b/device-discovery/custom_napalm/asa_ssh.py
@@ -226,6 +226,9 @@ class ASASSHDriver(_napalm_base.NetworkDriver):
         if retrieve in ("all", "running"):
             config["running"] = self.device.send_command("show running-config")
 
+        if retrieve in ("all", "startup"):
+            config["startup"] = self.device.send_command("show startup-config")
+
         if sanitized:
             for key in ("running", "candidate", "startup"):
                 if config[key]:

--- a/device-discovery/tests/custom_drivers/asa/mock_data/test_get_interfaces/normal/cli.json
+++ b/device-discovery/tests/custom_drivers/asa/mock_data/test_get_interfaces/normal/cli.json
@@ -1,6 +1,6 @@
 {
   "response": [
-    "Interface GigabitEthernet1/1 \"inside\", is up, line protocol is up\n  Hardware is EtherSVC, BW 1000 Mbps\n  MAC address aabb.cc00.0100, MTU 1500\n",
-    "Interface GigabitEthernet1/2 \"outside\", is administratively down, line protocol is down\n  Hardware is EtherSVC, BW 1000 Mbps\n  MAC address aabb.cc00.0200, MTU 1500\n"
+    "Interface GigabitEthernet1/1 \"inside\", is up, line protocol is up\r\n  Hardware is EtherSVC, BW 1000 Mbps\r\n  MAC address aabb.cc00.0100, MTU 1500\r\n",
+    "Interface GigabitEthernet1/2 \"outside\", is administratively down, line protocol is down\r\n  Hardware is EtherSVC, BW 1000 Mbps\r\n  MAC address aabb.cc00.0200, MTU 1500\r\n"
   ]
 }

--- a/device-discovery/tests/custom_drivers/asa_ssh/mock_data/test_get_config/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/asa_ssh/mock_data/test_get_config/normal/expected_result.json
@@ -1,5 +1,5 @@
 {
   "running": ": Saved\n!\nASA Version 9.16.4\n!\nhostname asa-firewall\ndomain-name example.com\n!\ninterface GigabitEthernet1/1\n nameif inside\n security-level 100\n ip address 192.168.1.1 255.255.255.0\n!\ninterface GigabitEthernet1/2\n nameif outside\n security-level 0\n ip address 203.0.113.1 255.255.255.0\n!\ninterface Management1/1\n nameif mgmt\n security-level 50\n ip address 10.0.0.1 255.255.255.0\n!\nroute outside 0.0.0.0 0.0.0.0 203.0.113.254 1\n!\nend\n",
   "candidate": "",
-  "startup": ""
+  "startup": ": Saved\n!\nASA Version 9.16.4\n!\nhostname asa-firewall\n!\ninterface GigabitEthernet1/1\n nameif inside\n!\nend\n"
 }

--- a/device-discovery/tests/custom_drivers/asa_ssh/mock_data/test_get_config/normal/show_startup-config.txt
+++ b/device-discovery/tests/custom_drivers/asa_ssh/mock_data/test_get_config/normal/show_startup-config.txt
@@ -1,0 +1,10 @@
+: Saved
+!
+ASA Version 9.16.4
+!
+hostname asa-firewall
+!
+interface GigabitEthernet1/1
+ nameif inside
+!
+end

--- a/device-discovery/tests/custom_drivers/asa_ssh/mock_data/test_get_config_sanitized/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/asa_ssh/mock_data/test_get_config_sanitized/normal/expected_result.json
@@ -1,5 +1,5 @@
 {
   "running": ": Saved\n!\nASA Version 9.16.4\n!\nhostname asa-firewall\nenable password <redacted> encrypted\npasswd <redacted> encrypted\n!\nusername admin password <redacted> privilege 15\nusername readonly password <redacted> privilege 5\n!\ninterface GigabitEthernet1/1\n nameif inside\n security-level 100\n ip address 192.168.1.1 255.255.255.0\n!\nsnmp-server community <redacted> RO\n!\ntacacs-server host 10.0.0.2 key <redacted>\ncrypto isakmp key <redacted> address 10.0.0.3\n ip ospf message-digest-key 1 md5 <redacted>\nrouter bgp 65000\n neighbor 10.0.0.4 password <redacted>\naaa-server RADIUS protocol radius\n key <redacted>\ntunnel-group 10.0.0.1 ipsec-attributes\n pre-shared-key <redacted>\n!\nend\n",
   "candidate": "",
-  "startup": ""
+  "startup": ": Saved\n!\nASA Version 9.16.4\n!\nhostname asa-firewall\nenable password <redacted> encrypted\n!\nend\n"
 }

--- a/device-discovery/tests/custom_drivers/asa_ssh/mock_data/test_get_config_sanitized/normal/show_startup-config.txt
+++ b/device-discovery/tests/custom_drivers/asa_ssh/mock_data/test_get_config_sanitized/normal/show_startup-config.txt
@@ -1,0 +1,8 @@
+: Saved
+!
+ASA Version 9.16.4
+!
+hostname asa-firewall
+enable password $sha512$5000$StartupHash encrypted
+!
+end


### PR DESCRIPTION
## Summary

- **`asa_ssh.py`** — `get_config` now executes `show startup-config` when `retrieve` is `"startup"` or `"all"` (previously startup was always empty)
- **`asa.py`** — `_get_interfaces_details` regex now uses `\r?\n` for both `line protocol is` and `MTU` matches, and strips whitespace before the `== "up"` comparison — fixes silent false-down reporting when the ASA REST API returns CRLF line endings

## Test plan

- [x] `pytest tests/custom_drivers/ -v` — all 37 tests pass
- [x] Mockit end-to-end for `asa_ssh` (requires Docker):
  ```bash
  docker run -d --rm --name asa-test -e DEVICE_TYPE=cisco_asa -e SSH_USERNAME=admin -e SSH_PASSWORD=admin -p 10049:22 registry.gitlab.com/slurpit.io/mockit:latest
  # start device-discovery in dry-run, submit policy with driver: asa_ssh, port: 10049
  # verify startup config non-empty in output JSON
  docker stop asa-test
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)