### PR TITLE
fix: preserve SNMP interface description and strip null bytes from string fields (OBS-1577/OBS-2702)

### DIFF
--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -358,15 +358,19 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				switch propertyMappingEntry.Field {
 				case "name":
 					name := strings.TrimRight(value.Value, "\x00 \t\n\r")
-					interfaceEntity.Name = &name
-					fieldFound = true
+					if name != "" {
+						interfaceEntity.Name = &name
+						fieldFound = true
+					}
 				case "description":
 					description := strings.TrimRight(value.Value, "\x00 \t\n\r")
-					if len(description) > 200 {
-						description = description[:197] + "..."
+					if description != "" {
+						if len(description) > 200 {
+							description = description[:197] + "..."
+						}
+						interfaceEntity.Description = &description
+						fieldFound = true
 					}
-					interfaceEntity.Description = &description
-					fieldFound = true
 				case "type":
 					// Store SNMP ifType but defer type resolution until after all fields are processed
 					// This ensures name and speed are available for pattern matching
@@ -620,15 +624,19 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 				switch propertyMappingEntry.Field {
 				case "name":
 					name := strings.TrimRight(value.Value, "\x00 \t\n\r")
-					deviceEntity.Name = &name
-					fieldFound = true
+					if name != "" {
+						deviceEntity.Name = &name
+						fieldFound = true
+					}
 				case "description":
 					description := strings.TrimRight(value.Value, "\x00 \t\n\r")
-					if len(description) > 200 {
-						description = description[:197] + "..."
+					if description != "" {
+						if len(description) > 200 {
+							description = description[:197] + "..."
+						}
+						deviceEntity.Description = &description
+						fieldFound = true
 					}
-					deviceEntity.Description = &description
-					fieldFound = true
 				case "platform":
 					manufacturerID, err := m.getManufacturerID(value.Value)
 					if err != nil {

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -357,10 +357,11 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				m.logger.Debug("mapping value to interface entity with mapper", "object_id", objectID, "value", value)
 				switch propertyMappingEntry.Field {
 				case "name":
-					interfaceEntity.Name = &value.Value
+					name := strings.TrimRight(value.Value, "\x00 \t\n\r")
+					interfaceEntity.Name = &name
 					fieldFound = true
 				case "description":
-					description := strings.TrimRight(value.Value, " \t\n\r")
+					description := strings.TrimRight(value.Value, "\x00 \t\n\r")
 					if len(description) > 200 {
 						description = description[:197] + "..."
 					}
@@ -626,10 +627,11 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 				m.logger.Debug("mapping value to device entity with mapper", "object_id", objectID, "value", value, "mapping_entry", propertyMappingEntry)
 				switch propertyMappingEntry.Field {
 				case "name":
-					deviceEntity.Name = &value.Value
+					name := strings.TrimRight(value.Value, "\x00 \t\n\r")
+					deviceEntity.Name = &name
 					fieldFound = true
 				case "description":
-					description := strings.TrimRight(value.Value, " \t\n\r")
+					description := strings.TrimRight(value.Value, "\x00 \t\n\r")
 					if len(description) > 200 {
 						description = description[:197] + "..."
 					}

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -545,14 +545,6 @@ func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defa
 	}
 	entityDefaults := defaults.Device
 
-	// Apply entity-specific defaults
-	if entityDefaults.Description != "" {
-		entity.Description = &entityDefaults.Description
-	}
-	if entityDefaults.Comments != "" {
-		entity.Comments = &entityDefaults.Comments
-	}
-
 	// Collect tags from both entity-specific and global defaults
 	var tags []*diode.Tag
 	if len(entityDefaults.Tags) > 0 {

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -306,11 +306,6 @@ func (m *InterfaceMapper) applyDefaults(entity *diode.Interface, defaults *confi
 	}
 	entityDefaults := defaults.Interface
 
-	// Apply entity-specific defaults
-	if entityDefaults.Description != "" {
-		entity.Description = &entityDefaults.Description
-	}
-
 	// Collect tags from both entity-specific and global defaults
 	var tags []*diode.Tag
 	if len(entityDefaults.Tags) > 0 {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -1327,6 +1327,60 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "trailing null bytes are stripped from interface name and description",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0\x00",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.31.1.1.1.18.1": {
+					OID:    "1.3.6.1.2.1.31.1.1.1.18.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.31.1.1.1.18",
+					Value:  "uplink\x00",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.31.1.1.1.18",
+						Entity: "interface",
+						Field:  "description",
+					},
+				},
+			},
+			defaults: nil,
+			expectedEntity: &diode.Interface{
+				Name:        mapping.StringPtr("eth0"),
+				Description: mapping.StringPtr("uplink"),
+			},
+			expectError: false,
+		},
+		{
 			// SNMP description must not be overwritten by the default description.
 			name: "SNMP description is preserved when defaults also specify a description",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
@@ -2300,6 +2354,45 @@ func TestDeviceMapper_Map(t *testing.T) {
 				Field:  "_id",
 			},
 			expectedEntity: &diode.Device{},
+			expectError:    false,
+		},
+		{
+			name: "trailing null bytes are stripped from device name and description",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.1.5.0": {
+					OID:    "1.3.6.1.2.1.1.5.0",
+					Index:  "0",
+					Parent: "1.3.6.1.2.1.1.5",
+					Value:  "router01\x00",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.1.1.0": {
+					OID:    "1.3.6.1.2.1.1.1.0",
+					Index:  "0",
+					Parent: "1.3.6.1.2.1.1.1",
+					Value:  "core router\x00",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.1",
+				Entity: "device",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.1.5",
+						Entity: "device",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.1.1",
+						Entity: "device",
+						Field:  "description",
+					},
+				},
+			},
+			defaults:       nil,
+			expectedEntity: &diode.Device{Name: mapping.StringPtr("router01"), Description: mapping.StringPtr("core router")},
 			expectError:    false,
 		},
 	}

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -1326,6 +1326,65 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			},
 			expectError: false,
 		},
