### PR TITLE
fix: report parent target as target when reporting runs

### DIFF
--- a/device-discovery/device_discovery/policy/run.py
+++ b/device-discovery/device_discovery/policy/run.py
@@ -73,15 +73,15 @@ class RunStore:
         """
         return run.model_copy(deep=True)
 
-    def create_run(self, policy_name: str, target: str, parent_target: str = "") -> Run:
+    def create_run(self, policy_name: str, target: str, child_target: str = "") -> Run:
         """
         Create a new run for the given policy and target.
 
         Args:
         ----
             policy_name: Name of the policy.
-            target: Target hostname or IP.
-            parent_target: Parent target if this was expanded from a range (optional).
+            target: Target hostname, IP, or CIDR range.
+            child_target: Specific host being discovered when target is a range (optional).
 
         Returns:
         -------
@@ -93,8 +93,8 @@ class RunStore:
 
             # Build metadata with targets as JSON array
             metadata = {"targets": json.dumps([target])}
-            if parent_target:
-                metadata["parent_target"] = parent_target
+            if child_target:
+                metadata["child_target"] = child_target
 
             # Create run with running status
             run = Run(

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -319,7 +319,6 @@ class PolicyRunner:
         scan_run = self.run_store.create_run(
             policy_name=self.name,
             target=original_hostname,
-            parent_target="",
         )
 
         try:
@@ -407,7 +406,6 @@ class PolicyRunner:
         run = self.run_store.create_run(
             policy_name=self.name,
             target=sanitized_hostname,
-            parent_target="",
         )
 
         # Try to discover driver if needed
@@ -510,11 +508,11 @@ class PolicyRunner:
         discovery_start_time = time.perf_counter()
         sanitized_hostname = scope.hostname.replace("\r\n", "").replace("\n", "")
 
-        # CREATE RUN WITH PARENT
+        # CREATE RUN WITH CHILD TARGET
         run = self.run_store.create_run(
             policy_name=self.name,
-            target=sanitized_hostname,
-            parent_target=parent_target,
+            target=parent_target,
+            child_target=sanitized_hostname,
         )
 
         # Try to discover driver if needed
@@ -523,7 +521,7 @@ class PolicyRunner:
             # UPDATE RUN ON DRIVER DISCOVERY FAILURE
             self.run_store.update_run(
                 policy_name=self.name,
-                target=sanitized_hostname,
+                target=parent_target,
                 run_id=run.id,
                 status=RunStatus.FAILED,
                 error=Exception("Not able to discover device driver"),
@@ -546,7 +544,7 @@ class PolicyRunner:
             # UPDATE RUN ON SUCCESS
             self.run_store.update_run(
                 policy_name=self.name,
-                target=sanitized_hostname,
+                target=parent_target,
                 run_id=run.id,
                 status=RunStatus.COMPLETED,
                 error=None,
@@ -570,7 +568,7 @@ class PolicyRunner:
             # UPDATE RUN ON FAILURE
             self.run_store.update_run(
                 policy_name=self.name,
-                target=sanitized_hostname,
+                target=parent_target,
                 run_id=run.id,
                 status=RunStatus.FAILED,
                 error=e,

--- a/device-discovery/tests/policy/test_run.py
+++ b/device-discovery/tests/policy/test_run.py
@@ -26,41 +26,41 @@ def test_run_creation():
     assert run.updated_at
 
 
-def test_run_with_parent():
-    """Test run creation with parent tracking."""
+def test_run_with_child_target():
+    """Test run creation with child target tracking."""
     run = Run(
         policy_id="test-policy",
         status=RunStatus.RUNNING,
         metadata={
-            "targets": '["192.168.1.5"]',
-            "parent_target": "192.168.1.0/24",
+            "targets": '["192.168.1.0/24"]',
+            "child_target": "192.168.1.5",
         },
     )
 
-    assert run.metadata["targets"] == '["192.168.1.5"]'
-    assert run.metadata["parent_target"] == "192.168.1.0/24"
+    assert run.metadata["targets"] == '["192.168.1.0/24"]'
+    assert run.metadata["child_target"] == "192.168.1.5"
 
 
 def test_create_run_basic():
     """Test basic run creation."""
     store = RunStore()
-    run = store.create_run("policy1", "192.168.1.1", "")
+    run = store.create_run("policy1", "192.168.1.1")
 
     assert run.policy_id == "policy1"
     assert run.status == RunStatus.RUNNING
     assert run.metadata["targets"] == '["192.168.1.1"]'
     assert "target" not in run.metadata
-    assert "parent_target" not in run.metadata
+    assert "child_target" not in run.metadata
 
 
-def test_create_run_with_parent():
-    """Test run creation with parent tracking."""
+def test_create_run_with_child_target():
+    """Test run creation with child target tracking."""
     store = RunStore()
-    run = store.create_run("policy1", "192.168.1.5", "192.168.1.0/24")
+    run = store.create_run("policy1", "192.168.1.0/24", child_target="192.168.1.5")
 
-    assert run.metadata["targets"] == '["192.168.1.5"]'
+    assert run.metadata["targets"] == '["192.168.1.0/24"]'
     assert "target" not in run.metadata
-    assert run.metadata["parent_target"] == "192.168.1.0/24"
+    assert run.metadata["child_target"] == "192.168.1.5"
 
 
 def test_update_run_success():
@@ -297,29 +297,29 @@ def test_parent_child_relationship():
     """Test parent-child relationship tracking."""
     store = RunStore()
 
-    # Create parent run (scan)
-    store.create_run("policy1", "192.168.1.0/24", "")
+    # Create scan run for the range
+    store.create_run("policy1", "192.168.1.0/24")
 
-    # Create child runs
-    store.create_run("policy1", "192.168.1.5", "192.168.1.0/24")
-    store.create_run("policy1", "192.168.1.10", "192.168.1.0/24")
+    # Create child runs - stored under the same range key
+    store.create_run("policy1", "192.168.1.0/24", child_target="192.168.1.5")
+    store.create_run("policy1", "192.168.1.0/24", child_target="192.168.1.10")
 
-    # Verify parent run
-    parent_runs = store.get_runs_for_target("policy1", "192.168.1.0/24")
-    assert len(parent_runs) == 1
-    assert parent_runs[0].metadata["targets"] == '["192.168.1.0/24"]'
-    assert "parent_target" not in parent_runs[0].metadata
+    # All runs are stored under the CIDR key
+    all_runs = store.get_runs_for_target("policy1", "192.168.1.0/24")
+    assert len(all_runs) == 3
 
-    # Verify child runs have parent reference
-    child1_runs = store.get_runs_for_target("policy1", "192.168.1.5")
-    assert len(child1_runs) == 1
-    assert child1_runs[0].metadata["targets"] == '["192.168.1.5"]'
-    assert child1_runs[0].metadata["parent_target"] == "192.168.1.0/24"
+    scan_runs = [r for r in all_runs if "child_target" not in r.metadata]
+    child_runs = [r for r in all_runs if "child_target" in r.metadata]
 
-    child2_runs = store.get_runs_for_target("policy1", "192.168.1.10")
-    assert len(child2_runs) == 1
-    assert child2_runs[0].metadata["targets"] == '["192.168.1.10"]'
-    assert child2_runs[0].metadata["parent_target"] == "192.168.1.0/24"
+    # Verify scan run
+    assert len(scan_runs) == 1
+    assert scan_runs[0].metadata["targets"] == '["192.168.1.0/24"]'
+
+    # Verify child runs reference specific hosts via child_target
+    assert len(child_runs) == 2
+    assert {r.metadata["child_target"] for r in child_runs} == {"192.168.1.5", "192.168.1.10"}
+    for r in child_runs:
+        assert r.metadata["targets"] == '["192.168.1.0/24"]'
 
 
 def test_metadata_preserved():


### PR DESCRIPTION
## Summary
Rename `parent_target` to `child_target` in device-discovery run metadata to clarify the semantics:
- Runs now use the range/CIDR as the `target` (what is currently the parent)
- The specific host is stored as `child_target` (what is currently the target)
- This groups related runs under the same storage key, simplifying parent/child aggregation

## Changes
- `run.py`: `create_run()` signature changes to `child_target` parameter
- `runner.py`: `run_with_parent()` now stores parent range as run target, specific host as child_target
- `test_run.py`: Updated assertions and test logic for new semantics

## Testing
- All 55 existing tests pass
- Test storage model updated to reflect new key structure

## Notes
All runs from a range scan are now stored under the CIDR key, allowing easier aggregation of parent and child runs.