### PR TITLE
fix(device-discovery): deep-merge nested override_defaults sub-models

### DIFF
--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -28,6 +28,21 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def _deep_merge(base: dict, override: dict) -> dict:
+    """Recursively merge ``override`` into ``base``; override wins on non-dict conflicts."""
+    merged = dict(base)
+    for key, value in override.items():
+        if (
+            key in merged
+            and isinstance(merged[key], dict)
+            and isinstance(value, dict)
+        ):
+            merged[key] = _deep_merge(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
+
+
 class PolicyRunner:
     """Policy Runner class."""
 
@@ -118,9 +133,11 @@ class PolicyRunner:
 
             config = self.config.model_copy(deep=True)
             if scope.override_defaults is not None:
-                config.defaults = config.defaults.model_copy(
-                    update=scope.override_defaults.model_dump(exclude_none=True)
+                merged = _deep_merge(
+                    config.defaults.model_dump(),
+                    scope.override_defaults.model_dump(exclude_unset=True),
                 )
+                config.defaults = Defaults.model_validate(merged)
             hostnames, parsed_as_range = expand_hostnames(sanitized_hostname)
 
             if parsed_as_range:

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -135,7 +135,9 @@ class PolicyRunner:
             if scope.override_defaults is not None:
                 merged = _deep_merge(
                     config.defaults.model_dump(),
-                    scope.override_defaults.model_dump(exclude_unset=True),
+                    scope.override_defaults.model_dump(
+                        exclude_unset=True, exclude_none=True
+                    ),
                 )
                 config.defaults = Defaults.model_validate(merged)
             hostnames, parsed_as_range = expand_hostnames(sanitized_hostname)

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -849,7 +849,8 @@ def test_run_scan_stores_completed_run_when_some_hosts_reachable():
 def test_setup_policy_runner_override_defaults_deep_merges_nested_models(
     policy_runner, run_store
 ):
-    """override_defaults on a nested sub-model must deep-merge and stay a model instance.
+    """
+    override_defaults on a nested sub-model must deep-merge and stay a model instance.
 
     Regression for AttributeError: 'dict' object has no attribute 'tags' — caused
     by model_copy(update=dict) replacing nested Pydantic sub-models with raw dicts
@@ -892,7 +893,8 @@ def test_setup_policy_runner_override_defaults_deep_merges_nested_models(
 def test_setup_policy_runner_override_defaults_empty_list_preserves_parent(
     policy_runner, run_store
 ):
-    """Empty list on override must not clear inherited interface_patterns.
+    """
+    Empty list on override must not clear inherited interface_patterns.
 
     `Defaults.coerce_empty_list_to_none` coerces an empty list to None; combined
     with `exclude_none=True` during merge, the parent value must survive.

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -856,18 +856,18 @@ def test_setup_policy_runner_override_defaults_deep_merges_nested_models(
     """
     base_config = Config(
         defaults=Defaults(
-            site="Mycity",
+            site="HQ",
             tags=["switch-device-discovery", "orb-agent"],
-            device=DeviceParameters(manufacturer="HPE", model="Aruba 2530-48G"),
+            device=DeviceParameters(manufacturer="Cisco", model="Catalyst 2960"),
         )
     )
     override_scope = Napalm(
         driver="ios",
-        hostname="172.29.91.43",
+        hostname="192.0.2.1",
         username="admin",
         password="password",
         override_defaults=Defaults(
-            device=DeviceParameters(model="Aruba 2540-24G-PoE+-4SFP"),
+            device=DeviceParameters(model="Catalyst 9300"),
         ),
     )
 
@@ -880,9 +880,9 @@ def test_setup_policy_runner_override_defaults_deep_merges_nested_models(
     passed_config = mock_add_job.call_args_list[0][1]["args"][2]
 
     assert isinstance(passed_config.defaults.device, DeviceParameters)
-    assert passed_config.defaults.device.model == "Aruba 2540-24G-PoE+-4SFP"
-    assert passed_config.defaults.device.manufacturer == "HPE"
+    assert passed_config.defaults.device.model == "Catalyst 9300"
+    assert passed_config.defaults.device.manufacturer == "Cisco"
     assert passed_config.defaults.tags == ["switch-device-discovery", "orb-agent"]
-    assert passed_config.defaults.site == "Mycity"
+    assert passed_config.defaults.site == "HQ"
 
-    assert policy_runner.config.defaults.device.model == "Aruba 2530-48G"
+    assert policy_runner.config.defaults.device.model == "Catalyst 2960"

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -13,6 +13,7 @@ from device_discovery.policy.models import (
     Config,
     Defaults,
     DeviceParameters,
+    InterfacePattern,
     Napalm,
     Options,
     Status,
@@ -886,3 +887,40 @@ def test_setup_policy_runner_override_defaults_deep_merges_nested_models(
     assert passed_config.defaults.site == "HQ"
 
     assert policy_runner.config.defaults.device.model == "Catalyst 2960"
+
+
+def test_setup_policy_runner_override_defaults_empty_list_preserves_parent(
+    policy_runner, run_store
+):
+    """Empty list on override must not clear inherited interface_patterns.
+
+    `Defaults.coerce_empty_list_to_none` coerces an empty list to None; combined
+    with `exclude_none=True` during merge, the parent value must survive.
+    """
+    parent_patterns = [InterfacePattern(match=r"^Gi", type="1000base-t")]
+    base_config = Config(
+        defaults=Defaults(interface_patterns=parent_patterns),
+    )
+    override_scope = Napalm(
+        driver="ios",
+        hostname="192.0.2.2",
+        username="admin",
+        password="password",
+        override_defaults=Defaults(
+            interface_patterns=[],
+            interface_exclude_patterns=[],
+        ),
+    )
+
+    with (
+        patch.object(policy_runner.scheduler, "start"),
+        patch.object(policy_runner.scheduler, "add_job") as mock_add_job,
+    ):
+        policy_runner.setup("policy1", base_config, [override_scope], run_store)
+
+    passed_config = mock_add_job.call_args_list[0][1]["args"][2]
+
+    assert passed_config.defaults.interface_patterns is not None
+    assert len(passed_config.defaults.interface_patterns) == 1
+    assert passed_config.defaults.interface_patterns[0].match == r"^Gi"
+    assert passed_config.defaults.interface_exclude_patterns is None

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -9,7 +9,14 @@ from apscheduler.triggers.base import BaseTrigger
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
 
-from device_discovery.policy.models import Config, Defaults, Napalm, Options, Status
+from device_discovery.policy.models import (
+    Config,
+    Defaults,
+    DeviceParameters,
+    Napalm,
+    Options,
+    Status,
+)
 from device_discovery.policy.run import RunStore
 from device_discovery.policy.runner import PolicyRunner
 
@@ -836,3 +843,46 @@ def test_run_scan_stores_completed_run_when_some_hosts_reachable():
     assert range_runs[0].status.value == "completed"
     assert range_runs[0].entity_count == 1
     runner.scheduler.add_job.assert_called_once()
+
+
+def test_setup_policy_runner_override_defaults_deep_merges_nested_models(
+    policy_runner, run_store
+):
+    """override_defaults on a nested sub-model must deep-merge and stay a model instance.
+
+    Regression for AttributeError: 'dict' object has no attribute 'tags' — caused
+    by model_copy(update=dict) replacing nested Pydantic sub-models with raw dicts
+    and shallow-overwriting sibling fields.
+    """
+    base_config = Config(
+        defaults=Defaults(
+            site="Mycity",
+            tags=["switch-device-discovery", "orb-agent"],
+            device=DeviceParameters(manufacturer="HPE", model="Aruba 2530-48G"),
+        )
+    )
+    override_scope = Napalm(
+        driver="ios",
+        hostname="172.29.91.43",
+        username="admin",
+        password="password",
+        override_defaults=Defaults(
+            device=DeviceParameters(model="Aruba 2540-24G-PoE+-4SFP"),
+        ),
+    )
+
+    with (
+        patch.object(policy_runner.scheduler, "start"),
+        patch.object(policy_runner.scheduler, "add_job") as mock_add_job,
+    ):
+        policy_runner.setup("policy1", base_config, [override_scope], run_store)
+
+    passed_config = mock_add_job.call_args_list[0][1]["args"][2]
+
+    assert isinstance(passed_config.defaults.device, DeviceParameters)
+    assert passed_config.defaults.device.model == "Aruba 2540-24G-PoE+-4SFP"
+    assert passed_config.defaults.device.manufacturer == "HPE"
+    assert passed_config.defaults.tags == ["switch-device-discovery", "orb-agent"]
+    assert passed_config.defaults.site == "Mycity"
+
+    assert policy_runner.config.defaults.device.model == "Aruba 2530-48G"


### PR DESCRIPTION
## Summary
- Using `override_defaults` with a nested sub-model (e.g. `device.model`) raised `AttributeError: 'dict' object has no attribute 'tags'` in translate. The runner's `model_copy(update=...)` did a shallow replace, so nested `DeviceParameters` became a raw dict and sibling fields were bulldozed.
- Replaced the shallow update with a recursive dict merge + `Defaults.model_validate()` so nested sub-models stay model instances and sibling fields survive.
- Dump the override with `exclude_unset=True` + `exclude_none=True` so:
  - (a) fields the user didn't explicitly set in `override_defaults` (e.g. `site`/`role`/`if_type` that take their string default `"undefined"`/`"other"`) no longer overwrite the parent's value — the parent's own value survives, which itself may be user-set or defaulted. The parent is dumped in full, so fields not present in the override are still populated from the parent;
  - (b) fields coerced to `None` by `Defaults.coerce_empty_list_to_none` (empty `interface_patterns` / `interface_exclude_patterns`) are dropped from the merge, preserving the validator's documented intent.

Reproduces a user-reported config pattern (generic Cisco values shown):

```yaml
defaults:
  site: HQ
  device:
    manufacturer: Cisco
    model: Catalyst 2960
  tags: [switch-device-discovery, orb-agent]
scope:
  - hostname: 192.0.2.1
    override_defaults:
      device:
        model: Catalyst 9300
```

## Test plan
- [x] Regression test `test_setup_policy_runner_override_defaults_deep_merges_nested_models` asserts: `device` stays a `DeviceParameters` instance, overridden `model` wins, parent `manufacturer` is preserved, sibling `tags`/`site` untouched, `policy_runner.config` (shared base) not mutated
- [x] Regression test `test_setup_policy_runner_override_defaults_empty_list_preserves_parent` asserts empty-list overrides for `interface_patterns` / `interface_exclude_patterns` don't clear the parent list (Codex review finding)
- [x] Failing test first on both: confirmed each reproduced the respective bug on unpatched code
- [x] Full device-discovery suite: 515 passed