### PR TITLE
fix(OBS-2250): device discovery job silently stops executing on schedule after failure

### DIFF
--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -318,15 +318,16 @@ class PolicyRunner:
                     error=Exception("No reachable hosts found in range"),
                     entity_count=0,
                 )
-            else:
-                self.run_store.update_run(
-                    policy_name=self.name,
-                    target=original_hostname,
-                    run_id=scan_run.id,
-                    status=RunStatus.COMPLETED,
-                    error=None,
-                    entity_count=reachable_count,
-                )
+                return
+
+            self.run_store.update_run(
+                policy_name=self.name,
+                target=original_hostname,
+                run_id=scan_run.id,
+                status=RunStatus.COMPLETED,
+                error=None,
+                entity_count=reachable_count,
+            )
 
             for hostname in hostnames:
                 sanitized_hostname = hostname.replace("\r\n", "").replace("\n", "")

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -333,7 +333,7 @@ class PolicyRunner:
                 sanitized_hostname = hostname.replace("\r\n", "").replace("\n", "")
                 existing_job_id = self.active_host_jobs.get((original_hostname, sanitized_hostname))
                 if existing_job_id and self.scheduler.get_job(existing_job_id):
-                    logger.info(
+                    logger.debug(
                         f"Policy {self.name}, Hostname {sanitized_hostname}: Discovery job already active, skipping"
                     )
                     continue

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -339,8 +339,21 @@ class PolicyRunner:
                     )
                     self.active_host_jobs[sanitized_hostname] = id
                 else:
