### PR TITLE
feat(snmp-discovery): lookup overrides for manufacturer, device model, per-target device fields

### DIFF
--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -61,9 +61,12 @@ type InterfacePattern struct {
 
 // DeviceDefaults represents default values for a specific entity type
 type DeviceDefaults struct {
-	Description string   `yaml:"description,omitempty"`
-	Tags        []string `yaml:"tags,omitempty"`
-	Comments    string   `yaml:"comments,omitempty"`
+	Description  string   `yaml:"description,omitempty"`
+	Tags         []string `yaml:"tags,omitempty"`
+	Comments     string   `yaml:"comments,omitempty"`
+	Model        string   `yaml:"model,omitempty"`
+	Manufacturer string   `yaml:"manufacturer,omitempty"`
+	Platform     string   `yaml:"platform,omitempty"`
 }
 
 // Defaults represents the supported default values for a policy
@@ -143,6 +146,15 @@ func MergeDefaults(policyDefaults, overrideDefaults *Defaults) *Defaults {
 	}
 	if overrideDefaults.Device.Comments != "" {
 		merged.Device.Comments = overrideDefaults.Device.Comments
+	}
+	if overrideDefaults.Device.Model != "" {
+		merged.Device.Model = overrideDefaults.Device.Model
+	}
+	if overrideDefaults.Device.Manufacturer != "" {
+		merged.Device.Manufacturer = overrideDefaults.Device.Manufacturer
+	}
+	if overrideDefaults.Device.Platform != "" {
+		merged.Device.Platform = overrideDefaults.Device.Platform
 	}
 
 	// Override InterfacePatterns if provided

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -260,6 +260,59 @@ func TestMergeDefaults(t *testing.T) {
 	})
 }
 
