### PR TITLE
feat(snmp-discovery): set Device.PrimaryIp4 from SNMP target (OBS-1896)

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -425,6 +425,12 @@ When snmp-discovery encounters a device during scanning, it:
 
 This provides much more meaningful device identification in your discovery results, making it easier to understand what equipment has been discovered on your network.
 
+### Primary IP Assignment
+
+When an SNMP discovery scan completes, `snmp-discovery` populates the device's `primary_ip4` field with the target host address — **but only if that address was also discovered as an interface IP during the walk**. The verification step avoids recording unreachable or unvalidated addresses in NetBox.
+
+Hostname targets are resolved via DNS once per scan (2s timeout); only IPv4 results are considered for matching. If the target cannot be resolved, is IPv6, or no discovered interface IP matches, the device is emitted with `primary_ip4` left unset. Only IPv4 is supported today.
+
 ## Run snmp-discovery
 snmp-discovery can be run by cloning it's git repo
 ```sh

--- a/snmp-discovery/mapping/export_test.go
+++ b/snmp-discovery/mapping/export_test.go
@@ -1,0 +1,29 @@
+package mapping
+
+import (
+	"log/slog"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+)
+
+// HostResolverForTest is the resolver interface re-exported for tests.
+type HostResolverForTest = hostResolver
+
+// NewObjectIDMapperForTest exposes the resolver-injection constructor to
+// tests in other files of this package.
+func NewObjectIDMapperForTest(mappingConfig *Config, logger *slog.Logger, defaults *config.Defaults, targetHost string, resolver HostResolverForTest) *ObjectIDMapper {
+	return newObjectIDMapperWithResolver(mappingConfig, logger, defaults, targetHost, resolver)
+}
+
+// CurrentDevice returns the current-device entity held by the mapper's
+// registry. Test-only helper so assertions can reach the device even when
+// it has no observable emitted reference (e.g. when its only interface was
+// excluded).
+func (m *ObjectIDMapper) CurrentDevice() *diode.Device {
+	entity := m.registry.GetOrCreateEntity(DeviceEntityType, CurrentDeviceIndex)
+	if d, ok := entity.(*diode.Device); ok {
+		return d
+	}
+	return nil
+}

--- a/snmp-discovery/mapping/export_test.go
+++ b/snmp-discovery/mapping/export_test.go
@@ -27,3 +27,10 @@ func (m *ObjectIDMapper) CurrentDevice() *diode.Device {
 	}
 	return nil
 }
+
+// AssignPrimaryIPForTest invokes the unexported primary-IP assignment with
+// a synthetic entities set, so tests can construct multi-match scenarios
+// that are hard to trigger through the real OID pipeline.
+func (m *ObjectIDMapper) AssignPrimaryIPForTest(device *diode.Device, entities map[diode.Entity]bool) {
+	m.assignPrimaryIP(device, entities)
+}

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -6,7 +6,9 @@ import (
 	"log/slog"
 	"net"
 	"regexp"
+	"sort"
 	"strings"
+	"time"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
@@ -477,7 +479,118 @@ func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diod
 			entities = append(entities, entity)
 		}
 	}
+
+	m.assignPrimaryIP(currentDevice, uniqueEntities)
+
 	return entities
+}
+
+// assignPrimaryIP points currentDevice.PrimaryIp4 at the surviving IPAddress
+// entity whose address matches the SNMP target host (literal IPv4 or DNS-
+// resolved). No-op when the target is not IPv4-addressable, when DNS lookup
+// fails, or when no surviving IPAddress entity matches.
+func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diode.Entity]bool) {
+	if m.targetHost == "" {
+		return
+	}
+
+	candidates := m.resolveTargetIPv4s()
+	if len(candidates) == 0 {
+		m.logger.Debug("no IPv4 candidates for primary IP assignment", "target", m.targetHost)
+		return
+	}
+
+	type hit struct {
+		key string
+		ip  *diode.IPAddress
+	}
+	var hits []hit
+	for entity := range entities {
+		ip, ok := entity.(*diode.IPAddress)
+		if !ok || ip.Address == nil {
+			continue
+		}
+		stripped := stripPrefix(*ip.Address)
+		for _, cand := range candidates {
+			if stripped == cand {
+				hits = append(hits, hit{key: primaryIPSortKey(ip), ip: ip})
+				break
+			}
+		}
+	}
+
+	if len(hits) == 0 {
+		m.logger.Debug("no matching IP for primary IP assignment", "target", m.targetHost)
+		return
+	}
+
+	sort.Slice(hits, func(i, j int) bool { return hits[i].key < hits[j].key })
+
+	if len(hits) > 1 {
+		all := make([]string, 0, len(hits))
+		for _, h := range hits {
+			all = append(all, h.key)
+		}
+		m.logger.Warn("multiple IP candidates for primary IP assignment; picking deterministic first",
+			"target", m.targetHost, "candidates", all)
+	}
+
+	device.PrimaryIp4 = hits[0].ip
+}
+
+// primaryIPSortKey returns a stable composite ordering key for an IPAddress
+// entity: "<address>|<interface-name>". Deterministic even when two
+// IPAddresses share the same stripped address.
+func primaryIPSortKey(ip *diode.IPAddress) string {
+	addr := ""
+	if ip.Address != nil {
+		addr = *ip.Address
+	}
+	ifName := ""
+	if iface, ok := ip.AssignedObject.(*diode.Interface); ok && iface != nil && iface.Name != nil {
+		ifName = *iface.Name
+	}
+	return addr + "|" + ifName
+}
+
+// resolveTargetIPv4s returns the IPv4 candidate addresses for the current
+// SNMP target. If targetHost is an IPv4 literal, the single address is
+// returned. Otherwise DNS is consulted with a 2s timeout and IPv4 results
+// are returned. Returns an empty slice on any failure.
+func (m *ObjectIDMapper) resolveTargetIPv4s() []string {
+	if ip := net.ParseIP(m.targetHost); ip != nil {
+		if v4 := ip.To4(); v4 != nil {
+			return []string{v4.String()}
+		}
+		return nil
+	}
+	if m.resolver == nil {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	addrs, err := m.resolver.LookupHost(ctx, m.targetHost)
+	if err != nil {
+		m.logger.Debug("target host DNS lookup failed", "target", m.targetHost, "error", err)
+		return nil
+	}
+	out := make([]string, 0, len(addrs))
+	for _, a := range addrs {
+		if ip := net.ParseIP(a); ip != nil {
+			if v4 := ip.To4(); v4 != nil {
+				out = append(out, v4.String())
+			}
+		}
+	}
+	return out
+}
+
+// stripPrefix removes a "/prefix" suffix from an IP/CIDR string.
+func stripPrefix(addr string) string {
+	if i := strings.IndexByte(addr, '/'); i >= 0 {
+		return addr[:i]
+	}
+	return addr
 }
 
 func (m *ObjectIDMapper) filterExcludedEntities(entities map[diode.Entity]bool) {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -2,6 +2,7 @@ package mapping
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net"
@@ -9,7 +10,6 @@ import (
 	"sort"
 	"strings"
 	"time"
-	"unsafe"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
@@ -510,9 +510,9 @@ func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diod
 	}
 
 	type hit struct {
-		key  string
-		ip   *diode.IPAddress
-		addr uintptr // stable tiebreaker when key collides
+		key     string
+		ip      *diode.IPAddress
+		content string // stable, data-derived tiebreaker when key collides
 	}
 	var hits []hit
 	for entity := range entities {
@@ -524,9 +524,9 @@ func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diod
 		for _, cand := range candidates {
 			if stripped == cand {
 				hits = append(hits, hit{
-					key:  primaryIPSortKey(ip),
-					ip:   ip,
-					addr: uintptr(unsafe.Pointer(ip)),
+					key:     primaryIPSortKey(ip),
+					ip:      ip,
+					content: primaryIPContentKey(ip),
 				})
 				break
 			}
@@ -538,13 +538,14 @@ func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diod
 		return
 	}
 
-	// Primary sort by composite key; pointer address is a deterministic
-	// tiebreaker within this process when two entries share a key.
+	// Primary sort by composite key; content hash is a data-derived,
+	// run-to-run-stable tiebreaker for the rare case of two entries
+	// sharing a key.
 	sort.Slice(hits, func(i, j int) bool {
 		if hits[i].key != hits[j].key {
 			return hits[i].key < hits[j].key
 		}
-		return hits[i].addr < hits[j].addr
+		return hits[i].content < hits[j].content
 	})
 
 	if len(hits) > 1 {
@@ -572,6 +573,21 @@ func primaryIPSortKey(ip *diode.IPAddress) string {
 		ifName = *iface.Name
 	}
 	return addr + "|" + ifName
+}
+
+// primaryIPContentKey returns a run-to-run-stable secondary ordering key
+// derived from the IPAddress entity's content. Used as a tiebreaker when
+// two entries produce the same primaryIPSortKey. JSON marshalling is
+// deterministic for a given struct value, so the returned string is the
+// same across process invocations for the same input.
+func primaryIPContentKey(ip *diode.IPAddress) string {
+	if ip == nil {
+		return ""
+	}
+	if b, err := json.Marshal(ip); err == nil {
+		return string(b)
+	}
+	return fmt.Sprintf("%+v", *ip)
 }
 
 // resolveTargetIPv4s returns the IPv4 candidate addresses for the current

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -520,6 +520,11 @@ func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diod
 		if !ok || ip.Address == nil {
 			continue
 		}
+		// Enforce the "verified interface IP" guarantee: only accept
+		// addresses that were discovered on an interface during the walk.
+		if _, assigned := ip.AssignedObject.(*diode.Interface); !assigned {
+			continue
+		}
 		stripped := stripPrefix(*ip.Address)
 		for _, cand := range candidates {
 			if stripped == cand {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -207,6 +207,7 @@ type ObjectIDMapper struct {
 	registry        *EntityRegistry
 	defaults        *config.Defaults
 	excludePatterns []*regexp.Regexp
+	targetHost      string
 }
 
 // Entry is a struct that contains a mapping entry
@@ -282,14 +283,15 @@ func NewConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturer
 	}, nil
 }
 
-// NewObjectIDMapper creates a new ObjectIDMapper
-func NewObjectIDMapper(mappingConfig *Config, logger *slog.Logger, defaults *config.Defaults) *ObjectIDMapper {
+// NewObjectIDMapper creates a new ObjectIDMapper for a given SNMP target host.
+func NewObjectIDMapper(mappingConfig *Config, logger *slog.Logger, defaults *config.Defaults, targetHost string) *ObjectIDMapper {
 	return &ObjectIDMapper{
 		mappingConfig:   mappingConfig,
 		logger:          logger,
 		registry:        NewEntityRegistry(logger),
 		defaults:        defaults,
 		excludePatterns: compileExcludePatterns(defaults, logger),
+		targetHost:      targetHost,
 	}
 }
 

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unsafe"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
@@ -213,6 +214,14 @@ type ObjectIDMapper struct {
 	excludePatterns []*regexp.Regexp
 	targetHost      string
 	resolver        hostResolver
+	ctx             context.Context
+}
+
+// SetContext stores the scan's context on the mapper. If set, the primary-IP
+// DNS lookup will derive its 2s timeout from this parent context so that a
+// cancelled scan also aborts the lookup.
+func (m *ObjectIDMapper) SetContext(ctx context.Context) {
+	m.ctx = ctx
 }
 
 // hostResolver is the minimal DNS lookup surface used by ObjectIDMapper.
@@ -501,8 +510,9 @@ func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diod
 	}
 
 	type hit struct {
-		key string
-		ip  *diode.IPAddress
+		key  string
+		ip   *diode.IPAddress
+		addr uintptr // stable tiebreaker when key collides
 	}
 	var hits []hit
 	for entity := range entities {
@@ -513,7 +523,11 @@ func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diod
 		stripped := stripPrefix(*ip.Address)
 		for _, cand := range candidates {
 			if stripped == cand {
-				hits = append(hits, hit{key: primaryIPSortKey(ip), ip: ip})
+				hits = append(hits, hit{
+					key:  primaryIPSortKey(ip),
+					ip:   ip,
+					addr: uintptr(unsafe.Pointer(ip)),
+				})
 				break
 			}
 		}
@@ -524,7 +538,14 @@ func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diod
 		return
 	}
 
-	sort.Slice(hits, func(i, j int) bool { return hits[i].key < hits[j].key })
+	// Primary sort by composite key; pointer address is a deterministic
+	// tiebreaker within this process when two entries share a key.
+	sort.Slice(hits, func(i, j int) bool {
+		if hits[i].key != hits[j].key {
+			return hits[i].key < hits[j].key
+		}
+		return hits[i].addr < hits[j].addr
+	})
 
 	if len(hits) > 1 {
 		all := make([]string, 0, len(hits))
@@ -567,7 +588,11 @@ func (m *ObjectIDMapper) resolveTargetIPv4s() []string {
 	if m.resolver == nil {
 		return nil
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	parent := m.ctx
+	if parent == nil {
+		parent = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(parent, 2*time.Second)
 	defer cancel()
 	addrs, err := m.resolver.LookupHost(ctx, m.targetHost)
 	if err != nil {

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -599,27 +599,38 @@ func primaryIPContentKey(ip *diode.IPAddress) string {
 	// Fallback for the unlikely case json.Marshal fails (e.g. a custom
 	// field that contains a channel or function). Explicit dereferences
 	// avoid the process-local pointer addresses that %+v would print.
-	addr := ""
-	if ip.Address != nil {
-		addr = *ip.Address
+	// We pull every scalar field that could legitimately distinguish
+	// two otherwise-matching IPAddress entities.
+	parts := []string{
+		derefString(ip.Address),
+		derefString(ip.Description),
+		derefString(ip.Comments),
+		derefString(ip.DnsName),
+		derefString(ip.Status),
+		derefString(ip.Role),
 	}
-	desc := ""
-	if ip.Description != nil {
-		desc = *ip.Description
+	if ip.Tenant != nil {
+		parts = append(parts, derefString(ip.Tenant.Name))
 	}
-	comments := ""
-	if ip.Comments != nil {
-		comments = *ip.Comments
+	if ip.Vrf != nil {
+		parts = append(parts, derefString(ip.Vrf.Name))
 	}
-	dnsName := ""
-	if ip.DnsName != nil {
-		dnsName = *ip.DnsName
+	if iface, ok := ip.AssignedObject.(*diode.Interface); ok && iface != nil {
+		parts = append(parts, derefString(iface.Name))
 	}
-	ifName := ""
-	if iface, ok := ip.AssignedObject.(*diode.Interface); ok && iface != nil && iface.Name != nil {
-		ifName = *iface.Name
+	for _, tag := range ip.Tags {
+		if tag != nil {
+			parts = append(parts, derefString(tag.Name))
+		}
 	}
-	return strings.Join([]string{addr, desc, comments, dnsName, ifName}, "\x00")
+	return strings.Join(parts, "\x00")
+}
+
+func derefString(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
 }
 
 // resolveTargetIPv4s returns the IPv4 candidate addresses for the current

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -1,8 +1,10 @@
 package mapping
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
+	"net"
 	"regexp"
 	"strings"
 
@@ -208,6 +210,14 @@ type ObjectIDMapper struct {
 	defaults        *config.Defaults
 	excludePatterns []*regexp.Regexp
 	targetHost      string
+	resolver        hostResolver
+}
+
+// hostResolver is the minimal DNS lookup surface used by ObjectIDMapper.
+// It is satisfied by *net.Resolver (including net.DefaultResolver) and
+// overridable in tests.
+type hostResolver interface {
+	LookupHost(ctx context.Context, host string) ([]string, error)
 }
 
 // Entry is a struct that contains a mapping entry
@@ -285,6 +295,12 @@ func NewConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturer
 
 // NewObjectIDMapper creates a new ObjectIDMapper for a given SNMP target host.
 func NewObjectIDMapper(mappingConfig *Config, logger *slog.Logger, defaults *config.Defaults, targetHost string) *ObjectIDMapper {
+	return newObjectIDMapperWithResolver(mappingConfig, logger, defaults, targetHost, net.DefaultResolver)
+}
+
+// newObjectIDMapperWithResolver is the test seam that allows injecting a
+// custom DNS resolver. Production code uses NewObjectIDMapper.
+func newObjectIDMapperWithResolver(mappingConfig *Config, logger *slog.Logger, defaults *config.Defaults, targetHost string, resolver hostResolver) *ObjectIDMapper {
 	return &ObjectIDMapper{
 		mappingConfig:   mappingConfig,
 		logger:          logger,
@@ -292,6 +308,7 @@ func NewObjectIDMapper(mappingConfig *Config, logger *slog.Logger, defaults *con
 		defaults:        defaults,
 		excludePatterns: compileExcludePatterns(defaults, logger),
 		targetHost:      targetHost,
+		resolver:        resolver,
 	}
 }
 

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -578,8 +578,17 @@ func primaryIPSortKey(ip *diode.IPAddress) string {
 // primaryIPContentKey returns a run-to-run-stable secondary ordering key
 // derived from the IPAddress entity's content. Used as a tiebreaker when
 // two entries produce the same primaryIPSortKey. JSON marshalling is
-// deterministic for a given struct value, so the returned string is the
-// same across process invocations for the same input.
+// deterministic for a given struct value (encoding/json sorts map keys,
+// and diode.IPAddress has no time.Time or custom MarshalJSON with
+// randomness), so the returned string is the same across process
+// invocations for the same input. The fallback dereferences scalar
+// pointer fields explicitly and never embeds pointer addresses.
+//
+// If two *distinct* IPAddress entities produce byte-for-byte identical
+// content (identical address, description, tags, interface, ...), the
+// selection between them is semantically equivalent — the NetBox
+// payload for either is the same — so the residual non-determinism in
+// that case has no observable effect on downstream data.
 func primaryIPContentKey(ip *diode.IPAddress) string {
 	if ip == nil {
 		return ""
@@ -587,7 +596,30 @@ func primaryIPContentKey(ip *diode.IPAddress) string {
 	if b, err := json.Marshal(ip); err == nil {
 		return string(b)
 	}
-	return fmt.Sprintf("%+v", *ip)
+	// Fallback for the unlikely case json.Marshal fails (e.g. a custom
+	// field that contains a channel or function). Explicit dereferences
+	// avoid the process-local pointer addresses that %+v would print.
+	addr := ""
+	if ip.Address != nil {
+		addr = *ip.Address
+	}
+	desc := ""
+	if ip.Description != nil {
+		desc = *ip.Description
+	}
+	comments := ""
+	if ip.Comments != nil {
+		comments = *ip.Comments
+	}
+	dnsName := ""
+	if ip.DnsName != nil {
+		dnsName = *ip.DnsName
+	}
+	ifName := ""
+	if iface, ok := ip.AssignedObject.(*diode.Interface); ok && iface != nil && iface.Name != nil {
+		ifName = *iface.Name
+	}
+	return strings.Join([]string{addr, desc, comments, dnsName, ifName}, "\x00")
 }
 
 // resolveTargetIPv4s returns the IPv4 candidate addresses for the current

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -423,7 +423,7 @@ func TestMapObjectIDsToEntity(t *testing.T) {
 					},
 				}
 			}
-			mapper := mapping.NewObjectIDMapper(mappingConfig, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), defaults)
+			mapper := mapping.NewObjectIDMapper(mappingConfig, slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false})), defaults, "")
 			entities := mapper.MapObjectIDsToEntity(tt.objectIDs)
 
 			assert.ElementsMatch(t, tt.expected, entities)
@@ -679,7 +679,7 @@ func TestIPAddressIdentifierSizeInheritance(t *testing.T) {
 			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
 			mappingConfig, err := mapping.NewConfig(tt.mapping, logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
 			assert.NoError(t, err)
-			objectIDMapper := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{})
+			objectIDMapper := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{}, "")
 
 			entities := objectIDMapper.MapObjectIDsToEntity(tt.objectIDs)
 

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -892,6 +892,28 @@ func TestAssignPrimaryIP_NoMatch(t *testing.T) {
 	assert.Nil(t, device.PrimaryIp4, "primary IP must not be set when no match")
 }
 
+func TestAssignPrimaryIP_ExcludedInterfaceIP(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// The IP is assigned to an interface whose name matches the exclusion
+	// pattern; filterExcludedEntities drops the IPAddress, so primary-IP
+	// must remain nil.
+	defaults := &config.Defaults{
+		InterfaceExcludePatterns: []string{"^Null.*"},
+	}
+	mappingConfig, err := mapping.NewConfig(primaryIPFixture(), logger, &FakeManufacturers{}, &FakeDeviceLookup{}, defaults)
+	assert.NoError(t, err)
+
+	m := mapping.NewObjectIDMapper(mappingConfig, logger, defaults, "10.0.0.1")
+	_ = m.MapObjectIDsToEntity(primaryIPOneInterfaceOIDs("10.0.0.1", "Null0"))
+
+	// Interface+IP are both excluded from the output, so reach the device
+	// directly via the test helper.
+	device := m.CurrentDevice()
+	assert.NotNil(t, device)
+	assert.Nil(t, device.PrimaryIp4, "primary IP must not point to an IPAddress on an excluded interface")
+}
+
 func TestAssignPrimaryIP_PrefixStripping(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -1,8 +1,10 @@
 package mapping_test
 
 import (
+	"context"
 	"log/slog"
 	"os"
+	"sync"
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
@@ -890,6 +892,70 @@ func TestAssignPrimaryIP_NoMatch(t *testing.T) {
 	device := findDevice(entities)
 	assert.NotNil(t, device)
 	assert.Nil(t, device.PrimaryIp4, "primary IP must not be set when no match")
+}
+
+// bufferHandler captures slog records for assertion.
+type bufferHandler struct {
+	mu      sync.Mutex
+	records []slog.Record
+}
+
+func (h *bufferHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *bufferHandler) Handle(_ context.Context, r slog.Record) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.records = append(h.records, r)
+	return nil
+}
+func (h *bufferHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *bufferHandler) WithGroup(_ string) slog.Handler     { return h }
+
+func (h *bufferHandler) find(level slog.Level, msg string) *slog.Record {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for i := range h.records {
+		if h.records[i].Level == level && h.records[i].Message == msg {
+			return &h.records[i]
+		}
+	}
+	return nil
+}
+
+func TestAssignPrimaryIP_MultipleMatches(t *testing.T) {
+	handler := &bufferHandler{}
+	logger := slog.New(handler)
+
+	mappingConfig, err := mapping.NewConfig(primaryIPFixture(), logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+	assert.NoError(t, err)
+
+	m := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{}, "10.0.0.1")
+
+	// Build two IPAddress entities sharing the same stripped address but
+	// assigned to two distinct interfaces, so primaryIPSortKey differs.
+	ip1Name := "Loopback0"
+	ip2Name := "GigabitEthernet0/1"
+	addr := "10.0.0.1/32"
+	ip1 := &diode.IPAddress{
+		Address:        &addr,
+		AssignedObject: &diode.Interface{Name: &ip1Name},
+	}
+	ip2 := &diode.IPAddress{
+		Address:        &addr,
+		AssignedObject: &diode.Interface{Name: &ip2Name},
+	}
+
+	entities := map[diode.Entity]bool{ip1: true, ip2: true}
+	device := m.CurrentDevice()
+
+	m.AssignPrimaryIPForTest(device, entities)
+
+	assert.NotNil(t, device.PrimaryIp4)
+	// Lexicographically smaller key wins:
+	//   "10.0.0.1/32|GigabitEthernet0/1" < "10.0.0.1/32|Loopback0"
+	assert.Equal(t, ip2, device.PrimaryIp4, "deterministic selection must prefer the smaller sort key")
+
+	rec := handler.find(slog.LevelWarn, "multiple IP candidates for primary IP assignment; picking deterministic first")
+	assert.NotNil(t, rec, "expected Warn log for multi-match")
 }
 
 func TestAssignPrimaryIP_ExcludedInterfaceIP(t *testing.T) {

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -909,7 +909,7 @@ func (h *bufferHandler) Handle(_ context.Context, r slog.Record) error {
 	return nil
 }
 func (h *bufferHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
-func (h *bufferHandler) WithGroup(_ string) slog.Handler     { return h }
+func (h *bufferHandler) WithGroup(_ string) slog.Handler      { return h }
 
 func (h *bufferHandler) find(level slog.Level, msg string) *slog.Record {
 	h.mu.Lock()

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -1050,3 +1050,64 @@ func TestAssignPrimaryIP_PrefixStripping(t *testing.T) {
 	assert.NotNil(t, device.PrimaryIp4)
 	assert.Equal(t, "10.0.0.1/32", *device.PrimaryIp4.Address)
 }
+
+// TestAssignPrimaryIP_NonDefaultPrefix exercises the stripPrefix path with a
+// real subnet-mask-derived prefix (/24) rather than the default /32.
+func TestAssignPrimaryIP_NonDefaultPrefix(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Extend the default fixture with addressPrefixSize so the emitted
+	// IPAddress carries /24.
+	entries := []config.MappingEntry{
+		{
+			OID:            ".1.3.6.1.2.1.2.2.1",
+			Entity:         "interface",
+			Field:          "_id",
+			IdentifierSize: 1,
+			MappingEntries: []config.MappingEntry{
+				{OID: ".1.3.6.1.2.1.2.2.1.2", Entity: "interface", Field: "name"},
+			},
+		},
+		{
+			OID:            ".1.3.6.1.2.1.4.20.1",
+			Entity:         "ipAddress",
+			Field:          "_id",
+			IdentifierSize: 4,
+			MappingEntries: []config.MappingEntry{
+				{OID: ".1.3.6.1.2.1.4.20.1.1", Entity: "ipAddress", Field: "address"},
+				{OID: ".1.3.6.1.2.1.4.20.1.3", Entity: "ipAddress", Field: "addressPrefixSize"},
+				{
+					OID:          ".1.3.6.1.2.1.4.20.1.2",
+					Entity:       "ipAddress",
+					Field:        "assignedObject",
+					Relationship: config.Relationship{Type: "interface"},
+				},
+			},
+		},
+	}
+	mappingConfig, err := mapping.NewConfig(entries, logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+	assert.NoError(t, err)
+
+	oids := mapping.ObjectIDValueMap{
+		".1.3.6.1.2.1.2.2.1.2.1": mapping.Value{
+			Value: "Gi0", Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1,
+		},
+		".1.3.6.1.2.1.4.20.1.1.10.0.0.1": mapping.Value{
+			Value: "10.0.0.1", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4,
+		},
+		".1.3.6.1.2.1.4.20.1.3.10.0.0.1": mapping.Value{
+			Value: "255.255.255.0", Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4,
+		},
+		".1.3.6.1.2.1.4.20.1.2.10.0.0.1": mapping.Value{
+			Value: "1", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 4,
+		},
+	}
+
+	m := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{}, "10.0.0.1")
+	entities := m.MapObjectIDsToEntity(oids)
+
+	device := findDevice(entities)
+	assert.NotNil(t, device.PrimaryIp4)
+	assert.Equal(t, "10.0.0.1/24", *device.PrimaryIp4.Address,
+		"primary IP must carry the discovered /24 prefix, and stripPrefix must still match against the bare target")
+}

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -786,3 +786,93 @@ func TestObjectIDsMethodWithIdentifierSizeInheritance(t *testing.T) {
 		})
 	}
 }
+
+// --- OBS-1896: primary IP assignment tests ---
+
+// primaryIPFixture is the minimal mapping config the primary-IP tests reuse:
+// one interface entry + one ipAddress entry that assigns itself to the
+// interface. The ipAddress index carries the full IPv4 address (IdentifierSize
+// = 4) so different discovered IPs live under different ObjectIDIndex keys.
+func primaryIPFixture() []config.MappingEntry {
+	return []config.MappingEntry{
+		{
+			OID:            ".1.3.6.1.2.1.2.2.1",
+			Entity:         "interface",
+			Field:          "_id",
+			IdentifierSize: 1,
+			MappingEntries: []config.MappingEntry{
+				{OID: ".1.3.6.1.2.1.2.2.1.2", Entity: "interface", Field: "name"},
+			},
+		},
+		{
+			OID:            ".1.3.6.1.2.1.4.20.1",
+			Entity:         "ipAddress",
+			Field:          "_id",
+			IdentifierSize: 4,
+			MappingEntries: []config.MappingEntry{
+				{OID: ".1.3.6.1.2.1.4.20.1.1", Entity: "ipAddress", Field: "address"},
+				{
+					OID:          ".1.3.6.1.2.1.4.20.1.2",
+					Entity:       "ipAddress",
+					Field:        "assignedObject",
+					Relationship: config.Relationship{Type: "interface"},
+				},
+			},
+		},
+	}
+}
+
+// primaryIPOneInterfaceOIDs seeds one interface named "Gi0" (ifIndex 1) and
+// one IP address at the given literal address, assigned to that interface.
+func primaryIPOneInterfaceOIDs(address, ifName string) mapping.ObjectIDValueMap {
+	return mapping.ObjectIDValueMap{
+		".1.3.6.1.2.1.2.2.1.2.1": mapping.Value{
+			Value: ifName, Type: mapping.Asn1BER(mapping.OctetString), IdentifierSize: 1,
+		},
+		".1.3.6.1.2.1.4.20.1.1." + address: mapping.Value{
+			Value: address, Type: mapping.Asn1BER(mapping.IPAddress), IdentifierSize: 4,
+		},
+		".1.3.6.1.2.1.4.20.1.2." + address: mapping.Value{
+			Value: "1", Type: mapping.Asn1BER(mapping.Integer), IdentifierSize: 4,
+		},
+	}
+}
+
+// findDevice returns the first non-nil device pointer reachable through the
+// emitted entities. It prefers a standalone diode.Device entity but falls
+// back to an Interface's Device reference (the same currentDevice pointer).
+func findDevice(entities []diode.Entity) *diode.Device {
+	for _, e := range entities {
+		if d, ok := e.(*diode.Device); ok {
+			return d
+		}
+	}
+	for _, e := range entities {
+		if iface, ok := e.(*diode.Interface); ok && iface.Device != nil {
+			return iface.Device
+		}
+		if ip, ok := e.(*diode.IPAddress); ok {
+			if iface, ok := ip.AssignedObject.(*diode.Interface); ok && iface.Device != nil {
+				return iface.Device
+			}
+		}
+	}
+	return nil
+}
+
+func TestAssignPrimaryIP_DirectIPv4Match(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	mappingConfig, err := mapping.NewConfig(primaryIPFixture(), logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+	assert.NoError(t, err)
+
+	m := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{}, "10.0.0.1")
+	entities := m.MapObjectIDsToEntity(primaryIPOneInterfaceOIDs("10.0.0.1", "Gi0"))
+
+	device := findDevice(entities)
+	assert.NotNil(t, device, "device reference must be reachable")
+	assert.NotNil(t, device.PrimaryIp4, "primary IP must be assigned")
+	if device.PrimaryIp4 != nil {
+		assert.Equal(t, "10.0.0.1/32", *device.PrimaryIp4.Address)
+	}
+}

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -1013,6 +1013,49 @@ func TestAssignPrimaryIP_MultipleMatches(t *testing.T) {
 	assert.NotNil(t, rec, "expected Warn log for multi-match")
 }
 
+// TestAssignPrimaryIP_MultipleMatches_EqualCompositeKey exercises the
+// content-based tiebreaker when two entries have the same primaryIPSortKey
+// (same address, same assigned interface name). Deterministic selection
+// must still hold via primaryIPContentKey.
+func TestAssignPrimaryIP_MultipleMatches_EqualCompositeKey(t *testing.T) {
+	handler := &bufferHandler{}
+	logger := slog.New(handler)
+
+	mappingConfig, err := mapping.NewConfig(primaryIPFixture(), logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+	assert.NoError(t, err)
+
+	m := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{}, "10.0.0.1")
+
+	// Identical address and interface name: composite sort key collides.
+	// The entities differ by Description so the content-based tiebreaker
+	// picks the lexicographically-smaller JSON serialization.
+	ifName := "Loopback0"
+	addr := "10.0.0.1/32"
+	descA := "alpha"
+	descB := "bravo"
+	ipA := &diode.IPAddress{
+		Address:        &addr,
+		AssignedObject: &diode.Interface{Name: &ifName},
+		Description:    &descA,
+	}
+	ipB := &diode.IPAddress{
+		Address:        &addr,
+		AssignedObject: &diode.Interface{Name: &ifName},
+		Description:    &descB,
+	}
+	entities := map[diode.Entity]bool{ipA: true, ipB: true}
+	device := m.CurrentDevice()
+
+	m.AssignPrimaryIPForTest(device, entities)
+
+	assert.NotNil(t, device.PrimaryIp4)
+	// JSON of ipA contains "alpha" which is < "bravo"; deterministic pick: ipA.
+	assert.Equal(t, ipA, device.PrimaryIp4)
+
+	rec := handler.find(slog.LevelWarn, "multiple IP candidates for primary IP assignment; picking deterministic first")
+	assert.NotNil(t, rec, "expected Warn log for multi-match")
+}
+
 func TestAssignPrimaryIP_ExcludedInterfaceIP(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -2,6 +2,7 @@ package mapping_test
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"os"
 	"sync"
@@ -919,6 +920,60 @@ func (h *bufferHandler) find(level slog.Level, msg string) *slog.Record {
 		}
 	}
 	return nil
+}
+
+type fakeResolver struct {
+	addrs []string
+	err   error
+}
+
+func (f *fakeResolver) LookupHost(_ context.Context, _ string) ([]string, error) {
+	return f.addrs, f.err
+}
+
+func TestAssignPrimaryIP_HostnameResolvesToIPv4(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	mappingConfig, err := mapping.NewConfig(primaryIPFixture(), logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+	assert.NoError(t, err)
+
+	resolver := &fakeResolver{addrs: []string{"10.0.0.1"}}
+	m := mapping.NewObjectIDMapperForTest(mappingConfig, logger, &config.Defaults{}, "router.example", resolver)
+
+	entities := m.MapObjectIDsToEntity(primaryIPOneInterfaceOIDs("10.0.0.1", "Gi0"))
+	device := findDevice(entities)
+	assert.NotNil(t, device.PrimaryIp4)
+	assert.Equal(t, "10.0.0.1/32", *device.PrimaryIp4.Address)
+}
+
+func TestAssignPrimaryIP_HostnameResolvesToIPv6Only(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	mappingConfig, err := mapping.NewConfig(primaryIPFixture(), logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+	assert.NoError(t, err)
+
+	resolver := &fakeResolver{addrs: []string{"2001:db8::1"}}
+	m := mapping.NewObjectIDMapperForTest(mappingConfig, logger, &config.Defaults{}, "router.example", resolver)
+
+	entities := m.MapObjectIDsToEntity(primaryIPOneInterfaceOIDs("10.0.0.1", "Gi0"))
+	device := findDevice(entities)
+	assert.NotNil(t, device)
+	assert.Nil(t, device.PrimaryIp4, "IPv6-only DNS result must not yield a PrimaryIp4")
+}
+
+func TestAssignPrimaryIP_InvalidHost(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	mappingConfig, err := mapping.NewConfig(primaryIPFixture(), logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+	assert.NoError(t, err)
+
+	resolver := &fakeResolver{err: errors.New("nxdomain")}
+	m := mapping.NewObjectIDMapperForTest(mappingConfig, logger, &config.Defaults{}, "nope.invalid", resolver)
+
+	entities := m.MapObjectIDsToEntity(primaryIPOneInterfaceOIDs("10.0.0.1", "Gi0"))
+	device := findDevice(entities)
+	assert.NotNil(t, device)
+	assert.Nil(t, device.PrimaryIp4)
 }
 
 func TestAssignPrimaryIP_MultipleMatches(t *testing.T) {

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -905,7 +905,9 @@ func (h *bufferHandler) Enabled(_ context.Context, _ slog.Level) bool { return t
 func (h *bufferHandler) Handle(_ context.Context, r slog.Record) error {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	h.records = append(h.records, r)
+	// r.Clone() is required per slog docs: the Record's contents may be
+	// reused by the caller after Handle returns.
+	h.records = append(h.records, r.Clone())
 	return nil
 }
 func (h *bufferHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
@@ -1054,6 +1056,28 @@ func TestAssignPrimaryIP_MultipleMatches_EqualCompositeKey(t *testing.T) {
 
 	rec := handler.find(slog.LevelWarn, "multiple IP candidates for primary IP assignment; picking deterministic first")
 	assert.NotNil(t, rec, "expected Warn log for multi-match")
+}
+
+// TestAssignPrimaryIP_UnassignedIPIgnored verifies the "verified interface
+// IP" guarantee: a discovered IPAddress whose AssignedObject is not an
+// Interface is not a valid primary-IP candidate even if its address matches
+// the target.
+func TestAssignPrimaryIP_UnassignedIPIgnored(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	mappingConfig, err := mapping.NewConfig(primaryIPFixture(), logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+	assert.NoError(t, err)
+
+	m := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{}, "10.0.0.1")
+
+	addr := "10.0.0.1/32"
+	unassigned := &diode.IPAddress{Address: &addr} // AssignedObject is nil
+	entities := map[diode.Entity]bool{unassigned: true}
+	device := m.CurrentDevice()
+
+	m.AssignPrimaryIPForTest(device, entities)
+
+	assert.Nil(t, device.PrimaryIp4, "primary IP must not be set from an IPAddress without an Interface assignment")
 }
 
 func TestAssignPrimaryIP_ExcludedInterfaceIP(t *testing.T) {

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -876,3 +876,34 @@ func TestAssignPrimaryIP_DirectIPv4Match(t *testing.T) {
 		assert.Equal(t, "10.0.0.1/32", *device.PrimaryIp4.Address)
 	}
 }
+
+func TestAssignPrimaryIP_NoMatch(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	mappingConfig, err := mapping.NewConfig(primaryIPFixture(), logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+	assert.NoError(t, err)
+
+	// Target 10.0.0.1, discovered only 10.0.0.2.
+	m := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{}, "10.0.0.1")
+	entities := m.MapObjectIDsToEntity(primaryIPOneInterfaceOIDs("10.0.0.2", "Gi0"))
+
+	device := findDevice(entities)
+	assert.NotNil(t, device)
+	assert.Nil(t, device.PrimaryIp4, "primary IP must not be set when no match")
+}
+
+func TestAssignPrimaryIP_PrefixStripping(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	// Reuses the default /32 emission: verifies stripPrefix drops "/32"
+	// before comparing to the bare target literal.
+	mappingConfig, err := mapping.NewConfig(primaryIPFixture(), logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+	assert.NoError(t, err)
+
+	m := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{}, "10.0.0.1")
+	entities := m.MapObjectIDsToEntity(primaryIPOneInterfaceOIDs("10.0.0.1", "Gi0"))
+
+	device := findDevice(entities)
+	assert.NotNil(t, device.PrimaryIp4)
+	assert.Equal(t, "10.0.0.1/32", *device.PrimaryIp4.Address)
+}

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -415,7 +415,7 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 	objectIDs := mappingConfig.ObjectIDs()
 	r.logger.Info("querying target", "host", target.Host, "port", target.Port, "object_count", len(objectIDs))
 
-	mapper := mapping.NewObjectIDMapper(mappingConfig, r.logger, targetDefaults)
+	mapper := mapping.NewObjectIDMapper(mappingConfig, r.logger, targetDefaults, target.Host)
 	policyName := r.ctx.Value(policyKey).(string)
 	// Track discovery attempt
 	if rMetric := metrics.GetDiscoveryAttempts(); rMetric != nil {

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -431,7 +431,7 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 
 	auth := r.resolveTargetAuthentication(target)
 
-	host := snmp.NewHost(target.Host, target.Port, r.config.Retries, r.snmpTimeout, auth, r.logger, r.ClientFactory)
+	host := snmp.NewHost(targetHost, target.Port, r.config.Retries, r.snmpTimeout, auth, r.logger, r.ClientFactory)
 
 	type walkResult struct {
 		oids mapping.ObjectIDValueMap

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -413,9 +413,11 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 		return nil, err
 	}
 	objectIDs := mappingConfig.ObjectIDs()
-	r.logger.Info("querying target", "host", target.Host, "port", target.Port, "object_count", len(objectIDs))
+	targetHost := strings.TrimSpace(target.Host)
+	r.logger.Info("querying target", "host", targetHost, "port", target.Port, "object_count", len(objectIDs))
 
-	mapper := mapping.NewObjectIDMapper(mappingConfig, r.logger, targetDefaults, target.Host)
+	mapper := mapping.NewObjectIDMapper(mappingConfig, r.logger, targetDefaults, targetHost)
+	mapper.SetContext(ctx)
 	policyName := r.ctx.Value(policyKey).(string)
 	// Track discovery attempt
 	if rMetric := metrics.GetDiscoveryAttempts(); rMetric != nil {

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -459,7 +459,7 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 		return nil, ctx.Err()
 	case res := <-resultCh:
 		if res.err != nil {
-			r.logger.Warn("error crawling host", "host", target.Host, "error", res.err)
+			r.logger.Warn("error crawling host", "host", targetHost, "error", res.err)
 			if rMetric := metrics.GetDiscoveryFailure(); rMetric != nil {
 				rMetric.Add(r.ctx, 1,
 					metric.WithAttributes(

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -11,6 +11,8 @@ import (
 
 	"github.com/go-co-op/gocron/v2"
 	"github.com/google/uuid"
+	"github.com/gosnmp/gosnmp"
+	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
 	"github.com/stretchr/testify/assert"
@@ -335,6 +337,85 @@ func TestQueryTargetSuccess(t *testing.T) {
 	entities, err := runner.queryTarget(context.Background(), config.Target{Host: "127.0.0.1", Port: 161})
 	require.NoError(t, err)
 	assert.NotEmpty(t, entities)
+}
+
+// staticWalker emits a fixed PDU set per walked OID. Used by the OBS-1896
+// integration test so we can seed properly-indexed interface + ipAddress
+// PDUs that the mapping pipeline will group correctly.
+type staticWalker struct {
+	pdus map[string]map[string]snmp.PDU
+}
+
+func (w *staticWalker) Connect() error { return nil }
+func (w *staticWalker) Close() error   { return nil }
+func (w *staticWalker) Walk(oid string, _ int) (map[string]snmp.PDU, error) {
+	if p, ok := w.pdus[oid]; ok {
+		return p, nil
+	}
+	return map[string]snmp.PDU{}, nil
+}
+
+// TestQueryTargetAssignsPrimaryIPFromTarget is the OBS-1896 end-to-end check:
+// when the SNMP target host equals a discovered interface IP, the emitted
+// Device (reachable via any Interface entity) must carry that IPAddress as
+// its PrimaryIp4.
+func TestQueryTargetAssignsPrimaryIPFromTarget(t *testing.T) {
+	walker := &staticWalker{
+		pdus: map[string]map[string]snmp.PDU{
+			"1.3.6.1.2.1.2.2.1.2": {
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					Value: "Gi0", Type: gosnmp.OctetString, IdentifierSize: 1,
+				},
+			},
+			"1.3.6.1.2.1.4.20.1.1": {
+				"1.3.6.1.2.1.4.20.1.1.10.0.0.1": {
+					Value: "10.0.0.1", Type: gosnmp.IPAddress, IdentifierSize: 4,
+				},
+			},
+		},
+	}
+	factory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return walker, nil
+	}
+
+	entries := []config.MappingEntry{
+		{
+			OID:            "1.3.6.1.2.1.2.2.1",
+			Entity:         "interface",
+			Field:          "_id",
+			IdentifierSize: 1,
+			MappingEntries: []config.MappingEntry{
+				{OID: "1.3.6.1.2.1.2.2.1.2", Entity: "interface", Field: "name"},
+			},
+		},
+		{
+			OID:            "1.3.6.1.2.1.4.20.1",
+			Entity:         "ipAddress",
+			Field:          "_id",
+			IdentifierSize: 4,
+			MappingEntries: []config.MappingEntry{
+				{OID: "1.3.6.1.2.1.4.20.1.1", Entity: "ipAddress", Field: "address"},
+			},
+		},
+	}
+
+	runner := queryTargetRunner(factory, entries)
+	entities, err := runner.queryTarget(context.Background(), config.Target{Host: "10.0.0.1", Port: 161})
+	require.NoError(t, err)
+	require.NotEmpty(t, entities)
+
+	// The Device is reached via any emitted Interface's Device pointer;
+	// all interfaces share the same currentDevice instance.
+	var device *diode.Device
+	for _, e := range entities {
+		if iface, ok := e.(*diode.Interface); ok && iface.Device != nil {
+			device = iface.Device
+			break
+		}
+	}
+	require.NotNil(t, device, "expected an Interface entity carrying a device reference")
+	require.NotNil(t, device.PrimaryIp4, "device.PrimaryIp4 must be set from target host")
+	assert.Equal(t, "10.0.0.1/32", *device.PrimaryIp4.Address)
 }
 
 func TestRunner_HasActiveHostJobsField(t *testing.T) {

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -360,6 +360,9 @@ func (w *staticWalker) Walk(oid string, _ int) (map[string]snmp.PDU, error) {
 // Device (reachable via any Interface entity) must carry that IPAddress as
 // its PrimaryIp4.
 func TestQueryTargetAssignsPrimaryIPFromTarget(t *testing.T) {
+	// Walker emits the same OIDs as production mapping.yaml: one interface
+	// (ifIndex=1, name=Gi0), one IPv4 address 10.0.0.1 assigned to that
+	// interface via ipAdEntIfIndex=1.
 	walker := &staticWalker{
 		pdus: map[string]map[string]snmp.PDU{
 			"1.3.6.1.2.1.2.2.1.2": {
@@ -370,6 +373,11 @@ func TestQueryTargetAssignsPrimaryIPFromTarget(t *testing.T) {
 			"1.3.6.1.2.1.4.20.1.1": {
 				"1.3.6.1.2.1.4.20.1.1.10.0.0.1": {
 					Value: "10.0.0.1", Type: gosnmp.IPAddress, IdentifierSize: 4,
+				},
+			},
+			"1.3.6.1.2.1.4.20.1.2": {
+				"1.3.6.1.2.1.4.20.1.2.10.0.0.1": {
+					Value: 1, Type: gosnmp.Integer, IdentifierSize: 4,
 				},
 			},
 		},
@@ -395,6 +403,12 @@ func TestQueryTargetAssignsPrimaryIPFromTarget(t *testing.T) {
 			IdentifierSize: 4,
 			MappingEntries: []config.MappingEntry{
 				{OID: "1.3.6.1.2.1.4.20.1.1", Entity: "ipAddress", Field: "address"},
+				{
+					OID:          "1.3.6.1.2.1.4.20.1.2",
+					Entity:       "ipAddress",
+					Field:        "assignedObject",
+					Relationship: config.Relationship{Type: "interface"},
+				},
 			},
 		},
 	}
@@ -404,18 +418,27 @@ func TestQueryTargetAssignsPrimaryIPFromTarget(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, entities)
 
-	// The Device is reached via any emitted Interface's Device pointer;
-	// all interfaces share the same currentDevice instance.
-	var device *diode.Device
+	// Locate the emitted IPAddress and confirm it is wired to the Gi0
+	// interface — this is the "verified interface IP" guarantee the
+	// primary-IP assignment depends on.
+	var primaryIP *diode.IPAddress
 	for _, e := range entities {
-		if iface, ok := e.(*diode.Interface); ok && iface.Device != nil {
-			device = iface.Device
+		if ip, ok := e.(*diode.IPAddress); ok && ip.Address != nil && *ip.Address == "10.0.0.1/32" {
+			primaryIP = ip
 			break
 		}
 	}
-	require.NotNil(t, device, "expected an Interface entity carrying a device reference")
-	require.NotNil(t, device.PrimaryIp4, "device.PrimaryIp4 must be set from target host")
-	assert.Equal(t, "10.0.0.1/32", *device.PrimaryIp4.Address)
+	require.NotNil(t, primaryIP, "expected IPAddress 10.0.0.1/32 in emitted entities")
+	iface, ok := primaryIP.AssignedObject.(*diode.Interface)
+	require.True(t, ok, "IPAddress must be assigned to an Interface")
+	require.NotNil(t, iface.Name)
+	assert.Equal(t, "Gi0", *iface.Name)
+
+	// The Device is reached via the assigned interface's Device pointer;
+	// device.PrimaryIp4 must reference the exact same IPAddress entity.
+	require.NotNil(t, iface.Device, "assigned interface must carry a device reference")
+	require.NotNil(t, iface.Device.PrimaryIp4, "device.PrimaryIp4 must be set from target host")
+	assert.Same(t, primaryIP, iface.Device.PrimaryIp4, "device.PrimaryIp4 must point at the matched IPAddress entity")
 }
 
 func TestRunner_HasActiveHostJobsField(t *testing.T) {


### PR DESCRIPTION
## Summary

- Populate `Device.PrimaryIp4` from the SNMP target host on each scan.
- Match is verified: only IPs discovered on the device's interfaces are eligible, so the agent never records an unvalidated primary IP.
- Hostname targets are resolved via DNS (2s timeout honoring scan cancellation); IPv4 results only.
- Always-on, IPv4-only, no new config knobs.
- Closes [orb-agent#265](https://github.com/netboxlabs/orb-agent/issues/265) / OBS-1896.

## Architecture

- `ObjectIDMapper` gained a `targetHost` field, an injectable `hostResolver`, and a `SetContext(ctx)` setter.
- `assignPrimaryIP` runs at the tail of `MapObjectIDsToEntity`, after exclusions and interface→device wiring. It scans surviving `*diode.IPAddress` entities for one whose stripped address matches the target.
- Multi-match tiebreaker: sort by composite `<address>|<interface-name>` key, then by `json.Marshal(ip)` content (run-to-run stable). A documented fallback dereferences scalar fields explicitly if JSON ever fails.
- `runner.queryTarget` trims `target.Host` once and passes the normalized value to both the mapper and `snmp.NewHost`.

## Test plan

- [x] `go build ./... && go test ./...` in `snmp-discovery/` passes locally
- [x] Unit tests added (10 new): direct IPv4, no match, prefix stripping, /24 non-default prefix, excluded-interface IP, multi-match with warn log (distinct keys), multi-match with equal composite key (content tiebreaker), hostname → IPv4, hostname → IPv6-only, hostname → resolution failure
- [x] Integration test `TestQueryTargetAssignsPrimaryIPFromTarget` in `policy/runner_internal_test.go` exercises the end-to-end `target.Host` → `PrimaryIp4` wiring via a custom `staticWalker`
- [x] Codex code review iterated five rounds; final pass confirmed no blockers remain
- [x] Manual smoke against a live SNMP device with a management IP walked via `ipAddrTable`; observe `primary_ip4` populated in the diode ingestion payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)