### PR TITLE
fix(snmp-discovery): break proto-serialization cycle in Device.PrimaryIp4

### DIFF
--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -562,7 +562,32 @@ func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diod
 			"target", m.targetHost, "candidates", all)
 	}
 
-	device.PrimaryIp4 = hits[0].ip
+	// Break the reference cycle before attaching. The matched IPAddress is
+	// also emitted as a standalone entity whose AssignedObject points at an
+	// Interface whose Device points back at the same currentDevice. Sharing
+	// that pointer graph into device.PrimaryIp4 would make the diode SDK's
+	// proto serializer recurse forever (device -> primary_ip4 -> ip ->
+	// interface -> device -> ...). We detach with a shallow snapshot: copy
+	// the IPAddress, then (if present) copy the assigned Interface and
+	// clear its Device so the snapshot is a tree, not a cycle. The
+	// standalone emitted entities keep their full graph untouched.
+	device.PrimaryIp4 = detachForPrimaryIP(hits[0].ip)
+}
+
+// detachForPrimaryIP returns a shallow copy of the matched IPAddress with
+// its AssignedObject interface's Device cleared, so the resulting pointer
+// tree contains no cycle back to the owning Device.
+func detachForPrimaryIP(ip *diode.IPAddress) *diode.IPAddress {
+	if ip == nil {
+		return nil
+	}
+	snapshot := *ip
+	if iface, ok := snapshot.AssignedObject.(*diode.Interface); ok && iface != nil {
+		ifaceCopy := *iface
+		ifaceCopy.Device = nil
+		snapshot.AssignedObject = &ifaceCopy
+	}
+	return &snapshot
 }
 
 // primaryIPSortKey returns a stable composite ordering key for an IPAddress

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -579,9 +579,14 @@ func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diod
 
 // detachForPrimaryIP returns a shallow copy of the matched IPAddress
 // suitable to attach as Device.PrimaryIp4 without introducing a reference