+func TestMergeDefaults_DeviceModelManufacturerPlatform(t *testing.T) {
+	policy := &Defaults{
+		Device: DeviceDefaults{
+			Description: "policy-desc",
+		},
+	}
+	override := &Defaults{
+		Device: DeviceDefaults{
+			Model:        "C9300-48P",
+			Manufacturer: "Cisco Systems",
+			Platform:     "IOS-XE 17.09.04a",
+		},
+	}
+	merged := MergeDefaults(policy, override)
+	assert.Equal(t, "C9300-48P", merged.Device.Model)
+	assert.Equal(t, "Cisco Systems", merged.Device.Manufacturer)
+	assert.Equal(t, "IOS-XE 17.09.04a", merged.Device.Platform)
+	assert.Equal(t, "policy-desc", merged.Device.Description, "description must survive the override")
+}
+
+func TestMergeDefaults_DeviceOverrideFieldLevel(t *testing.T) {
+	policy := &Defaults{
+		Device: DeviceDefaults{
+			Model:        "policy-model",
+			Manufacturer: "policy-mfr",
+			Platform:     "policy-plat",
+		},
+	}
+	override := &Defaults{
+		Device: DeviceDefaults{
+			Model: "override-model",
+		},
+	}
+	merged := MergeDefaults(policy, override)
+	assert.Equal(t, "override-model", merged.Device.Model, "Model is overridden")
+	assert.Equal(t, "policy-mfr", merged.Device.Manufacturer, "Manufacturer preserved (override was empty)")
+	assert.Equal(t, "policy-plat", merged.Device.Platform, "Platform preserved (override was empty)")
+}
+
+func TestMergeDefaults_PolicyDeviceModelManufacturerPlatformSurviveNilOverride(t *testing.T) {
+	policy := &Defaults{
+		Device: DeviceDefaults{
+			Model:        "policy-model",
+			Manufacturer: "policy-mfr",
+			Platform:     "policy-plat",
+		},
+	}
+	merged := MergeDefaults(policy, nil)
+	assert.Equal(t, "policy-model", merged.Device.Model)
+	assert.Equal(t, "policy-mfr", merged.Device.Manufacturer)
+	assert.Equal(t, "policy-plat", merged.Device.Platform)
+}
+
 func TestTargetNetboxID_parsed(t *testing.T) {
 	input := `
 host: "192.168.1.1"

--- a/snmp-discovery/data/lookup_extensions.go
+++ b/snmp-discovery/data/lookup_extensions.go
@@ -145,7 +145,9 @@ func loadBuiltInManufacturerOverrides(overrides map[string]string) error {
 			return fmt.Errorf("failed to open file %s: %w", file.Name(), err)
 		}
 		fileData, err := io.ReadAll(extensionFile)
-		_ = extensionFile.Close()
+		if cerr := extensionFile.Close(); cerr != nil {
+			log.Println("Error closing file:", cerr)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to read file %s: %w", file.Name(), err)
 		}

--- a/snmp-discovery/data/lookup_extensions.go
+++ b/snmp-discovery/data/lookup_extensions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -96,7 +97,11 @@ type ManufacturerResolver struct {
 // snmp-discovery lookup_extensions/*.yaml and (b) every *.yaml/*.yml file
 // under userDir (if non-empty). User overrides take precedence over
 // built-in extension overrides, which take precedence over the IANA catalog.
-func NewManufacturerResolver(builtin ManufacturerRetriever, userDir string) (*ManufacturerResolver, error) {
+//
+// logger receives non-fatal warnings emitted while loading user override
+// files (missing directory, unreadable file, malformed YAML). A nil logger
+// is permitted; warnings are silently dropped in that case.
+func NewManufacturerResolver(builtin ManufacturerRetriever, userDir string, logger *slog.Logger) (*ManufacturerResolver, error) {
 	overrides := make(map[string]string)
 
 	if err := loadBuiltInManufacturerOverrides(overrides); err != nil {
@@ -104,7 +109,7 @@ func NewManufacturerResolver(builtin ManufacturerRetriever, userDir string) (*Ma
 	}
 
 	if userDir != "" {
-		if err := loadUserManufacturerOverrides(userDir, overrides); err != nil {
+		if err := loadUserManufacturerOverrides(userDir, overrides, logger); err != nil {
 			return nil, err
 		}
 	}
@@ -150,12 +155,10 @@ func loadBuiltInManufacturerOverrides(overrides map[string]string) error {
 	return nil
 }
 
-func loadUserManufacturerOverrides(dir string, overrides map[string]string) error {
+func loadUserManufacturerOverrides(dir string, overrides map[string]string, logger *slog.Logger) error {
 	files, err := os.ReadDir(dir)
 	if err != nil {
-		safeDir := strings.ReplaceAll(dir, "\n", "")
-		safeDir = strings.ReplaceAll(safeDir, "\r", "")
-		log.Printf("Warning: failed to read manufacturer overrides directory %s: %v", safeDir, err)
+		warn(logger, "failed to read manufacturer overrides directory", "directory", dir, "error", err)
 		return nil
 	}
 	for _, file := range files {
@@ -165,16 +168,27 @@ func loadUserManufacturerOverrides(dir string, overrides map[string]string) erro
 		filePath := filepath.Join(dir, file.Name())
 		fileData, err := os.ReadFile(filePath)
 		if err != nil {
-			return fmt.Errorf("failed to read file %s: %w", filePath, err)
+			// Soft-fail per file: a single unreadable file must not
+			// drop every other override (including built-in extension
+			// blocks already merged into overrides above).
+			warn(logger, "failed to read manufacturer overrides file", "file", filePath, "error", err)
+			continue
 		}
 		if err := loadManufacturerYAML(fileData, overrides); err != nil {
-			safePath := strings.ReplaceAll(filePath, "\n", "")
-			safePath = strings.ReplaceAll(safePath, "\r", "")
-			log.Printf("Warning: failed to load manufacturer overrides from %s: %v", safePath, err)
+			warn(logger, "failed to load manufacturer overrides", "file", filePath, "error", err)
 			continue
 		}
 	}
 	return nil
+}
+
+// warn forwards a structured warning to logger, or silently drops it when
+// logger is nil. Centralizes the nil-check so call sites stay terse.
+func warn(logger *slog.Logger, msg string, args ...any) {
+	if logger == nil {
+		return
+	}
+	logger.Warn(msg, args...)
 }
 
 // loadManufacturerYAML parses the optional manufacturers: block from a

--- a/snmp-discovery/data/lookup_extensions.go
+++ b/snmp-discovery/data/lookup_extensions.go
@@ -283,11 +283,28 @@ type DeviceLookup struct {
 	devicesByVendor map[string]deviceRef
 }
 
+// lookupOIDBothSpellings indexes m by oid, accepting either leading-dot or
+// no-leading-dot spellings since callers and YAML authors may disagree.
+func lookupOIDBothSpellings[V any](m map[string]V, oid string) (V, bool) {
+	if v, ok := m[oid]; ok {
+		return v, true
+	}
+	alt := strings.TrimPrefix(oid, ".")
+	if v, ok := m[alt]; ok {
+		return v, true
+	}
+	if v, ok := m["."+alt]; ok {
+		return v, true
+	}
+	var zero V
+	return zero, false
+}
+
 // GetDevice returns the device name for a given device OID using only the
 // static catalog. Dynamic references cannot be resolved without a walked
 // OID map; callers that need them must use GetDeviceModel.
 func (d *DeviceLookup) GetDevice(deviceOID string) (string, error) {
-	ref, ok := d.devicesByVendor[deviceOID]
+	ref, ok := lookupOIDBothSpellings(d.devicesByVendor, deviceOID)
 	if !ok {
 		return "", fmt.Errorf("device ID %s not found", deviceOID)
 	}
@@ -306,23 +323,14 @@ func (d *DeviceLookup) GetDevice(deviceOID string) (string, error) {
 // dynamic references (e.g. a shared sysObjectID that indexes into
 // sysDescr) can resolve without performing extra SNMP traffic.
 func (d *DeviceLookup) GetDeviceModel(deviceOID string, walked map[string]string) (string, error) {
-	ref, ok := d.devicesByVendor[deviceOID]
+	ref, ok := lookupOIDBothSpellings(d.devicesByVendor, deviceOID)
 	if !ok {
 		return "", fmt.Errorf("device ID %s not found", deviceOID)
 	}
 	if ref.kind == devRefStatic {
 		return ref.literal, nil
 	}
-	value, ok := walked[ref.sourceOID]
-	if !ok {
-		// Accept leading-dot and no-leading-dot spellings since callers
-		// may normalize differently than the YAML author did.
-		alt := strings.TrimPrefix(ref.sourceOID, ".")
-		value, ok = walked[alt]
-		if !ok {
-			value, ok = walked["."+alt]
-		}
-	}
+	value, ok := lookupOIDBothSpellings(walked, ref.sourceOID)
 	if !ok {
 		return "", fmt.Errorf("device ID %s references walked OID %s which was not found in the walk set", deviceOID, ref.sourceOID)
 	}

--- a/snmp-discovery/data/lookup_extensions.go
+++ b/snmp-discovery/data/lookup_extensions.go
@@ -330,12 +330,10 @@ func loadBuiltInExtensions(devicesByVendor map[string]deviceRef) error {
 			return fmt.Errorf("failed to open file %s: %w", file.Name(), err)
 		}
 
-		defer func() {
-			if err := extensionFile.Close(); err != nil {
-				log.Println("Error closing file:", err)
-			}
-		}()
 		extensionFileData, err := io.ReadAll(extensionFile)
+		if cerr := extensionFile.Close(); cerr != nil {
+			log.Println("Error closing file:", cerr)
+		}
 		if err != nil {
 			return fmt.Errorf("failed to read file %s: %w", file.Name(), err)
 		}

--- a/snmp-discovery/data/lookup_extensions.go
+++ b/snmp-discovery/data/lookup_extensions.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -138,7 +139,7 @@ func loadBuiltInManufacturerOverrides(overrides map[string]string) error {
 		if !isLookupExtensionFile(file) {
 			continue
 		}
-		filePath := filepath.Join("lookup_extensions", file.Name())
+		filePath := path.Join("lookup_extensions", file.Name())
 		extensionFile, err := lookupExtensionsData.Open(filePath)
 		if err != nil {
 			return fmt.Errorf("failed to open file %s: %w", file.Name(), err)
@@ -338,7 +339,7 @@ func loadBuiltInExtensions(devicesByVendor map[string]deviceRef) error {
 			continue
 		}
 
-		filePath := filepath.Join("lookup_extensions", file.Name())
+		filePath := path.Join("lookup_extensions", file.Name())
 		extensionFile, err := lookupExtensionsData.Open(filePath)
 		if err != nil {
 			return fmt.Errorf("failed to open file %s: %w", file.Name(), err)

--- a/snmp-discovery/data/lookup_extensions.go
+++ b/snmp-discovery/data/lookup_extensions.go
@@ -152,7 +152,10 @@ func loadBuiltInManufacturerOverrides(overrides map[string]string) error {
 func loadUserManufacturerOverrides(dir string, overrides map[string]string) error {
 	files, err := os.ReadDir(dir)
 	if err != nil {
-		return fmt.Errorf("failed to read directory %s: %w", dir, err)
+		safeDir := strings.ReplaceAll(dir, "\n", "")
+		safeDir = strings.ReplaceAll(safeDir, "\r", "")
+		log.Printf("Warning: failed to read manufacturer overrides directory %s: %v", safeDir, err)
+		return nil
 	}
 	for _, file := range files {
 		if !isLookupExtensionFile(file) {

--- a/snmp-discovery/data/lookup_extensions.go
+++ b/snmp-discovery/data/lookup_extensions.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 
 	"gopkg.in/yaml.v3"
 )
@@ -99,14 +100,21 @@ type ManufacturerResolver struct {
 // under userDir (if non-empty). User overrides take precedence over
 // built-in extension overrides, which take precedence over the IANA catalog.
 //
+// The built-in extension scan is parsed once per process and cached, so
+// callers (including per-policy StartPolicy invocations) only pay the
+// userDir merge cost on subsequent constructions.
+//
 // logger receives non-fatal warnings emitted while loading user override
 // files (missing directory, unreadable file, malformed YAML). A nil logger
 // is permitted; warnings are silently dropped in that case.
 func NewManufacturerResolver(builtin ManufacturerRetriever, userDir string, logger *slog.Logger) (*ManufacturerResolver, error) {
-	overrides := make(map[string]string)
-
-	if err := loadBuiltInManufacturerOverrides(overrides); err != nil {
+	cached, err := getBuiltInManufacturerOverrides()
+	if err != nil {
 		return nil, err
+	}
+	overrides := make(map[string]string, len(cached))
+	for k, v := range cached {
+		overrides[k] = v
 	}
 
 	if userDir != "" {
@@ -119,6 +127,28 @@ func NewManufacturerResolver(builtin ManufacturerRetriever, userDir string, logg
 		builtin:   builtin,
 		overrides: overrides,
 	}, nil
+}
+
+// getBuiltInManufacturerOverrides parses the embedded lookup_extensions/*.yaml
+// manufacturers blocks once per process and returns the cached map. The
+// returned map is not safe to mutate — callers must clone before merging
+// user overrides.
+var (
+	builtInManufacturerOverridesOnce sync.Once
+	builtInManufacturerOverrides     map[string]string
+	builtInManufacturerOverridesErr  error
+)
+
+func getBuiltInManufacturerOverrides() (map[string]string, error) {
+	builtInManufacturerOverridesOnce.Do(func() {
+		overrides := make(map[string]string)
+		if err := loadBuiltInManufacturerOverrides(overrides); err != nil {
+			builtInManufacturerOverridesErr = err
+			return
+		}
+		builtInManufacturerOverrides = overrides
+	})
+	return builtInManufacturerOverrides, builtInManufacturerOverridesErr
 }
 
 // GetManufacturer returns the manufacturer name for an IANA PEN, honoring
@@ -146,7 +176,7 @@ func loadBuiltInManufacturerOverrides(overrides map[string]string) error {
 		}
 		fileData, err := io.ReadAll(extensionFile)
 		if cerr := extensionFile.Close(); cerr != nil {
-			log.Println("Error closing file:", cerr)
+			log.Printf("Error closing file %s: %v", filePath, cerr)
 		}
 		if err != nil {
 			return fmt.Errorf("failed to read file %s: %w", file.Name(), err)
@@ -349,7 +379,7 @@ func loadBuiltInExtensions(devicesByVendor map[string]deviceRef) error {
 
 		extensionFileData, err := io.ReadAll(extensionFile)
 		if cerr := extensionFile.Close(); cerr != nil {
-			log.Println("Error closing file:", cerr)
+			log.Printf("Error closing file %s: %v", filePath, cerr)
 		}
 		if err != nil {
 			return fmt.Errorf("failed to read file %s: %w", file.Name(), err)

--- a/snmp-discovery/data/lookup_extensions.go
+++ b/snmp-discovery/data/lookup_extensions.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -192,22 +193,98 @@ func loadManufacturerYAML(fileData []byte, overrides map[string]string) error {
 	return nil
 }
 
-// DeviceRetriever is an interface that provides a method to retrieve device information by device OID
+// devRefKind discriminates a devices[] map value between a literal model
+// string and an already-walked OID reference whose value becomes the model.
+type devRefKind uint8
+
+const (
+	devRefStatic devRefKind = iota
+	devRefDynamic
+)
+
+// deviceRef is the stored form of a lookup_extensions devices[] entry after
+// the loader classifies the raw YAML value.
+type deviceRef struct {
+	kind      devRefKind
+	literal   string // populated when kind == devRefStatic
+	sourceOID string // populated when kind == devRefDynamic; format: ".1.3.6..." or "1.3.6..."
+}
+
+// oidPattern matches an SNMP numeric OID (optionally leading dot).
+// Any map value that matches is treated as a dynamic reference.
+var oidPattern = regexp.MustCompile(`^\.?\d+(\.\d+)+$`)
+
+func classifyDeviceValue(value string) deviceRef {
+	if oidPattern.MatchString(value) {
+		return deviceRef{kind: devRefDynamic, sourceOID: value}
+	}
+	return deviceRef{kind: devRefStatic, literal: value}
+}
+
+// DeviceRetriever is an interface that provides methods to retrieve device
+// information by device OID. GetDevice returns the model name for static
+// entries only and is preserved for backward compatibility. GetDeviceModel
+// additionally resolves dynamic references (where the YAML value is an
+// OID whose walked value is the model name).
 type DeviceRetriever interface {
 	GetDevice(deviceOID string) (string, error)
+	GetDeviceModel(deviceOID string, walked map[string]string) (string, error)
 }
 
-// DeviceLookup represents a device lookup service
+// DeviceLookup represents a device lookup service.
 type DeviceLookup struct {
-	devicesByVendor *map[string]string
+	devicesByVendor map[string]deviceRef
 }
 
-// GetDevice returns the device name for given device OID
+// GetDevice returns the device name for a given device OID using only the
+// static catalog. Dynamic references cannot be resolved without a walked
+// OID map; callers that need them must use GetDeviceModel.
 func (d *DeviceLookup) GetDevice(deviceOID string) (string, error) {
-	if device, ok := (*d.devicesByVendor)[deviceOID]; ok {
-		return device, nil
+	ref, ok := d.devicesByVendor[deviceOID]
+	if !ok {
+		return "", fmt.Errorf("device ID %s not found", deviceOID)
 	}
-	return "", fmt.Errorf("device ID %s not found", deviceOID)
+	if ref.kind == devRefStatic {
+		return ref.literal, nil
+	}
+	return "", fmt.Errorf("device ID %s resolves dynamically; call GetDeviceModel", deviceOID)
+}
+
+// GetDeviceModel resolves a device model name. For static entries it returns
+// the literal; for dynamic entries it reads walked[sourceOID], trims null
+// bytes and whitespace, and returns the result (or an error if the source
+// OID is missing or empty).
+//
+// Callers pass the walked OID->string map for the current scan so that
+// dynamic references (e.g. a shared sysObjectID that indexes into
+// sysDescr) can resolve without performing extra SNMP traffic.
+func (d *DeviceLookup) GetDeviceModel(deviceOID string, walked map[string]string) (string, error) {
+	ref, ok := d.devicesByVendor[deviceOID]
+	if !ok {
+		return "", fmt.Errorf("device ID %s not found", deviceOID)
+	}
+	if ref.kind == devRefStatic {
+		return ref.literal, nil
+	}
+	value, ok := walked[ref.sourceOID]
+	if !ok {
+		// Accept leading-dot and no-leading-dot spellings since callers
+		// may normalize differently than the YAML author did.
+		alt := strings.TrimPrefix(ref.sourceOID, ".")
+		value, ok = walked[alt]
+		if !ok {
+			value, ok = walked["."+alt]
+		}
+	}
+	if !ok {
+		return "", fmt.Errorf("device ID %s references walked OID %s which was not found in the walk set", deviceOID, ref.sourceOID)
+	}
+	trimmed := strings.TrimRight(value, "\x00 \t\n\r")
+	trimmed = strings.TrimLeft(trimmed, " \t\n\r")
+	if trimmed == "" {
+		return "", fmt.Errorf("device ID %s references walked OID %s whose value is empty", deviceOID, ref.sourceOID)
+	}
+	return trimmed, nil
 }
 
 //go:embed lookup_extensions/*.yaml
@@ -215,19 +292,19 @@ var lookupExtensionsData embed.FS
 
 // LoadDeviceLookupExtensions loads device data from YAML files in the specified directory
 func LoadDeviceLookupExtensions(dir string) (*DeviceLookup, error) {
-	devicesByVendor := make(map[string]string)
+	devicesByVendor := make(map[string]deviceRef)
 	deviceLookup := DeviceLookup{
-		devicesByVendor: &devicesByVendor,
+		devicesByVendor: devicesByVendor,
 	}
 
-	err := loadBuiltInExtensions(&devicesByVendor)
+	err := loadBuiltInExtensions(devicesByVendor)
 	if err != nil {
 		return &deviceLookup, err
 	}
 
 	if dir != "" {
 		// Extend built in extensions with user provided extensions
-		err = loadUserProvidedExtensions(dir, &devicesByVendor)
+		err = loadUserProvidedExtensions(dir, devicesByVendor)
 		if err != nil {
 			return &deviceLookup, err
 		}
@@ -236,7 +313,7 @@ func LoadDeviceLookupExtensions(dir string) (*DeviceLookup, error) {
 	return &deviceLookup, nil
 }
 
-func loadBuiltInExtensions(devicesByVendor *map[string]string) error {
+func loadBuiltInExtensions(devicesByVendor map[string]deviceRef) error {
 	files, err := lookupExtensionsData.ReadDir("lookup_extensions")
 	if err != nil {
 		return fmt.Errorf("failed to read directory %s: %w", "lookup_extensions", err)
@@ -270,7 +347,7 @@ func loadBuiltInExtensions(devicesByVendor *map[string]string) error {
 	return nil
 }
 
-func loadUserProvidedExtensions(dir string, devicesByVendor *map[string]string) error {
+func loadUserProvidedExtensions(dir string, devicesByVendor map[string]deviceRef) error {
 	// Read all files in the directory
 	files, err := os.ReadDir(dir)
 	if err != nil {
@@ -307,8 +384,10 @@ func isLookupExtensionFile(file os.DirEntry) bool {
 			strings.HasSuffix(strings.ToLower(file.Name()), ".yml"))
 }
 
-// loadYAMLFile loads a single YAML file and merges its data into devicesByVendor
-func loadYAMLFile(data []byte, devicesByVendor *map[string]string) error {
+// loadYAMLFile loads a single YAML file and merges its data into
+// devicesByVendor, classifying each value as a static literal or a
+// dynamic OID reference.
+func loadYAMLFile(data []byte, devicesByVendor map[string]deviceRef) error {
 	var fileData struct {
 		Devices map[string]string `yaml:"devices"`
 	}
@@ -317,9 +396,8 @@ func loadYAMLFile(data []byte, devicesByVendor *map[string]string) error {
 		return fmt.Errorf("failed to parse YAML: %w", err)
 	}
 
-	// Merge the data into devicesByVendor
-	for deviceOID, deviceName := range fileData.Devices {
-		(*devicesByVendor)[deviceOID] = deviceName
+	for deviceOID, deviceValue := range fileData.Devices {
+		devicesByVendor[deviceOID] = classifyDeviceValue(deviceValue)
 	}
 
 	return nil

--- a/snmp-discovery/data/lookup_extensions.go
+++ b/snmp-discovery/data/lookup_extensions.go
@@ -81,6 +81,114 @@ func (m *ManufacturerLookup) GetManufacturer(id string) (string, error) {
 	return "", fmt.Errorf("manufacturer not found")
 }
 
+// ManufacturerResolver wraps a built-in ManufacturerLookup with user-supplied
+// overrides loaded from lookup_extensions YAML files. Overrides are keyed by
+// IANA PEN (integer encoded as a string) and consulted first; if no override
+// matches, the lookup falls back to the built-in catalog.
+type ManufacturerResolver struct {
+	builtin   ManufacturerRetriever
+	overrides map[string]string
+}
+
+// NewManufacturerResolver builds a resolver from the given built-in lookup,
+// merging the optional manufacturers: blocks from (a) the embedded
+// snmp-discovery lookup_extensions/*.yaml and (b) every *.yaml/*.yml file
+// under userDir (if non-empty). User overrides take precedence over
+// built-in extension overrides, which take precedence over the IANA catalog.
+func NewManufacturerResolver(builtin ManufacturerRetriever, userDir string) (*ManufacturerResolver, error) {
+	overrides := make(map[string]string)
+
+	if err := loadBuiltInManufacturerOverrides(overrides); err != nil {
+		return nil, err
+	}
+
+	if userDir != "" {
+		if err := loadUserManufacturerOverrides(userDir, overrides); err != nil {
+			return nil, err
+		}
+	}
+
+	return &ManufacturerResolver{
+		builtin:   builtin,
+		overrides: overrides,
+	}, nil
+}
+
+// GetManufacturer returns the manufacturer name for an IANA PEN, honoring
+// user/extension overrides before falling back to the built-in catalog.
+func (r *ManufacturerResolver) GetManufacturer(id string) (string, error) {
+	if name, ok := r.overrides[id]; ok {
+		return name, nil
+	}
+	return r.builtin.GetManufacturer(id)
+}
+
+func loadBuiltInManufacturerOverrides(overrides map[string]string) error {
+	files, err := lookupExtensionsData.ReadDir("lookup_extensions")
+	if err != nil {
+		return fmt.Errorf("failed to read directory lookup_extensions: %w", err)
+	}
+	for _, file := range files {
+		if !isLookupExtensionFile(file) {
+			continue
+		}
+		filePath := filepath.Join("lookup_extensions", file.Name())
+		extensionFile, err := lookupExtensionsData.Open(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to open file %s: %w", file.Name(), err)
+		}
+		fileData, err := io.ReadAll(extensionFile)
+		_ = extensionFile.Close()
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", file.Name(), err)
+		}
+		if err := loadManufacturerYAML(fileData, overrides); err != nil {
+			return fmt.Errorf("failed to load manufacturers from %s: %w", file.Name(), err)
+		}
+	}
+	return nil
+}
+
+func loadUserManufacturerOverrides(dir string, overrides map[string]string) error {
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("failed to read directory %s: %w", dir, err)
+	}
+	for _, file := range files {
+		if !isLookupExtensionFile(file) {
+			continue
+		}
+		filePath := filepath.Join(dir, file.Name())
+		fileData, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %w", filePath, err)
+		}
+		if err := loadManufacturerYAML(fileData, overrides); err != nil {
+			safePath := strings.ReplaceAll(filePath, "\n", "")
+			safePath = strings.ReplaceAll(safePath, "\r", "")
+			log.Printf("Warning: failed to load manufacturer overrides from %s: %v", safePath, err)
+			continue
+		}
+	}
+	return nil
+}
+
+// loadManufacturerYAML parses the optional manufacturers: block from a
+// lookup-extension YAML file and merges it into overrides. Files without
+// the block are silently ignored (they only carry devices:).
+func loadManufacturerYAML(fileData []byte, overrides map[string]string) error {
+	var parsed struct {
+		Manufacturers map[string]string `yaml:"manufacturers"`
+	}
+	if err := yaml.Unmarshal(fileData, &parsed); err != nil {
+		return fmt.Errorf("failed to parse YAML: %w", err)
+	}
+	for id, name := range parsed.Manufacturers {
+		overrides[id] = name
+	}
+	return nil
+}
+
 // DeviceRetriever is an interface that provides a method to retrieve device information by device OID
 type DeviceRetriever interface {
 	GetDevice(deviceOID string) (string, error)

--- a/snmp-discovery/data/lookup_extensions.go
+++ b/snmp-discovery/data/lookup_extensions.go
@@ -280,7 +280,7 @@ func (d *DeviceLookup) GetDeviceModel(deviceOID string, walked map[string]string
 		return "", fmt.Errorf("device ID %s references walked OID %s which was not found in the walk set", deviceOID, ref.sourceOID)
 	}
 	trimmed := strings.TrimRight(value, "\x00 \t\n\r")
-	trimmed = strings.TrimLeft(trimmed, " \t\n\r")
+	trimmed = strings.TrimLeft(trimmed, "\x00 \t\n\r")
 	if trimmed == "" {
 		return "", fmt.Errorf("device ID %s references walked OID %s whose value is empty", deviceOID, ref.sourceOID)
 	}

--- a/snmp-discovery/data/lookup_extensions/mikrotik.yaml
+++ b/snmp-discovery/data/lookup_extensions/mikrotik.yaml
@@ -1,4 +1,6 @@
 devices:
   # MikroTik devices (enterprise 14988)
-  .1.3.6.1.4.1.14988.1: mikrotikRouter
+  # .1.3.6.1.4.1.14988.1 covers all RouterOS devices; the actual model
+  # name is read at runtime from sysDescr (.1.3.6.1.2.1.1.1.0).
+  .1.3.6.1.4.1.14988.1: .1.3.6.1.2.1.1.1.0
   .1.3.6.1.4.1.14988.2: mikrotikSwOSSwitch

--- a/snmp-discovery/data/lookup_extensions/mikrotik.yaml
+++ b/snmp-discovery/data/lookup_extensions/mikrotik.yaml
@@ -1,6 +1,9 @@
 devices:
   # MikroTik devices (enterprise 14988)
-  # .1.3.6.1.4.1.14988.1 covers all RouterOS devices; the actual model
-  # name is read at runtime from sysDescr (.1.3.6.1.2.1.1.1.0).
-  .1.3.6.1.4.1.14988.1: .1.3.6.1.2.1.1.1.0
+  # .1.3.6.1.4.1.14988.1 covers every RouterOS model. The bundled
+  # mapping keeps the historical static "mikrotikRouter" string for
+  # backward compatibility; operators who want a per-device model
+  # name can shadow this entry from lookup_extensions_dir with a
+  # dynamic ref pointing at sysDescr (.1.3.6.1.2.1.1.1.0).
+  .1.3.6.1.4.1.14988.1: mikrotikRouter
   .1.3.6.1.4.1.14988.2: mikrotikSwOSSwitch

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -550,6 +550,71 @@ func TestEmbeddedLookupExtensions_AllOIDsMappedCorrectly(t *testing.T) {
 	}
 }
 
+func TestManufacturerResolver_UserOverrideWins(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "custom.yaml"), []byte(`
+manufacturers:
+  "9": "Cisco Systems"
+  "14823": "Aruba"
+`), 0o644)
+	require.NoError(t, err)
+
+	builtin, err := NewManufacturerLookup()
+	require.NoError(t, err)
+
+	resolver, err := NewManufacturerResolver(builtin, dir)
+	require.NoError(t, err)
+
+	got, err := resolver.GetManufacturer("9")
+	require.NoError(t, err)
+	assert.Equal(t, "Cisco Systems", got)
+
+	got, err = resolver.GetManufacturer("14823")
+	require.NoError(t, err)
+	assert.Equal(t, "Aruba", got)
+}
+
+func TestManufacturerResolver_FallsBackToBuiltin(t *testing.T) {
+	dir := t.TempDir()
+	builtin, err := NewManufacturerLookup()
+	require.NoError(t, err)
+
+	resolver, err := NewManufacturerResolver(builtin, dir)
+	require.NoError(t, err)
+
+	// PEN 9 is ciscoSystems in the shipped manufacturers.yaml; no user
+	// override was written, so the built-in value must flow through.
+	got, err := resolver.GetManufacturer("9")
+	require.NoError(t, err)
+	assert.Equal(t, "ciscoSystems", got)
+}
+
+func TestManufacturerResolver_BuiltinExtensionFileManufacturers(t *testing.T) {
+	// A built-in lookup_extensions/*.yaml file may ship its own
+	// manufacturers: block. This test asserts the loader picks it up
+	// without requiring a user dir.
+	builtin, err := NewManufacturerLookup()
+	require.NoError(t, err)
+
+	resolver, err := NewManufacturerResolver(builtin, "")
+	require.NoError(t, err)
+
+	// Sanity: builtin PEN 9 -> "ciscoSystems" still flows through.
+	got, err := resolver.GetManufacturer("9")
+	require.NoError(t, err)
+	assert.Equal(t, "ciscoSystems", got)
+}
+
+func TestManufacturerResolver_UnknownPENBubblesError(t *testing.T) {
+	builtin, err := NewManufacturerLookup()
+	require.NoError(t, err)
+	resolver, err := NewManufacturerResolver(builtin, "")
+	require.NoError(t, err)
+
+	_, err = resolver.GetManufacturer("999999999")
+	require.Error(t, err)
+}
+
 func TestLoadYAMLFile(t *testing.T) {
 	// Create a temporary directory for test files
 	tempDir, err := os.MkdirTemp("", "yaml_file_test")

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -747,6 +747,35 @@ func TestDeviceLookup_GetDevice_BackwardCompatibleLiteral(t *testing.T) {
 	assert.Equal(t, "f5BIGIPi10800", got)
 }
 
+// Embedded YAML keys carry leading dots (e.g. ".1.3.6.1.4.1...") but
+// callers may pass either spelling depending on how their SNMP layer
+// formats OIDs. Both Get* methods must normalize.
+func TestDeviceLookup_GetDevice_NoLeadingDotMatches(t *testing.T) {
+	deviceLookup, err := LoadDeviceLookupExtensions("")
+	require.NoError(t, err)
+	got, err := deviceLookup.GetDevice("1.3.6.1.4.1.3375.2.1.3.4.113")
+	require.NoError(t, err, "GetDevice should accept the no-leading-dot spelling for a YAML key written with a leading dot")
+	assert.Equal(t, "f5BIGIPi10800", got)
+}
+
+func TestDeviceLookup_GetDeviceModel_DeviceOIDNoLeadingDotMatches(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "custom.yaml"), []byte(`
+devices:
+  ".1.3.6.1.4.1.99994.1": .1.3.6.1.2.1.1.1.0
+`), 0o644)
+	require.NoError(t, err)
+
+	deviceLookup, err := LoadDeviceLookupExtensions(dir)
+	require.NoError(t, err)
+
+	walked := map[string]string{".1.3.6.1.2.1.1.1.0": "RouterOS X"}
+	// Caller passes deviceOID *without* the leading dot present in YAML.
+	got, err := deviceLookup.GetDeviceModel("1.3.6.1.4.1.99994.1", walked)
+	require.NoError(t, err, "GetDeviceModel must normalize deviceOID dot spelling against the loaded keys")
+	assert.Equal(t, "RouterOS X", got)
+}
+
 func TestLoadYAMLFile(t *testing.T) {
 	// Create a temporary directory for test files
 	tempDir, err := os.MkdirTemp("", "yaml_file_test")

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -171,9 +171,9 @@ func TestManufacturerLookup_EdgeCases(t *testing.T) {
 func TestDeviceLookup_GetDevice(t *testing.T) {
 	// Create a test DeviceLookup with sample data
 	deviceLookup := &DeviceLookup{
-		devicesByVendor: &map[string]string{
-			"1.3.6.1.4.1.9.1.1234": "Test Device A",
-			"1.3.6.1.4.1.9.1.4321": "Test Device B",
+		devicesByVendor: map[string]deviceRef{
+			"1.3.6.1.4.1.9.1.1234": {kind: devRefStatic, literal: "Test Device A"},
+			"1.3.6.1.4.1.9.1.4321": {kind: devRefStatic, literal: "Test Device B"},
 		},
 	}
 
@@ -314,7 +314,11 @@ func TestLoadDeviceLookupExtensions(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, deviceLookup)
-				assert.Equal(t, tt.expected["1.3.6.1.4.1.9.1.1234"], (*deviceLookup.devicesByVendor)["1.3.6.1.4.1.9.1.1234"])
+				if wantModel, ok := tt.expected["1.3.6.1.4.1.9.1.1234"]; ok {
+					got, getErr := deviceLookup.GetDevice("1.3.6.1.4.1.9.1.1234")
+					assert.NoError(t, getErr)
+					assert.Equal(t, wantModel, got)
+				}
 			}
 		})
 	}
@@ -376,10 +380,9 @@ func TestLoadDeviceLookupExtensions_InvalidYAML(t *testing.T) {
 	assert.NotNil(t, deviceLookup)
 
 	// Should only contain data from valid file
-	expected := map[string]string{
-		"1.3.6.1.4.1.9.1.1234": "Valid Device",
-	}
-	assert.Equal(t, expected["1.3.6.1.4.1.9.1.1234"], (*deviceLookup.devicesByVendor)["1.3.6.1.4.1.9.1.1234"])
+	got, getErr := deviceLookup.GetDevice("1.3.6.1.4.1.9.1.1234")
+	assert.NoError(t, getErr)
+	assert.Equal(t, "Valid Device", got)
 }
 
 func TestIsLookupExtensionFile(t *testing.T) {
@@ -483,7 +486,7 @@ func TestEmbeddedLookupExtensions_DataIntegrity(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, deviceLookup)
 
-	count := len(*deviceLookup.devicesByVendor)
+	count := len(deviceLookup.devicesByVendor)
 	assert.Greater(t, count, 500, "Expected at least 500 device entries across all embedded lookup files")
 }
 
@@ -541,6 +544,11 @@ func TestEmbeddedLookupExtensions_AllOIDsMappedCorrectly(t *testing.T) {
 
 		for oid, expectedModel := range fileData.Devices {
 			oid, expectedModel := oid, expectedModel // capture loop vars
+			// Dynamic entries (YAML value is itself an OID) cannot be
+			// resolved by GetDevice alone; skip them here.
+			if oidPattern.MatchString(expectedModel) {
+				continue
+			}
 			t.Run(fmt.Sprintf("%s/%s", file.Name(), oid), func(t *testing.T) {
 				got, err := deviceLookup.GetDevice(oid)
 				assert.NoError(t, err, "OID %s from %s should be found in the lookup", oid, file.Name())
@@ -631,6 +639,73 @@ func TestManufacturerResolver_MissingUserDirIsSoftError(t *testing.T) {
 	assert.Equal(t, "ciscoSystems", got)
 }
 
+func TestDeviceLookup_GetDeviceModel_Static(t *testing.T) {
+	deviceLookup, err := LoadDeviceLookupExtensions("")
+	require.NoError(t, err)
+
+	got, err := deviceLookup.GetDeviceModel(".1.3.6.1.4.1.3375.2.1.3.4.113", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "f5BIGIPi10800", got)
+}
+
+func TestDeviceLookup_GetDeviceModel_DynamicRef(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "custom.yaml"), []byte(`
+devices:
+  ".1.3.6.1.4.1.99999.1": .1.3.6.1.2.1.1.1.0
+`), 0o644)
+	require.NoError(t, err)
+
+	deviceLookup, err := LoadDeviceLookupExtensions(dir)
+	require.NoError(t, err)
+
+	walked := map[string]string{
+		".1.3.6.1.2.1.1.1.0": "RouterOS CCR2004-16G-2S+",
+	}
+	got, err := deviceLookup.GetDeviceModel(".1.3.6.1.4.1.99999.1", walked)
+	require.NoError(t, err)
+	assert.Equal(t, "RouterOS CCR2004-16G-2S+", got)
+}
+
+func TestDeviceLookup_GetDeviceModel_DynamicRefMissingFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "custom.yaml"), []byte(`
+devices:
+  ".1.3.6.1.4.1.99998.1": .1.3.6.1.2.1.1.1.0
+`), 0o644)
+	require.NoError(t, err)
+
+	deviceLookup, err := LoadDeviceLookupExtensions(dir)
+	require.NoError(t, err)
+
+	_, err = deviceLookup.GetDeviceModel(".1.3.6.1.4.1.99998.1", map[string]string{})
+	require.Error(t, err)
+}
+
+func TestDeviceLookup_GetDeviceModel_DynamicRefEmptyValueFallsBack(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "custom.yaml"), []byte(`
+devices:
+  ".1.3.6.1.4.1.99997.1": .1.3.6.1.2.1.1.1.0
+`), 0o644)
+	require.NoError(t, err)
+
+	deviceLookup, err := LoadDeviceLookupExtensions(dir)
+	require.NoError(t, err)
+
+	walked := map[string]string{".1.3.6.1.2.1.1.1.0": "   \x00  "}
+	_, err = deviceLookup.GetDeviceModel(".1.3.6.1.4.1.99997.1", walked)
+	require.Error(t, err, "whitespace/null-only source value must not be returned as a model")
+}
+
+func TestDeviceLookup_GetDevice_BackwardCompatibleLiteral(t *testing.T) {
+	deviceLookup, err := LoadDeviceLookupExtensions("")
+	require.NoError(t, err)
+	got, err := deviceLookup.GetDevice(".1.3.6.1.4.1.3375.2.1.3.4.113")
+	require.NoError(t, err)
+	assert.Equal(t, "f5BIGIPi10800", got)
+}
+
 func TestLoadYAMLFile(t *testing.T) {
 	// Create a temporary directory for test files
 	tempDir, err := os.MkdirTemp("", "yaml_file_test")
@@ -642,19 +717,19 @@ func TestLoadYAMLFile(t *testing.T) {
 	}()
 
 	tests := []struct {
-		name     string
-		content  string
-		initial  map[string]string
-		expected map[string]string
-		wantErr  bool
+		name            string
+		content         string
+		initialLiterals map[string]string // pre-seeded static entries
+		expectedLiteral map[string]string // oid -> expected literal for static entries
+		wantErr         bool
 	}{
 		{
 			name: "valid YAML file",
 			content: `devices:
     "1.3.6.1.4.1.9.1.1234": "Device A"
     "1.3.6.1.4.1.9.1.4321": "Device B"`,
-			initial: make(map[string]string),
-			expected: map[string]string{
+			initialLiterals: make(map[string]string),
+			expectedLiteral: map[string]string{
 				"1.3.6.1.4.1.9.1.1234": "Device A",
 				"1.3.6.1.4.1.9.1.4321": "Device B",
 			},
@@ -665,10 +740,10 @@ func TestLoadYAMLFile(t *testing.T) {
 			content: `devices:
     "1.3.6.1.4.1.9.1.1234": "Device A"
     "1.3.6.1.4.1.9.1.4321": "Device B"`,
-			initial: map[string]string{
+			initialLiterals: map[string]string{
 				"1.3.6.1.4.1.9.1.1234": "Device A",
 			},
-			expected: map[string]string{
+			expectedLiteral: map[string]string{
 				"1.3.6.1.4.1.9.1.1234": "Device A",
 				"1.3.6.1.4.1.9.1.4321": "Device B",
 			},
@@ -681,34 +756,41 @@ func TestLoadYAMLFile(t *testing.T) {
     "5678": [unclosed list
       - item1
       - item2`,
-			initial:  make(map[string]string),
-			expected: make(map[string]string),
-			wantErr:  true,
+			initialLiterals: make(map[string]string),
+			expectedLiteral: make(map[string]string),
+			wantErr:         true,
 		},
 		{
-			name:     "empty file",
-			content:  "",
-			initial:  make(map[string]string),
-			expected: make(map[string]string),
-			wantErr:  false,
+			name:            "empty file",
+			content:         "",
+			initialLiterals: make(map[string]string),
+			expectedLiteral: make(map[string]string),
+			wantErr:         false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create initial devicesByVendor map
-			devicesByVendor := make(map[string]string)
-			for k, v := range tt.initial {
-				devicesByVendor[k] = v
+			// Create initial devicesByVendor map using the internal type.
+			devicesByVendor := make(map[string]deviceRef)
+			for k, v := range tt.initialLiterals {
+				devicesByVendor[k] = deviceRef{kind: devRefStatic, literal: v}
 			}
 
 			// Test loadYAMLFile
-			err = loadYAMLFile([]byte(tt.content), &devicesByVendor)
+			err = loadYAMLFile([]byte(tt.content), devicesByVendor)
 			if tt.wantErr {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
-				assert.Equal(t, tt.expected, devicesByVendor)
+				// Verify each expected static entry.
+				for oid, want := range tt.expectedLiteral {
+					ref, ok := devicesByVendor[oid]
+					if assert.True(t, ok, "OID %s should be present", oid) {
+						assert.Equal(t, devRefStatic, ref.kind)
+						assert.Equal(t, want, ref.literal)
+					}
+				}
 			}
 		})
 	}

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -715,6 +715,29 @@ devices:
 	assert.Equal(t, "RouterOS 7.18", got)
 }
 