+		{
+			// SNMP description must not be overwritten by the default description.
+			name: "SNMP description is preserved when defaults also specify a description",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.31.1.1.1.18.1": {
+					OID:    "1.3.6.1.2.1.31.1.1.1.18.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.31.1.1.1.18",
+					Value:  "uplink to core",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.31.1.1.1.18",
+						Entity: "interface",
+						Field:  "description",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Interface: config.InterfaceDefaults{
+					Description: "default interface description",
+				},
+			},
+			expectedEntity: &diode.Interface{
+				Name:        mapping.StringPtr("eth0"),
+				Description: mapping.StringPtr("uplink to core"),
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -2357,6 +2357,53 @@ func TestDeviceMapper_Map(t *testing.T) {
 			expectError:    false,
 		},
 		{
+			// SNMP description must not be overwritten by the default description.
+			name: "SNMP description is preserved when defaults also specify a description",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.1.5.0": {
+					OID:    "1.3.6.1.2.1.1.5.0",
+					Index:  "0",
+					Parent: "1.3.6.1.2.1.1.5",
+					Value:  "router1",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.1.1.0": {
+					OID:    "1.3.6.1.2.1.1.1.0",
+					Index:  "0",
+					Parent: "1.3.6.1.2.1.1.1",
+					Value:  "description from SNMP",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.1",
+				Entity: "device",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.1.5",
+						Entity: "device",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.1.1",
+						Entity: "device",
+						Field:  "description",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				Device: config.DeviceDefaults{
+					Description: "default device description",
+				},
+			},
+			expectedEntity: &diode.Device{
+				Name:        mapping.StringPtr("router1"),
+				Description: mapping.StringPtr("description from SNMP"),
+			},
+			expectError: false,
+		},
+		{
 			name: "trailing null bytes are stripped from device name and description",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.1.5.0": {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -1381,6 +1381,52 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "null-byte-only description falls back to configured default",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth0",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.31.1.1.1.18.1": {
+					OID:    "1.3.6.1.2.1.31.1.1.1.18.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.31.1.1.1.18",
+					Value:  "\x00",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{OID: "1.3.6.1.2.1.2.2.1.1", Entity: "interface", Field: "_id"},
+					{OID: "1.3.6.1.2.1.2.2.1.2", Entity: "interface", Field: "name"},
+					{OID: "1.3.6.1.2.1.31.1.1.1.18", Entity: "interface", Field: "description"},
+				},
+			},
+			defaults: &config.Defaults{
+				Interface: config.InterfaceDefaults{
+					Description: "default interface description",
+				},
+			},
+			expectedEntity: &diode.Interface{
+				Name:        mapping.StringPtr("eth0"),
+				Description: mapping.StringPtr("default interface description"),
+			},
+			expectError: false,
+		},
+		{
 			// SNMP description must not be overwritten by the default description.
 			name: "SNMP description is preserved when defaults also specify a description",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
@@ -2355,6 +2401,44 @@ func TestDeviceMapper_Map(t *testing.T) {
 			},
 			expectedEntity: &diode.Device{},
 			expectError:    false,
+		},
+		{
+			name: "null-byte-only description falls back to configured default",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.1.5.0": {
+					OID:    "1.3.6.1.2.1.1.5.0",
+					Index:  "0",
+					Parent: "1.3.6.1.2.1.1.5",
+					Value:  "router1",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.1.1.0": {
+					OID:    "1.3.6.1.2.1.1.1.0",
+					Index:  "0",
+					Parent: "1.3.6.1.2.1.1.1",
+					Value:  "\x00",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.1",
+				Entity: "device",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{OID: "1.3.6.1.2.1.1.5", Entity: "device", Field: "name"},
+					{OID: "1.3.6.1.2.1.1.1", Entity: "device", Field: "description"},
+				},
+			},
+			defaults: &config.Defaults{
+				Device: config.DeviceDefaults{
+					Description: "default device description",
+				},
+			},
+			expectedEntity: &diode.Device{
+				Name:        mapping.StringPtr("router1"),
+				Description: mapping.StringPtr("default device description"),
+			},
+			expectError: false,
 		},
 		{
 			// SNMP description must not be overwritten by the default description.


### PR DESCRIPTION
## Summary
**Fix 1 (OBS-1577) — Interface description overwritten by defaults**
- `applyDefaults` in `InterfaceMapper` had an unconditional block that overwrote `entity.Description` with the default value whenever a default was configured, discarding any description already populated from SNMP
- Removed the redundant unconditional block; the nil-guarded block that follows already handles applying the default only when no SNMP description was mapped

**Fix 2 (OBS-2702) — Trailing null bytes in SNMP string fields cause Diode ingestion failure**
- Avocent KVM switches (and others) return `ifName`/`ifDescr` with a trailing `\x00` null byte
- PostgreSQL/NetBox rejects null bytes in text fields, causing Diode ingestion to fail
- Extended the existing `TrimRight` cutset to include `\x00` for interface and device `name` and `description` fields

## Test plan
- [x] `go test ./mapping/...` passes (regression tests included for both fixes)
- [x] Verify interface descriptions from SNMP are preserved when `defaults.interface.description` is configured
- [x] Verify devices/interfaces from switches returning null-terminated strings are ingested correctly by Diode