### PR TITLE
fix(OBS-2250): fix SNMP range discovery jobs — cron rescheduling, crawl-job dedup, and failure tracking

### DIFF
--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -198,6 +198,14 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 		return
 	}
 
+	if len(responsive) == 0 {
+		r.logger.Warn("no hosts responded to SNMP probe",
+			"policy", policyName, "target", originalTarget)
+		r.runStore.UpdateRun(policyName, originalTarget, port, scanRun.ID,
+			RunStatusFailed, fmt.Errorf("no hosts responded to SNMP probe"), 0)
+		return
+	}
+
 	// Snapshot live job IDs before the loop to avoid holding two locks simultaneously
 	liveIDs := make(map[uuid.UUID]struct{}, len(r.scheduler.Jobs()))
 	for _, j := range r.scheduler.Jobs() {

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"sync"
 	"time"
 
@@ -197,11 +198,16 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 		liveIDs[j.ID()] = struct{}{}
 	}
 
-	// Prune stale host->job mappings so completed/removed jobs do not accumulate indefinitely.
+	// Prune stale host->job mappings for this originalTarget only.
+	// Scoped to the current range to avoid deleting entries freshly added by a concurrent
+	// runScanWithOriginal invocation for a different range target in the same policy.
+	keyPrefix := originalTarget + "::"
 	r.activeHostJobsMu.Lock()
 	for jobKey, jobID := range r.activeHostJobs {
-		if _, alive := liveIDs[jobID]; !alive {
-			delete(r.activeHostJobs, jobKey)
+		if strings.HasPrefix(jobKey, keyPrefix) {
+			if _, alive := liveIDs[jobID]; !alive {
+				delete(r.activeHostJobs, jobKey)
+			}
 		}
 	}
 	r.activeHostJobsMu.Unlock()
@@ -224,6 +230,9 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 	var err error
 	for _, target := range responsive {
 		jobKey := fmt.Sprintf("%s::%s:%d", originalTarget, target.Host, target.Port)
+
+		// Check under lock, then unlock before calling scheduler to avoid holding mutex
+		// across scheduler's internal locks.
 		r.activeHostJobsMu.Lock()
 		if existingID, ok := r.activeHostJobs[jobKey]; ok {
 			if _, alive := liveIDs[existingID]; alive {
@@ -233,6 +242,7 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 				continue
 			}
 		}
+		r.activeHostJobsMu.Unlock()
 
 		task := gocron.NewTask(r.runWithMetadata, target, originalTarget)
 		var newJob gocron.Job
@@ -245,11 +255,12 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 				gocron.WithSingletonMode(gocron.LimitModeReschedule))
 		}
 		if err != nil {
-			r.activeHostJobsMu.Unlock()
 			r.logger.Error("failed to schedule crawl task for responsive target",
 				"host", target.Host, "policy", policyName, "error", err)
 			continue
 		}
+
+		r.activeHostJobsMu.Lock()
 		r.activeHostJobs[jobKey] = newJob.ID()
 		liveIDs[newJob.ID()] = struct{}{} // keep snapshot current for remaining iterations
 		r.activeHostJobsMu.Unlock()

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -240,6 +240,7 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 			continue
 		}
 		r.activeHostJobs[jobKey] = newJob.ID()
+		liveIDs[newJob.ID()] = struct{}{} // keep snapshot current for remaining iterations
 		r.activeHostJobsMu.Unlock()
 	}
 

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -198,19 +198,18 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 		return
 	}
 
+	// Snapshot live job IDs before the loop to avoid holding two locks simultaneously
+	liveIDs := make(map[uuid.UUID]struct{}, len(r.scheduler.Jobs()))
+	for _, j := range r.scheduler.Jobs() {
+		liveIDs[j.ID()] = struct{}{}
+	}
+
 	var err error
 	for _, target := range responsive {
 		jobKey := fmt.Sprintf("%s::%s:%d", originalTarget, target.Host, target.Port)
 		r.activeHostJobsMu.Lock()
 		if existingID, ok := r.activeHostJobs[jobKey]; ok {
-			alive := false
-			for _, j := range r.scheduler.Jobs() {
-				if j.ID() == existingID {
-					alive = true
-					break
-				}
-			}
-			if alive {
+			if _, alive := liveIDs[existingID]; alive {
 				r.activeHostJobsMu.Unlock()
 				r.logger.Debug("crawl job already active, skipping",
 					"host", target.Host, "policy", policyName)
@@ -234,12 +233,9 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 				"host", target.Host, "policy", policyName, "error", err)
 			continue
 		}
-		if r.activeHostJobs == nil {
-			r.activeHostJobs = make(map[string]uuid.UUID)
-		}
 		r.activeHostJobs[jobKey] = newJob.ID()
+		r.tasks = append(r.tasks, task) // protected by activeHostJobsMu
 		r.activeHostJobsMu.Unlock()
-		r.tasks = append(r.tasks, task)
 	}
 
 	// Update scan run status

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -210,6 +210,15 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 		liveIDs[j.ID()] = struct{}{}
 	}
 
