### PR TITLE
feat: standardise run metadata "targets" key across all discovery backends

### DIFF
--- a/device-discovery/device_discovery/policy/run.py
+++ b/device-discovery/device_discovery/policy/run.py
@@ -3,6 +3,7 @@
 """Device Discovery Run Store."""
 
 import ipaddress
+import json
 import threading
 import time
 
@@ -90,8 +91,8 @@ class RunStore:
         with self._lock:
             normalized_target = self._normalize_target(target)
 
-            # Build metadata with target information
-            metadata = {"target": target}  # Store original, not normalized
+            # Build metadata with targets as JSON array
+            metadata = {"targets": json.dumps([target])}
             if parent_target:
                 metadata["parent_target"] = parent_target
 

--- a/device-discovery/tests/policy/test_run.py
+++ b/device-discovery/tests/policy/test_run.py
@@ -13,7 +13,7 @@ def test_run_creation():
     run = Run(
         policy_id="test-policy",
         status=RunStatus.RUNNING,
-        metadata={"target": "router1.example.com"},
+        metadata={"targets": '["router1.example.com"]'},
     )
 
     assert run.id  # UUID should be generated
@@ -21,7 +21,7 @@ def test_run_creation():
     assert run.status == RunStatus.RUNNING
     assert run.reason == ""
     assert run.entity_count == 0
-    assert run.metadata["target"] == "router1.example.com"
+    assert run.metadata["targets"] == '["router1.example.com"]'
     assert run.created_at
     assert run.updated_at
 
@@ -32,12 +32,12 @@ def test_run_with_parent():
         policy_id="test-policy",
         status=RunStatus.RUNNING,
         metadata={
-            "target": "192.168.1.5",
+            "targets": '["192.168.1.5"]',
             "parent_target": "192.168.1.0/24",
         },
     )
 
-    assert run.metadata["target"] == "192.168.1.5"
+    assert run.metadata["targets"] == '["192.168.1.5"]'
     assert run.metadata["parent_target"] == "192.168.1.0/24"
 
 
@@ -48,7 +48,8 @@ def test_create_run_basic():
 
     assert run.policy_id == "policy1"
     assert run.status == RunStatus.RUNNING
-    assert run.metadata["target"] == "192.168.1.1"
+    assert run.metadata["targets"] == '["192.168.1.1"]'
+    assert "target" not in run.metadata
     assert "parent_target" not in run.metadata
 
 
@@ -57,7 +58,8 @@ def test_create_run_with_parent():
     store = RunStore()
     run = store.create_run("policy1", "192.168.1.5", "192.168.1.0/24")
 
-    assert run.metadata["target"] == "192.168.1.5"
+    assert run.metadata["targets"] == '["192.168.1.5"]'
+    assert "target" not in run.metadata
     assert run.metadata["parent_target"] == "192.168.1.0/24"
 
 
@@ -305,18 +307,18 @@ def test_parent_child_relationship():
     # Verify parent run
     parent_runs = store.get_runs_for_target("policy1", "192.168.1.0/24")
     assert len(parent_runs) == 1
-    assert parent_runs[0].metadata["target"] == "192.168.1.0/24"
+    assert parent_runs[0].metadata["targets"] == '["192.168.1.0/24"]'
     assert "parent_target" not in parent_runs[0].metadata
 
     # Verify child runs have parent reference
     child1_runs = store.get_runs_for_target("policy1", "192.168.1.5")
     assert len(child1_runs) == 1
-    assert child1_runs[0].metadata["target"] == "192.168.1.5"
+    assert child1_runs[0].metadata["targets"] == '["192.168.1.5"]'
     assert child1_runs[0].metadata["parent_target"] == "192.168.1.0/24"
 
     child2_runs = store.get_runs_for_target("policy1", "192.168.1.10")
     assert len(child2_runs) == 1
-    assert child2_runs[0].metadata["target"] == "192.168.1.10"
+    assert child2_runs[0].metadata["targets"] == '["192.168.1.10"]'
     assert child2_runs[0].metadata["parent_target"] == "192.168.1.0/24"
 
 
