### PR TITLE
feat: add interface_exclude_patterns to snmp-discovery and device-discovery

### DIFF
--- a/device-discovery/device_discovery/interface.py
+++ b/device-discovery/device_discovery/interface.py
@@ -382,7 +382,7 @@ def build_interface_entities(
 ) -> list[Entity]:
     """Create interface entities from interface definitions and IP data."""
     exclude_patterns = []
-    if getattr(defaults, "interface_exclude_patterns", None):
+    if defaults.interface_exclude_patterns:
         for p in defaults.interface_exclude_patterns:
             try:
                 exclude_patterns.append(re.compile(p))
@@ -392,6 +392,8 @@ def build_interface_entities(
                 )
 
     def is_excluded(name: str) -> bool:
+        # Uses search (not match) so patterns match anywhere in the name.
+        # Use ^ to anchor to start, e.g. "^tap.*"
         return any(pat.search(name) for pat in exclude_patterns)
 
     interface_entities: dict[str, Interface] = {}

--- a/device-discovery/device_discovery/interface.py
+++ b/device-discovery/device_discovery/interface.py
@@ -373,6 +373,16 @@ def extract_parent_interface_name(interface_name: str) -> str | None:
     return None
 
 
+def _compile_exclude_patterns(patterns: list[str]) -> list[re.Pattern]:
+    compiled = []
+    for p in patterns:
+        try:
+            compiled.append(re.compile(p))
+        except re.error as e:
+            logger.warning(f"Invalid interface exclude pattern '{p}': {e}. Skipping.")
+    return compiled
+
+
 def build_interface_entities(
     device: Device,
     interfaces: dict,
@@ -380,15 +390,7 @@ def build_interface_entities(
     defaults: Defaults,
 ) -> list[Entity]:
     """Create interface entities from interface definitions and IP data."""
-    exclude_patterns = []
-    if defaults.interface_exclude_patterns:
-        for p in defaults.interface_exclude_patterns:
-            try:
-                exclude_patterns.append(re.compile(p))
-            except re.error as e:
-                logger.warning(
-                    f"Invalid interface exclude pattern '{p}': {e}. Skipping."
-                )
+    exclude_patterns = _compile_exclude_patterns(defaults.interface_exclude_patterns or [])
 
     def is_excluded(name: str) -> bool:
         # Uses search (not match) so patterns match anywhere in the name.

--- a/device-discovery/device_discovery/interface.py
+++ b/device-discovery/device_discovery/interface.py
@@ -229,8 +229,7 @@ def translate_interface(
         )
     else:
         # Tier 2 & 3: Try pattern matching (user + built-in merged)
-        # Use getattr for backward compatibility with SimpleNamespace in tests
-        user_patterns = getattr(defaults, 'interface_patterns', None)
+        user_patterns = defaults.interface_patterns
         merged_patterns = merge_interface_patterns(user_patterns, include_defaults=True)
 
         # Count user patterns to maintain priority during matching
@@ -382,10 +381,8 @@ def build_interface_entities(
 ) -> list[Entity]:
     """Create interface entities from interface definitions and IP data."""
     exclude_patterns = []
-    # Use getattr for backward compatibility with SimpleNamespace in tests
-    exclude_patterns_config = getattr(defaults, "interface_exclude_patterns", None)
-    if exclude_patterns_config:
-        for p in exclude_patterns_config:
+    if defaults.interface_exclude_patterns:
+        for p in defaults.interface_exclude_patterns:
             try:
                 exclude_patterns.append(re.compile(p))
             except re.error as e:

--- a/device-discovery/device_discovery/interface.py
+++ b/device-discovery/device_discovery/interface.py
@@ -381,6 +381,19 @@ def build_interface_entities(
     defaults: Defaults,
 ) -> list[Entity]:
     """Create interface entities from interface definitions and IP data."""
+    exclude_patterns = []
+    if getattr(defaults, "interface_exclude_patterns", None):
+        for p in defaults.interface_exclude_patterns:
+            try:
+                exclude_patterns.append(re.compile(p))
+            except re.error as e:
+                logger.warning(
+                    f"Invalid interface exclude pattern '{p}': {e}. Skipping."
+                )
+
+    def is_excluded(name: str) -> bool:
+        return any(pat.search(name) for pat in exclude_patterns)
+
     interface_entities: dict[str, Interface] = {}
     entities: list[Entity] = []
     defined_interface_names = set(interfaces.keys())
@@ -398,6 +411,8 @@ def build_interface_entities(
     for if_name, interface_info in sorted(
         interfaces.items(), key=lambda item: interface_sort_key(item[0])
     ):
+        if is_excluded(if_name):
+            continue
         parent = resolve_parent(if_name)
         interface = translate_interface(
             device, if_name, interface_info, defaults, parent=parent
@@ -408,6 +423,8 @@ def build_interface_entities(
 
     for if_name in sorted(interfaces_ip.keys(), key=interface_sort_key):
         if if_name in interface_entities:
+            continue
+        if is_excluded(if_name):
             continue
         parent = resolve_parent(if_name)
         interface = translate_interface(device, if_name, {}, defaults, parent=parent)

--- a/device-discovery/device_discovery/interface.py
+++ b/device-discovery/device_discovery/interface.py
@@ -382,8 +382,10 @@ def build_interface_entities(
 ) -> list[Entity]:
     """Create interface entities from interface definitions and IP data."""
     exclude_patterns = []
-    if defaults.interface_exclude_patterns:
-        for p in defaults.interface_exclude_patterns:
+    # Use getattr for backward compatibility with SimpleNamespace in tests
+    exclude_patterns_config = getattr(defaults, "interface_exclude_patterns", None)
+    if exclude_patterns_config:
+        for p in exclude_patterns_config:
             try:
                 exclude_patterns.append(re.compile(p))
             except re.error as e:

--- a/device-discovery/device_discovery/interface.py
+++ b/device-discovery/device_discovery/interface.py
@@ -376,6 +376,10 @@ def extract_parent_interface_name(interface_name: str) -> str | None:
 def _compile_exclude_patterns(patterns: list[str]) -> list[re.Pattern]:
     compiled = []
     for p in patterns:
+        p = p.strip()
+        if not p:
+            logger.warning("Empty interface exclude pattern, skipping.")
+            continue
         try:
             compiled.append(re.compile(p))
         except re.error as e:

--- a/device-discovery/device_discovery/policy/models.py
+++ b/device-discovery/device_discovery/policy/models.py
@@ -121,6 +121,14 @@ class Defaults(BaseModel):
         description="Interface name patterns (regex) to exclude from ingestion, optional",
     )
     location: str | None = Field(default=None, description="Location name, optional")
+
+    @field_validator("interface_patterns", "interface_exclude_patterns", mode="before")
+    @classmethod
+    def coerce_empty_list_to_none(cls, v: object) -> object:
+        """Treat an empty list as None so override_defaults does not clear the global list."""
+        if isinstance(v, list) and len(v) == 0:
+            return None
+        return v
     tenant: str | TenantParameters | None = Field(
         default=None, description="Tenant, optional"
     )

--- a/device-discovery/device_discovery/policy/models.py
+++ b/device-discovery/device_discovery/policy/models.py
@@ -116,6 +116,10 @@ class Defaults(BaseModel):
         default=None,
         description="Interface type patterns for name-based matching, optional",
     )
+    interface_exclude_patterns: list[str] | None = Field(
+        default=None,
+        description="Interface name patterns (regex) to exclude from ingestion, optional",
+    )
     location: str | None = Field(default=None, description="Location name, optional")
     tenant: str | TenantParameters | None = Field(
         default=None, description="Tenant, optional"

--- a/device-discovery/tests/test_client.py
+++ b/device-discovery/tests/test_client.py
@@ -2,12 +2,12 @@
 # Copyright 2024 NetBox Labs Inc
 """NetBox Labs - Client Unit Tests."""
 
-from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
 
 from device_discovery.client import Client
+from device_discovery.policy.models import Defaults
 from device_discovery.translate import translate_data
 
 
@@ -43,7 +43,7 @@ def sample_data():
             2: {"name": "vlan2", "interfaces": []},
         },
         "driver": "ios",
-        "defaults": SimpleNamespace(
+        "defaults": Defaults(
             site="New York",
             role=None,
             tags=None,

--- a/device-discovery/tests/test_interface.py
+++ b/device-discovery/tests/test_interface.py
@@ -5,6 +5,7 @@
 import pytest
 
 from device_discovery.interface import (
+    build_interface_entities,
     match_interface_type,
     translate_interface,
 )
@@ -583,3 +584,61 @@ def test_defaults_without_interface_patterns():
     """Test Defaults model works without interface_patterns (backward compatibility)."""
     defaults = Defaults(site="Test Site", if_type="other")
     assert defaults.interface_patterns is None
+
+
+# Tests for build_interface_entities exclusion filtering
+
+
+@pytest.fixture
+def sample_diode_device(sample_device_info, sample_defaults):
+    """A minimal DiodeDevice for use in interface tests."""
+    return translate_device(sample_device_info, sample_defaults, config_info=None, options=None)
+
+
+def test_build_interface_entities_excludes_matching_interfaces(sample_diode_device):
+    interfaces = {
+        "GigabitEthernet0/0": {
+            "is_enabled": True, "mtu": 1500, "speed": 1000,
+            "mac_address": "00:11:22:33:44:55", "description": "Uplink",
+        },
+        "tap103i0": {
+            "is_enabled": True, "mtu": 1500, "speed": 10,
+            "mac_address": "", "description": "",
+        },
+    }
+    interfaces_ip = {
+        "tap103i0": {"ipv4": {"10.0.0.1": {"prefix_length": 24}}, "ipv6": {}},
+        "GigabitEthernet0/0": {"ipv4": {"192.168.1.1": {"prefix_length": 24}}, "ipv6": {}},
+    }
+    defaults = Defaults(interface_exclude_patterns=["^tap.*"])
+    entities = build_interface_entities(sample_diode_device, interfaces, interfaces_ip, defaults)
+
+    interface_names = [
+        e.interface.name
+        for e in entities
+        if e.HasField("interface")
+    ]
+    ip_addresses = [
+        e.ip_address.address
+        for e in entities
+        if e.HasField("ip_address")
+    ]
+
+    assert "GigabitEthernet0/0" in interface_names
+    assert "tap103i0" not in interface_names
+    assert not any("10.0.0.1" in addr for addr in ip_addresses)
+    assert any("192.168.1.1" in addr for addr in ip_addresses)
+
+
+def test_build_interface_entities_no_exclude_patterns(sample_diode_device):
+    interfaces = {
+        "tap103i0": {"is_enabled": True, "mtu": 1500, "speed": 10, "mac_address": "", "description": ""},
+    }
+    interfaces_ip = {
+        "tap103i0": {"ipv4": {"10.0.0.1": {"prefix_length": 24}}, "ipv6": {}},
+    }
+    defaults = Defaults()
+    entities = build_interface_entities(sample_diode_device, interfaces, interfaces_ip, defaults)
+
+    interface_names = [e.interface.name for e in entities if e.HasField("interface")]
+    assert "tap103i0" in interface_names

--- a/device-discovery/tests/test_interface.py
+++ b/device-discovery/tests/test_interface.py
@@ -596,6 +596,7 @@ def sample_diode_device(sample_device_info, sample_defaults):
 
 
 def test_build_interface_entities_excludes_matching_interfaces(sample_diode_device):
+    """Interfaces matching exclude patterns and their IPs are not ingested."""
     interfaces = {
         "GigabitEthernet0/0": {
             "is_enabled": True, "mtu": 1500, "speed": 1000,
@@ -631,6 +632,7 @@ def test_build_interface_entities_excludes_matching_interfaces(sample_diode_devi
 
 
 def test_build_interface_entities_no_exclude_patterns(sample_diode_device):
+    """All interfaces are ingested when no exclude patterns are configured."""
     interfaces = {
         "tap103i0": {"is_enabled": True, "mtu": 1500, "speed": 10, "mac_address": "", "description": ""},
     }

--- a/device-discovery/tests/test_interface.py
+++ b/device-discovery/tests/test_interface.py
@@ -642,3 +642,15 @@ def test_build_interface_entities_no_exclude_patterns(sample_diode_device):
 
     interface_names = [e.interface.name for e in entities if e.HasField("interface")]
     assert "tap103i0" in interface_names
+
+
+def test_build_interface_entities_excludes_ip_only_interface(sample_diode_device):
+    """Excluded interface absent from interfaces dict is also suppressed via ip-only fallback loop."""
+    interfaces = {}
+    interfaces_ip = {
+        "tap103i0": {"ipv4": {"10.0.0.1": {"prefix_length": 24}}, "ipv6": {}},
+    }
+    defaults = Defaults(interface_exclude_patterns=["^tap"])
+    entities = build_interface_entities(sample_diode_device, interfaces, interfaces_ip, defaults)
+    assert not any(e.HasField("interface") for e in entities)
+    assert not any(e.HasField("ip_address") for e in entities)

--- a/device-discovery/tests/test_interface.py
+++ b/device-discovery/tests/test_interface.py
@@ -654,3 +654,18 @@ def test_build_interface_entities_excludes_ip_only_interface(sample_diode_device
     entities = build_interface_entities(sample_diode_device, interfaces, interfaces_ip, defaults)
     assert not any(e.HasField("interface") for e in entities)
     assert not any(e.HasField("ip_address") for e in entities)
+
+
+def test_build_interface_entities_invalid_exclude_pattern_skipped(sample_diode_device):
+    """Invalid regex patterns are skipped with a warning; valid ones still apply."""
+    interfaces = {
+        "tap0": {"is_enabled": True, "mtu": 1500, "speed": 10, "mac_address": "", "description": ""},
+        "eth0": {"is_enabled": True, "mtu": 1500, "speed": 1000, "mac_address": "", "description": ""},
+    }
+    defaults = Defaults(interface_exclude_patterns=["[invalid", "^tap"])
+    entities = build_interface_entities(sample_diode_device, interfaces, {}, defaults)
+
+    interface_names = [e.interface.name for e in entities if e.HasField("interface")]
+    # invalid pattern "[invalid" is skipped; valid "^tap" still excludes tap0
+    assert "tap0" not in interface_names
+    assert "eth0" in interface_names

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -68,14 +68,15 @@ type DeviceDefaults struct {
 
 // Defaults represents the supported default values for a policy
 type Defaults struct {
-	Tags              []string           `yaml:"tags,omitempty"`
-	Site              string             `yaml:"site,omitempty"`
-	Location          string             `yaml:"location,omitempty"`
-	Role              string             `yaml:"role,omitempty"`
-	IPAddress         IPAddressDefaults  `yaml:"ip_address,omitempty"`
-	Interface         InterfaceDefaults  `yaml:"interface,omitempty"`
-	Device            DeviceDefaults     `yaml:"device,omitempty"`
-	InterfacePatterns []InterfacePattern `yaml:"interface_patterns,omitempty"`
+	Tags                     []string           `yaml:"tags,omitempty"`
+	Site                     string             `yaml:"site,omitempty"`
+	Location                 string             `yaml:"location,omitempty"`
+	Role                     string             `yaml:"role,omitempty"`
+	IPAddress                IPAddressDefaults  `yaml:"ip_address,omitempty"`
+	Interface                InterfaceDefaults  `yaml:"interface,omitempty"`
+	Device                   DeviceDefaults     `yaml:"device,omitempty"`
+	InterfacePatterns        []InterfacePattern `yaml:"interface_patterns,omitempty"`
+	InterfaceExcludePatterns []string           `yaml:"interface_exclude_patterns,omitempty"`
 }
 
 // MergeDefaults merges target-level override defaults with policy-level defaults
@@ -147,6 +148,11 @@ func MergeDefaults(policyDefaults, overrideDefaults *Defaults) *Defaults {
 	// Override InterfacePatterns if provided
 	if len(overrideDefaults.InterfacePatterns) > 0 {
 		merged.InterfacePatterns = overrideDefaults.InterfacePatterns
+	}
+
+	// Override InterfaceExcludePatterns if provided
+	if len(overrideDefaults.InterfaceExcludePatterns) > 0 {
+		merged.InterfaceExcludePatterns = overrideDefaults.InterfaceExcludePatterns
 	}
 
 	return &merged

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -236,6 +236,28 @@ func TestMergeDefaults(t *testing.T) {
 		assert.Equal(t, []string{"default", "policy"}, result.Tags)
 		assert.Len(t, result.InterfacePatterns, 1)
 	})
+
+	t.Run("Override InterfaceExcludePatterns replaces global list", func(t *testing.T) {
+		policyDefaults := &Defaults{
+			InterfaceExcludePatterns: []string{"^eth.*"},
+		}
+		overrideDefaults := &Defaults{
+			InterfaceExcludePatterns: []string{"^tap.*", "^veth.*"},
+		}
+		result := MergeDefaults(policyDefaults, overrideDefaults)
+		assert.Equal(t, []string{"^tap.*", "^veth.*"}, result.InterfaceExcludePatterns)
+	})
+
+	t.Run("Empty override does not replace InterfaceExcludePatterns", func(t *testing.T) {
+		policyDefaults := &Defaults{
+			InterfaceExcludePatterns: []string{"^eth.*"},
+		}
+		overrideDefaults := &Defaults{
+			Site: "Override Site",
+		}
+		result := MergeDefaults(policyDefaults, overrideDefaults)
+		assert.Equal(t, []string{"^eth.*"}, result.InterfaceExcludePatterns)
+	})
 }
 
 func TestTargetNetboxID_parsed(t *testing.T) {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -3,6 +3,7 @@ package mapping
 import (
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
@@ -48,20 +49,30 @@ const (
 
 // EntityRegistry is a struct that contains a map of entities
 type EntityRegistry struct {
-	entities map[EntityType]map[ObjectIDIndex]diode.Entity
-	logger   *slog.Logger
+	entities           map[EntityType]map[ObjectIDIndex]diode.Entity
+	logger             *slog.Logger
+	excludedInterfaces map[string]struct{}
 }
 
 // NewEntityRegistry creates a new EntityRegistry
 func NewEntityRegistry(logger *slog.Logger) *EntityRegistry {
 	return &EntityRegistry{
-		entities: make(map[EntityType]map[ObjectIDIndex]diode.Entity),
-		logger:   logger,
+		entities:           make(map[EntityType]map[ObjectIDIndex]diode.Entity),
+		logger:             logger,
+		excludedInterfaces: make(map[string]struct{}),
 	}
+}
+
+// ExcludeInterface marks an interface name as excluded so it is skipped during lookups
+func (r *EntityRegistry) ExcludeInterface(name string) {
+	r.excludedInterfaces[name] = struct{}{}
 }
 
 // GetInterfaceByName searches for an interface entity by its name field
 func (r *EntityRegistry) GetInterfaceByName(interfaceName string) *diode.Interface {
+	if _, excluded := r.excludedInterfaces[interfaceName]; excluded {
+		return nil
+	}
 	if r.entities[InterfaceEntityType] == nil {
 		return nil
 	}
@@ -185,10 +196,11 @@ const (
 
 // ObjectIDMapper is a struct that maps ObjectIDs to entities
 type ObjectIDMapper struct {
-	mappingConfig *Config
-	logger        *slog.Logger
-	registry      *EntityRegistry
-	defaults      *config.Defaults
+	mappingConfig   *Config
+	logger          *slog.Logger
+	registry        *EntityRegistry
+	defaults        *config.Defaults
+	excludePatterns []*regexp.Regexp
 }
 
 // Entry is a struct that contains a mapping entry
@@ -267,11 +279,28 @@ func NewConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturer
 // NewObjectIDMapper creates a new ObjectIDMapper
 func NewObjectIDMapper(mappingConfig *Config, logger *slog.Logger, defaults *config.Defaults) *ObjectIDMapper {
 	return &ObjectIDMapper{
-		mappingConfig: mappingConfig,
-		logger:        logger,
-		registry:      NewEntityRegistry(logger),
-		defaults:      defaults,
+		mappingConfig:   mappingConfig,
+		logger:          logger,
+		registry:        NewEntityRegistry(logger),
+		defaults:        defaults,
+		excludePatterns: compileExcludePatterns(defaults, logger),
 	}
+}
+
+func compileExcludePatterns(defaults *config.Defaults, logger *slog.Logger) []*regexp.Regexp {
+	if defaults == nil || len(defaults.InterfaceExcludePatterns) == 0 {
+		return nil
+	}
+	patterns := make([]*regexp.Regexp, 0, len(defaults.InterfaceExcludePatterns))
+	for _, p := range defaults.InterfaceExcludePatterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			logger.Warn("invalid interface exclude pattern, skipping", "pattern", p, "error", err)
+			continue
+		}
+		patterns = append(patterns, re)
+	}
+	return patterns
 }
 
 type orbToEntityMapper interface {
@@ -386,6 +415,8 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 		uniqueEntities[newEntity] = true
 	}
 
+	m.filterExcludedEntities(uniqueEntities)
+
 	currentDevice := m.registry.GetOrCreateEntity(DeviceEntityType, CurrentDeviceIndex).(*diode.Device)
 
 	// Resolve parent interface relationships for subinterfaces now that all interfaces are discovered
@@ -413,6 +444,40 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 		}
 	}
 	return entities
+}
+
+func (m *ObjectIDMapper) filterExcludedEntities(entities map[diode.Entity]bool) {
+	if len(m.excludePatterns) == 0 {
+		return
+	}
+	for entity := range entities {
+		iface, ok := entity.(*diode.Interface)
+		if !ok || iface.Name == nil {
+			continue
+		}
+		for _, pat := range m.excludePatterns {
+			if pat.MatchString(*iface.Name) {
+				m.registry.ExcludeInterface(*iface.Name)
+				delete(entities, entity)
+				m.logger.Debug("excluding interface by pattern", "name", *iface.Name)
+				break
+			}
+		}
+	}
+	for entity := range entities {
+		ip, ok := entity.(*diode.IPAddress)
+		if !ok || ip.AssignedObject == nil {
+			continue
+		}
+		iface, ok := ip.AssignedObject.(*diode.Interface)
+		if !ok || iface.Name == nil {
+			continue
+		}
+		if _, excluded := m.registry.excludedInterfaces[*iface.Name]; excluded {
+			delete(entities, entity)
+			m.logger.Debug("excluding IP for excluded interface", "interface", *iface.Name)
+		}
+	}
 }
 
 func (*ObjectIDMapper) getAssignedInterfaces(uniqueEntities map[diode.Entity]bool) map[diode.Entity]bool {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -68,9 +68,15 @@ func (r *EntityRegistry) ExcludeInterface(name string) {
 	r.excludedInterfaces[name] = struct{}{}
 }
 
+// IsInterfaceExcluded checks whether an interface name is excluded
+func (r *EntityRegistry) IsInterfaceExcluded(name string) bool {
+	_, excluded := r.excludedInterfaces[name]
+	return excluded
+}
+
 // GetInterfaceByName searches for an interface entity by its name field
 func (r *EntityRegistry) GetInterfaceByName(interfaceName string) *diode.Interface {
-	if _, excluded := r.excludedInterfaces[interfaceName]; excluded {
+	if r.IsInterfaceExcluded(interfaceName) {
 		return nil
 	}
 	if r.entities[InterfaceEntityType] == nil {
@@ -447,6 +453,8 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 }
 
 func (m *ObjectIDMapper) filterExcludedEntities(entities map[diode.Entity]bool) {
+	// Deletion from a map during range is safe in Go: deleted entries are not
+	// visited in subsequent iterations.
 	if len(m.excludePatterns) == 0 {
 		return
 	}
@@ -473,7 +481,7 @@ func (m *ObjectIDMapper) filterExcludedEntities(entities map[diode.Entity]bool) 
 		if !ok || iface.Name == nil {
 			continue
 		}
-		if _, excluded := m.registry.excludedInterfaces[*iface.Name]; excluded {
+		if m.registry.IsInterfaceExcluded(*iface.Name) {
 			delete(entities, entity)
 			m.logger.Debug("excluding IP for excluded interface", "interface", *iface.Name)
 		}

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -418,7 +418,9 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 			continue
 		}
 		newEntity := entry.MapToEntity(value.Values, m.registry, m.defaults, m.logger)
-		uniqueEntities[newEntity] = true
+		if newEntity != nil {
+			uniqueEntities[newEntity] = true
+		}
 	}
 
 	m.filterExcludedEntities(uniqueEntities)

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -299,6 +299,11 @@ func compileExcludePatterns(defaults *config.Defaults, logger *slog.Logger) []*r
 	}
 	patterns := make([]*regexp.Regexp, 0, len(defaults.InterfaceExcludePatterns))
 	for _, p := range defaults.InterfaceExcludePatterns {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			logger.Warn("empty interface exclude pattern, skipping")
+			continue
+		}
 		re, err := regexp.Compile(p)
 		if err != nil {
 			logger.Warn("invalid interface exclude pattern, skipping", "pattern", p, "error", err)

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -425,7 +425,9 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 
 	currentDevice := m.registry.GetOrCreateEntity(DeviceEntityType, CurrentDeviceIndex).(*diode.Device)
 
-	// Resolve parent interface relationships for subinterfaces now that all interfaces are discovered
+	// ResolveSubinterfaceParents must run after filterExcludedEntities: excluded interface
+	// names are marked in the registry so GetInterfaceByName returns nil for them,
+	// preventing subinterfaces from receiving a parent pointer to an excluded interface.
 	m.registry.ResolveSubinterfaceParents()
 
 	assignedInterfaceIndices := m.getAssignedInterfaces(uniqueEntities)

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -28,6 +28,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 		name      string
 		mapping   []config.MappingEntry
 		objectIDs mapping.ObjectIDValueMap
+		defaults  *config.Defaults
 		expected  []diode.Entity
 	}{
 		{
@@ -297,6 +298,52 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 			},
 		},
 		{
+			name: "Excluded interface and its IP are not ingested",
+			mapping: []config.MappingEntry{
+				{
+					OID:            ".1.3.6.1.2.1.2.2.1",
+					Entity:         "interface",
+					Field:          "_id",
+					IdentifierSize: 1,
+					MappingEntries: []config.MappingEntry{
+						{OID: ".1.3.6.1.2.1.2.2.1.2", Entity: "interface", Field: "name"},
+					},
+				},
+				{
+					OID:            ".1.3.6.1.2.1.4.20.1",
+					Entity:         "ipAddress",
+					Field:          "_id",
+					IdentifierSize: 4,
+					MappingEntries: []config.MappingEntry{
+						{OID: ".1.3.6.1.2.1.4.20.1.1", Entity: "ipAddress", Field: "address"},
+						{
+							OID:    ".1.3.6.1.2.1.4.20.1.2",
+							Entity: "ipAddress",
+							Field:  "assignedObject",
+							Relationship: config.Relationship{Type: "interface", Field: "_id"},
+						},
+					},
+				},
+			},
+			objectIDs: mapping.ObjectIDValueMap{
+				".1.3.6.1.2.1.2.2.1.2.1":          mapping.Value{Value: "eth0", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.2.2":          mapping.Value{Value: "tap0", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.4.20.1.1.10.0.0.1": mapping.Value{Value: "10.0.0.1", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4},
+				".1.3.6.1.2.1.4.20.1.2.10.0.0.1": mapping.Value{Value: "2", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 4},
+			},
+			defaults: &config.Defaults{
+				Interface:                config.InterfaceDefaults{Type: "other"},
+				InterfaceExcludePatterns: []string{"^tap.*"},
+			},
+			expected: []diode.Entity{
+				&diode.Interface{
+					Name:   diode.String("eth0"),
+					Type:   diode.String("other"),
+					Device: &diode.Device{},
+				},
+			},
+		},
+		{
 			name: "Device with platform from sysObjectID",
 			mapping: []config.MappingEntry{
 				{
@@ -339,11 +386,15 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			mappingConfig, err := mapping.NewConfig(tt.mapping, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
 			assert.NoError(t, err)
-			mapper := mapping.NewObjectIDMapper(mappingConfig, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), &config.Defaults{
-				Interface: config.InterfaceDefaults{
-					Type: "other",
-				},
-			})
+			defaults := tt.defaults
+			if defaults == nil {
+				defaults = &config.Defaults{
+					Interface: config.InterfaceDefaults{
+						Type: "other",
+					},
+				}
+			}
+			mapper := mapping.NewObjectIDMapper(mappingConfig, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), defaults)
 			entities := mapper.MapObjectIDsToEntity(tt.objectIDs)
 
 			assert.ElementsMatch(t, tt.expected, entities)

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -380,6 +380,35 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Invalid exclude pattern is skipped, valid pattern still applies",
+			mapping: []config.MappingEntry{
+				{
+					OID:            ".1.3.6.1.2.1.2.2.1",
+					Entity:         "interface",
+					Field:          "_id",
+					IdentifierSize: 1,
+					MappingEntries: []config.MappingEntry{
+						{OID: ".1.3.6.1.2.1.2.2.1.2", Entity: "interface", Field: "name"},
+					},
+				},
+			},
+			objectIDs: mapping.ObjectIDValueMap{
+				".1.3.6.1.2.1.2.2.1.2.1": mapping.Value{Value: "tap0", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.2.2": mapping.Value{Value: "eth0", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+			},
+			defaults: &config.Defaults{
+				Interface:                config.InterfaceDefaults{Type: "other"},
+				InterfaceExcludePatterns: []string{"[invalid", "^tap.*"},
+			},
+			expected: []diode.Entity{
+				&diode.Interface{
+					Name:   diode.String("eth0"),
+					Type:   diode.String("other"),
+					Device: &diode.Device{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -317,17 +317,17 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 					MappingEntries: []config.MappingEntry{
 						{OID: ".1.3.6.1.2.1.4.20.1.1", Entity: "ipAddress", Field: "address"},
 						{
-							OID:    ".1.3.6.1.2.1.4.20.1.2",
-							Entity: "ipAddress",
-							Field:  "assignedObject",
+							OID:          ".1.3.6.1.2.1.4.20.1.2",
+							Entity:       "ipAddress",
+							Field:        "assignedObject",
 							Relationship: config.Relationship{Type: "interface", Field: "_id"},
 						},
 					},
 				},
 			},
 			objectIDs: mapping.ObjectIDValueMap{
-				".1.3.6.1.2.1.2.2.1.2.1":          mapping.Value{Value: "eth0", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
-				".1.3.6.1.2.1.2.2.1.2.2":          mapping.Value{Value: "tap0", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.2.1":         mapping.Value{Value: "eth0", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
+				".1.3.6.1.2.1.2.2.1.2.2":         mapping.Value{Value: "tap0", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1},
 				".1.3.6.1.2.1.4.20.1.1.10.0.0.1": mapping.Value{Value: "10.0.0.1", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4},
 				".1.3.6.1.2.1.4.20.1.2.10.0.0.1": mapping.Value{Value: "2", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 4},
 			},


### PR DESCRIPTION
## Summary

- Adds `interface_exclude_patterns` (list of regex strings) to policy `defaults` config in both snmp-discovery (Go) and device-discovery (Python), allowing users to exclude matching interfaces — and their associated IPs — from being ingested into NetBox
- Follows the same override semantics as the existing `interface_patterns` field: `override_defaults` replaces the global list wholesale when non-empty
- Invalid regex patterns are logged and skipped gracefully

## Config Example

```yaml
defaults:
  interface_exclude_patterns:
    - "^tap.*"
    - "^veth.*"

# Per-target override (replaces global list)
scope:
  - hostname: 192.168.1.1
    override_defaults:
      interface_exclude_patterns:
        - "^tap.*"
```

## Test Plan

- [x] snmp-discovery: `cd snmp-discovery && go test ./...` — all packages pass
- [x] device-discovery: `cd device-discovery && python -m pytest tests/` — 505 tests pass
- [ ] Verify excluded interface names do not appear in NetBox after a discovery run
- [ ] Verify IPs on excluded interfaces are also absent
- [ ] Verify non-excluded interfaces and their IPs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)