+	// Prune stale host->job mappings so completed/removed jobs do not accumulate indefinitely.
+	r.activeHostJobsMu.Lock()
+	for jobKey, jobID := range r.activeHostJobs {
+		if _, alive := liveIDs[jobID]; !alive {
+			delete(r.activeHostJobs, jobKey)
+		}
+	}
+	r.activeHostJobsMu.Unlock()
+
 	var err error
 	for _, target := range responsive {
 		jobKey := fmt.Sprintf("%s::%s:%d", originalTarget, target.Host, target.Port)

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -207,8 +207,9 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 	}
 
 	// Snapshot live job IDs before the loop to avoid holding two locks simultaneously
-	liveIDs := make(map[uuid.UUID]struct{}, len(r.scheduler.Jobs()))
-	for _, j := range r.scheduler.Jobs() {
+	jobs := r.scheduler.Jobs()
+	liveIDs := make(map[uuid.UUID]struct{}, len(jobs))
+	for _, j := range jobs {
 		liveIDs[j.ID()] = struct{}{}
 	}
 

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/go-co-op/gocron/v2"
+	"github.com/google/uuid"
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/data"
@@ -54,6 +55,8 @@ type Runner struct {
 	mappingConfig    *config.Mapping
 	deviceLookup     data.DeviceRetriever
 	runStore         *RunStore
+	activeHostJobs   map[string]uuid.UUID
+	activeHostJobsMu sync.Mutex
 }
 
 // NewRunner returns a new policy runner
@@ -64,14 +67,15 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 	}
 
 	runner := &Runner{
-		scheduler:     s,
-		client:        client,
-		logger:        logger,
-		ClientFactory: ClientFactory,
-		manufacturers: manufacturers,
-		mappingConfig: mappingConfig,
-		deviceLookup:  deviceLookup,
-		runStore:      runStore,
+		scheduler:      s,
+		client:         client,
+		logger:         logger,
+		ClientFactory:  ClientFactory,
+		manufacturers:  manufacturers,
+		mappingConfig:  mappingConfig,
+		deviceLookup:   deviceLookup,
+		runStore:       runStore,
+		activeHostJobs: make(map[string]uuid.UUID),
 	}
 
 	runner.timeout = time.Duration(policy.Config.Timeout) * time.Second

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -42,7 +42,6 @@ type expandedTargetGroup struct {
 type Runner struct {
 	scheduler        gocron.Scheduler
 	ctx              context.Context
-	tasks            []gocron.Task
 	client           diode.Client
 	logger           *slog.Logger
 	timeout          time.Duration
@@ -114,7 +113,6 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 			if err != nil {
 				return nil, err
 			}
-			runner.tasks = append(runner.tasks, task)
 			continue
 		}
 		// Create scan task for multiple targets with original target
@@ -130,7 +128,6 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 		if err != nil {
 			return nil, err
 		}
-		runner.tasks = append(runner.tasks, task)
 	}
 	return runner, nil
 }
@@ -243,7 +240,6 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 			continue
 		}
 		r.activeHostJobs[jobKey] = newJob.ID()
-		r.tasks = append(r.tasks, task) // protected by activeHostJobsMu
 		r.activeHostJobsMu.Unlock()
 	}
 

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -119,9 +119,14 @@ func NewRunner(ctx context.Context, logger *slog.Logger, name string, policy con
 		}
 		// Create scan task for multiple targets with original target
 		task := gocron.NewTask(runner.runScanWithOriginal, group.targets, group.originalTarget)