@@ -327,6 +329,6 @@ def test_metadata_preserved():
     # Create run with IP that will be normalized
     store.create_run("policy1", "Router1.Example.COM", "")
 
-    # Verify metadata contains original (not normalized)
+    # Verify metadata contains original (not normalized) target in targets JSON
     retrieved = store.get_runs_for_target("policy1", "router1.example.com")[0]
-    assert retrieved.metadata["target"] == "Router1.Example.COM"
+    assert retrieved.metadata["targets"] == '["Router1.Example.COM"]'

--- a/snmp-discovery/policy/run.go
+++ b/snmp-discovery/policy/run.go
@@ -3,8 +3,10 @@ package policy
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/netip"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -103,7 +105,7 @@ func (rs *RunStore) CreateRun(policyName string, target string, port uint16, par
 	normalizedTarget := normalizeTarget(target, port)
 
 	// Create metadata with targets as JSON array of host:port strings
-	hostPort := fmt.Sprintf("%s:%d", target, port)
+	hostPort := net.JoinHostPort(target, strconv.FormatUint(uint64(port), 10))
 	targetsJSON, _ := json.Marshal([]string{hostPort})
 	metadata := map[string]string{
 		"targets": string(targetsJSON),

--- a/snmp-discovery/policy/run.go
+++ b/snmp-discovery/policy/run.go
@@ -1,10 +1,10 @@
 package policy
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/netip"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
 
@@ -102,10 +102,12 @@ func (rs *RunStore) CreateRun(policyName string, target string, port uint16, par
 	// Normalize target for consistent storage (includes port)
 	normalizedTarget := normalizeTarget(target, port)
 
-	// Create metadata with target and port information
-	metadata := make(map[string]string)
-	metadata["target"] = target // Store original host, not normalized
-	metadata["port"] = strconv.FormatUint(uint64(port), 10)
+	// Create metadata with targets as JSON array of host:port strings
+	hostPort := fmt.Sprintf("%s:%d", target, port)
+	targetsJSON, _ := json.Marshal([]string{hostPort})
+	metadata := map[string]string{
+		"targets": string(targetsJSON),
+	}
 	if parentTarget != "" {
 		metadata["parent_target"] = parentTarget
 	}

--- a/snmp-discovery/policy/run_test.go
+++ b/snmp-discovery/policy/run_test.go
@@ -29,8 +29,9 @@ func TestRunStore_CreateRun(t *testing.T) {
 
 	// Verify metadata
 	assert.NotNil(t, run.Metadata)
-	assert.Equal(t, target, run.Metadata["target"])
-	assert.Equal(t, "161", run.Metadata["port"])
+	assert.Equal(t, `["192.168.1.10:161"]`, run.Metadata["targets"])
+	assert.NotContains(t, run.Metadata, "target")
+	assert.NotContains(t, run.Metadata, "port")
 	assert.Equal(t, parentTarget, run.Metadata["parent_target"])
 
 	assert.Greater(t, run.CreatedAt, int64(0))
@@ -51,10 +52,11 @@ func TestRunStore_CreateRun_NoParentTarget(t *testing.T) {
 
 	run := store.CreateRun(policyName, target, port, "")
 
-	// Verify metadata has target and port, but not parent_target
+	// Verify metadata has targets but not parent_target, target, or port
 	assert.NotNil(t, run.Metadata)
-	assert.Equal(t, target, run.Metadata["target"])
-	assert.Equal(t, "161", run.Metadata["port"])
+	assert.Equal(t, `["192.168.1.10:161"]`, run.Metadata["targets"])
+	assert.NotContains(t, run.Metadata, "target")
+	assert.NotContains(t, run.Metadata, "port")
 	assert.NotContains(t, run.Metadata, "parent_target")
 }
 
@@ -146,13 +148,11 @@ func TestRunStore_MaxThreeRunsPerTarget_MultipleTargets(t *testing.T) {
 
 	// Verify runs have correct metadata
 	for _, run := range runs1 {
-		assert.Equal(t, target1, run.Metadata["target"])
-		assert.Equal(t, "161", run.Metadata["port"])
+		assert.Equal(t, `["192.168.1.10:161"]`, run.Metadata["targets"])
 		assert.Equal(t, parentTarget, run.Metadata["parent_target"])
 	}
 	for _, run := range runs2 {
-		assert.Equal(t, target2, run.Metadata["target"])
-		assert.Equal(t, "161", run.Metadata["port"])
+		assert.Equal(t, `["192.168.1.11:161"]`, run.Metadata["targets"])
 		assert.Equal(t, parentTarget, run.Metadata["parent_target"])
 	}
 
@@ -186,12 +186,10 @@ func TestRunStore_GetRunsForTarget(t *testing.T) {
 
 	// Verify runs are for correct target
 	for _, run := range runs1 {
-		assert.Equal(t, target1, run.Metadata["target"])
-		assert.Equal(t, "161", run.Metadata["port"])
+		assert.Equal(t, `["192.168.1.10:161"]`, run.Metadata["targets"])
 	}
 	for _, run := range runs2 {
-		assert.Equal(t, target2, run.Metadata["target"])
-		assert.Equal(t, "161", run.Metadata["port"])
+		assert.Equal(t, `["192.168.1.11:161"]`, run.Metadata["targets"])
 	}
 }
 
@@ -219,12 +217,12 @@ func TestRunStore_GetRunsForPolicy(t *testing.T) {
 	assert.Greater(t, runs[1].CreatedAt, runs[2].CreatedAt)
 
 	// Verify each run has correct metadata
-	targets := make(map[string]bool)
+	targetsSet := make(map[string]bool)
 	for _, run := range runs {
-		targets[run.Metadata["target"]] = true
+		targetsSet[run.Metadata["targets"]] = true
 		assert.Equal(t, "192.168.1.0/24", run.Metadata["parent_target"])
 	}
-	assert.Len(t, targets, 3)
+	assert.Len(t, targetsSet, 3)
 }
 
 func TestRunStore_GetRunsForPolicy_Empty(t *testing.T) {
@@ -390,11 +388,9 @@ func TestRunStore_TargetNormalization(t *testing.T) {
 	runs2 := store.GetRunsForTarget(policyName, target2, port)
 	assert.Len(t, runs2, 1, "Second target should have one run")
 
-	// Verify metadata preserves original target strings
-	assert.Equal(t, target1, run1.Metadata["target"])
-	assert.Equal(t, "161", run1.Metadata["port"])
-	assert.Equal(t, target2, run2.Metadata["target"])
-	assert.Equal(t, "161", run2.Metadata["port"])
+	// Verify metadata contains correct targets
+	assert.Equal(t, `["192.168.1.10:161"]`, run1.Metadata["targets"])
+	assert.Equal(t, `["192.168.1.11:161"]`, run2.Metadata["targets"])
 
 	// Test that same IP in different notation normalizes correctly
 	target3 := "192.168.1.10" // Same as target1
@@ -414,8 +410,7 @@ func TestRunStore_ScanRunWithRange(t *testing.T) {
 	// Create scan run (no parent_target)
 	scanRun := store.CreateRun(policyName, scanTarget, port, "")
 
-	assert.Equal(t, scanTarget, scanRun.Metadata["target"])
-	assert.Equal(t, "161", scanRun.Metadata["port"])
+	assert.Equal(t, `["192.168.1.0/24:161"]`, scanRun.Metadata["targets"])
 	assert.NotContains(t, scanRun.Metadata, "parent_target")
 
 	// Create individual target runs from scan
@@ -425,12 +420,10 @@ func TestRunStore_ScanRunWithRange(t *testing.T) {
 	run1 := store.CreateRun(policyName, target1, port, scanTarget)
 	run2 := store.CreateRun(policyName, target2, port, scanTarget)
 
-	assert.Equal(t, target1, run1.Metadata["target"])
-	assert.Equal(t, "161", run1.Metadata["port"])
+	assert.Equal(t, `["192.168.1.10:161"]`, run1.Metadata["targets"])
 	assert.Equal(t, scanTarget, run1.Metadata["parent_target"])
 
-	assert.Equal(t, target2, run2.Metadata["target"])
-	assert.Equal(t, "161", run2.Metadata["port"])
+	assert.Equal(t, `["192.168.1.11:161"]`, run2.Metadata["targets"])
 	assert.Equal(t, scanTarget, run2.Metadata["parent_target"])
 
 	// Verify scan run is tracked separately (with its own port)
@@ -497,16 +490,16 @@ func TestRunStore_SameHostDifferentPorts(t *testing.T) {
 	allRuns := store.GetRunsForPolicy(policyName)
 	assert.Len(t, allRuns, 6, "Should have 3 runs from each port")
 
-	// Verify metadata has correct port values
+	// Verify metadata has correct targets values (host:port format)
 	for _, run := range runsPort161 {
-		assert.Equal(t, "161", run.Metadata["port"], "Port 161 runs should have port=161 in metadata")
+		assert.Equal(t, `["192.168.1.10:161"]`, run.Metadata["targets"], "Port 161 runs should embed port in targets")
 	}
 	for _, run := range runsPort162 {
-		assert.Equal(t, "162", run.Metadata["port"], "Port 162 runs should have port=162 in metadata")
+		assert.Equal(t, `["192.168.1.10:162"]`, run.Metadata["targets"], "Port 162 runs should embed port in targets")
 	}
 }
 
-func TestRunStore_PortInMetadata(t *testing.T) {
+func TestRunStore_PortInTargets(t *testing.T) {
 	store := policy.NewRunStore()
 	policyName := "test-policy"
 	target := "192.168.1.10"
@@ -515,14 +508,11 @@ func TestRunStore_PortInMetadata(t *testing.T) {
 	// Create run with non-default port
 	run := store.CreateRun(policyName, target, port, "")
 
-	// Verify metadata contains port as separate field
+	// Verify metadata contains port embedded in targets as host:port JSON array
 	assert.NotNil(t, run.Metadata, "Metadata should not be nil")
-	assert.Equal(t, target, run.Metadata["target"], "Metadata should have target field")
-	assert.Equal(t, "162", run.Metadata["port"], "Metadata should have port as string")
-
-	// Verify port is stored as string, not concatenated with target
-	assert.NotContains(t, run.Metadata["target"], ":", "Target should not contain port")
-	assert.NotContains(t, run.Metadata["target"], "162", "Target should not contain port number")
+	assert.Equal(t, `["192.168.1.10:162"]`, run.Metadata["targets"], "Metadata should have targets as JSON [host:port]")
+	assert.NotContains(t, run.Metadata, "target", "Metadata should not have separate target field")
+	assert.NotContains(t, run.Metadata, "port", "Metadata should not have separate port field")
 }
 
 func TestRunStore_EmptyRunsJSONSerialization(t *testing.T) {

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -254,8 +254,7 @@ func TestRunScanSchedulesResponsiveTargets(t *testing.T) {
 	// Verify scan run was created
 	runs := runStore.GetRunsForTarget("test-policy", "192.168.1.0/24", 161)
 	require.Len(t, runs, 1, "Scan run should be created")
-	assert.Equal(t, "192.168.1.0/24", runs[0].Metadata["target"])
-	assert.Equal(t, "161", runs[0].Metadata["port"])
+	assert.Equal(t, `["192.168.1.0/24:161"]`, runs[0].Metadata["targets"])
 	assert.Equal(t, RunStatusCompleted, runs[0].Status)
 }
 


### PR DESCRIPTION
## Summary

- All `*-discovery` backends now store the run target in `metadata["targets"]` as a JSON array string, matching the existing `network-discovery` convention
- `snmp-discovery`: format is `["host:port"]` (e.g. `["192.168.1.1:161"]`)
- `device-discovery`: format is `["host"]` (e.g. `["192.168.1.1"]`)
- `network-discovery`: unchanged — already used `"targets"` with a JSON array

## Test Plan
- [x] `snmp-discovery`: `go test ./policy/...` passes
- [x] `device-discovery`: `pytest tests/policy/test_run.py` passes
- [x] No remaining references to old `"target"` or `"port"` metadata keys in either service

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Related: https://github.com/netboxlabs/orb-agent/pull/328