### PR TITLE
chore: update go and docker dependencies

### DIFF
--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
 
 jobs:
   build-and-scan:

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -14,9 +14,6 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  GO_VERSION: '1.26.2'
-
 jobs:
   build-and-scan:
     name: ${{ matrix.service }}
@@ -43,6 +40,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Extract Go version from go.mod
+        run: echo "GO_VERSION=$(grep '^go ' ${{ matrix.context }}/go.mod | awk '{print $2}')" >> $GITHUB_ENV
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0

--- a/.github/workflows/container-scan.yaml
+++ b/.github/workflows/container-scan.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.26'
+  GO_VERSION: '1.26.2'
 
 jobs:
   build-and-scan:

--- a/.github/workflows/network-discovery-lint.yaml
+++ b/.github/workflows/network-discovery-lint.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           check-latest: true
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0

--- a/.github/workflows/network-discovery-lint.yaml
+++ b/.github/workflows/network-discovery-lint.yaml
@@ -23,8 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.2'
-          check-latest: true
+          go-version-file: 'network-discovery/go.mod'
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0
         with:

--- a/.github/workflows/network-discovery-lint.yaml
+++ b/.github/workflows/network-discovery-lint.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.x'
+          go-version: '1.26.2'
           check-latest: true
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0

--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -14,7 +14,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   APP_NAME: network-discovery
 
 permissions:

--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -14,7 +14,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.26'
+  GO_VERSION: '1.26.2'
   APP_NAME: network-discovery
 
 permissions:

--- a/.github/workflows/network-discovery-release.yaml
+++ b/.github/workflows/network-discovery-release.yaml
@@ -14,7 +14,6 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.26.2'
   APP_NAME: network-discovery
 
 permissions:
@@ -131,6 +130,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Extract Go version from go.mod
+        run: echo "GO_VERSION=$(grep '^go ' network-discovery/go.mod | awk '{print $2}')" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0

--- a/.github/workflows/network-discovery-tests.yaml
+++ b/.github/workflows/network-discovery-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           check-latest: true
       - name: Run go build
         run: go build ./...

--- a/.github/workflows/network-discovery-tests.yaml
+++ b/.github/workflows/network-discovery-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.x'
+          go-version: '1.26.2'
           check-latest: true
       - name: Run go build
         run: go build ./...

--- a/.github/workflows/network-discovery-tests.yaml
+++ b/.github/workflows/network-discovery-tests.yaml
@@ -32,8 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.2'
-          check-latest: true
+          go-version-file: 'network-discovery/go.mod'
       - name: Run go build
         run: go build ./...
       - name: Install additional dependencies

--- a/.github/workflows/snmp-discovery-lint.yaml
+++ b/.github/workflows/snmp-discovery-lint.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           check-latest: true
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0

--- a/.github/workflows/snmp-discovery-lint.yaml
+++ b/.github/workflows/snmp-discovery-lint.yaml
@@ -23,8 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.2'
-          check-latest: true
+          go-version-file: 'snmp-discovery/go.mod'
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0
         with:

--- a/.github/workflows/snmp-discovery-lint.yaml
+++ b/.github/workflows/snmp-discovery-lint.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.x'
+          go-version: '1.26.2'
           check-latest: true
       - name: Lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -14,7 +14,6 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.26.2'
   APP_NAME: snmp-discovery
 
 permissions:
@@ -131,6 +130,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - name: Extract Go version from go.mod
+        run: echo "GO_VERSION=$(grep '^go ' snmp-discovery/go.mod | awk '{print $2}')" >> $GITHUB_ENV
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -14,7 +14,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.26'
+  GO_VERSION: '1.26.2'
   APP_NAME: snmp-discovery
 
 permissions:

--- a/.github/workflows/snmp-discovery-release.yaml
+++ b/.github/workflows/snmp-discovery-release.yaml
@@ -14,7 +14,7 @@ concurrency:
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   SEMANTIC_RELEASE_PACKAGE: ${{ github.repository }}
-  GO_VERSION: '1.25'
+  GO_VERSION: '1.26'
   APP_NAME: snmp-discovery
 
 permissions:

--- a/.github/workflows/snmp-discovery-tests.yaml
+++ b/.github/workflows/snmp-discovery-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.25.x'
+          go-version: '1.26.x'
           check-latest: true
       - name: Run go build
         run: go build ./...

--- a/.github/workflows/snmp-discovery-tests.yaml
+++ b/.github/workflows/snmp-discovery-tests.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.x'
+          go-version: '1.26.2'
           check-latest: true
       - name: Run go build
         run: go build ./...

--- a/.github/workflows/snmp-discovery-tests.yaml
+++ b/.github/workflows/snmp-discovery-tests.yaml
@@ -32,8 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.26.2'
-          check-latest: true
+          go-version-file: 'snmp-discovery/go.mod'
       - name: Run go build
         run: go build ./...
       - name: Install additional dependencies