-		_, err = runner.scheduler.NewJob(gocron.OneTimeJob(
-			gocron.OneTimeJobStartDateTime(time.Now().Add(1*time.Second))), task,
-			gocron.WithSingletonMode(gocron.LimitModeReschedule))
+		if policy.Config.Schedule != nil {
+			_, err = runner.scheduler.NewJob(gocron.CronJob(*policy.Config.Schedule, false), task,
+				gocron.WithSingletonMode(gocron.LimitModeReschedule))
+		} else {
+			_, err = runner.scheduler.NewJob(gocron.OneTimeJob(
+				gocron.OneTimeJobStartDateTime(time.Now().Add(1*time.Second))), task,
+				gocron.WithSingletonMode(gocron.LimitModeReschedule))
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -188,22 +188,9 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 		r.logger.Debug("SNMP probe succeeded", "host", target.Host, "port", target.Port, "policy", policyName)
 	}
 
-	// Check if context was canceled or timed out
-	if ctxErr := ctx.Err(); ctxErr != nil {
-		r.logger.Warn("SNMP probe scan interrupted", "policy", policyName, "error", ctxErr, "responsive_target_count", len(responsive))
-		r.runStore.UpdateRun(policyName, originalTarget, port, scanRun.ID, RunStatusFailed, ctxErr, len(responsive))
-		return
-	}
-
-	if len(responsive) == 0 {
-		r.logger.Warn("no hosts responded to SNMP probe",
-			"policy", policyName, "target", originalTarget)
-		r.runStore.UpdateRun(policyName, originalTarget, port, scanRun.ID,
-			RunStatusFailed, fmt.Errorf("no hosts responded to SNMP probe"), 0)
-		return
-	}
-
-	// Snapshot live job IDs before the loop to avoid holding two locks simultaneously
+	// Snapshot live job IDs before the loop to avoid holding two locks simultaneously.
+	// Done here (before early returns) so stale entries are pruned on every probe invocation,
+	// including the zero-responsive and context-timeout paths.
 	jobs := r.scheduler.Jobs()
 	liveIDs := make(map[uuid.UUID]struct{}, len(jobs))
 	for _, j := range jobs {
@@ -218,6 +205,21 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 		}
 	}
 	r.activeHostJobsMu.Unlock()
