### PR TITLE
feat(snmp-discovery): map entPhysicalSerialNum to device.Serial

### DIFF
--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -641,7 +641,20 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 	}
 
 	fieldFound := false
-	for objectID, value := range values {
+	// Iterate values in sorted-OID order (ascending) instead of relying on
+	// Go's randomized map iteration. For table-valued mappings such as
+	// entPhysicalSerialNum (.1.3.6.1.2.1.47.1.1.1.1.11.X), this means the
+	// lowest entPhysicalIndex — typically the chassis at .1 — is visited
+	// first. Combined with "skip if already set" guards in cases like
+	// serialNumber, this yields deterministic "lowest-index non-empty wins"
+	// behaviour. Scalar fields (sysName etc.) are unaffected by ordering.
+	valueKeys := make([]ObjectIDIndex, 0, len(values))
+	for objectID := range values {
+		valueKeys = append(valueKeys, objectID)
+	}
+	slices.SortFunc(valueKeys, compareOIDsNumerically)
+	for _, objectID := range valueKeys {
+		value := values[objectID]
 		for _, propertyMappingEntry := range mappingEntry.MappingEntries {
 			if objectID.HasParent(propertyMappingEntry.OID) {
 				m.logger.Debug("mapping value to device entity with mapper", "object_id", objectID, "value", value, "mapping_entry", propertyMappingEntry)
@@ -718,6 +731,20 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 						Manufacturer: &manufacturerEntity,
 					}
 					fieldFound = true
+				case "serialNumber":
+					serial := strings.TrimRight(strings.TrimSpace(value.Value), "\x00")
+					if serial == "" {
+						m.logger.Debug("empty serial number, skipping", "object_id", objectID)
+						continue
+					}
+					// entPhysicalSerialNum is a table — keep the first non-empty
+					// value (chassis at entPhysicalIndex .1) so module/SFP
+					// serials don't overwrite it.
+					if deviceEntity.Serial != nil && *deviceEntity.Serial != "" {
+						continue
+					}
+					deviceEntity.Serial = &serial
+					fieldFound = true
 				default:
 					m.logger.Warn("unknown field", "field", propertyMappingEntry.Field)
 				}
@@ -773,4 +800,29 @@ func toSlug(input *string) *string {
 	slug = strings.Trim(slug, "-")
 
 	return &slug
+}
+
+// compareOIDsNumerically compares two OID strings by their numeric components,
+// not lexicographically. This ensures .11.2 sorts before .11.10.
+func compareOIDsNumerically(a, b ObjectIDIndex) int {
+	partsA := strings.Split(strings.Trim(string(a), "."), ".")
+	partsB := strings.Split(strings.Trim(string(b), "."), ".")
+	for i := 0; i < len(partsA) && i < len(partsB); i++ {
+		na, errA := strconv.Atoi(partsA[i])
+		nb, errB := strconv.Atoi(partsB[i])
+		if errA != nil || errB != nil {
+			// Fall back to string comparison for non-numeric components
+			if partsA[i] != partsB[i] {
+				if partsA[i] < partsB[i] {
+					return -1
+				}
+				return 1
+			}
+			continue
+		}
+		if na != nb {
+			return na - nb
+		}
+	}
+	return len(partsA) - len(partsB)
 }

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -2689,6 +2689,325 @@ func TestDeviceMapper_Map(t *testing.T) {
 	}
 }
 
+func TestDeviceMapper_Map_SerialNumber(t *testing.T) {
+	logger := slog.Default()
+	mapper := mapping.NewDeviceMapper(&MockManufacturerDataRetriever{}, &MockDeviceLookup{}, logger)
+
+	serialMappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.47.1.1.1.1.11",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{
+				OID:    "1.3.6.1.2.1.47.1.1.1.1.11",
+				Entity: "device",
+				Field:  "serialNumber",
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		values         map[mapping.ObjectIDIndex]*mapping.ObjectIDValue
+		mappingEntry   *mapping.Entry
+		expectedSerial *string
+	}{
+		{
+			name: "single chassis serial maps to Serial field",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.47.1.1.1.1.11.1": {
+					OID:    "1.3.6.1.2.1.47.1.1.1.1.11.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+					Value:  "FTX1234ABCD",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry:   serialMappingEntry,
+			expectedSerial: mapping.StringPtr("FTX1234ABCD"),
+		},
+		{
+			name: "empty value is skipped and Serial remains nil",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.47.1.1.1.1.11.1": {
+					OID:    "1.3.6.1.2.1.47.1.1.1.1.11.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+					Value:  "",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry:   serialMappingEntry,
+			expectedSerial: nil,
+		},
+		{
+			name: "whitespace-only value is skipped",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.47.1.1.1.1.11.1": {
+					OID:    "1.3.6.1.2.1.47.1.1.1.1.11.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+					Value:  "   \t\n",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry:   serialMappingEntry,
+			expectedSerial: nil,
+		},
+		{
+			name: "leading and trailing whitespace is trimmed from valid value",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.47.1.1.1.1.11.1": {
+					OID:    "1.3.6.1.2.1.47.1.1.1.1.11.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+					Value:  "  FTX1234ABCD\t\n",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry:   serialMappingEntry,
+			expectedSerial: mapping.StringPtr("FTX1234ABCD"),
+		},
+		{
+			name: "empty entry skipped, non-empty entry recorded",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.47.1.1.1.1.11.1": {
+					OID:    "1.3.6.1.2.1.47.1.1.1.1.11.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+					Value:  "",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.47.1.1.1.1.11.2": {
+					OID:    "1.3.6.1.2.1.47.1.1.1.1.11.2",
+					Index:  "2",
+					Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+					Value:  "MOD-SERIAL-7777",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry:   serialMappingEntry,
+			expectedSerial: mapping.StringPtr("MOD-SERIAL-7777"),
+		},
+		{
+			name:           "empty values map leaves Serial nil",
+			values:         map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{},
+			mappingEntry:   serialMappingEntry,
+			expectedSerial: nil,
+		},
+		{
+			name: "NUL-padded serial is trimmed to valid value",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.47.1.1.1.1.11.1": {
+					OID:    "1.3.6.1.2.1.47.1.1.1.1.11.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+					Value:  "SER123\x00",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry:   serialMappingEntry,
+			expectedSerial: mapping.StringPtr("SER123"),
+		},
+		{
+			name: "NUL-only value is skipped and does not block later valid row",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.47.1.1.1.1.11.1": {
+					OID:    "1.3.6.1.2.1.47.1.1.1.1.11.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+					Value:  "\x00\x00",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.47.1.1.1.1.11.2": {
+					OID:    "1.3.6.1.2.1.47.1.1.1.1.11.2",
+					Index:  "2",
+					Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+					Value:  "VALID-SERIAL",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry:   serialMappingEntry,
+			expectedSerial: mapping.StringPtr("VALID-SERIAL"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := mapping.NewEntityRegistry(logger)
+			entity := mapper.Map(tt.values, tt.mappingEntry, registry, nil)
+
+			assert.NotNil(t, entity)
+			device, ok := entity.(*diode.Device)
+			assert.True(t, ok)
+			assert.Equal(t, tt.expectedSerial, device.Serial)
+		})
+	}
+}
+
+// TestDeviceMapper_Map_SerialNumber_LowestIndexWins verifies that when the
+// entPhysicalSerialNum walk returns multiple non-empty values, the mapper
+// deterministically picks the lowest-indexed row (typically the chassis at
+// entPhysicalIndex .1) regardless of Go's randomized map iteration order.
+// The mapper sorts value keys ascending before iterating so this is stable.
+func TestDeviceMapper_Map_SerialNumber_LowestIndexWins(t *testing.T) {
+	logger := slog.Default()
+	mapper := mapping.NewDeviceMapper(&MockManufacturerDataRetriever{}, &MockDeviceLookup{}, logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.47.1.1.1.1.11.1": {
+			OID:    "1.3.6.1.2.1.47.1.1.1.1.11.1",
+			Index:  "1",
+			Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+			Value:  "CHASSIS-SERIAL-001",
+			Type:   mapping.OctetString,
+		},
+		"1.3.6.1.2.1.47.1.1.1.1.11.2": {
+			OID:    "1.3.6.1.2.1.47.1.1.1.1.11.2",
+			Index:  "2",
+			Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+			Value:  "MODULE-SERIAL-002",
+			Type:   mapping.OctetString,
+		},
+		"1.3.6.1.2.1.47.1.1.1.1.11.3": {
+			OID:    "1.3.6.1.2.1.47.1.1.1.1.11.3",
+			Index:  "3",
+			Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+			Value:  "SFP-SERIAL-003",
+			Type:   mapping.OctetString,
+		},
+	}
+	mappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.47.1.1.1.1.11",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{
+				OID:    "1.3.6.1.2.1.47.1.1.1.1.11",
+				Entity: "device",
+				Field:  "serialNumber",
+			},
+		},
+	}
+
+	// Run multiple times to flush out any reliance on map iteration order.
+	for i := 0; i < 50; i++ {
+		registry := mapping.NewEntityRegistry(logger)
+		entity := mapper.Map(values, mappingEntry, registry, nil)
+		device, ok := entity.(*diode.Device)
+		assert.True(t, ok)
+		assert.Equal(t, mapping.StringPtr("CHASSIS-SERIAL-001"), device.Serial)
+	}
+}
+
+// TestDeviceMapper_Map_SerialNumber_LowestIndexEmpty verifies that when the
+// chassis row (lowest index) is empty, the mapper falls through to the next
+// non-empty row deterministically.
+func TestDeviceMapper_Map_SerialNumber_LowestIndexEmpty(t *testing.T) {
+	logger := slog.Default()
+	mapper := mapping.NewDeviceMapper(&MockManufacturerDataRetriever{}, &MockDeviceLookup{}, logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.47.1.1.1.1.11.1": {
+			OID:    "1.3.6.1.2.1.47.1.1.1.1.11.1",
+			Index:  "1",
+			Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+			Value:  "",
+			Type:   mapping.OctetString,
+		},
+		"1.3.6.1.2.1.47.1.1.1.1.11.2": {
+			OID:    "1.3.6.1.2.1.47.1.1.1.1.11.2",
+			Index:  "2",
+			Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+			Value:  "MODULE-SERIAL-002",
+			Type:   mapping.OctetString,
+		},
+		"1.3.6.1.2.1.47.1.1.1.1.11.3": {
+			OID:    "1.3.6.1.2.1.47.1.1.1.1.11.3",
+			Index:  "3",
+			Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+			Value:  "SFP-SERIAL-003",
+			Type:   mapping.OctetString,
+		},
+	}
+	mappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.47.1.1.1.1.11",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{
+				OID:    "1.3.6.1.2.1.47.1.1.1.1.11",
+				Entity: "device",
+				Field:  "serialNumber",
+			},
+		},
+	}
+
+	for i := 0; i < 50; i++ {
+		registry := mapping.NewEntityRegistry(logger)
+		entity := mapper.Map(values, mappingEntry, registry, nil)
+		device, ok := entity.(*diode.Device)
+		assert.True(t, ok)
+		assert.Equal(t, mapping.StringPtr("MODULE-SERIAL-002"), device.Serial)
+	}
+}
+
+// TestDeviceMapper_Map_SerialNumber_NumericSortOrder verifies that OID suffixes
+// are sorted numerically, not lexicographically. Lexicographic order would visit
+// .11.10 before .11.2, causing a module serial to win over the chassis serial.
+func TestDeviceMapper_Map_SerialNumber_NumericSortOrder(t *testing.T) {
+	logger := slog.Default()
+	mapper := mapping.NewDeviceMapper(&MockManufacturerDataRetriever{}, &MockDeviceLookup{}, logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.47.1.1.1.1.11.2": {
+			OID:    "1.3.6.1.2.1.47.1.1.1.1.11.2",
+			Index:  "2",
+			Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+			Value:  "CHASSIS-SERIAL-002",
+			Type:   mapping.OctetString,
+		},
+		"1.3.6.1.2.1.47.1.1.1.1.11.10": {
+			OID:    "1.3.6.1.2.1.47.1.1.1.1.11.10",
+			Index:  "10",
+			Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+			Value:  "MODULE-SERIAL-010",
+			Type:   mapping.OctetString,
+		},
+		"1.3.6.1.2.1.47.1.1.1.1.11.11": {
+			OID:    "1.3.6.1.2.1.47.1.1.1.1.11.11",
+			Index:  "11",
+			Parent: "1.3.6.1.2.1.47.1.1.1.1.11",
+			Value:  "SFP-SERIAL-011",
+			Type:   mapping.OctetString,
+		},
+	}
+	mappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.47.1.1.1.1.11",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{
+				OID:    "1.3.6.1.2.1.47.1.1.1.1.11",
+				Entity: "device",
+				Field:  "serialNumber",
+			},
+		},
+	}
+
+	// Run multiple times to eliminate any map iteration luck.
+	for i := 0; i < 50; i++ {
+		registry := mapping.NewEntityRegistry(logger)
+		entity := mapper.Map(values, mappingEntry, registry, nil)
+		device, ok := entity.(*diode.Device)
+		assert.True(t, ok)
+		// Numeric sort: .2 < .10 < .11 → chassis serial at .2 wins.
+		// Lexicographic sort would give .10 < .11 < .2 → MODULE-SERIAL-010 incorrectly wins.
+		assert.Equal(t, mapping.StringPtr("CHASSIS-SERIAL-002"), device.Serial,
+			"iteration %d: expected lowest numeric index (.2) to win over .10 and .11", i)
+	}
+}
+
 // MockManufacturerDataRetriever is a mock implementation of ManufacturerDataRetriever
 type MockManufacturerDataRetriever struct {
 	mock.Mock

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -451,7 +452,13 @@ func NewObjectIDIndexDetails(index string) *ObjectIDIndexDetails {
 func (m *ObjectIDMapper) MapObjectIDsToEntity(objectIDs ObjectIDValueMap) []diode.Entity {
 	objectIDIndexMap := m.groupByObjectIDIndex(objectIDs)
 	uniqueEntities := make(map[diode.Entity]bool)
-	for index, value := range objectIDIndexMap {
+	sortedIndexes := make([]ObjectIDIndex, 0, len(objectIDIndexMap))
+	for index := range objectIDIndexMap {
+		sortedIndexes = append(sortedIndexes, index)
+	}
+	slices.SortFunc(sortedIndexes, compareOIDsNumerically)
+	for _, index := range sortedIndexes {
+		value := objectIDIndexMap[index]
 		m.logger.Debug("mapping object ID index", "object_id_index", index, "values", value.Values)
 		entry, err := m.resolveMappingEntry(value)
 		if err != nil {

--- a/snmp-discovery/mapping/mapping_internal_test.go
+++ b/snmp-discovery/mapping/mapping_internal_test.go
@@ -86,3 +86,25 @@ func TestResolveMappingEntry_FallsBackThroughPDUs(t *testing.T) {
 	_, err = m.resolveMappingEntry(details2)
 	assert.Error(t, err, "when no PDU parent resolves, the original error must propagate")
 }
+
+// TestGroupByObjectIDIndex_SerialDoesNotCollideWithIfIndex verifies that
+// identifier_size:2 on the entPhysicalSerialNum entry produces an index
+// ("11.1") that is disjoint from single-component ifIndex values ("1"),
+// preventing groupByObjectIDIndex from merging serial PDUs into interface
+// index buckets.
+func TestGroupByObjectIDIndex_SerialDoesNotCollideWithIfIndex(t *testing.T) {
+	// With identifier_size:2, entPhysicalSerialNum.1 gets index "11.1",
+	// not "1", so it is never merged into the ifIndex "1" bucket.
+	objectIDs := ObjectIDValueMap{
+		".1.3.6.1.2.1.2.2.1.2.1":       {Value: "eth0", Type: OctetString, IdentifierSize: 1},
+		".1.3.6.1.2.1.47.1.1.1.1.11.1": {Value: "SER001", Type: OctetString, IdentifierSize: 2},
+	}
+	mapper := &ObjectIDMapper{logger: slog.Default()}
+	groups := mapper.groupByObjectIDIndex(objectIDs)
+
+	assert.Len(t, groups, 2)
+	_, hasIfIndex := groups["1"]
+	_, hasSerialIndex := groups["11.1"]
+	assert.True(t, hasIfIndex, "ifIndex group '1' should exist")
+	assert.True(t, hasSerialIndex, "serial group '11.1' should exist")
+}

--- a/snmp-discovery/policy/mapping.yaml
+++ b/snmp-discovery/policy/mapping.yaml
@@ -66,3 +66,18 @@ entries:
       - oid: ".1.3.6.1.2.1.1.5.0"
         entity: "device"
         field: "name"
+
+  # Device serial number (ENTITY-MIB entPhysicalSerialNum).
+  # identifier_size: 2 uses the last two OID components (column.row,
+  # e.g. "11.1") as the grouping index, which is disjoint from the
+  # single-component ifIndex values ("1", "2", ...) used by the
+  # interface table. This prevents groupByObjectIDIndex from merging
+  # serial PDUs into interface index buckets.
+  - oid: ".1.3.6.1.2.1.47.1.1.1"
+    entity: "device"
+    field: "_id"
+    identifier_size: 2
+    mapping_entries:
+      - oid: ".1.3.6.1.2.1.47.1.1.1.1.11"
+        entity: "device"
+        field: "serialNumber"


### PR DESCRIPTION
## Summary

`snmp-discovery` currently maps `sysName`, `sysDescr`, and `sysObjectID` onto the Diode Device entity but does not record a serial number. NetBox's Device model (and the corresponding diode.Device.Serial field in diode-sdk-go) supports serial numbers, so this gap means discovered devices land in NetBox without one — affecting asset tracking, RMA workflows, and any downstream tooling that joins on serial.

## Proposal
Walk **ENTITY-MIB** `entPhysicalSerialNum` (`.1.3.6.1.2.1.47.1.1.1.1.11`) during device discovery and populate `diode.Device.Serial`. **ENTITY-MIB** is the cross-vendor standard and is supported by the vast majority of modern enterprise network gear (Cisco IOS/IOS-XE/NX-OS, Juniper, Arista, etc.).

## Design
`entPhysicalSerialNum` is a table indexed by `entPhysicalIndex`, so a walk returns one row per physical entity — chassis, line cards, power supplies, fans, transceivers, etc. We want the chassis serial, which by convention sits at the lowest physical index (typically .1).

Two changes make this deterministic:

1. New mapping entry in `policy/mapping.yaml` under the device entity, rooted at `.1.3.6.1.2.1.47.1.1.1.1.11` with field `serialNumber`. Sharing entity: "device" means it merges into the same Device instance as the existing `sysName/sysDescr` entry via `CurrentDeviceIndex`.
2. `DeviceMapper.Map` now iterates values in `sorted-OID` order (mirroring the existing pattern in `InterfaceMapper.Map`) rather than relying on Go's randomized map iteration. Combined with a "skip if already set" guard on the `serialNumber` case, this guarantees the lowest-indexed non-empty row wins. Module/SFP serials cannot overwrite the chassis serial. 

## Behavior

- Chassis present at index `.1` with non-empty serial → `device.Seria`l = chassis serial. ✅
- Chassis row empty, modules populated → falls through to lowest-indexed non-empty row deterministically.
- All rows empty / whitespace-only → `device.Serial` remains `nil`. No spurious updates.
- Whitespace is trimmed before assignment.
- Devices that don't implement **ENTITY-MIB** → no `serialNumber` values in the walk → `device.Serial` stays nil. No regression for non-ENTITY-MIB hardware.