### PR TITLE
feat: add netbox_id per-target field for NetBox PK-based device matching

### DIFF
--- a/device-discovery/device_discovery/policy/models.py
+++ b/device-discovery/device_discovery/policy/models.py
@@ -211,6 +211,10 @@ class Napalm(BaseModel):
     optional_args: dict[str, Any] | None = Field(
         default=None, description="Optional arguments"
     )
+    netbox_id: int | None = Field(
+        default=None,
+        description="NetBox device primary key for PK-based matching. Ignored when hostname is a range or subnet.",
+    )
     override_defaults: Defaults | None = Field(
         default=None,
         description="Override default configuration for this host, optional",

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -321,7 +321,7 @@ class PolicyRunner:
                         f"Policy {self.name}, Hostname {hostname}: Reachable port found, scheduling discovery job"
                     )
                     id = str(uuid.uuid4())
-                    self.scopes[id] = scope.model_copy(update={"hostname": hostname})
+                    self.scopes[id] = scope.model_copy(update={"hostname": hostname, "netbox_id": None})
                     self.scheduler.add_job(
                         self.run_with_parent,
                         id=id,

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -244,6 +244,7 @@ class PolicyRunner:
                 "interface_ip": device.get_interfaces_ip(),
                 "defaults": config.defaults,
                 "options": config.options,
+                "netbox_id": scope.netbox_id,
             }
             # Only retrieve config if at least one capture flag is enabled
             if config.options and (

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -58,6 +58,9 @@ def translate_device(
         defaults (Defaults): Default configuration.
         config_info (dict | None): Dictionary containing configuration data from NAPALM.
         options (Options | None): Discovery options.
+        netbox_id (int | None): NetBox device primary key for PK-based matching.
+            When set, writes ``source_match.netbox_id`` to device metadata.
+            Ignored when None.
 
     Returns:
     -------

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -47,6 +47,7 @@ def translate_device(
     defaults: Defaults,
     config_info: dict | None = None,
     options: Options | None = None,
+    netbox_id: int | None = None,
 ) -> Device:
     """
     Translate device information from NAPALM format to Diode SDK Device entity.
@@ -122,6 +123,8 @@ def translate_device(
     if device_config is not None:
         device_params["config"] = device_config
     device = Device(**device_params)
+    if netbox_id is not None:
+        device.metadata.update({"source_match": {"netbox_id": netbox_id}})
     return device
 
 
@@ -244,6 +247,7 @@ def translate_data(data: dict) -> Iterable[Entity]:
     config_info = data.get("config") or {}
     interfaces = data.get("interface") or {}
     interfaces_ip = data.get("interface_ip") or {}
+    netbox_id = data.get("netbox_id")
     if device_info:
         if options.platform_omit_version:
             device_info["platform"] = data.get("driver")
@@ -253,7 +257,7 @@ def translate_data(data: dict) -> Iterable[Entity]:
             )
             if len(device_info["platform"]) > 100:
                 device_info["platform"] = device_info.get("os_version")[:100]
-        device = translate_device(device_info, defaults, config_info, options)
+        device = translate_device(device_info, defaults, config_info, options, netbox_id=netbox_id)
         entities.append(Entity(device=device))
         device_for_interfaces = copy.deepcopy(device)
         device_for_interfaces.ClearField("config")

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -492,6 +492,37 @@ def test_options_discovery_drivers_parsed():
     assert opts.discovery_drivers == ["ios", "panos"]
 
 
+def test_run_scan_clears_netbox_id_for_range_expanded_hosts():
+    """Hosts expanded from a range/subnet must not inherit the scope's netbox_id."""
+    runner = PolicyRunner()
+    runner.name = "policy1"
+    runner.run_store = RunStore()
+    runner.scheduler = MagicMock()
+    scope = Napalm(
+        driver="ios",
+        hostname="192.168.1.0/24",
+        username="admin",
+        password="password",
+        netbox_id=42,
+    )
+    config = Config(options=Options(port_scan_ports=[22], port_scan_timeout=0.1))
+    trigger = MagicMock(spec=BaseTrigger)
+
+    with (
+        patch(
+            "device_discovery.policy.runner.find_reachable_hosts",
+            return_value={"192.168.1.1": True},
+        ),
+        patch("uuid.uuid4", side_effect=["scan-run-id", "job-1"]),
+    ):
+        runner.run_scan(["192.168.1.1"], trigger, scope, config)
+
+    scheduled_call = runner.scheduler.add_job.call_args
+    scheduled_scope = scheduled_call[1]["args"][1]
+    assert scheduled_scope.hostname == "192.168.1.1"
+    assert scheduled_scope.netbox_id is None
+
+
 def test_setup_raises_on_unknown_discovery_drivers():
     """setup() raises if discovery_drivers contains a driver not in supported_drivers."""
     from device_discovery.policy.models import Config, Napalm, Options

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -25,6 +25,20 @@ from device_discovery.translate import (
 )
 
 
+def test_napalm_netbox_id_parsed():
+    """netbox_id field is parsed correctly."""
+    from device_discovery.policy.models import Napalm
+    n = Napalm(hostname="192.168.1.1", username="admin", password="secret", netbox_id=42)
+    assert n.netbox_id == 42
+
+
+def test_napalm_netbox_id_optional():
+    """netbox_id defaults to None."""
+    from device_discovery.policy.models import Napalm
+    n = Napalm(hostname="192.168.1.1", username="admin", password="secret")
+    assert n.netbox_id is None
+
+
 @pytest.fixture
 def sample_device_info():
     """Sample device information for testing."""

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -789,6 +789,19 @@ def test_translate_data_with_config(sample_device_info):
     # When SDK supports it, device will have config attached
 
 
+def test_translate_device_with_netbox_id(sample_device_info, sample_defaults):
+    """Device metadata contains source_match when netbox_id is provided."""
+    device = translate_device(sample_device_info, sample_defaults, netbox_id=42)
+    assert "source_match" in device.metadata
+    assert device.metadata["source_match"]["netbox_id"] == 42
+
+
+def test_translate_device_without_netbox_id(sample_device_info, sample_defaults):
+    """Device metadata has no source_match key when netbox_id is not provided."""
+    device = translate_device(sample_device_info, sample_defaults)
+    assert "source_match" not in device.metadata
+
+
 def test_translate_data_with_config_disabled(sample_device_info):
     """Test that config is not captured when flags are disabled."""
     config_info = {

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -12,6 +12,7 @@ from device_discovery.policy.models import (
     Defaults,
     DeviceParameters,
     IpamParameters,
+    Napalm,
     ObjectParameters,
     Options,
     TenantParameters,
@@ -27,14 +28,12 @@ from device_discovery.translate import (
 
 def test_napalm_netbox_id_parsed():
     """netbox_id field is parsed correctly."""
-    from device_discovery.policy.models import Napalm
     n = Napalm(hostname="192.168.1.1", username="admin", password="secret", netbox_id=42)
     assert n.netbox_id == 42
 
 
 def test_napalm_netbox_id_optional():
     """netbox_id defaults to None."""
-    from device_discovery.policy.models import Napalm
     n = Napalm(hostname="192.168.1.1", username="admin", password="secret")
     assert n.netbox_id is None
 

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -21,6 +21,7 @@ type Target struct {
 	Port             uint16          `yaml:"port" default:"161"`
 	Authentication   *Authentication `yaml:"authentication,omitempty"`
 	OverrideDefaults *Defaults       `yaml:"override_defaults,omitempty"`
+	NetboxID         *int            `yaml:"netbox_id,omitempty"`
 }
 
 // Authentication represents the authentication credentials for a target host

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v3"
 )
 
 func TestMergeDefaults(t *testing.T) {
@@ -234,4 +236,24 @@ func TestMergeDefaults(t *testing.T) {
 		assert.Equal(t, []string{"default", "policy"}, result.Tags)
 		assert.Len(t, result.InterfacePatterns, 1)
 	})
+}
+
+func TestTargetNetboxID_parsed(t *testing.T) {
+	input := `
+host: "192.168.1.1"
+netbox_id: 42
+`
+	var target Target
+	err := yaml.Unmarshal([]byte(input), &target)
+	require.NoError(t, err)
+	require.NotNil(t, target.NetboxID)
+	assert.Equal(t, 42, *target.NetboxID)
+}
+
+func TestTargetNetboxID_optional(t *testing.T) {
+	input := `host: "10.0.0.1"`
+	var target Target
+	err := yaml.Unmarshal([]byte(input), &target)
+	require.NoError(t, err)
+	assert.Nil(t, target.NetboxID)
 }

--- a/snmp-discovery/policy/entity_run_metadata.go
+++ b/snmp-discovery/policy/entity_run_metadata.go
@@ -7,8 +7,10 @@ import (
 )
 
 // annotateDeviceWithSourceMatch sets source_match metadata on the *diode.Device
-// reachable from the entity batch — either at the top level or nested inside
-// Interface/IPAddress entities, mirroring the traversal in annotateEntitiesWithRunID.
+// reachable from the entity batch — either at the top level, via Interface.Device,
+// or via IPAddress→Interface.Device. This covers the shapes produced by
+// MapObjectIDsToEntity; deeper links (Interface.Parent/Bridge/Lag,
+// IPAddress.NatInside) are not traversed.
 func annotateDeviceWithSourceMatch(entities []diode.Entity, netboxID int) {
 	seen := make(map[unsafe.Pointer]struct{})
 	for _, e := range entities {

--- a/snmp-discovery/policy/entity_run_metadata.go
+++ b/snmp-discovery/policy/entity_run_metadata.go
@@ -6,6 +6,20 @@ import (
 	"github.com/netboxlabs/diode-sdk-go/diode"
 )
 
+// annotateDeviceWithSourceMatch sets source_match metadata on the first *diode.Device
+// in the top-level entity slice. No-op if no Device is present.
+func annotateDeviceWithSourceMatch(entities []diode.Entity, netboxID int) {
+	for _, e := range entities {
+		if d, ok := e.(*diode.Device); ok && d != nil {
+			if d.Metadata == nil {
+				d.Metadata = make(diode.Metadata)
+			}
+			d.Metadata["source_match"] = diode.Metadata{"netbox_id": netboxID}
+			return
+		}
+	}
+}
+
 // annotateEntitiesWithRunID sets per-entity Diode metadata key "run_id" on each entity
 // in the batch and on nested Device, Interface, and IPAddress references.
 func annotateEntitiesWithRunID(entities []diode.Entity, runID string) {

--- a/snmp-discovery/policy/entity_run_metadata.go
+++ b/snmp-discovery/policy/entity_run_metadata.go
@@ -6,18 +6,42 @@ import (
 	"github.com/netboxlabs/diode-sdk-go/diode"
 )
 
-// annotateDeviceWithSourceMatch sets source_match metadata on the first *diode.Device
-// in the top-level entity slice. No-op if no Device is present.
+// annotateDeviceWithSourceMatch sets source_match metadata on the *diode.Device
+// reachable from the entity batch — either at the top level or nested inside
+// Interface/IPAddress entities, mirroring the traversal in annotateEntitiesWithRunID.
 func annotateDeviceWithSourceMatch(entities []diode.Entity, netboxID int) {
+	seen := make(map[unsafe.Pointer]struct{})
 	for _, e := range entities {
-		if d, ok := e.(*diode.Device); ok && d != nil {
-			if d.Metadata == nil {
-				d.Metadata = make(diode.Metadata)
+		switch v := e.(type) {
+		case *diode.Device:
+			setDeviceSourceMatch(v, netboxID, seen)
+		case *diode.Interface:
+			if v != nil {
+				setDeviceSourceMatch(v.Device, netboxID, seen)
 			}
-			d.Metadata["source_match"] = diode.Metadata{"netbox_id": netboxID}
-			return
+		case *diode.IPAddress:
+			if v != nil {
+				if iface, ok := v.AssignedObject.(*diode.Interface); ok && iface != nil {
+					setDeviceSourceMatch(iface.Device, netboxID, seen)
+				}
+			}
 		}
 	}
+}
+
+func setDeviceSourceMatch(d *diode.Device, netboxID int, seen map[unsafe.Pointer]struct{}) {
+	if d == nil {
+		return
+	}
+	p := unsafe.Pointer(d)
+	if _, ok := seen[p]; ok {
+		return
+	}
+	seen[p] = struct{}{}
+	if d.Metadata == nil {
+		d.Metadata = make(diode.Metadata)
+	}
+	d.Metadata["source_match"] = diode.Metadata{"netbox_id": netboxID}
 }
 
 // annotateEntitiesWithRunID sets per-entity Diode metadata key "run_id" on each entity

--- a/snmp-discovery/policy/entity_run_metadata_test.go
+++ b/snmp-discovery/policy/entity_run_metadata_test.go
@@ -52,3 +52,21 @@ func TestAnnotateEntitiesWithRunID_sharedDeviceVisitedOnce(t *testing.T) {
 	annotateEntitiesWithRunID(entities, "run-shared")
 	assert.Equal(t, "run-shared", dev.Metadata["run_id"])
 }
+
+func TestAnnotateDeviceWithSourceMatch_sets_metadata(t *testing.T) {
+	dev := &diode.Device{Name: diode.String("r1")}
+	entities := []diode.Entity{dev}
+	annotateDeviceWithSourceMatch(entities, 42)
+	require.Contains(t, dev.Metadata, "source_match")
+	nested, ok := dev.Metadata["source_match"].(diode.Metadata)
+	require.True(t, ok, "source_match value should be diode.Metadata")
+	assert.Equal(t, 42, nested["netbox_id"])
+}
+
+func TestAnnotateDeviceWithSourceMatch_no_device_is_noop(t *testing.T) {
+	iface := &diode.Interface{Name: diode.String("eth0")}
+	entities := []diode.Entity{iface}
+	// Should not panic when no *diode.Device is present
+	annotateDeviceWithSourceMatch(entities, 99)
+	assert.Nil(t, iface.Metadata)
+}

--- a/snmp-discovery/policy/entity_run_metadata_test.go
+++ b/snmp-discovery/policy/entity_run_metadata_test.go
@@ -70,3 +70,35 @@ func TestAnnotateDeviceWithSourceMatch_no_device_is_noop(t *testing.T) {
 	annotateDeviceWithSourceMatch(entities, 99)
 	assert.Nil(t, iface.Metadata)
 }
+
+func TestAnnotateDeviceWithSourceMatch_nested_in_interface(t *testing.T) {
+	dev := &diode.Device{Name: diode.String("r1")}
+	iface := &diode.Interface{Name: diode.String("eth0"), Device: dev}
+	entities := []diode.Entity{iface}
+	annotateDeviceWithSourceMatch(entities, 42)
+	require.Contains(t, dev.Metadata, "source_match")
+	nested, ok := dev.Metadata["source_match"].(diode.Metadata)
+	require.True(t, ok)
+	assert.Equal(t, 42, nested["netbox_id"])
+}
+
+func TestAnnotateDeviceWithSourceMatch_nested_in_ip_address(t *testing.T) {
+	dev := &diode.Device{Name: diode.String("r1")}
+	iface := &diode.Interface{Name: diode.String("eth0"), Device: dev}
+	ip := &diode.IPAddress{Address: diode.String("10.0.0.1/24"), AssignedObject: iface}
+	entities := []diode.Entity{ip}
+	annotateDeviceWithSourceMatch(entities, 7)
+	require.Contains(t, dev.Metadata, "source_match")
+	nested, ok := dev.Metadata["source_match"].(diode.Metadata)
+	require.True(t, ok)
+	assert.Equal(t, 7, nested["netbox_id"])
+}
+
+func TestAnnotateDeviceWithSourceMatch_shared_device_annotated_once(t *testing.T) {
+	dev := &diode.Device{Name: diode.String("shared")}
+	if1 := &diode.Interface{Name: diode.String("a"), Device: dev}
+	if2 := &diode.Interface{Name: diode.String("b"), Device: dev}
+	entities := []diode.Entity{if1, if2}
+	annotateDeviceWithSourceMatch(entities, 5)
+	assert.Equal(t, diode.Metadata{"netbox_id": 5}, dev.Metadata["source_match"])
+}

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -455,6 +455,9 @@ func (r *Runner) expandTargetRanges(configuredTargets []config.Target) []expande
 				Authentication:   target.Authentication,
 				OverrideDefaults: target.OverrideDefaults,
 			}
+			if len(ips) == 1 {
+				expandedTargets[i].NetboxID = target.NetboxID
+			}
 		}
 		expandedGroups = append(expandedGroups, expandedTargetGroup{
 			originalTarget: originalHost,

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -314,6 +314,9 @@ func (r *Runner) runWithMetadata(target config.Target, parentTarget string) {
 	}
 
 	r.logEntitiesForIngestion(entities)
+	if target.NetboxID != nil {
+		annotateDeviceWithSourceMatch(entities, *target.NetboxID)
+	}
 	annotateEntitiesWithRunID(entities, run.ID)
 
 	resp, err := r.client.Ingest(r.ctx, entities, diode.WithIngestMetadata(diode.Metadata{

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -458,7 +458,7 @@ func (r *Runner) expandTargetRanges(configuredTargets []config.Target) []expande
 				Authentication:   target.Authentication,
 				OverrideDefaults: target.OverrideDefaults,
 			}
-			if len(ips) == 1 {
+			if len(ips) == 1 && originalHost == ips[i] {
 				expandedTargets[i].NetboxID = target.NetboxID
 			}
 		}

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -313,11 +313,11 @@ func (r *Runner) runWithMetadata(target config.Target, parentTarget string) {
 		return
 	}
 
-	r.logEntitiesForIngestion(entities)
 	if target.NetboxID != nil {
 		annotateDeviceWithSourceMatch(entities, *target.NetboxID)
 	}
 	annotateEntitiesWithRunID(entities, run.ID)
+	r.logEntitiesForIngestion(entities)
 
 	resp, err := r.client.Ingest(r.ctx, entities, diode.WithIngestMetadata(diode.Metadata{
 		"policy_name": policyName,

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -87,6 +87,41 @@ func TestExpandTargetRangesGroupsTargets(t *testing.T) {
 	assert.Equal(t, uint16(162), expanded[1].targets[0].Port)
 }
 
+func TestExpandTargetRanges_NetboxID_propagation(t *testing.T) {
+	netboxID := 42
+	runner := &Runner{
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	tests := []struct {
+		name         string
+		host         string
+		wantNetboxID bool
+	}{
+		{"plain IP carries netbox_id", "192.168.1.1", true},
+		{"CIDR /32 clears netbox_id", "192.168.1.1/32", false},
+		{"single-IP range clears netbox_id", "192.168.1.1-192.168.1.1", false},
+		{"multi-IP range clears netbox_id", "192.168.1.1-192.168.1.2", false},
+		{"subnet clears netbox_id", "192.168.1.0/30", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			targets := []config.Target{{Host: tc.host, Port: 161, NetboxID: &netboxID}}
+			expanded := runner.expandTargetRanges(targets)
+			require.NotEmpty(t, expanded)
+			for _, target := range expanded[0].targets {
+				if tc.wantNetboxID {
+					require.NotNil(t, target.NetboxID)
+					assert.Equal(t, netboxID, *target.NetboxID)
+				} else {
+					assert.Nil(t, target.NetboxID)
+				}
+			}
+		})
+	}
+}
+
 func TestProbeTargetCanceledContextSkipsClientFactory(t *testing.T) {
 	var factoryCalls int32
 	runner := &Runner{


### PR DESCRIPTION
## Summary

- Adds optional `netbox_id` integer field at the per-target level in both device-discovery and snmp-discovery policy config
- Propagates the value to the Diode `Device` entity metadata as `source_match: {netbox_id: <int>}` to enable PK-based matching in the diode-netbox-plugin (netboxlabs/diode-netbox-plugin#158)
- `netbox_id` is silently ignored when the target hostname/host is a range or subnet (a single PK cannot map to multiple devices)
- Fully backward-compatible — targets without `netbox_id` behave identically to before

## Test plan

- [x] device-discovery: `cd device-discovery && .venv/bin/pytest tests/ -v`
- [x] snmp-discovery: `cd snmp-discovery && go test ./...`
- [ ] Manual: configure a target with `netbox_id: <existing NetBox device ID>` and verify discovery updates the correct device by PK

🤖 Generated with [Claude Code](https://claude.com/claude-code)