+
+	// Check if context was canceled or timed out
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		r.logger.Warn("SNMP probe scan interrupted", "policy", policyName, "error", ctxErr, "responsive_target_count", len(responsive))
+		r.runStore.UpdateRun(policyName, originalTarget, port, scanRun.ID, RunStatusFailed, ctxErr, len(responsive))
+		return
+	}
+
+	if len(responsive) == 0 {
+		r.logger.Warn("no hosts responded to SNMP probe",
+			"policy", policyName, "target", originalTarget)
+		r.runStore.UpdateRun(policyName, originalTarget, port, scanRun.ID,
+			RunStatusFailed, fmt.Errorf("no hosts responded to SNMP probe"), 0)
+		return
+	}
 
 	var err error
 	for _, target := range responsive {

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -200,20 +200,45 @@ func (r *Runner) runScanWithOriginal(targets []config.Target, originalTarget str
 
 	var err error
 	for _, target := range responsive {
+		jobKey := fmt.Sprintf("%s::%s:%d", originalTarget, target.Host, target.Port)
+		r.activeHostJobsMu.Lock()
+		if existingID, ok := r.activeHostJobs[jobKey]; ok {
+			alive := false
+			for _, j := range r.scheduler.Jobs() {
+				if j.ID() == existingID {
+					alive = true
+					break
+				}
+			}
+			if alive {
+				r.activeHostJobsMu.Unlock()
+				r.logger.Debug("crawl job already active, skipping",
+					"host", target.Host, "policy", policyName)
+				continue
+			}
+		}
+
 		task := gocron.NewTask(r.runWithMetadata, target, originalTarget)
+		var newJob gocron.Job
 		if r.config.Schedule != nil {
-			_, err = r.scheduler.NewJob(gocron.CronJob(*r.config.Schedule, false), task,
+			newJob, err = r.scheduler.NewJob(gocron.CronJob(*r.config.Schedule, false), task,
 				gocron.WithSingletonMode(gocron.LimitModeReschedule))
 		} else {
-			_, err = r.scheduler.NewJob(gocron.OneTimeJob(
+			newJob, err = r.scheduler.NewJob(gocron.OneTimeJob(
 				gocron.OneTimeJobStartDateTime(time.Now().Add(1*time.Second))), task,
 				gocron.WithSingletonMode(gocron.LimitModeReschedule))
 		}
 		if err != nil {
+			r.activeHostJobsMu.Unlock()
 			r.logger.Error("failed to schedule crawl task for responsive target",
 				"host", target.Host, "policy", policyName, "error", err)
 			continue
 		}
+		if r.activeHostJobs == nil {
+			r.activeHostJobs = make(map[string]uuid.UUID)
+		}
+		r.activeHostJobs[jobKey] = newJob.ID()
+		r.activeHostJobsMu.Unlock()
 		r.tasks = append(r.tasks, task)
 	}
 

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -418,6 +418,33 @@ func TestRunScanWithOriginal_FailsWhenNoResponsiveHosts(t *testing.T) {
 	assert.Len(t, scheduler.Jobs(), 0, "no crawl jobs should be scheduled")
 }
 
+func TestRunScanWithOriginal_NoDuplicateForRepeatedResponsiveHost(t *testing.T) {
+	scheduler, err := gocron.NewScheduler()
+	require.NoError(t, err)
+
+	runStore := NewRunStore()
+	runner := &Runner{
+		scheduler:      scheduler,
+		ctx:            context.WithValue(context.Background(), policyKey, "test-policy"),
+		timeout:        5 * time.Second,
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		runStore:       runStore,
+		activeHostJobs: make(map[string]uuid.UUID),
+	}
+	runner.ClientFactory = func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return &testWalker{}, nil
+	}
+
+	// Same host appears twice in the targets list (simulates misconfigured overlapping range)
+	runner.runScanWithOriginal([]config.Target{
+		{Host: "192.168.1.1", Port: 161},
+		{Host: "192.168.1.1", Port: 161},
+	}, "192.168.1.0/24")
+
+	// Only one crawl job should be scheduled despite duplicate in responsive list
+	assert.Len(t, scheduler.Jobs(), 1)
+}
+
 func TestNewRunner_RangeScheduledWithCron(t *testing.T) {
 	cron := "0 * * * *"
 	pol := config.Policy{

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -343,3 +343,33 @@ func TestRunner_HasActiveHostJobsField(t *testing.T) {
 	r.activeHostJobs = make(map[string]uuid.UUID)
 	assert.NotNil(t, r.activeHostJobs)
 }
+
+func TestNewRunner_RangeScheduledWithCron(t *testing.T) {
+	cron := "0 * * * *"
+	pol := config.Policy{
+		Config: config.PolicyConfig{
+			Schedule: &cron,
+			Timeout:  120,
+		},
+		Scope: config.Scope{
+			Targets: []config.Target{
+				{Host: "192.168.1.1-2", Port: 161},
+			},
+		},
+	}
+	runStore := NewRunStore()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	runner, err := NewRunner(context.Background(), logger, "test-policy", pol, nil,
+		snmp.NewFakeSNMPWalker, &config.Mapping{}, nil, nil, runStore)
+	require.NoError(t, err)
+	runner.scheduler.Start()
+	defer func() { _ = runner.Stop() }()
+
+	jobs := runner.scheduler.Jobs()
+	require.Len(t, jobs, 1, "one job for the range scan")
+
+	nextRuns, err := jobs[0].NextRuns(2)
+	require.NoError(t, err)
+	assert.Len(t, nextRuns, 2, "cron job must have at least 2 future runs")
+}

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -344,6 +344,42 @@ func TestRunner_HasActiveHostJobsField(t *testing.T) {
 	assert.NotNil(t, r.activeHostJobs)
 }
 
+func TestRunScanWithOriginal_SkipsDuplicateCrawlJob(t *testing.T) {
+	scheduler, err := gocron.NewScheduler()
+	require.NoError(t, err)
+
+	// Schedule a pre-existing crawl job with a known ID
+	existingJobID := uuid.New()
+	_, err = scheduler.NewJob(
+		gocron.CronJob("0 * * * *", false),
+		gocron.NewTask(func() {}),
+		gocron.WithIdentifier(existingJobID),
+	)
+	require.NoError(t, err)
+
+	runStore := NewRunStore()
+	runner := &Runner{
+		scheduler: scheduler,
+		ctx:       context.WithValue(context.Background(), policyKey, "test-policy"),
+		timeout:   5 * time.Second,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		runStore:  runStore,
+		activeHostJobs: map[string]uuid.UUID{
+			"192.168.1.0/24::192.168.1.1:161": existingJobID,
+		},
+	}
+	runner.ClientFactory = func(host string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return &testWalker{}, nil // all hosts probe successfully
+	}
+
+	runner.runScanWithOriginal([]config.Target{
+		{Host: "192.168.1.1", Port: 161},
+	}, "192.168.1.0/24")
+
+	// Still only 1 job — the pre-existing one; no duplicate was added
+	assert.Len(t, scheduler.Jobs(), 1)
+}
+
 func TestNewRunner_RangeScheduledWithCron(t *testing.T) {
 	cron := "0 * * * *"
 	pol := config.Policy{

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -376,8 +376,8 @@ func TestRunScanWithOriginal_SkipsDuplicateCrawlJob(t *testing.T) {
 			"192.168.1.0/24::192.168.1.1:161": existingJobID,
 		},
 	}
-	runner.ClientFactory = func(host string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
-		return &testWalker{}, nil // all hosts probe successfully
+	runner.ClientFactory = func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return &testWalker{}, nil
 	}
 
 	runner.runScanWithOriginal([]config.Target{

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -229,11 +229,12 @@ func TestRunScanSchedulesResponsiveTargets(t *testing.T) {
 	runStore := NewRunStore()
 
 	runner := &Runner{
-		scheduler: scheduler,
-		ctx:       context.WithValue(context.Background(), policyKey, "test-policy"),
-		timeout:   5 * time.Second,
-		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
-		runStore:  runStore,
+		scheduler:      scheduler,
+		ctx:            context.WithValue(context.Background(), policyKey, "test-policy"),
+		timeout:        5 * time.Second,
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		runStore:       runStore,
+		activeHostJobs: make(map[string]uuid.UUID),
 	}
 
 	runner.ClientFactory = func(host string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
@@ -339,9 +340,17 @@ func TestQueryTargetSuccess(t *testing.T) {
 }
 
 func TestRunner_HasActiveHostJobsField(t *testing.T) {
-	r := &Runner{}
-	r.activeHostJobs = make(map[string]uuid.UUID)
-	assert.NotNil(t, r.activeHostJobs)
+	cron := "0 * * * *"
+	pol := config.Policy{
+		Config: config.PolicyConfig{Schedule: &cron, Timeout: 120},
+		Scope:  config.Scope{Targets: []config.Target{{Host: "192.168.1.1", Port: 161}}},
+	}
+	runner, err := NewRunner(context.Background(),
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+		"test-policy", pol, nil, snmp.NewFakeSNMPWalker, &config.Mapping{}, nil, nil, NewRunStore())
+	require.NoError(t, err)
+	defer func() { _ = runner.Stop() }()
+	assert.NotNil(t, runner.activeHostJobs, "NewRunner must initialize activeHostJobs")
 }
 
 func TestRunScanWithOriginal_SkipsDuplicateCrawlJob(t *testing.T) {

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -250,7 +250,6 @@ func TestRunScanSchedulesResponsiveTargets(t *testing.T) {
 		{Host: "good-2", Port: 161},
 	}, "192.168.1.0/24")
 
-	assert.Len(t, runner.tasks, 2)
 	assert.Len(t, runner.scheduler.Jobs(), 2)
 
 	// Verify scan run was created

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-co-op/gocron/v2"
+	"github.com/google/uuid"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
 	"github.com/stretchr/testify/assert"
@@ -335,4 +336,10 @@ func TestQueryTargetSuccess(t *testing.T) {
 	entities, err := runner.queryTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161})
 	require.NoError(t, err)
 	assert.NotEmpty(t, entities)
+}
+
+func TestRunner_HasActiveHostJobsField(t *testing.T) {
+	r := &Runner{}
+	r.activeHostJobs = make(map[string]uuid.UUID)
+	assert.NotNil(t, r.activeHostJobs)
 }

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -389,6 +389,36 @@ func TestRunScanWithOriginal_SkipsDuplicateCrawlJob(t *testing.T) {
 	assert.Len(t, scheduler.Jobs(), 1)
 }
 
+func TestRunScanWithOriginal_FailsWhenNoResponsiveHosts(t *testing.T) {
+	scheduler, err := gocron.NewScheduler()
+	require.NoError(t, err)
+
+	runStore := NewRunStore()
+	runner := &Runner{
+		scheduler:      scheduler,
+		ctx:            context.WithValue(context.Background(), policyKey, "test-policy"),
+		timeout:        5 * time.Second,
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+		runStore:       runStore,
+		activeHostJobs: make(map[string]uuid.UUID),
+	}
+	// All hosts fail the SNMP probe
+	runner.ClientFactory = func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return &testWalker{walkErr: errors.New("no response")}, nil
+	}
+
+	runner.runScanWithOriginal([]config.Target{
+		{Host: "192.168.1.1", Port: 161},
+		{Host: "192.168.1.2", Port: 161},
+	}, "192.168.1.0/24")
+
+	runs := runStore.GetRunsForTarget("test-policy", "192.168.1.0/24", 161)
+	require.Len(t, runs, 1, "scan run should be created")
+	assert.Equal(t, RunStatusFailed, runs[0].Status, "scan run should be FAILED when no hosts respond")
+	assert.Contains(t, runs[0].Reason, "no hosts responded to SNMP probe")
+	assert.Len(t, scheduler.Jobs(), 0, "no crawl jobs should be scheduled")
+}
+
 func TestNewRunner_RangeScheduledWithCron(t *testing.T) {
 	cron := "0 * * * *"
 	pol := config.Policy{

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -446,5 +446,7 @@ func TestNewRunner_RangeScheduledWithCron(t *testing.T) {
 
 	nextRuns, err := jobs[0].NextRuns(2)
 	require.NoError(t, err)
-	assert.Len(t, nextRuns, 2, "cron job must have at least 2 future runs")
+	require.Len(t, nextRuns, 2)
+	assert.False(t, nextRuns[1].IsZero(), "second next run must be a real future time, not zero — proves this is a cron job not a one-time job")
+	assert.True(t, nextRuns[1].After(nextRuns[0]), "cron next runs must be strictly increasing")
 }


### PR DESCRIPTION
## Summary

- **Cron for range scans:** \`runScanWithOriginal\` was always scheduled as \`OneTimeJob\`, causing scheduled policies with CIDR/range targets to probe once and never re-scan. Now uses the same cron-or-one-shot branching as single targets.
- **Per-IP crawl job dedup:** Added \`activeHostJobs map[string]uuid.UUID\` to \`Runner\`. Before scheduling a crawl job for a responsive IP, checks if a live job already exists (keyed by \`originalTarget::host:port\`). Prevents duplicate crawl jobs stacking up across cron ticks. Prune pass runs on every probe invocation (including timeout/zero-responsive paths) and is scoped to the current range to avoid interfering with concurrent invocations for other ranges in the same policy.
- **FAILED run when no hosts respond:** If the probe phase finds zero responsive IPs, the scan run is now marked \`RunStatusFailed\` instead of silently succeeding as \`RunStatusCompleted\`.
- **Lock safety:** \`activeHostJobsMu\` is no longer held across \`scheduler.NewJob\` calls, eliminating the potential for lock-order inversion with gocron's internal scheduler lock.

## Test Plan

- [x] \`go test ./... -race -timeout 120s\` passes in \`snmp-discovery/\`
- [x] \`TestNewRunner_RangeScheduledWithCron\` — range target with cron schedule produces a job with 2 future runs (not one-shot)
- [x] \`TestRunScanWithOriginal_SkipsDuplicateCrawlJob\` — pre-seeded live job is not duplicated
- [x] \`TestRunScanWithOriginal_NoDuplicateForRepeatedResponsiveHost\` — same host twice in responsive list produces one job
- [x] \`TestRunScanWithOriginal_FailsWhenNoResponsiveHosts\` — zero responsive hosts marks scan run as FAILED
- [x] End-to-end validated locally against \`orb-test-lab\` snmpsim containers (Cisco C2960X, Cisco C2950, Juniper SRX, Juniper EX) — range re-scans on each cron tick, no duplicate crawl jobs, entities ingested successfully

🤖 Generated with [Claude Code](https://claude.ai/claude-code)