+func TestDeviceLookup_GetDeviceModel_DynamicRefLeadingDotNormalization(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "custom.yaml"), []byte(`
+devices:
+  ".1.3.6.1.4.1.99995.1": .1.3.6.1.2.1.1.1.0
+  ".1.3.6.1.4.1.99995.2": .1.3.6.1.2.1.1.1.0
+`), 0o644)
+	require.NoError(t, err)
+
+	deviceLookup, err := LoadDeviceLookupExtensions(dir)
+	require.NoError(t, err)
+
+	walkedNoDot := map[string]string{"1.3.6.1.2.1.1.1.0": "RouterOS A"}
+	got, err := deviceLookup.GetDeviceModel(".1.3.6.1.4.1.99995.1", walkedNoDot)
+	require.NoError(t, err, "resolver must find walked entry whose key lacks the leading dot present in YAML")
+	assert.Equal(t, "RouterOS A", got)
+
+	walkedWithDot := map[string]string{".1.3.6.1.2.1.1.1.0": "RouterOS B"}
+	got, err = deviceLookup.GetDeviceModel(".1.3.6.1.4.1.99995.2", walkedWithDot)
+	require.NoError(t, err)
+	assert.Equal(t, "RouterOS B", got)
+}
+
 func TestDeviceLookup_GetDevice_BackwardCompatibleLiteral(t *testing.T) {
 	deviceLookup, err := LoadDeviceLookupExtensions("")
 	require.NoError(t, err)

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -698,6 +698,23 @@ devices:
 	require.Error(t, err, "whitespace/null-only source value must not be returned as a model")
 }
 
