### PR TITLE
feat: VLAN support

### DIFF
--- a/device-discovery/device_discovery/interface.py
+++ b/device-discovery/device_discovery/interface.py
@@ -7,7 +7,7 @@ import logging
 import re
 from collections.abc import Iterable
 
-from netboxlabs.diode.sdk.ingester import Device, Entity, Interface, IPAddress, Prefix
+from netboxlabs.diode.sdk.ingester import Device, Entity, Interface, IPAddress, Prefix, VLAN
 
 from device_discovery.defaults import DEFAULT_INTERFACE_PATTERNS
 from device_discovery.policy.models import Defaults
@@ -179,6 +179,7 @@ def translate_interface(
     interface_info: dict,
     defaults: Defaults,
     parent: Interface | None = None,
+    tagged_vlans: list[VLAN] | None = None,
 ) -> Interface:
     """
     Translate interface information from NAPALM format to Diode SDK Interface entity.
@@ -254,6 +255,7 @@ def translate_interface(
         parent=parent,
         tags=tags,
         type=interface_type,
+        tagged_vlans=tagged_vlans or None,
     )
 
     # Convert napalm interface speed from Mbps to Netbox Kbps
@@ -379,11 +381,13 @@ def build_interface_entities(
     interfaces: dict,
     interfaces_ip: dict,
     defaults: Defaults,
+    vlans_by_interface: dict[str, list[VLAN]] | None = None,
 ) -> list[Entity]:
     """Create interface entities from interface definitions and IP data."""
     interface_entities: dict[str, Interface] = {}
     entities: list[Entity] = []
     defined_interface_names = set(interfaces.keys())
+    vlans_map = vlans_by_interface or {}
 
     def interface_sort_key(name: str) -> tuple[int, str]:
         separator_score = name.count(".") + name.count(":")
@@ -400,7 +404,8 @@ def build_interface_entities(
     ):
         parent = resolve_parent(if_name)
         interface = translate_interface(
-            device, if_name, interface_info, defaults, parent=parent
+            device, if_name, interface_info, defaults, parent=parent,
+            tagged_vlans=vlans_map.get(if_name),
         )
         interface_entities[if_name] = interface
         entities.append(Entity(interface=interface))
@@ -410,7 +415,10 @@ def build_interface_entities(
         if if_name in interface_entities:
             continue
         parent = resolve_parent(if_name)
-        interface = translate_interface(device, if_name, {}, defaults, parent=parent)
+        interface = translate_interface(
+            device, if_name, {}, defaults, parent=parent,
+            tagged_vlans=vlans_map.get(if_name),
+        )
         interface_entities[if_name] = interface
         entities.append(Entity(interface=interface))
         entities.extend(translate_interface_ips(interface, interfaces_ip, defaults))

--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -264,8 +264,20 @@ def translate_data(data: dict) -> Iterable[Entity]:
         entities.append(Entity(device=device))
         device_for_interfaces = copy.deepcopy(device)
         device_for_interfaces.ClearField("config")
+
+        # Build interface→VLANs reverse map from VLAN data so interfaces
+        # carry their VLAN assignments.
+        vlans_by_interface: dict[str, list[VLAN]] = {}
+        if data.get("vlan"):
+            for vid, vlan_info in data["vlan"].items():
+                vlan = translate_vlan(vid, vlan_info.get("name"), defaults)
+                if vlan:
+                    for iface_name in vlan_info.get("interfaces", []):
+                        vlans_by_interface.setdefault(iface_name, []).append(vlan)
+
         interface_related_entities = build_interface_entities(
-            device_for_interfaces, interfaces, interfaces_ip, defaults
+            device_for_interfaces, interfaces, interfaces_ip, defaults,
+            vlans_by_interface=vlans_by_interface,
         )
         entities.extend(interface_related_entities)
 


### PR DESCRIPTION
This pull request enhances the device discovery process by adding support for associating VLAN assignments with interfaces. The main changes involve updating the interface translation and entity-building logic to propagate VLAN information from VLAN definitions to the corresponding interface entities.

**VLAN association enhancements:**

* The `translate_interface` function now accepts a new `tagged_vlans` parameter, allowing VLAN assignments to be passed and included in the resulting `Interface` entity. (`device-discovery/device_discovery/interface.py`, [[1]](diffhunk://#diff-bec065ea8940265410f52211ea63a1c929fdd96cef828f38b594c88e83021f7dR182) [[2]](diffhunk://#diff-bec065ea8940265410f52211ea63a1c929fdd96cef828f38b594c88e83021f7dR258)
* The `build_interface_entities` function is updated to accept a `vlans_by_interface` mapping, which is used to assign VLANs to interfaces during entity creation. (`device-discovery/device_discovery/interface.py`, [[1]](diffhunk://#diff-bec065ea8940265410f52211ea63a1c929fdd96cef828f38b594c88e83021f7dR384-R390) [[2]](diffhunk://#diff-bec065ea8940265410f52211ea63a1c929fdd96cef828f38b594c88e83021f7dL403-R408) [[3]](diffhunk://#diff-bec065ea8940265410f52211ea63a1c929fdd96cef828f38b594c88e83021f7dL413-R421)
* In `translate_data`, a reverse mapping from interfaces to their VLANs is constructed from the VLAN data, ensuring interfaces carry their VLAN assignments when entities are built. (`device-discovery/device_discovery/translate.py`, [device-discovery/device_discovery/translate.pyR267-R280](diffhunk://#diff-a9cfda0eb5ef3d184f3bdd20767bb4a830ba39fcf39069bf43f1186b1b9d1527R267-R280))

**Dependency updates:**

* The `VLAN` class is now imported from the Diode SDK ingester to support the new VLAN-related logic. (`device-discovery/device_discovery/interface.py`, [device-discovery/device_discovery/interface.pyL10-R10](diffhunk://#diff-bec065ea8940265410f52211ea63a1c929fdd96cef828f38b594c88e83021f7dL10-R10))