--- a/network-discovery/docker/Dockerfile
+++ b/network-discovery/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 
@@ -15,7 +15,7 @@ RUN --mount=target=. \
     --mount=type=cache,target=/go/pkg \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -trimpath -o /build/network-discovery ./cmd/main.go
 
-FROM alpine:3.22
+FROM alpine:3.23
 
 RUN apk update && apk add --no-cache nmap
 

--- a/network-discovery/go.mod
+++ b/network-discovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/orb-discovery/network-discovery
 
-go 1.25.4
+go 1.26.2
 
 require (
 	github.com/Ullaakut/nmap/v3 v3.0.4

--- a/snmp-discovery/docker/Dockerfile
+++ b/snmp-discovery/docker/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.25
+ARG GO_VERSION=1.26
 
 FROM --platform=$BUILDPLATFORM golang:${GO_VERSION}-alpine AS builder
 
@@ -10,7 +10,7 @@ ARG TARGETOS TARGETARCH
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -trimpath -o /build/snmp-discovery ./cmd/main.go
 
-FROM alpine:3.22
+FROM alpine:3.23
 
 # Copy the binary
 COPY --from=builder /build/snmp-discovery /usr/local/bin/snmp-discovery

--- a/snmp-discovery/go.mod
+++ b/snmp-discovery/go.mod
@@ -1,6 +1,6 @@
 module github.com/netboxlabs/orb-discovery/snmp-discovery
 
-go 1.25.4
+go 1.26.2
 
 require (
 	github.com/gin-gonic/gin v1.10.0


### PR DESCRIPTION
This pull request updates both the `network-discovery` and `snmp-discovery` services to use Go 1.26.2 instead of Go 1.25.4, and makes related improvements to Dockerfiles and GitHub Actions workflows. It also ensures that workflows dynamically extract the Go version from each service's `go.mod` file, improving maintainability and consistency.

**Go Version Upgrades and Consistency**

* Upgraded Go version in `go.mod` for both `network-discovery` and `snmp-discovery` from 1.25.4 to 1.26.2. [[1]](diffhunk://#diff-622e1b493a8288886b8db66d986869ea28f51acd15da599c7949de15c561b09cL3-R3) [[2]](diffhunk://#diff-b317fe0c907478d97c235e904821194309658448be78cf050d9ada1dd275ec8fL3-R3)
* Updated `GO_VERSION` ARG in both services' `Dockerfile` and changed Alpine base image from 3.22 to 3.23. [[1]](diffhunk://#diff-509ff02d0e569a0a7033887310e5655a0e8cdb0c0ff006d0f5d845df6cf2e1faL1-R1) [[2]](diffhunk://#diff-509ff02d0e569a0a7033887310e5655a0e8cdb0c0ff006d0f5d845df6cf2e1faL18-R18) [[3]](diffhunk://#diff-f843a06d81f89848c1fd359f129a47d9ae7e1a13f300fc6641222e3786767906L1-R1) [[4]](diffhunk://#diff-f843a06d81f89848c1fd359f129a47d9ae7e1a13f300fc6641222e3786767906L13-R13)

**GitHub Actions Workflow Improvements**

* Removed hardcoded `GO_VERSION` environment variable and now extract the Go version dynamically from each service's `go.mod` using a shell command. [[1]](diffhunk://#diff-02c6d5909534c7ebd5d376f4a8439d7181aab898c98f166dccfc172fdd703b4fL17-L19) [[2]](diffhunk://#diff-9e83be94be4c5a084d3b8bd5b054f1fd774314525af718e3a1a03b1f2fa09421L17) [[3]](diffhunk://#diff-97f7673ffb778603a67a9739dfc61695ae28aa5d9fa8d1c8c4014c6a0feca04eL17) [[4]](diffhunk://#diff-02c6d5909534c7ebd5d376f4a8439d7181aab898c98f166dccfc172fdd703b4fR44-R46) [[5]](diffhunk://#diff-9e83be94be4c5a084d3b8bd5b054f1fd774314525af718e3a1a03b1f2fa09421R134-R136) [[6]](diffhunk://#diff-97f7673ffb778603a67a9739dfc61695ae28aa5d9fa8d1c8c4014c6a0feca04eR134-R136)
* Updated setup steps in lint and test workflows to use the `go-version-file` parameter, pointing to the respective `go.mod` files, instead of a hardcoded Go version. [[1]](diffhunk://#diff-72d364ed486d082b1baa9779bea6304f105df4279534774e8961c32b0a8dd341L26-R26) [[2]](diffhunk://#diff-df3afb3fd5b0c46175c7e95d8247596a60540a49524b1eab1dff774dfae4a0aaL35-R35) [[3]](diffhunk://#diff-c39a5aa4a354c7f3183ca64e559aaec2508b8b74c53fc83efc31cb10ac6b8797L26-R26) [[4]](diffhunk://#diff-aaa7dbb08f9c9e15953d3e75405abbf9d28f9d84ce453fb6d8628f82129840aaL35-R35)