+func TestDeviceLookup_GetDeviceModel_StripsLeadingNullByte(t *testing.T) {
+	dir := t.TempDir()
+	err := os.WriteFile(filepath.Join(dir, "custom.yaml"), []byte(`
+devices:
+  ".1.3.6.1.4.1.99996.1": .1.3.6.1.2.1.1.1.0
+`), 0o644)
+	require.NoError(t, err)
+
+	deviceLookup, err := LoadDeviceLookupExtensions(dir)
+	require.NoError(t, err)
+
+	walked := map[string]string{".1.3.6.1.2.1.1.1.0": "\x00\x00RouterOS 7.18"}
+	got, err := deviceLookup.GetDeviceModel(".1.3.6.1.4.1.99996.1", walked)
+	require.NoError(t, err)
+	assert.Equal(t, "RouterOS 7.18", got)
+}
+
 func TestDeviceLookup_GetDevice_BackwardCompatibleLiteral(t *testing.T) {
 	deviceLookup, err := LoadDeviceLookupExtensions("")
 	require.NoError(t, err)

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -597,17 +597,17 @@ func TestManufacturerResolver_FallsBackToBuiltin(t *testing.T) {
 	assert.Equal(t, "ciscoSystems", got)
 }
 
-func TestManufacturerResolver_BuiltinExtensionFileManufacturers(t *testing.T) {
-	// A built-in lookup_extensions/*.yaml file may ship its own
-	// manufacturers: block. This test asserts the loader picks it up
-	// without requiring a user dir.
+func TestManufacturerResolver_NoUserDirFallsBackToBuiltinCatalog(t *testing.T) {
+	// With no user override directory and no shipped manufacturers:
+	// block, the resolver must still answer lookups from the base
+	// IANA catalog. This guards against the resolver wrapping the
+	// base catalog in a way that hides its entries.
 	builtin, err := NewManufacturerLookup()
 	require.NoError(t, err)
 
 	resolver, err := NewManufacturerResolver(builtin, "")
 	require.NoError(t, err)
 
-	// Sanity: builtin PEN 9 -> "ciscoSystems" still flows through.
 	got, err := resolver.GetManufacturer("9")
 	require.NoError(t, err)
 	assert.Equal(t, "ciscoSystems", got)

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -570,7 +570,7 @@ manufacturers:
 	builtin, err := NewManufacturerLookup()
 	require.NoError(t, err)
 
-	resolver, err := NewManufacturerResolver(builtin, dir)
+	resolver, err := NewManufacturerResolver(builtin, dir, nil)
 	require.NoError(t, err)
 
 	got, err := resolver.GetManufacturer("9")
@@ -587,7 +587,7 @@ func TestManufacturerResolver_FallsBackToBuiltin(t *testing.T) {
 	builtin, err := NewManufacturerLookup()
 	require.NoError(t, err)
 
-	resolver, err := NewManufacturerResolver(builtin, dir)
+	resolver, err := NewManufacturerResolver(builtin, dir, nil)
 	require.NoError(t, err)
 
 	// PEN 9 is ciscoSystems in the shipped manufacturers.yaml; no user
@@ -605,7 +605,7 @@ func TestManufacturerResolver_NoUserDirFallsBackToBuiltinCatalog(t *testing.T) {
 	builtin, err := NewManufacturerLookup()
 	require.NoError(t, err)
 
-	resolver, err := NewManufacturerResolver(builtin, "")
+	resolver, err := NewManufacturerResolver(builtin, "", nil)
 	require.NoError(t, err)
 
 	got, err := resolver.GetManufacturer("9")
@@ -616,7 +616,7 @@ func TestManufacturerResolver_NoUserDirFallsBackToBuiltinCatalog(t *testing.T) {
 func TestManufacturerResolver_UnknownPENBubblesError(t *testing.T) {
 	builtin, err := NewManufacturerLookup()
 	require.NoError(t, err)
-	resolver, err := NewManufacturerResolver(builtin, "")
+	resolver, err := NewManufacturerResolver(builtin, "", nil)
 	require.NoError(t, err)
 
 	_, err = resolver.GetManufacturer("999999999")
@@ -629,7 +629,7 @@ func TestManufacturerResolver_MissingUserDirIsSoftError(t *testing.T) {
 
 	// A directory that does not exist must not fail construction —
 	// the resolver should degrade to built-in-only.
-	resolver, err := NewManufacturerResolver(builtin, "/this/path/does/not/exist/snmp-discovery-test")
+	resolver, err := NewManufacturerResolver(builtin, "/this/path/does/not/exist/snmp-discovery-test", nil)
 	require.NoError(t, err)
 	require.NotNil(t, resolver)
 

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -615,6 +615,22 @@ func TestManufacturerResolver_UnknownPENBubblesError(t *testing.T) {
 	require.Error(t, err)
 }
 
+func TestManufacturerResolver_MissingUserDirIsSoftError(t *testing.T) {
+	builtin, err := NewManufacturerLookup()
+	require.NoError(t, err)
+
+	// A directory that does not exist must not fail construction —
+	// the resolver should degrade to built-in-only.
+	resolver, err := NewManufacturerResolver(builtin, "/this/path/does/not/exist/snmp-discovery-test")
+	require.NoError(t, err)
+	require.NotNil(t, resolver)
+
+	// Built-in catalog still works.
+	got, err := resolver.GetManufacturer("9")
+	require.NoError(t, err)
+	assert.Equal(t, "ciscoSystems", got)
+}
+
 func TestLoadYAMLFile(t *testing.T) {
 	// Create a temporary directory for test files
 	tempDir, err := os.MkdirTemp("", "yaml_file_test")

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -3,6 +3,7 @@ package data
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"testing"
 
@@ -501,7 +502,7 @@ func TestEmbeddedLookupExtensions_NoDuplicateOIDs(t *testing.T) {
 			continue
 		}
 
-		filePath := filepath.Join("lookup_extensions", file.Name())
+		filePath := path.Join("lookup_extensions", file.Name())
 		data, err := lookupExtensionsData.ReadFile(filePath)
 		require.NoError(t, err, "file %s should be readable", file.Name())
 
@@ -533,7 +534,7 @@ func TestEmbeddedLookupExtensions_AllOIDsMappedCorrectly(t *testing.T) {
 			continue
 		}
 
-		filePath := filepath.Join("lookup_extensions", file.Name())
+		filePath := path.Join("lookup_extensions", file.Name())
 		data, err := lookupExtensionsData.ReadFile(filePath)
 		require.NoError(t, err, "file %s should be readable", file.Name())
 

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -632,6 +632,14 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 	m.logger.Debug("mapping values to device entity", "values", values, "mapping_entry", mappingEntry)
 	deviceEntity := entityRegistry.GetOrCreateEntity(EntityType(mappingEntry.Entity), CurrentDeviceIndex).(*diode.Device)
 
+	// Build the walked OID->value map once per Map() call so the
+	// "platform" branch (and any future dynamic-ref consumer) reuses
+	// the same snapshot instead of rebuilding it on every iteration.
+	walked := make(map[string]string, len(values))
+	for _, w := range values {
+		walked[w.OID] = w.Value
+	}
+
 	fieldFound := false
 	for objectID, value := range values {
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
@@ -665,18 +673,14 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 						manufacturer = value.Value
 					}
 
-					// Build the walked map once per group so a dynamic
-					// devices[] ref (e.g. MikroTik's shared sysObjectID
-					// that points at sysDescr) can resolve against
-					// already-walked OID values without any extra SNMP
-					// traffic. The MIB-II system-group scalars sysObjectID
-					// (.1.3.6.1.2.1.1.2.0) and sysDescr (.1.3.6.1.2.1.1.1.0)
+					// Resolve the device model against the walked OID
+					// snapshot built at the top of Map(). Dynamic
+					// devices[] refs (e.g. MikroTik's shared sysObjectID
+					// pointing at sysDescr) read from this snapshot
+					// without any extra SNMP traffic — the MIB-II
+					// system-group scalars sysObjectID and sysDescr
 					// share ifIndex "0" under the device mapping's
-					// identifier_size=1, so sysDescr IS present in values.
-					walked := make(map[string]string, len(values))
-					for _, w := range values {
-						walked[w.OID] = w.Value
-					}
+					// identifier_size=1, so sysDescr IS present.
 					deviceModel, err := m.deviceLookup.GetDeviceModel(value.Value, walked)
 					if err != nil {
 						m.logger.Warn("error getting device model falling back to OID", "error", err, "device_oid", value.Value)

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -665,20 +665,45 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 						manufacturer = value.Value
 					}
 
-					manufacturerEntity := diode.Manufacturer{
-						Name: &manufacturer,
+					// Build the walked map once per group so a dynamic
+					// devices[] ref (e.g. MikroTik's shared sysObjectID
+					// that points at sysDescr) can resolve against
+					// already-walked OID values without any extra SNMP
+					// traffic. The MIB-II system-group scalars sysObjectID
+					// (.1.3.6.1.2.1.1.2.0) and sysDescr (.1.3.6.1.2.1.1.1.0)
+					// share ifIndex "0" under the device mapping's
+					// identifier_size=1, so sysDescr IS present in values.
+					walked := make(map[string]string, len(values))
+					for _, w := range values {
+						walked[w.OID] = w.Value
 					}
-
-					deviceEntity.Platform = &diode.Platform{
-						Name:         &manufacturer,
-						Slug:         toSlug(&manufacturer),
-						Manufacturer: &manufacturerEntity,
-					}
-
-					deviceModel, err := m.deviceLookup.GetDevice(value.Value)
+					deviceModel, err := m.deviceLookup.GetDeviceModel(value.Value, walked)
 					if err != nil {
 						m.logger.Warn("error getting device model falling back to OID", "error", err, "device_oid", value.Value)
 						deviceModel = value.Value
+					}
+
+					// Apply per-target overrides (config.DeviceDefaults)
+					// after auto-discovery so a policy author can hard-pin
+					// any subset of {Model, Manufacturer, Platform}.
+					platformName := manufacturer
+					if defaults != nil && defaults.Device.Platform != "" {
+						platformName = defaults.Device.Platform
+					}
+					if defaults != nil && defaults.Device.Manufacturer != "" {
+						manufacturer = defaults.Device.Manufacturer
+					}
+					if defaults != nil && defaults.Device.Model != "" {
+						deviceModel = defaults.Device.Model
+					}
+
+					manufacturerEntity := diode.Manufacturer{
+						Name: &manufacturer,
+					}
+					deviceEntity.Platform = &diode.Platform{
+						Name:         &platformName,
+						Slug:         toSlug(&platformName),
+						Manufacturer: &manufacturerEntity,
 					}
 					deviceEntity.DeviceType = &diode.DeviceType{
 						Model:        &deviceModel,

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -686,12 +686,16 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 					// Apply per-target overrides (config.DeviceDefaults)
 					// after auto-discovery so a policy author can hard-pin
 					// any subset of {Model, Manufacturer, Platform}.
+					// Order matters: apply Manufacturer first so a
+					// Manufacturer-only override also flows into Platform.Name
+					// (which defaults to the manufacturer string). An
+					// explicit Platform override then wins over that.
+					if defaults != nil && defaults.Device.Manufacturer != "" {
+						manufacturer = defaults.Device.Manufacturer
+					}
 					platformName := manufacturer
 					if defaults != nil && defaults.Device.Platform != "" {
 						platformName = defaults.Device.Platform
-					}
-					if defaults != nil && defaults.Device.Manufacturer != "" {
-						manufacturer = defaults.Device.Manufacturer
 					}
 					if defaults != nil && defaults.Device.Model != "" {
 						deviceModel = defaults.Device.Model

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -3,6 +3,7 @@ package mapping_test
 import (
 	"fmt"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
@@ -2708,8 +2709,42 @@ func (m *MockDeviceLookup) GetDevice(deviceOID string) (string, error) {
 }
 
 func (m *MockDeviceLookup) GetDeviceModel(deviceOID string, walked map[string]string) (string, error) {
-	args := m.Called(deviceOID, walked)
-	return args.Get(0).(string), args.Error(1)
+	// If an explicit GetDeviceModel expectation is registered, honour it.
+	// Otherwise fall back to GetDevice so that tests written against the
+	// old interface continue to work without modification.
+	for _, call := range m.ExpectedCalls {
+		if call.Method == "GetDeviceModel" {
+			args := m.Called(deviceOID, walked)
+			return args.Get(0).(string), args.Error(1)
+		}
+	}
+	return m.GetDevice(deviceOID)
+}
+
+// FakeDynamicDeviceLookup resolves GetDeviceModel by looking up sourceOID
+// in the walked map that the mapper passes in. GetDevice is unused.
+type FakeDynamicDeviceLookup struct {
+	sourceOID string
+}
+
+func (f *FakeDynamicDeviceLookup) GetDevice(_ string) (string, error) {
+	return "", fmt.Errorf("dynamic ref; use GetDeviceModel")
+}
+
+func (f *FakeDynamicDeviceLookup) GetDeviceModel(_ string, walked map[string]string) (string, error) {
+	// Accept both leading-dot and no-leading-dot spellings, mirroring the
+	// real DeviceLookup.GetDeviceModel normalisation.
+	if v, ok := walked[f.sourceOID]; ok {
+		return v, nil
+	}
+	alt := strings.TrimPrefix(f.sourceOID, ".")
+	if v, ok := walked[alt]; ok {
+		return v, nil
+	}
+	if v, ok := walked["."+alt]; ok {
+		return v, nil
+	}
+	return "", fmt.Errorf("not found")
 }
 
 // Helper functions to create pointers
@@ -3542,4 +3577,116 @@ func TestIPAddressMapper_Map_InvalidCases(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDeviceMapper_Map_OverrideDeviceModelManufacturerPlatform(t *testing.T) {
+	logger := slog.Default()
+	registry := mapping.NewEntityRegistry(logger)
+	mapper := mapping.NewDeviceMapper(&FakeManufacturers{}, &FakeDeviceLookup{}, logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.1.2.0": {
+			OID:    "1.3.6.1.2.1.1.2.0",
+			Parent: "1.3.6.1.2.1.1.2",
+			Value:  ".1.3.6.1.4.1.9.1.2495",
+			Type:   mapping.ObjectIdentifier,
+		},
+	}
+	entry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.1.2",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{OID: "1.3.6.1.2.1.1.2", Entity: "device", Field: "platform"},
+		},
+	}
+	defaults := &config.Defaults{
+		Device: config.DeviceDefaults{
+			Model:        "C9300-48P",
+			Manufacturer: "Cisco Systems",
+			Platform:     "IOS-XE 17.9",
+		},
+	}
+	entity := mapper.Map(values, entry, registry, defaults)
+	device, ok := entity.(*diode.Device)
+	assert.True(t, ok)
+	assert.NotNil(t, device.DeviceType)
+	assert.Equal(t, "C9300-48P", *device.DeviceType.Model)
+	assert.Equal(t, "Cisco Systems", *device.DeviceType.Manufacturer.Name)
+	assert.Equal(t, "IOS-XE 17.9", *device.Platform.Name)
+	assert.Equal(t, "Cisco Systems", *device.Platform.Manufacturer.Name,
+		"Platform.Manufacturer must also follow the Manufacturer override")
+}
+
+func TestDeviceMapper_Map_OverrideModelOnlyPreservesAutoManufacturer(t *testing.T) {
+	logger := slog.Default()
+	registry := mapping.NewEntityRegistry(logger)
+	mapper := mapping.NewDeviceMapper(&FakeManufacturers{}, &FakeDeviceLookup{}, logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.1.2.0": {
+			OID:    "1.3.6.1.2.1.1.2.0",
+			Parent: "1.3.6.1.2.1.1.2",
+			Value:  ".1.3.6.1.4.1.9.1.2495",
+			Type:   mapping.ObjectIdentifier,
+		},
+	}
+	entry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.1.2",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{OID: "1.3.6.1.2.1.1.2", Entity: "device", Field: "platform"},
+		},
+	}
+	defaults := &config.Defaults{
+		Device: config.DeviceDefaults{
+			Model: "custom-model",
+			// Manufacturer + Platform intentionally unset
+		},
+	}
+	entity := mapper.Map(values, entry, registry, defaults)
+	device := entity.(*diode.Device)
+	assert.Equal(t, "custom-model", *device.DeviceType.Model)
+	// FakeManufacturers.GetManufacturer returns "Cisco"; that should flow
+	// through unchanged because Manufacturer override is empty.
+	assert.Equal(t, "Cisco", *device.DeviceType.Manufacturer.Name)
+}
+
+func TestDeviceMapper_Map_DynamicModelRefResolvedFromWalked(t *testing.T) {
+	logger := slog.Default()
+	registry := mapping.NewEntityRegistry(logger)
+	mapper := mapping.NewDeviceMapper(&FakeManufacturers{}, &FakeDynamicDeviceLookup{
+		sourceOID: ".1.3.6.1.2.1.1.1.0",
+	}, logger)
+
+	// The group for ifIndex "0" (all MIB-II system group scalars) contains
+	// both the sysObjectID PDU and the sysDescr PDU; the mapper must
+	// pass the walked map through to GetDeviceModel so the dynamic ref
+	// resolves.
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.1.2.0": {
+			OID:    "1.3.6.1.2.1.1.2.0",
+			Parent: "1.3.6.1.2.1.1.2",
+			Value:  ".1.3.6.1.4.1.14988.1",
+			Type:   mapping.ObjectIdentifier,
+		},
+		"1.3.6.1.2.1.1.1.0": {
+			OID:    "1.3.6.1.2.1.1.1.0",
+			Parent: "1.3.6.1.2.1.1.1",
+			Value:  "RouterOS CCR2004-16G-2S+",
+			Type:   mapping.OctetString,
+		},
+	}
+	entry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.1.2",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{OID: "1.3.6.1.2.1.1.2", Entity: "device", Field: "platform"},
+		},
+	}
+	entity := mapper.Map(values, entry, registry, nil)
+	device := entity.(*diode.Device)
+	assert.Equal(t, "RouterOS CCR2004-16G-2S+", *device.DeviceType.Model)
 }

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -3653,6 +3653,42 @@ func TestDeviceMapper_Map_OverrideModelOnlyPreservesAutoManufacturer(t *testing.
 	assert.Equal(t, "Cisco", *device.DeviceType.Manufacturer.Name)
 }
 
+func TestDeviceMapper_Map_OverrideManufacturerOnlyFlowsIntoPlatformName(t *testing.T) {
+	logger := slog.Default()
+	registry := mapping.NewEntityRegistry(logger)
+	mapper := mapping.NewDeviceMapper(&FakeManufacturers{}, &FakeDeviceLookup{}, logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.1.2.0": {
+			OID:    "1.3.6.1.2.1.1.2.0",
+			Parent: "1.3.6.1.2.1.1.2",
+			Value:  ".1.3.6.1.4.1.9.1.2495",
+			Type:   mapping.ObjectIdentifier,
+		},
+	}
+	entry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.1.2",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{OID: "1.3.6.1.2.1.1.2", Entity: "device", Field: "platform"},
+		},
+	}
+	defaults := &config.Defaults{
+		Device: config.DeviceDefaults{
+			Manufacturer: "Cisco Systems",
+			// Platform intentionally unset: spec says Manufacturer
+			// override should also flow into Platform.Name.
+		},
+	}
+	entity := mapper.Map(values, entry, registry, defaults)
+	device := entity.(*diode.Device)
+	assert.Equal(t, "Cisco Systems", *device.DeviceType.Manufacturer.Name)
+	assert.Equal(t, "Cisco Systems", *device.Platform.Manufacturer.Name)
+	assert.Equal(t, "Cisco Systems", *device.Platform.Name,
+		"Platform.Name must track the Manufacturer override when Platform override is unset")
+}
+
 func TestDeviceMapper_Map_DynamicModelRefResolvedFromWalked(t *testing.T) {
 	logger := slog.Default()
 	registry := mapping.NewEntityRegistry(logger)

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -2707,6 +2707,11 @@ func (m *MockDeviceLookup) GetDevice(deviceOID string) (string, error) {
 	return args.Get(0).(string), args.Error(1)
 }
 
+func (m *MockDeviceLookup) GetDeviceModel(deviceOID string, walked map[string]string) (string, error) {
+	args := m.Called(deviceOID, walked)
+	return args.Get(0).(string), args.Error(1)
+}
+
 // Helper functions to create pointers
 func int64Ptr(i int64) *int64 {
 	return &i

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -26,6 +26,10 @@ func (f *FakeDeviceLookup) GetDevice(_ string) (string, error) {
 	return "cisco4000", nil
 }
 
+func (f *FakeDeviceLookup) GetDeviceModel(_ string, _ map[string]string) (string, error) {
+	return "cisco4000", nil
+}
+
 func TestMapObjectIDsToEntity(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -233,7 +233,7 @@ func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 		// the built-in catalog itself being unreadable) falls back to
 		// the built-in-only catalog so the policy can still run.
 		manufacturerRetriever := m.manufacturers
-		if resolver, err := data.NewManufacturerResolver(m.manufacturers, policy.Config.LookupExtensionsDir); err != nil {
+		if resolver, err := data.NewManufacturerResolver(m.manufacturers, policy.Config.LookupExtensionsDir, m.logger); err != nil {
 			m.logger.Warn("failed to load manufacturer overrides", "error", err, "directory", policy.Config.LookupExtensionsDir)
 		} else {
 			manufacturerRetriever = resolver

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -224,12 +224,25 @@ func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 			m.logger.Info("loaded device lookup extensions", "directory", policy.Config.LookupExtensionsDir)
 		}
 
+		// Build the per-policy manufacturer resolver: the built-in IANA
+		// catalog held by the Manager + any manufacturers: blocks in
+		// built-in extension files + optional user overrides from
+		// policy.Config.LookupExtensionsDir. If the resolver fails to
+		// construct (e.g. malformed YAML in a user file), degrade to the
+		// built-in catalog alone so the policy still runs.
+		var manufacturerRetriever data.ManufacturerRetriever = m.manufacturers
+		if resolver, err := data.NewManufacturerResolver(m.manufacturers, policy.Config.LookupExtensionsDir); err != nil {
+			m.logger.Warn("failed to load manufacturer overrides", "error", err, "directory", policy.Config.LookupExtensionsDir)
+		} else {
+			manufacturerRetriever = resolver
+		}
+
 		// Create logger-aware ClientFactory wrapper
 		clientFactory := func(host string, port uint16, retries int, timeout time.Duration, authentication *config.Authentication, logger *slog.Logger) (snmp.Walker, error) {
 			return snmp.NewClient(host, port, retries, timeout, authentication, logger)
 		}
 
-		r, err := NewRunner(m.ctx, m.logger, name, policy, m.client, clientFactory, &m.mappingConfig, m.manufacturers, deviceLookup, m.runStore)
+		r, err := NewRunner(m.ctx, m.logger, name, policy, m.client, clientFactory, &m.mappingConfig, manufacturerRetriever, deviceLookup, m.runStore)
 		if err != nil {
 			return err
 		}

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -227,9 +227,11 @@ func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 		// Build the per-policy manufacturer resolver: the built-in IANA
 		// catalog held by the Manager + any manufacturers: blocks in
 		// built-in extension files + optional user overrides from
-		// policy.Config.LookupExtensionsDir. If the resolver fails to
-		// construct (e.g. malformed YAML in a user file), degrade to the
-		// built-in catalog alone so the policy still runs.
+		// policy.Config.LookupExtensionsDir. Per-file YAML parse errors
+		// inside the user directory are logged and skipped, so partial
+		// overrides still apply. Only a hard construction failure (e.g.
+		// the built-in catalog itself being unreadable) falls back to
+		// the built-in-only catalog so the policy can still run.
 		manufacturerRetriever := m.manufacturers
 		if resolver, err := data.NewManufacturerResolver(m.manufacturers, policy.Config.LookupExtensionsDir); err != nil {
 			m.logger.Warn("failed to load manufacturer overrides", "error", err, "directory", policy.Config.LookupExtensionsDir)

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -230,7 +230,7 @@ func (m *Manager) StartPolicy(name string, policy config.Policy) error {
 		// policy.Config.LookupExtensionsDir. If the resolver fails to
 		// construct (e.g. malformed YAML in a user file), degrade to the
 		// built-in catalog alone so the policy still runs.
-		var manufacturerRetriever data.ManufacturerRetriever = m.manufacturers
+		manufacturerRetriever := m.manufacturers
 		if resolver, err := data.NewManufacturerResolver(m.manufacturers, policy.Config.LookupExtensionsDir); err != nil {
 			m.logger.Warn("failed to load manufacturer overrides", "error", err, "directory", policy.Config.LookupExtensionsDir)
 		} else {


### PR DESCRIPTION
## Summary

Three coordinated additive changes to let operators override what SNMP auto-discovery produces. Addresses orb-agent#269 (non-friendly IANA manufacturer names) and orb-agent#295 (MikroTik and other vendors that return a single `sysObjectID` for every model).

### 1. Manufacturer overrides (`#269`)

`lookup_extensions/*.yaml` gains an optional `manufacturers:` block keyed by IANA PEN. User-provided extensions (`lookup_extensions_dir`) win over built-in, which win over the raw IANA catalog. A new `ManufacturerResolver` wraps the existing catalog and is constructed per policy in `StartPolicy`. Missing user dir soft-fails to the built-in catalog.

```yaml
manufacturers:
  9: Cisco Systems
  14823: Aruba
```

### 2. Polymorphic `devices:` values (`#295`)

Each YAML value in `devices:` can be either a literal model string (unchanged) or a numeric OID that references an already-walked PDU. Dynamic refs resolve without extra SNMP traffic. `DeviceLookup` gains `GetDeviceModel(deviceOID, walked)`; whitespace and null bytes are trimmed from both sides of the dereferenced value; missing/empty source OIDs fall back to the raw sysObjectID.

```yaml
# Pull the model from sysDescr when sysObjectID is shared across a fleet
devices:
  .1.3.6.1.4.1.14988.1: .1.3.6.1.2.1.1.1.0
```

The bundled `mikrotik.yaml` keeps the historical `mikrotikRouter` static string by default; operators who want per-device model names can opt in via their own `lookup_extensions_dir` shadowing that entry. This avoids changing emitted `Model` values for any existing MikroTik fleet on upgrade.

### 3. Per-target device overrides (`#295` hard override)

`config.DeviceDefaults` gains optional `Model` / `Manufacturer` / `Platform` string fields. `DeviceMapper.Map` applies them in order (Manufacturer first so Platform.Name picks it up) after auto-discovery runs. Field-level partials work: set only `Model` and the rest still comes from auto-discovery.

### Precedence (highest wins)

1. Per-target `override_defaults.device.{model,manufacturer,platform}`
2. User `lookup_extensions_dir/*.yaml`
3. Built-in `lookup_extensions/*.yaml`
4. Built-in `manufacturers.yaml` / raw `sysObjectID`

## Backward compatibility

This PR is strictly additive. No bundled YAML semantics change, no policy schema breakage:
- Existing static `devices:` entries resolve unchanged.
- Policies without `override_defaults.device.*` behave identically.
- Existing MikroTik fleets continue to emit `mikrotikRouter` until the operator opts in.

## Test plan

- [x] `go test ./...` passes locally (10/10 packages green)
- [x] `go vet ./...` and `gofmt -l .` clean
- [x] Existing static `devices:` entries resolve unchanged (backward compat)
- [x] Policies with no `override_defaults.device.*` behave identically
- [x] MikroTik fixture: shared sysObjectID + three distinct sysDescr values -> three distinct Model names (operator opts in)
- [x] User `manufacturers:` override wins over both built-in extension and IANA
- [x] Missing `lookup_extensions_dir` soft-fails with warning; policy still starts

Companion docs PR to follow on `orb-agent`.