-                    logger.info(
-                        f"Policy {self.name}, Hostname {sanitized_hostname}: No reachable port found, skipping discovery job"
+                    logger.warning(
+                        f"Policy {self.name}, Hostname {sanitized_hostname}: No reachable port found"
+                    )
+                    unreachable_run = self.run_store.create_run(
+                        policy_name=self.name,
+                        target=sanitized_hostname,
+                        parent_target=original_hostname,
+                    )
+                    self.run_store.update_run(
+                        policy_name=self.name,
+                        target=sanitized_hostname,
+                        run_id=unreachable_run.id,
+                        status=RunStatus.FAILED,
+                        error=Exception("No reachable port found"),
+                        entity_count=0,
                     )
         except Exception as e:
             logger.error(

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -39,6 +39,7 @@ class PolicyRunner:
         self.status = Status.NEW
         self.scheduler = BackgroundScheduler()
         self.run_store = None
+        self.active_host_jobs: dict[str, str] = {}
 
     def _validate_discovery_drivers(self):
         """
@@ -317,6 +318,12 @@ class PolicyRunner:
 
             for hostname in hostnames:
                 if results.get(hostname):
+                    existing_job_id = self.active_host_jobs.get(hostname)
+                    if existing_job_id and self.scheduler.get_job(existing_job_id):
+                        logger.info(
+                            f"Policy {self.name}, Hostname {hostname}: Discovery job already active, skipping"
+                        )
+                        continue
                     logger.info(
                         f"Policy {self.name}, Hostname {hostname}: Reachable port found, scheduling discovery job"
                     )
@@ -329,6 +336,7 @@ class PolicyRunner:
                         args=[id, self.scopes[id], config, original_hostname],
                         misfire_grace_time=None,
                     )
+                    self.active_host_jobs[hostname] = id
                 else:
                     logger.info(
                         f"Policy {self.name}, Hostname {hostname}: No reachable port found, skipping discovery job"

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -130,7 +130,7 @@ class PolicyRunner:
                 self.scheduler.add_job(
                     self.run_scan,
                     id=id,
-                    trigger=DateTrigger(run_date=datetime.now() + timedelta(seconds=1)),
+                    trigger=trigger,
                     args=[hostnames, trigger, scope, config],
                     misfire_grace_time=None,
                 )

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -381,17 +381,6 @@ class PolicyRunner:
                 error=Exception("Not able to discover device driver"),
                 entity_count=0,
             )
-            try:
-                self.scheduler.remove_job(id)
-            except JobLookupError as e:
-                logger.debug(
-                    f"Policy {self.name}, Hostname {sanitized_hostname}: Error removing job: {e}"
-                )
-            except Exception as e:
-                logger.warning(
-                    f"Policy {self.name}, Hostname {sanitized_hostname}: Unexpected error removing job: {e}",
-                    exc_info=True,
-                )
             return
 
         logger.info(

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -306,15 +306,27 @@ class PolicyRunner:
             results = find_reachable_hosts(hostnames, ports, timeout)
             reachable_count = sum(1 for v in results.values() if v)
 
-            # UPDATE SCAN RUN
-            self.run_store.update_run(
-                policy_name=self.name,
-                target=original_hostname,
-                run_id=scan_run.id,
-                status=RunStatus.COMPLETED,
-                error=None,
-                entity_count=reachable_count,
-            )
+            if reachable_count == 0:
+                logger.warning(
+                    f"Policy {self.name}, Hostname {original_hostname}: No reachable hosts found in range"
+                )
+                self.run_store.update_run(
+                    policy_name=self.name,
+                    target=original_hostname,
+                    run_id=scan_run.id,
+                    status=RunStatus.FAILED,
+                    error=Exception("No reachable hosts found in range"),
+                    entity_count=0,
+                )
+            else:
+                self.run_store.update_run(
+                    policy_name=self.name,
+                    target=original_hostname,
+                    run_id=scan_run.id,
+                    status=RunStatus.COMPLETED,
+                    error=None,
+                    entity_count=reachable_count,
+                )
 
             for hostname in hostnames:
                 sanitized_hostname = hostname.replace("\r\n", "").replace("\n", "")
@@ -339,21 +351,8 @@ class PolicyRunner:
                     )
                     self.active_host_jobs[sanitized_hostname] = id
                 else:
-                    logger.warning(
-                        f"Policy {self.name}, Hostname {sanitized_hostname}: No reachable port found"
-                    )
-                    unreachable_run = self.run_store.create_run(
-                        policy_name=self.name,
-                        target=sanitized_hostname,
-                        parent_target=original_hostname,
-                    )
-                    self.run_store.update_run(
-                        policy_name=self.name,
-                        target=sanitized_hostname,
-                        run_id=unreachable_run.id,
-                        status=RunStatus.FAILED,
-                        error=Exception("No reachable port found"),
-                        entity_count=0,
+                    logger.info(
+                        f"Policy {self.name}, Hostname {sanitized_hostname}: No reachable port found, skipping"
                     )
         except Exception as e:
             logger.error(

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -330,13 +330,13 @@ class PolicyRunner:
 
             for hostname in hostnames:
                 sanitized_hostname = hostname.replace("\r\n", "").replace("\n", "")
+                existing_job_id = self.active_host_jobs.get(sanitized_hostname)
+                if existing_job_id and self.scheduler.get_job(existing_job_id):
+                    logger.info(
+                        f"Policy {self.name}, Hostname {sanitized_hostname}: Discovery job already active, skipping"
+                    )
+                    continue
                 if results.get(hostname):
-                    existing_job_id = self.active_host_jobs.get(sanitized_hostname)
-                    if existing_job_id and self.scheduler.get_job(existing_job_id):
-                        logger.info(
-                            f"Policy {self.name}, Hostname {sanitized_hostname}: Discovery job already active, skipping"
-                        )
-                        continue
                     logger.info(
                         f"Policy {self.name}, Hostname {sanitized_hostname}: Reachable port found, scheduling discovery job"
                     )

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -317,18 +317,19 @@ class PolicyRunner:
             )
 
             for hostname in hostnames:
+                sanitized_hostname = hostname.replace("\r\n", "").replace("\n", "")
                 if results.get(hostname):
-                    existing_job_id = self.active_host_jobs.get(hostname)
+                    existing_job_id = self.active_host_jobs.get(sanitized_hostname)
                     if existing_job_id and self.scheduler.get_job(existing_job_id):
                         logger.info(
-                            f"Policy {self.name}, Hostname {hostname}: Discovery job already active, skipping"
+                            f"Policy {self.name}, Hostname {sanitized_hostname}: Discovery job already active, skipping"
                         )
                         continue
                     logger.info(
-                        f"Policy {self.name}, Hostname {hostname}: Reachable port found, scheduling discovery job"
+                        f"Policy {self.name}, Hostname {sanitized_hostname}: Reachable port found, scheduling discovery job"
                     )
                     id = str(uuid.uuid4())
-                    self.scopes[id] = scope.model_copy(update={"hostname": hostname, "netbox_id": None})
+                    self.scopes[id] = scope.model_copy(update={"hostname": sanitized_hostname, "netbox_id": None})
                     self.scheduler.add_job(
                         self.run_with_parent,
                         id=id,
@@ -336,10 +337,10 @@ class PolicyRunner:
                         args=[id, self.scopes[id], config, original_hostname],
                         misfire_grace_time=None,
                     )
-                    self.active_host_jobs[hostname] = id
+                    self.active_host_jobs[sanitized_hostname] = id
                 else:
                     logger.info(
-                        f"Policy {self.name}, Hostname {hostname}: No reachable port found, skipping discovery job"
+                        f"Policy {self.name}, Hostname {sanitized_hostname}: No reachable port found, skipping discovery job"
                     )
         except Exception as e:
             logger.error(

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -7,7 +7,6 @@ import time
 import uuid
 from datetime import datetime, timedelta
 
-from apscheduler.jobstores.base import JobLookupError
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.base import BaseTrigger
 from apscheduler.triggers.cron import CronTrigger
@@ -488,17 +487,6 @@ class PolicyRunner:
                 error=Exception("Not able to discover device driver"),
                 entity_count=0,
             )
-            try:
-                self.scheduler.remove_job(id)
-            except JobLookupError as e:
-                logger.debug(
-                    f"Policy {self.name}, Hostname {sanitized_hostname}: Error removing job: {e}"
-                )
-            except Exception as e:
-                logger.warning(
-                    f"Policy {self.name}, Hostname {sanitized_hostname}: Unexpected error removing job: {e}",
-                    exc_info=True,
-                )
             return
 
         logger.info(

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -39,7 +39,7 @@ class PolicyRunner:
         self.status = Status.NEW
         self.scheduler = BackgroundScheduler()
         self.run_store = None
-        self.active_host_jobs: dict[str, str] = {}
+        self.active_host_jobs: dict[tuple[str, str], str] = {}
 
     def _validate_discovery_drivers(self):
         """
@@ -331,7 +331,7 @@ class PolicyRunner:
 
             for hostname in hostnames:
                 sanitized_hostname = hostname.replace("\r\n", "").replace("\n", "")
-                existing_job_id = self.active_host_jobs.get(sanitized_hostname)
+                existing_job_id = self.active_host_jobs.get((original_hostname, sanitized_hostname))
                 if existing_job_id and self.scheduler.get_job(existing_job_id):
                     logger.info(
                         f"Policy {self.name}, Hostname {sanitized_hostname}: Discovery job already active, skipping"
@@ -350,7 +350,7 @@ class PolicyRunner:
                         args=[id, self.scopes[id], config, original_hostname],
                         misfire_grace_time=None,
                     )
-                    self.active_host_jobs[sanitized_hostname] = id
+                    self.active_host_jobs[(original_hostname, sanitized_hostname)] = id
                 else:
                     logger.info(
                         f"Policy {self.name}, Hostname {sanitized_hostname}: No reachable port found, skipping"

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -293,7 +293,7 @@ class PolicyRunner:
             return
 
         # Get original hostname from scope for parent tracking
-        original_hostname = scope.hostname
+        original_hostname = scope.hostname.replace("\r\n", "").replace("\n", "")
 
         # CREATE RUN FOR SCAN OPERATION
         scan_run = self.run_store.create_run(

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -725,3 +725,27 @@ def test_run_scan_reschedules_host_when_job_no_longer_active(monkeypatch):
 
     runner.scheduler.add_job.assert_called_once()
     assert runner.active_host_jobs["192.168.1.1"] == "new-job-id"
+
+
+def test_run_scan_stores_failed_run_for_unreachable_host(monkeypatch):
+    """run_scan must create a FAILED run record for each host with no reachable port."""
+    from device_discovery.policy.run import RunStatus
+
+    runner = PolicyRunner()
+    runner.name = "policy1"
+    runner.run_store = RunStore()
+    runner.scheduler = MagicMock()
+    scope = Napalm(driver="ios", hostname="192.168.1.0/24", username="admin", password="password")
+    config = Config(options=Options(port_scan_ports=[22], port_scan_timeout=0.1))
+    trigger = MagicMock(spec=BaseTrigger)
+
+    with patch(
+        "device_discovery.policy.runner.find_reachable_hosts",
+        return_value={"192.168.1.1": False},
+    ):
+        runner.run_scan(["192.168.1.1"], trigger, scope, config)
+
+    runs = runner.run_store.get_runs_for_target("policy1", "192.168.1.1")
+    assert len(runs) == 1
+    assert runs[0].status.value == "failed"
+    assert "No reachable port found" in runs[0].reason

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -242,6 +242,21 @@ def test_run_discovered_driver_error(
         assert policy_runner.status == Status.FAILED
 
 
+def test_run_driver_failure_does_not_remove_job(policy_runner, sample_scopes, sample_config, run_store):
+    """Driver discovery failure must NOT remove the job — the cron should keep firing."""
+    sample_scopes[0].driver = None
+    policy_runner.run_store = run_store
+    policy_runner.name = "test_policy"
+
+    with (
+        patch("device_discovery.policy.runner.discover_device_driver", return_value=None),
+        patch.object(policy_runner.scheduler, "remove_job") as mock_remove,
+    ):
+        policy_runner.run("test_id", sample_scopes[0], sample_config)
+
+    mock_remove.assert_not_called()
+
+
 def test_run_device_with_error_in_job(
     policy_runner, sample_scopes, sample_config, run_store
 ):

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -673,3 +673,28 @@ def test_run_with_parent_driver_failure_does_not_remove_job(policy_runner, run_s
         policy_runner.run_with_parent("test_id", scope, sample_config, "192.0.2.0/24")
 
     mock_remove.assert_not_called()
+
+
+def test_run_scan_skips_already_active_host(monkeypatch):
+    """run_scan must not schedule a second job for a host that already has one."""
+    runner = PolicyRunner()
+    runner.name = "policy1"
+    runner.run_store = RunStore()
+    runner.scheduler = MagicMock()
+    scope = Napalm(driver="ios", hostname="192.168.1.0/24", username="admin", password="password")
+    config = Config(options=Options(port_scan_ports=[22], port_scan_timeout=0.1))
+    trigger = MagicMock(spec=BaseTrigger)
+
+    existing_job = MagicMock()
+    runner.scheduler.get_job.return_value = existing_job
+
+    # Pre-populate active_host_jobs as if host was already scheduled
+    runner.active_host_jobs["192.168.1.1"] = "existing-job-id"
+
+    with patch(
+        "device_discovery.policy.runner.find_reachable_hosts",
+        return_value={"192.168.1.1": True},
+    ):
+        runner.run_scan(["192.168.1.1"], trigger, scope, config)
+
+    runner.scheduler.add_job.assert_not_called()

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -178,6 +178,8 @@ def test_setup_policy_runner_expands_hostname_ranges_one_shot(
     first_call = mock_add_job.call_args_list[0]
     assert first_call[0][0] == policy_runner.run_scan
     assert isinstance(first_call[1]["trigger"], DateTrigger)
+    _, date_trigger_arg, _, _ = first_call[1]["args"]
+    assert isinstance(date_trigger_arg, DateTrigger)
 
 
 def test_setup_with_unsupported_driver_raises_error(

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -714,7 +714,7 @@ def test_run_scan_skips_already_active_host(monkeypatch):
     runner.scheduler.get_job.return_value = existing_job
 
     # Pre-populate active_host_jobs as if host was already scheduled
-    runner.active_host_jobs["192.168.1.1"] = "existing-job-id"
+    runner.active_host_jobs[("192.168.1.0/24", "192.168.1.1")] = "existing-job-id"
 
     with patch(
         "device_discovery.policy.runner.find_reachable_hosts",
@@ -734,7 +734,7 @@ def test_run_scan_reschedules_host_when_job_no_longer_active(monkeypatch):
     runner.scheduler = MagicMock()
     runner.scheduler.get_job.return_value = None   # job is gone
 
-    runner.active_host_jobs["192.168.1.1"] = "stale-job-id"
+    runner.active_host_jobs[("192.168.1.0/24", "192.168.1.1")] = "stale-job-id"
     scope = Napalm(driver="ios", hostname="192.168.1.0/24", username="admin", password="password")
     config = Config(options=Options(port_scan_ports=[22], port_scan_timeout=0.1))
     trigger = MagicMock(spec=BaseTrigger)
@@ -749,7 +749,37 @@ def test_run_scan_reschedules_host_when_job_no_longer_active(monkeypatch):
         runner.run_scan(["192.168.1.1"], trigger, scope, config)
 
     runner.scheduler.add_job.assert_called_once()
-    assert runner.active_host_jobs["192.168.1.1"] == "new-job-id"
+    assert runner.active_host_jobs[("192.168.1.0/24", "192.168.1.1")] == "new-job-id"
+
+
+def test_run_scan_overlapping_scopes_each_schedule_independently():
+    """Two scopes whose ranges overlap must each schedule their own job for the shared host."""
+    runner = PolicyRunner()
+    runner.name = "policy1"
+    runner.run_store = RunStore()
+    runner.scheduler = MagicMock()
+    runner.scheduler.get_job.return_value = None  # no prior jobs
+    trigger = MagicMock(spec=BaseTrigger)
+    config = Config(options=Options(port_scan_ports=[22], port_scan_timeout=0.1))
+
+    scope_a = Napalm(driver="ios", hostname="192.168.1.0/24", username="admin", password="admin")
+    scope_b = Napalm(driver="ios", hostname="192.168.1.1-192.168.1.5", username="ops", password="ops")
+
+    with (
+        patch("device_discovery.policy.runner.find_reachable_hosts", return_value={"192.168.1.1": True}),
+        patch("uuid.uuid4", side_effect=["scan-a", "job-a"]),
+    ):
+        runner.run_scan(["192.168.1.1"], trigger, scope_a, config)
+
+    with (
+        patch("device_discovery.policy.runner.find_reachable_hosts", return_value={"192.168.1.1": True}),
+        patch("uuid.uuid4", side_effect=["scan-b", "job-b"]),
+    ):
+        runner.run_scan(["192.168.1.1"], trigger, scope_b, config)
+
+    assert runner.scheduler.add_job.call_count == 2
+    assert runner.active_host_jobs[("192.168.1.0/24", "192.168.1.1")] == "job-a"
+    assert runner.active_host_jobs[("192.168.1.1-192.168.1.5", "192.168.1.1")] == "job-b"
 
 
 def test_run_scan_stores_failed_run_on_range_when_no_hosts_reachable():

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -658,3 +658,18 @@ def test_run_with_parent_uses_entity_count_from_collect(policy_runner, run_store
     mock_update.assert_called_once()
     call_kwargs = mock_update.call_args[1]
     assert call_kwargs["entity_count"] == 12
+
+
+def test_run_with_parent_driver_failure_does_not_remove_job(policy_runner, run_store, sample_config):
+    """Driver discovery failure in run_with_parent must NOT remove the job."""
+    scope = Napalm(driver=None, hostname="192.0.2.1", username="admin", password="password")
+    policy_runner.run_store = run_store
+    policy_runner.name = "test_policy"
+
+    with (
+        patch("device_discovery.policy.runner.discover_device_driver", return_value=None),
+        patch.object(policy_runner.scheduler, "remove_job") as mock_remove,
+    ):
+        policy_runner.run_with_parent("test_id", scope, sample_config, "192.0.2.0/24")
+
+    mock_remove.assert_not_called()

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -752,8 +752,8 @@ def test_run_scan_reschedules_host_when_job_no_longer_active(monkeypatch):
     assert runner.active_host_jobs["192.168.1.1"] == "new-job-id"
 
 
-def test_run_scan_stores_failed_run_for_unreachable_host():
-    """run_scan must create a FAILED run record for each host with no reachable port."""
+def test_run_scan_stores_failed_run_on_range_when_no_hosts_reachable():
+    """When no host in a range is reachable, the range-level scan run must be FAILED."""
     from device_discovery.policy.run import RunStatus
 
     runner = PolicyRunner()
@@ -766,11 +766,43 @@ def test_run_scan_stores_failed_run_for_unreachable_host():
 
     with patch(
         "device_discovery.policy.runner.find_reachable_hosts",
-        return_value={"192.168.1.1": False},
+        return_value={"192.168.1.1": False, "192.168.1.2": False},
     ):
-        runner.run_scan(["192.168.1.1"], trigger, scope, config)
+        runner.run_scan(["192.168.1.1", "192.168.1.2"], trigger, scope, config)
 
-    runs = runner.run_store.get_runs_for_target("policy1", "192.168.1.1")
-    assert len(runs) == 1
-    assert runs[0].status.value == "failed"
-    assert "No reachable port found" in runs[0].reason
+    # Failure reported at range level, not per-host
+    range_runs = runner.run_store.get_runs_for_target("policy1", "192.168.1.0/24")
+    assert len(range_runs) == 1
+    assert range_runs[0].status.value == "failed"
+    assert "No reachable hosts found in range" in range_runs[0].reason
+
+    # No per-host run records created for unreachable hosts
+    assert runner.run_store.get_runs_for_target("policy1", "192.168.1.1") == []
+    assert runner.run_store.get_runs_for_target("policy1", "192.168.1.2") == []
+    runner.scheduler.add_job.assert_not_called()
+
+
+def test_run_scan_stores_completed_run_when_some_hosts_reachable():
+    """When at least one host is reachable, the range-level scan run is COMPLETED."""
+    runner = PolicyRunner()
+    runner.name = "policy1"
+    runner.run_store = RunStore()
+    runner.scheduler = MagicMock()
+    scope = Napalm(driver="ios", hostname="192.168.1.0/24", username="admin", password="password")
+    config = Config(options=Options(port_scan_ports=[22], port_scan_timeout=0.1))
+    trigger = MagicMock(spec=BaseTrigger)
+
+    with (
+        patch(
+            "device_discovery.policy.runner.find_reachable_hosts",
+            return_value={"192.168.1.1": True, "192.168.1.2": False},
+        ),
+        patch("uuid.uuid4", side_effect=["scan-run-id", "job-1"]),
+    ):
+        runner.run_scan(["192.168.1.1", "192.168.1.2"], trigger, scope, config)
+
+    range_runs = runner.run_store.get_runs_for_target("policy1", "192.168.1.0/24")
+    assert len(range_runs) == 1
+    assert range_runs[0].status.value == "completed"
+    assert range_runs[0].entity_count == 1
+    runner.scheduler.add_job.assert_called_once()

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -727,7 +727,7 @@ def test_run_scan_reschedules_host_when_job_no_longer_active(monkeypatch):
     assert runner.active_host_jobs["192.168.1.1"] == "new-job-id"
 
 
-def test_run_scan_stores_failed_run_for_unreachable_host(monkeypatch):
+def test_run_scan_stores_failed_run_for_unreachable_host():
     """run_scan must create a FAILED run record for each host with no reachable port."""
     from device_discovery.policy.run import RunStatus
 

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -698,3 +698,30 @@ def test_run_scan_skips_already_active_host(monkeypatch):
         runner.run_scan(["192.168.1.1"], trigger, scope, config)
 
     runner.scheduler.add_job.assert_not_called()
+    runner.scheduler.get_job.assert_called_once_with("existing-job-id")
+
+
+def test_run_scan_reschedules_host_when_job_no_longer_active(monkeypatch):
+    """When a previous job has finished, run_scan must schedule a new one."""
+    runner = PolicyRunner()
+    runner.name = "policy1"
+    runner.run_store = RunStore()
+    runner.scheduler = MagicMock()
+    runner.scheduler.get_job.return_value = None   # job is gone
+
+    runner.active_host_jobs["192.168.1.1"] = "stale-job-id"
+    scope = Napalm(driver="ios", hostname="192.168.1.0/24", username="admin", password="password")
+    config = Config(options=Options(port_scan_ports=[22], port_scan_timeout=0.1))
+    trigger = MagicMock(spec=BaseTrigger)
+
+    with (
+        patch(
+            "device_discovery.policy.runner.find_reachable_hosts",
+            return_value={"192.168.1.1": True},
+        ),
+        patch("uuid.uuid4", side_effect=["scan-run-id", "new-job-id"]),
+    ):
+        runner.run_scan(["192.168.1.1"], trigger, scope, config)
+
+    runner.scheduler.add_job.assert_called_once()
+    assert runner.active_host_jobs["192.168.1.1"] == "new-job-id"

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -152,9 +152,32 @@ def test_setup_policy_runner_expands_hostname_ranges(
     hostnames, cron_trigger, passed_scope, copied_config = first_call[1]["args"]
     assert hostnames == ["192.0.2.1", "192.0.2.2"]
     assert isinstance(cron_trigger, CronTrigger)
-    assert isinstance(first_call[1]["trigger"], DateTrigger)
+    assert isinstance(first_call[1]["trigger"], CronTrigger)
     assert passed_scope.hostname == ranged_scope.hostname
     assert copied_config.defaults.role == "Router"
+
+
+def test_setup_policy_runner_expands_hostname_ranges_one_shot(
+    policy_runner, run_store
+):
+    """Range scan with no schedule must still use DateTrigger for run_scan."""
+    ranged_scope = Napalm(
+        driver="ios",
+        hostname="192.0.2.1-192.0.2.2",
+        username="admin",
+        password="password",
+    )
+    one_shot_config = Config()  # no schedule
+
+    with (
+        patch.object(policy_runner.scheduler, "start"),
+        patch.object(policy_runner.scheduler, "add_job") as mock_add_job,
+    ):
+        policy_runner.setup("policy1", one_shot_config, [ranged_scope], run_store)
+
+    first_call = mock_add_job.call_args_list[0]
+    assert first_call[0][0] == policy_runner.run_scan
+    assert isinstance(first_call[1]["trigger"], DateTrigger)
 
 
 def test_setup_with_unsupported_driver_raises_error(


### PR DESCRIPTION
## Summary

- **Remove `remove_job` on driver discovery failure** in `run()` and `run_with_parent()` — previously the APScheduler job was permanently deleted on first failure; now it keeps its cron schedule and retries on the next tick
- **Make `run_scan` run on the policy trigger** (cron or one-shot) instead of a hardcoded one-shot `DateTrigger` — scheduled policies now re-scan the IP range on every tick, picking up hosts that come online after initial startup
- **Add `active_host_jobs` deduplication** — `run_scan` tracks active per-host job IDs and skips re-scheduling hosts that already have a live discovery job, preventing duplicate jobs on repeated scans
- **Report unreachable range at scan level** — when no host in an IP range has an open port, the scan run itself is marked `FAILED` with `"No reachable hosts found in range"`; partially-reachable scans stay `COMPLETED` with entity count. No per-host records for unreachable IPs (avoids noise for large subnets)

Fixes both reported failure modes: SSH port unreachable and driver discovery failure. Also fixes the comment case: driver discovery failure.

## Test Plan

- [x] Unit tests: `pytest tests/ --ignore=tests/custom_drivers` → 32 passed in runner, 211 total
- [x] Driver failure no longer removes job: `test_run_driver_failure_does_not_remove_job`, `test_run_with_parent_driver_failure_does_not_remove_job`
- [x] Deduplication: `test_run_scan_skips_already_active_host`, `test_run_scan_reschedules_host_when_job_no_longer_active`
- [x] Range-level failure: `test_run_scan_stores_failed_run_on_range_when_no_hosts_reachable` (no per-host records), `test_run_scan_stores_completed_run_when_some_hosts_reachable`
- [x] Trigger propagation: `test_setup_policy_runner_expands_hostname_ranges` (CronTrigger), `test_setup_policy_runner_expands_hostname_ranges_one_shot` (DateTrigger)
- [x] Integration (mockit): submit range policy with no container → scan run `failed / "No reachable hosts found in range"` → start mockit → next `run_scan` tick finds host → `completed` with entities
- [x] Integration (resilience): single-host policy → stop container → job keeps running with `failed` records → restart container → recovers to `completed`

Closes OBS-2250