-// cycle. The assigned Interface (if any) is copied, and its Device pointer
-// is replaced with a copy of the owning Device that has PrimaryIp4 cleared
-// so the resulting tree has no back-edge.
+// cycle. The assigned Interface (if any) is copied; its Device pointer is
+// replaced with a copy of the owning Device that has PrimaryIp4 cleared,
+// and all *Interface / *Module relationship fields (Parent, Bridge, Lag,
+// Module) are cleared -- otherwise a subinterface's Parent (or similar
+// back-reference) would point at another *diode.Interface whose Device
+// still carries PrimaryIp4, reintroducing the cycle. The standalone
+// emitted Interface entities keep their full graph; only the snapshot is
+// pruned.
 func detachForPrimaryIP(ip *diode.IPAddress, owner *diode.Device) *diode.IPAddress {
 	if ip == nil {
 		return nil
@@ -594,6 +599,12 @@ func detachForPrimaryIP(ip *diode.IPAddress, owner *diode.Device) *diode.IPAddre
 			deviceCopy.PrimaryIp4 = nil
 			ifaceCopy.Device = &deviceCopy
 		}
+		// Prune relationship pointers that can transitively reach a
+		// Device with PrimaryIp4 set. See the function doc for why.
+		ifaceCopy.Parent = nil
+		ifaceCopy.Bridge = nil
+		ifaceCopy.Lag = nil
+		ifaceCopy.Module = nil
 		snapshot.AssignedObject = &ifaceCopy
 	}
 	return &snapshot

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -568,23 +568,32 @@ func (m *ObjectIDMapper) assignPrimaryIP(device *diode.Device, entities map[diod
 	// that pointer graph into device.PrimaryIp4 would make the diode SDK's
 	// proto serializer recurse forever (device -> primary_ip4 -> ip ->
 	// interface -> device -> ...). We detach with a shallow snapshot: copy
-	// the IPAddress, then (if present) copy the assigned Interface and
-	// clear its Device so the snapshot is a tree, not a cycle. The
-	// standalone emitted entities keep their full graph untouched.
-	device.PrimaryIp4 = detachForPrimaryIP(hits[0].ip)
+	// the IPAddress and (if present) the assigned Interface, then replace
+	// the interface's Device with a Device copy that has PrimaryIp4 nil.
+	// The snapshot is then a tree (no back-edge), and the nested Device
+	// still satisfies Diode's validation requirement that an Interface
+	// reference a Device. The standalone emitted entities keep their full
+	// graph untouched.
+	device.PrimaryIp4 = detachForPrimaryIP(hits[0].ip, device)
 }
 
-// detachForPrimaryIP returns a shallow copy of the matched IPAddress with
-// its AssignedObject interface's Device cleared, so the resulting pointer
-// tree contains no cycle back to the owning Device.
-func detachForPrimaryIP(ip *diode.IPAddress) *diode.IPAddress {
+// detachForPrimaryIP returns a shallow copy of the matched IPAddress
+// suitable to attach as Device.PrimaryIp4 without introducing a reference
+// cycle. The assigned Interface (if any) is copied, and its Device pointer
+// is replaced with a copy of the owning Device that has PrimaryIp4 cleared
+// so the resulting tree has no back-edge.
+func detachForPrimaryIP(ip *diode.IPAddress, owner *diode.Device) *diode.IPAddress {
 	if ip == nil {
 		return nil
 	}
 	snapshot := *ip
 	if iface, ok := snapshot.AssignedObject.(*diode.Interface); ok && iface != nil {
 		ifaceCopy := *iface
-		ifaceCopy.Device = nil
+		if owner != nil {
+			deviceCopy := *owner
+			deviceCopy.PrimaryIp4 = nil
+			ifaceCopy.Device = &deviceCopy
+		}
 		snapshot.AssignedObject = &ifaceCopy
 	}
 	return &snapshot

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -934,16 +934,29 @@ func TestAssignPrimaryIP_DeviceIsProtoSerializable_WithSubinterfaceParent(t *tes
 	m := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{}, "10.0.0.1")
 	device := m.CurrentDevice()
 
-	// Build: subinterface "Gi0.10" whose Parent is "Gi0", and whose Parent's
-	// Device pointer points back at `device`. The IPAddress is assigned to
-	// the subinterface. Without the relationship-pointer prune in
+	// Build: subinterface "Gi0.10" with back-references on every cycle-prone
+	// field -- Parent, Bridge, Lag, and Module all point at entities whose
+	// Device is the owning `device` (which carries PrimaryIp4 once
+	// assignPrimaryIP runs). Without the relationship-pointer prune in
 	// detachForPrimaryIP, ConvertToProtoEntity would recurse forever via
-	// PrimaryIp4 -> subinterface copy -> Parent (original) -> Device
-	// (same) -> PrimaryIp4 -> ...
+	// PrimaryIp4 -> subinterface copy -> (any of those pointers) ->
+	// Device (same) -> PrimaryIp4 -> ...
 	parentName := "Gi0"
 	parent := &diode.Interface{Name: &parentName, Device: device}
+	bridgeName := "br0"
+	bridge := &diode.Interface{Name: &bridgeName, Device: device}
+	lagName := "Port-Channel1"
+	lag := &diode.Interface{Name: &lagName, Device: device}
+	module := &diode.Module{Device: device}
 	subName := "Gi0.10"
-	sub := &diode.Interface{Name: &subName, Device: device, Parent: parent}
+	sub := &diode.Interface{
+		Name:   &subName,
+		Device: device,
+		Parent: parent,
+		Bridge: bridge,
+		Lag:    lag,
+		Module: module,
+	}
 	addr := "10.0.0.1/32"
 	ip := &diode.IPAddress{Address: &addr, AssignedObject: sub}
 

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -880,6 +880,41 @@ func TestAssignPrimaryIP_DirectIPv4Match(t *testing.T) {
 	}
 }
 
+// TestAssignPrimaryIP_DeviceIsProtoSerializable is the regression test for
+// the reference-cycle bug that caused a stack overflow during ingestion
+// against a real diode target. Before the fix, device.PrimaryIp4 shared a
+// pointer with an IPAddress whose assigned Interface pointed back at the
+// same Device -- the diode SDK's proto serializer recursed forever.
+func TestAssignPrimaryIP_DeviceIsProtoSerializable(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	mappingConfig, err := mapping.NewConfig(primaryIPFixture(), logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+	assert.NoError(t, err)
+
+	m := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{}, "10.0.0.1")
+	entities := m.MapObjectIDsToEntity(primaryIPOneInterfaceOIDs("10.0.0.1", "Gi0"))
+
+	device := m.CurrentDevice()
+	assert.NotNil(t, device.PrimaryIp4)
+
+	// Converting every emitted entity to its proto form must complete
+	// without recursing into the primary_ip4 -> interface -> device cycle.
+	for _, e := range entities {
+		proto := e.ConvertToProtoEntity()
+		assert.NotNil(t, proto)
+	}
+	// The device itself is constructed on the fly by the caller; exercise
+	// the path that crashed in the lab (marshal a live Device entity).
+	proto := device.ConvertToProtoEntity()
+	assert.NotNil(t, proto)
+
+	// Belt-and-braces: the snapshot attached to PrimaryIp4 must not carry
+	// a back-pointer to the parent Device through its assigned interface.
+	if iface, ok := device.PrimaryIp4.AssignedObject.(*diode.Interface); ok && iface != nil {
+		assert.Nil(t, iface.Device, "PrimaryIp4 snapshot must not reference the parent Device")
+	}
+}
+
 func TestAssignPrimaryIP_NoMatch(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -908,10 +908,14 @@ func TestAssignPrimaryIP_DeviceIsProtoSerializable(t *testing.T) {
 	proto := device.ConvertToProtoEntity()
 	assert.NotNil(t, proto)
 
-	// Belt-and-braces: the snapshot attached to PrimaryIp4 must not carry
-	// a back-pointer to the parent Device through its assigned interface.
+	// The snapshot must keep the nested Device reference (Diode requires
+	// Interface.device to be set) but that nested Device must have
+	// PrimaryIp4 cleared so the graph is a tree, not a cycle.
 	if iface, ok := device.PrimaryIp4.AssignedObject.(*diode.Interface); ok && iface != nil {
-		assert.Nil(t, iface.Device, "PrimaryIp4 snapshot must not reference the parent Device")
+		assert.NotNil(t, iface.Device, "PrimaryIp4 snapshot must keep a Device on the assigned interface")
+		if iface.Device != nil {
+			assert.Nil(t, iface.Device.PrimaryIp4, "nested Device must have PrimaryIp4 cleared to break the cycle")
+		}
 	}
 }
 
@@ -1041,10 +1045,15 @@ func TestAssignPrimaryIP_MultipleMatches(t *testing.T) {
 
 	m.AssignPrimaryIPForTest(device, entities)
 
-	assert.NotNil(t, device.PrimaryIp4)
-	// Lexicographically smaller key wins:
-	//   "10.0.0.1/32|GigabitEthernet0/1" < "10.0.0.1/32|Loopback0"
-	assert.Equal(t, ip2, device.PrimaryIp4, "deterministic selection must prefer the smaller sort key")
+	if assert.NotNil(t, device.PrimaryIp4) && assert.NotNil(t, device.PrimaryIp4.Address) {
+		// Lexicographically smaller key wins:
+		//   "10.0.0.1/32|GigabitEthernet0/1" < "10.0.0.1/32|Loopback0"
+		assert.Equal(t, "10.0.0.1/32", *device.PrimaryIp4.Address)
+		if snapshotIface, ok := device.PrimaryIp4.AssignedObject.(*diode.Interface); assert.True(t, ok) && assert.NotNil(t, snapshotIface.Name) {
+			assert.Equal(t, ip2Name, *snapshotIface.Name,
+				"deterministic selection must prefer the smaller sort key")
+		}
+	}
 
 	rec := handler.find(slog.LevelWarn, "multiple IP candidates for primary IP assignment; picking deterministic first")
 	assert.NotNil(t, rec, "expected Warn log for multi-match")
@@ -1085,9 +1094,10 @@ func TestAssignPrimaryIP_MultipleMatches_EqualCompositeKey(t *testing.T) {
 
 	m.AssignPrimaryIPForTest(device, entities)
 
-	assert.NotNil(t, device.PrimaryIp4)
-	// JSON of ipA contains "alpha" which is < "bravo"; deterministic pick: ipA.
-	assert.Equal(t, ipA, device.PrimaryIp4)
+	if assert.NotNil(t, device.PrimaryIp4) && assert.NotNil(t, device.PrimaryIp4.Description) {
+		// JSON of ipA contains "alpha" which is < "bravo"; deterministic pick: ipA.
+		assert.Equal(t, "alpha", *device.PrimaryIp4.Description)
+	}
 
 	rec := handler.find(slog.LevelWarn, "multiple IP candidates for primary IP assignment; picking deterministic first")
 	assert.NotNil(t, rec, "expected Warn log for multi-match")

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -919,6 +919,52 @@ func TestAssignPrimaryIP_DeviceIsProtoSerializable(t *testing.T) {
 	}
 }
 
+// TestAssignPrimaryIP_DeviceIsProtoSerializable_WithSubinterfaceParent
+// covers the specific regression flagged by the PR #368 review: if the
+// matched IPAddress is assigned to a subinterface (which has a Parent
+// pointer back into the interface graph), a shallow-only copy still
+// serializes into a cycle unless the relationship pointers are cleared.
+// We seed the scenario directly via the test helper.
+func TestAssignPrimaryIP_DeviceIsProtoSerializable_WithSubinterfaceParent(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	mappingConfig, err := mapping.NewConfig(primaryIPFixture(), logger, &FakeManufacturers{}, &FakeDeviceLookup{}, nil)
+	assert.NoError(t, err)
+
+	m := mapping.NewObjectIDMapper(mappingConfig, logger, &config.Defaults{}, "10.0.0.1")
+	device := m.CurrentDevice()
+
+	// Build: subinterface "Gi0.10" whose Parent is "Gi0", and whose Parent's
+	// Device pointer points back at `device`. The IPAddress is assigned to
+	// the subinterface. Without the relationship-pointer prune in
+	// detachForPrimaryIP, ConvertToProtoEntity would recurse forever via
+	// PrimaryIp4 -> subinterface copy -> Parent (original) -> Device
+	// (same) -> PrimaryIp4 -> ...
+	parentName := "Gi0"
+	parent := &diode.Interface{Name: &parentName, Device: device}
+	subName := "Gi0.10"
+	sub := &diode.Interface{Name: &subName, Device: device, Parent: parent}
+	addr := "10.0.0.1/32"
+	ip := &diode.IPAddress{Address: &addr, AssignedObject: sub}
+
+	entities := map[diode.Entity]bool{ip: true}
+	m.AssignPrimaryIPForTest(device, entities)
+
+	assert.NotNil(t, device.PrimaryIp4)
+	// Serialization must terminate.
+	proto := device.ConvertToProtoEntity()
+	assert.NotNil(t, proto)
+
+	// Snapshot must not retain the Parent / Bridge / Lag / Module
+	// back-references.
+	snap, ok := device.PrimaryIp4.AssignedObject.(*diode.Interface)
+	assert.True(t, ok)
+	assert.Nil(t, snap.Parent, "snapshot interface must not retain Parent back-edge")
+	assert.Nil(t, snap.Bridge, "snapshot interface must not retain Bridge back-edge")
+	assert.Nil(t, snap.Lag, "snapshot interface must not retain Lag back-edge")
+	assert.Nil(t, snap.Module, "snapshot interface must not retain Module back-edge")
+}
+
 func TestAssignPrimaryIP_NoMatch(t *testing.T) {
 	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -444,8 +444,10 @@ func TestQueryTargetAssignsPrimaryIPFromTarget(t *testing.T) {
 	require.True(t, ok, "PrimaryIp4 snapshot must preserve the interface assignment")
 	require.NotNil(t, snapshotIface.Name)
 	assert.Equal(t, "Gi0", *snapshotIface.Name)
-	assert.Nil(t, snapshotIface.Device,
-		"PrimaryIp4 snapshot's interface must not back-reference the parent Device")
+	require.NotNil(t, snapshotIface.Device,
+		"PrimaryIp4 snapshot's interface must carry a Device (Diode validation)")
+	assert.Nil(t, snapshotIface.Device.PrimaryIp4,
+		"nested Device must have PrimaryIp4 cleared to break the cycle")
 }
 
 func TestRunner_HasActiveHostJobsField(t *testing.T) {

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -435,10 +435,17 @@ func TestQueryTargetAssignsPrimaryIPFromTarget(t *testing.T) {
 	assert.Equal(t, "Gi0", *iface.Name)
 
 	// The Device is reached via the assigned interface's Device pointer;
-	// device.PrimaryIp4 must reference the exact same IPAddress entity.
+	// device.PrimaryIp4 is a detached snapshot of the matched IPAddress
+	// (see detachForPrimaryIP) — compare by content, not by pointer.
 	require.NotNil(t, iface.Device, "assigned interface must carry a device reference")
 	require.NotNil(t, iface.Device.PrimaryIp4, "device.PrimaryIp4 must be set from target host")
-	assert.Same(t, primaryIP, iface.Device.PrimaryIp4, "device.PrimaryIp4 must point at the matched IPAddress entity")
+	assert.Equal(t, *primaryIP.Address, *iface.Device.PrimaryIp4.Address)
+	snapshotIface, ok := iface.Device.PrimaryIp4.AssignedObject.(*diode.Interface)
+	require.True(t, ok, "PrimaryIp4 snapshot must preserve the interface assignment")
+	require.NotNil(t, snapshotIface.Name)
+	assert.Equal(t, "Gi0", *snapshotIface.Name)
+	assert.Nil(t, snapshotIface.Device,
+		"PrimaryIp4 snapshot's interface must not back-reference the parent Device")
 }
 
 func TestRunner_HasActiveHostJobsField(t *testing.T) {


### PR DESCRIPTION
## Summary

Regression fix for [#366](https://github.com/netboxlabs/orb-discovery/pull/366) (OBS-1896). Setting \`device.PrimaryIp4\` to the matched IPAddress pointer created a reference cycle — \`device → primary_ip4 → ip → interface → device → ...\` — that made the diode-sdk-go protobuf serializer recurse forever and crashed the agent with \`goroutine stack exceeds 1000000000-byte limit\` on live ingestion. Caught while validating the feature end-to-end against a live Diode in the orb-test-lab.

The original unit tests didn't surface it because they only inspected the in-memory Device object. The dry-run path also didn't crash because it writes entities directly without invoking \`ConvertToProtoEntity\`.

## Fix

Attach a **detached snapshot** to \`PrimaryIp4\`. The snapshot is a shallow copy of the matched IPAddress whose assigned Interface carries a **copy** of the owning Device with \`PrimaryIp4\` cleared — so the pointer tree has no back-edge, and the nested Device still satisfies Diode's validation rule that every Interface reference must carry a Device:

```go
func detachForPrimaryIP(ip *diode.IPAddress, owner *diode.Device) *diode.IPAddress {
    if ip == nil {
        return nil
    }
    snapshot := *ip
    if iface, ok := snapshot.AssignedObject.(*diode.Interface); ok && iface != nil {
        ifaceCopy := *iface
        if owner != nil {
            deviceCopy := *owner
            deviceCopy.PrimaryIp4 = nil
            ifaceCopy.Device = &deviceCopy
        }
        snapshot.AssignedObject = &ifaceCopy
    }
    return &snapshot
}
```

The emitted standalone IPAddress / Interface entities keep their full pointer graph.

### First try — why it wasn't enough

The first attempt simply set \`ifaceCopy.Device = nil\`. That broke the cycle but Diode's reconciler immediately rejected the payload:

> \`dcim.interface\`: \`{ "device": ["Field device is required"] }\`

Diode's schema requires every nested Interface to reference a Device. The current fix uses a Device **copy** instead of nil, preserving the required back-reference while still breaking the cycle (the copy's \`PrimaryIp4\` is nil, so the graph terminates).

## Tests

- **New \`TestAssignPrimaryIP_DeviceIsProtoSerializable\`** — reproduces the crash (stack overflow when the fix is temporarily reverted) and asserts the snapshot carries a nested Device whose \`PrimaryIp4\` is cleared.
- **\`TestQueryTargetAssignsPrimaryIPFromTarget\` updated** — integration assertion now compares PrimaryIp4 by content (address, interface name, nested-Device-with-nil-PrimaryIp4) instead of pointer identity.
- **\`TestAssignPrimaryIP_MultipleMatches{,_EqualCompositeKey}\` updated** — no longer use whole-value \`assert.Equal\` (snapshot copy ≠ original pointer); assert address + interface name / description explicitly.

## Lab validation

Reproduced the crash, applied the nil-Device fix → \`Field device is required\`, applied the Device-copy fix → clean:

```
time=... level=INFO msg="SNMP crawl complete" host=172.28.0.42 entity_count=116
time=... level=INFO msg="entities ingested successfully" host=172.28.0.42 entity_count=116
```

No stack overflow, no reconciler "device required" error, 116 entities ingested to live Diode. Device appears in NetBox with \`primary_ip4 = 172.28.0.42/24\` on \`Vlan99\`.

## Test plan

- [x] \`go test ./...\` in snmp-discovery/ passes
- [x] Temporarily reverted the fix → the new regression test fails with \`fatal error: stack overflow\`
- [x] First-try fix (\`Device = nil\`) was reverted after Diode reported \`"Field device is required"\` — current fix uses a Device copy
- [x] Lab: snmp-discovery ingests against live Diode without crashing; Device appears in NetBox with \`primary_ip4\` populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)