### PR TITLE
chore: fix ruff lint errors in device-discovery

### DIFF
--- a/device-discovery/custom_napalm/fastiron.py
+++ b/device-discovery/custom_napalm/fastiron.py
@@ -218,6 +218,17 @@ _UNTAGGED_RE = re.compile(r"^\s+untagged\s+(?P<ports>.+)", re.IGNORECASE)
 # "router-interface ve <id>" — 08.x syntax attaching a VE as the L3 interface of a VLAN.
 _ROUTER_INTF_RE = re.compile(r"^\s+router-interface\s+ve\s+(?P<ve>\d+)", re.IGNORECASE)
 
+
+def _add_member_ports(line: str, interfaces: list) -> None:
+    for pattern in (_TAGGED_RE, _UNTAGGED_RE):
+        m = pattern.match(line)
+        if m:
+            for port in _split_port_list(m.group("ports")):
+                if port not in interfaces:
+                    interfaces.append(port)
+            break
+
+
 # ---------------------------------------------------------------------------
 # IP interface regex
 # ---------------------------------------------------------------------------
@@ -602,14 +613,7 @@ class FastIronDriver(_napalm_base.NetworkDriver):
             if current_id is None:
                 continue
 
-            for pattern in (_TAGGED_RE, _UNTAGGED_RE):
-                m = pattern.match(line)
-                if m:
-                    for port in _split_port_list(m.group("ports")):
-                        entry = vlans[current_id]
-                        if port not in entry["interfaces"]:
-                            entry["interfaces"].append(port)
-                    break
+            _add_member_ports(line, vlans[current_id]["interfaces"])
 
             m_ri = _ROUTER_INTF_RE.match(line)
             if m_ri:

--- a/device-discovery/tests/custom_drivers/arubaos/__init__.py
+++ b/device-discovery/tests/custom_drivers/arubaos/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ArubaOS custom NAPALM driver."""

--- a/device-discovery/tests/custom_drivers/arubaoss/__init__.py
+++ b/device-discovery/tests/custom_drivers/arubaoss/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ArubaOS-Switch custom NAPALM driver."""

--- a/device-discovery/tests/custom_drivers/edgerouter/__init__.py
+++ b/device-discovery/tests/custom_drivers/edgerouter/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the EdgeRouter custom NAPALM driver."""

--- a/device-discovery/tests/custom_drivers/edgeswitch/__init__.py
+++ b/device-discovery/tests/custom_drivers/edgeswitch/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the EdgeSwitch custom NAPALM driver."""

--- a/device-discovery/tests/custom_drivers/fastiron/__init__.py
+++ b/device-discovery/tests/custom_drivers/fastiron/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the FastIron custom NAPALM driver."""

--- a/device-discovery/tests/custom_drivers/gaia/__init__.py
+++ b/device-discovery/tests/custom_drivers/gaia/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Check Point Gaia custom NAPALM driver."""

--- a/device-discovery/tests/custom_drivers/powerconnect/__init__.py
+++ b/device-discovery/tests/custom_drivers/powerconnect/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the PowerConnect custom NAPALM driver."""

--- a/device-discovery/tests/custom_drivers/unifiswitch/__init__.py
+++ b/device-discovery/tests/custom_drivers/unifiswitch/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the UniFi Switch custom NAPALM driver."""


### PR DESCRIPTION
## Summary
- Extracts `_add_member_ports` helper from `get_vlans` in `fastiron.py` to reduce McCabe complexity from 11 → 7 (fixes C901)
- Adds module-level docstrings to 8 empty `__init__.py` files under `tests/custom_drivers/` (fixes D104)

## Test plan
- [x] `ruff check .` from `device-discovery/` reports no errors
- [x] `pytest tests/custom_drivers/ -v` — all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)