### PR TITLE
feat(device-discovery): generic interface↔VLAN associations across NAPALM-native drivers (OBS-1368/OBS-1640)

### DIFF
--- a/device-discovery/custom_napalm/CLAUDE.md
+++ b/device-discovery/custom_napalm/CLAUDE.md
@@ -66,6 +66,75 @@ hostname, vendor, model, os_version, serial_number, uptime (float, seconds), fqd
 
 ---
 
+## Optional method: `get_interfaces_vlans`
+
+A driver MAY implement `get_interfaces_vlans()` to populate NetBox
+`Interface.mode` / `untagged_vlan` / `tagged_vlans`. The runner calls it via
+`getattr(...)` so drivers without it are silently skipped.
+
+**Output shape** (per interface):
+
+```python
+{
+    "mode":     "access" | "trunk" | "trunk-all" | "routed",
+    "tagged":   list[int],          # VIDs in 1..4094, never the untagged VID
+    "untagged": int | None,         # VID in 1..4094, None for routed
+}
+```
+
+`device_discovery.translate.apply_interface_vlans()` maps these to NetBox:
+`access` → `access`, `trunk` → `tagged`, `trunk-all` → `tagged-all`,
+`routed` → no change (Diode PATCH semantics — see translate.py docstring).
+
+**Use the generic classifier — do NOT reimplement.** `custom_napalm/_vlan.py`
+exposes `SwitchportInfo` (vendor-neutral intermediate) and
+`classify_switchport()` (the pure-function classifier that handles voice-VLAN
+promotion, DTP fallback, wildcard signaling, VID clamping, and bool-rejection).
+
+**The driver only does field extraction:**
+
+```python
+from custom_napalm._vlan import SwitchportInfo, classify_switchport, parse_vlan_range_string
+
+def get_interfaces_vlans(self) -> dict[str, dict]:
+    raw = self.device.send_command("show interfaces switchport")  # or RPC, or eAPI
+    rows = parse_output(...)  # or vendor JSON / XML
+    result: dict[str, dict] = {}
+    for row in rows:
+        info = SwitchportInfo(
+            enabled=...,
+            admin_mode=...,    # "access" | "trunk" | "dynamic" | None
+            oper_mode=...,     # for DTP fallback; None if not applicable
+            access_vlan=...,
+            native_vlan=...,
+            allowed_vlans=...,  # list[int] | "all" | None
+            voice_vlan=...,
+        )
+        result[ifname] = classify_switchport(info)
+    return result
+```
+
+For Cisco NX-OS, both the NX-API and SSH paths share
+`custom_napalm/_nxos_common.nxos_row_to_switchport_info()` — pass it the
+NX-API/ntc-templates row dict directly.
+
+## Mock fakes for structured-API drivers
+
+For drivers that use a non-CLI transport, use these test fakes:
+
+| Transport | Fake | File convention |
+|---|---|---|
+| Netmiko (SSH CLI) | `FakeCLIDevice` | `<sanitized-cmd>.txt` |
+| pyeapi (Arista eAPI) / NX-API JSON | `FakeJsonRpcDevice` | `<sanitized-cmd>.json` |
+| PyEZ (Juniper NETCONF) | `FakePyEZDevice` | `<rpc-name>.xml` (kebab-case) |
+| Pure NETCONF (ncclient) | `FakeNetconfConn` | `response.xml`, `<source>_config.xml` |
+| pan.xapi (PAN-OS XML API) | `FakeXmlDevice` | `<sanitized-xml>.xml` |
+| ArubaOS-Switch REST | `FakeHTTPSession` | `<endpoint>.json` |
+| pyaoscx | `FakePyaoscxSession` | `<path>.json` |
+| Cisco ASA REST | `FakeRestDevice` | `<path>.json` |
+
+---
+
 ## Config sanitization
 
 `runner.py` calls `get_config(sanitized=True)` by default (operators can set `sanitize_config: false`

--- a/device-discovery/custom_napalm/__init__.py
+++ b/device-discovery/custom_napalm/__init__.py
@@ -39,6 +39,7 @@ from custom_napalm.nokia_srl import SRLDriver
 from custom_napalm.nokia_sros import SROSDriver
 from custom_napalm.nokia_sros_ssh import SROSSSHDriver
 from custom_napalm.nxos import NXOSDriver
+from custom_napalm.nxos_ssh import NXOSSSHDriver
 from custom_napalm.paloalto_panos import PANOSDriver
 from custom_napalm.paloalto_panos_ssh import PANOSSHDriver
 from custom_napalm.ubiquiti_edgerouter import EdgeRouterDriver
@@ -72,6 +73,7 @@ __all__ = [
     "MLNXOSDriver",
     "NetIronDriver",
     "NXOSDriver",
+    "NXOSSSHDriver",
     "PANOSDriver",
     "PANOSSHDriver",
     "PowerConnectDriver",

--- a/device-discovery/custom_napalm/__init__.py
+++ b/device-discovery/custom_napalm/__init__.py
@@ -22,6 +22,7 @@ from custom_napalm.cumulus_linux import CumulusDriver
 from custom_napalm.dell_ftos import FTOSDriver
 from custom_napalm.dell_powerconnect import PowerConnectDriver
 from custom_napalm.dell_sonic import SONiCDriver
+from custom_napalm.eos import EOSDriver
 from custom_napalm.ericsson_ipos import IPOSDriver
 from custom_napalm.extreme_exos import ExosDriver
 from custom_napalm.extreme_slx import SLXOSDriver
@@ -56,6 +57,7 @@ __all__ = [
     "CumulusDriver",
     "EdgeRouterDriver",
     "EdgeSwitchDriver",
+    "EOSDriver",
     "ERSDriver",
     "ExosDriver",
     "FastIronDriver",

--- a/device-discovery/custom_napalm/__init__.py
+++ b/device-discovery/custom_napalm/__init__.py
@@ -33,6 +33,7 @@ from custom_napalm.hp_procurve import ProcurveDriver
 from custom_napalm.huawei_smartax import SmartDriver
 from custom_napalm.huawei_vrp import VRPDriver
 from custom_napalm.ios import IOSDriver
+from custom_napalm.junos import JunOSDriver
 from custom_napalm.mellanox_mlnxos import MLNXOSDriver
 from custom_napalm.mikrotik_routeros import ROSDriver
 from custom_napalm.nokia_srl import SRLDriver
@@ -70,6 +71,7 @@ __all__ = [
     "GaiaDriver",
     "IOSDriver",
     "IPOSDriver",
+    "JunOSDriver",
     "MLNXOSDriver",
     "NetIronDriver",
     "NXOSDriver",

--- a/device-discovery/custom_napalm/__init__.py
+++ b/device-discovery/custom_napalm/__init__.py
@@ -38,6 +38,7 @@ from custom_napalm.mikrotik_routeros import ROSDriver
 from custom_napalm.nokia_srl import SRLDriver
 from custom_napalm.nokia_sros import SROSDriver
 from custom_napalm.nokia_sros_ssh import SROSSSHDriver
+from custom_napalm.nxos import NXOSDriver
 from custom_napalm.paloalto_panos import PANOSDriver
 from custom_napalm.paloalto_panos_ssh import PANOSSHDriver
 from custom_napalm.ubiquiti_edgerouter import EdgeRouterDriver
@@ -70,6 +71,7 @@ __all__ = [
     "IPOSDriver",
     "MLNXOSDriver",
     "NetIronDriver",
+    "NXOSDriver",
     "PANOSDriver",
     "PANOSSHDriver",
     "PowerConnectDriver",

--- a/device-discovery/custom_napalm/_nxos_common.py
+++ b/device-discovery/custom_napalm/_nxos_common.py
@@ -123,10 +123,36 @@ def nxos_row_to_switchport_info(row: dict) -> SwitchportInfo:
     else:
         allowed = None
 
+    admin = _normalize_admin(_read_admin_mode(row))
+    oper = _normalize_oper(_read_oper_mode(row))
+
+    # NX-OS SSH oper-down inference.
+    #
+    # ntc-templates' ``cisco_nxos_show_interface_switchport`` parser does NOT
+    # capture the ``Administrative Mode`` line — only ``Operational Mode``.
+    # Both ``_read_admin_mode`` and ``_read_oper_mode`` therefore fall back
+    # to the same ``mode`` field, and a down link reports ``mode: down`` →
+    # both normalize to ``None`` → ``classify_switchport`` would emit
+    # ``routed``, dropping the configured VLAN data on every disconnected
+    # interface at collection time.
+    #
+    # Default ``admin`` to ``"access"`` when ``Switchport: Enabled`` and
+    # neither admin nor oper resolves to a known mode. Access is the
+    # most common default for an enabled switchport with no other signal,
+    # and the access_vlan field is still populated by NX-OS even on down
+    # ports. Trunks that happen to be down are misclassified as access
+    # using their trunk's access_vlan field (typically VID 1) — corrected
+    # automatically on the next discovery cycle once the link is up.
+    # NX-API rows are unaffected because they emit ``admin_mode`` and
+    # ``oper_mode`` separately, so ``admin`` is non-None and this branch
+    # does not fire.
+    if admin is None and oper is None:
+        admin = "access"
+
     return SwitchportInfo(
         enabled=True,
-        admin_mode=_normalize_admin(_read_admin_mode(row)),  # type: ignore[arg-type]
-        oper_mode=_normalize_oper(_read_oper_mode(row)),     # type: ignore[arg-type]
+        admin_mode=admin,  # type: ignore[arg-type]
+        oper_mode=oper,    # type: ignore[arg-type]
         access_vlan=_maybe_int(row.get("access_vlan")),
         native_vlan=_maybe_int(row.get("native_vlan")),
         allowed_vlans=allowed,

--- a/device-discovery/custom_napalm/_nxos_common.py
+++ b/device-discovery/custom_napalm/_nxos_common.py
@@ -1,0 +1,124 @@
+# Copyright 2026 NetBox Labs Inc
+"""
+Shared NX-OS field mapper for the nxos (NX-API) and nxos_ssh subclass drivers.
+
+Both drivers ultimately produce the same per-interface row shape — NX-API
+emits it as JSON, ntc-templates emits it as a dict from CLI parsing.
+
+Field-name reconciliation
+-------------------------
+NX-API JSON fields:
+    interface, switchport, admin_mode, oper_mode, access_vlan, native_vlan,
+    voice_vlan, trunk_vlans
+
+ntc-templates ``cisco_nxos_show_interface_switchport`` template fields
+(observed in ntc-templates 7.x as installed in this venv):
+    interface, switchport, mode (= operational mode only — admin_mode is NOT
+    parsed by the template), access_vlan, access_vlan_name, native_vlan,
+    native_vlan_name, trunking_vlans, voice_vlan
+
+The mapper accepts BOTH naming conventions and normalizes them. NX-OS-SSH
+rows lack ``admin_mode`` because ``show interface switchport`` does not
+print it on every NX-OS release; the operational ``mode`` field is the
+only signal available, so we use it as both admin and oper. This is
+correct for NX-OS in practice — DTP (the reason IOS distinguishes admin
+vs oper) is rarely used on NX-OS, and when it IS used the operational
+mode reflects the negotiated state.
+"""
+
+from __future__ import annotations
+
+from custom_napalm._vlan import SwitchportInfo, parse_vlan_range_string
+
+
+def _maybe_int(value: object) -> int | None:
+    """Coerce to int or None; treats the string 'none' / empty / non-numeric as None."""
+    if value in (None, "", "none", "None", "NONE"):
+        return None
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_admin(value: str) -> str | None:
+    """Normalize a raw admin-mode string to 'access', 'trunk', 'dynamic', or None."""
+    raw = (value or "").lower()
+    if "access" in raw:
+        return "access"
+    if "trunk" in raw:
+        return "trunk"
+    if "dynamic" in raw:
+        return "dynamic"
+    return None
+
+
+def _normalize_oper(value: str) -> str | None:
+    """Normalize a raw oper-mode string to 'access', 'trunk', 'routed', or None."""
+    raw = (value or "").lower()
+    if "access" in raw:
+        return "access"
+    if "trunk" in raw:
+        return "trunk"
+    if "routed" in raw:
+        return "routed"
+    return None
+
+
+def _read_admin_mode(row: dict) -> str:
+    """Return raw admin_mode string, falling back to ``mode`` (ntc-templates alias)."""
+    return row.get("admin_mode") or row.get("mode") or ""
+
+
+def _read_oper_mode(row: dict) -> str:
+    """Return raw oper_mode string, falling back to ``mode`` (ntc-templates alias)."""
+    return row.get("oper_mode") or row.get("mode") or ""
+
+
+def _read_trunk_vlans(row: dict) -> str:
+    """Return raw trunk_vlans, accepting NX-API key ``trunk_vlans`` or ntc alias ``trunking_vlans``."""
+    return row.get("trunk_vlans") or row.get("trunking_vlans") or ""
+
+
+def nxos_row_to_switchport_info(row: dict) -> SwitchportInfo:
+    """
+    Build a SwitchportInfo from a normalized NX-OS row dict.
+
+    Accepts BOTH NX-API (JSON) and ntc-templates (CLI-parsed) shapes::
+
+        NX-API:     {"interface", "switchport", "admin_mode", "oper_mode",
+                     "access_vlan", "native_vlan", "voice_vlan", "trunk_vlans"}
+        ntc:        {"interface", "switchport", "mode",
+                     "access_vlan", "native_vlan", "voice_vlan", "trunking_vlans"}
+
+    NX-API uses "Enabled"/"Disabled" for ``switchport``; ntc-templates may
+    emit "Enabled"/"Disabled" or other casing. Both are tolerated.
+
+    When ntc-templates rows lack a separate ``admin_mode``, the ``mode``
+    field (operational) is used as both admin AND oper signals — which
+    keeps DTP-fallback correctness on the rare NX-OS deployment that
+    actually negotiates DTP, and is exactly equivalent to "admin = oper"
+    on the common case where DTP is disabled.
+    """
+    if (row.get("switchport") or "").lower() == "disabled":
+        return SwitchportInfo(
+            enabled=False, admin_mode=None, oper_mode=None,
+            access_vlan=None, native_vlan=None, allowed_vlans=None,
+        )
+
+    trunk_vlans_raw = _read_trunk_vlans(row)
+    if trunk_vlans_raw:
+        vids, is_wildcard = parse_vlan_range_string(trunk_vlans_raw)
+        allowed: list[int] | str | None = "all" if is_wildcard else vids
+    else:
+        allowed = None
+
+    return SwitchportInfo(
+        enabled=True,
+        admin_mode=_normalize_admin(_read_admin_mode(row)),  # type: ignore[arg-type]
+        oper_mode=_normalize_oper(_read_oper_mode(row)),     # type: ignore[arg-type]
+        access_vlan=_maybe_int(row.get("access_vlan")),
+        native_vlan=_maybe_int(row.get("native_vlan")),
+        allowed_vlans=allowed,
+        voice_vlan=_maybe_int(row.get("voice_vlan")),
+    )

--- a/device-discovery/custom_napalm/_nxos_common.py
+++ b/device-discovery/custom_napalm/_nxos_common.py
@@ -32,7 +32,17 @@ from custom_napalm._vlan import SwitchportInfo, parse_vlan_range_string
 
 
 def _maybe_int(value: object) -> int | None:
-    """Coerce to int or None; treats the string 'none' / empty / non-numeric as None."""
+    """
+    Coerce to int or None.
+
+    Returns None for the NX-OS sentinels (``None``, empty string, ``"none"``
+    / ``"None"`` / ``"NONE"``). Also rejects ``bool`` explicitly — ``bool``
+    is a subclass of ``int`` in Python (``int(True) == 1``), so without the
+    guard a buggy upstream parser passing a bool would slip past the
+    classifier's bool-rejection in ``_vlan.coerce_vid``.
+    """
+    if isinstance(value, bool):
+        return None
     if value in (None, "", "none", "None", "NONE"):
         return None
     try:

--- a/device-discovery/custom_napalm/_vlan.py
+++ b/device-discovery/custom_napalm/_vlan.py
@@ -13,7 +13,7 @@ Output shape (per interface)::
     {
         "mode":     "access" | "trunk" | "trunk-all" | "routed",
         "tagged":   list[int],          # VIDs in 1..4094, never the untagged VID
-        "untagged": int | None,         # VID in 1..4094, None for routed
+        "untagged": int | None,         # VID in 1..4094, or None when no valid VID
     }
 
 NetBox mapping is owned by ``device_discovery.translate``:

--- a/device-discovery/custom_napalm/_vlan.py
+++ b/device-discovery/custom_napalm/_vlan.py
@@ -1,0 +1,194 @@
+# Copyright 2026 NetBox Labs Inc
+"""
+Generic, vendor-neutral interface↔VLAN classifier for custom NAPALM drivers.
+
+Each driver's ``get_interfaces_vlans()`` extracts native fields per interface,
+builds a :class:`SwitchportInfo`, and calls :func:`classify_switchport`. The
+classifier is the only place that encodes voice-VLAN promotion, DTP fallback,
+wildcard handling, VID range clamping, and the routed/access/trunk/trunk-all
+output enum consumed by ``device_discovery.translate.apply_interface_vlans``.
+
+Output shape (per interface)::
+
+    {
+        "mode":     "access" | "trunk" | "trunk-all" | "routed",
+        "tagged":   list[int],          # VIDs in 1..4094, never the untagged VID
+        "untagged": int | None,         # VID in 1..4094, None for routed
+    }
+
+NetBox mapping is owned by ``device_discovery.translate``:
+``access`` → ``access``, ``trunk`` → ``tagged``, ``trunk-all`` → ``tagged-all``,
+``routed`` → ``null`` (no NetBox change applied).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+
+@dataclass
+class SwitchportInfo:
+    """Vendor-neutral normalized intermediate. One per interface."""
+
+    enabled: bool
+    admin_mode: Literal["access", "trunk", "dynamic"] | None
+    oper_mode: Literal["access", "trunk", "routed"] | None
+    access_vlan: int | None
+    native_vlan: int | None
+    allowed_vlans: list[int] | Literal["all"] | None
+    voice_vlan: int | None = None
+
+
+def coerce_vid(value: object) -> int | None:
+    """Coerce a value to an int in [1, 4094]. Reject bools (subclass of int)."""
+    if isinstance(value, bool):
+        return None
+    if not isinstance(value, (int, str)):
+        return None
+    try:
+        v = int(value)
+    except ValueError:
+        return None
+    return v if 1 <= v <= 4094 else None
+
+
+def _is_full_vlan_range(vids: list[int]) -> bool:
+    """Return True iff ``vids`` covers the full 1..4094 dot1q range."""
+    return (
+        bool(vids)
+        and min(vids) <= 1
+        and max(vids) >= 4094
+        and len(set(vids)) >= 4094
+    )
+
+
+def _expand_range_chunk(chunk: str) -> list[int]:
+    """Expand one range or single VID chunk into a list of VIDs (clamped to 1..4094)."""
+    chunk = chunk.strip()
+    if not chunk:
+        return []
+    if "-" in chunk:
+        lo_s, hi_s = chunk.split("-", 1)
+        try:
+            lo, hi = int(lo_s), int(hi_s)
+        except ValueError:
+            return []
+        lo = max(lo, 1)
+        hi = min(hi, 4094)
+        if lo > hi:
+            return []
+        return list(range(lo, hi + 1))
+    try:
+        return [int(chunk)]
+    except ValueError:
+        return []
+
+
+def parse_vlan_range_string(spec: str) -> tuple[list[int], bool]:
+    """
+    Expand a comma-separated VLAN list/range spec into ``(vids, is_wildcard)``.
+
+    Examples::
+
+        "1,10-12,20"   → ([1, 10, 11, 12, 20], False)
+        "all" / "ALL"  → ([], True)        # genuine wildcard
+        "1-4094"       → ([], True)        # full-range expansion → wildcard
+        "none"         → ([], False)
+        ""             → ([], False)
+        "5000-9000"    → ([], False)       # clamped out, NOT a wildcard
+        "junk,10"      → ([10], False)     # junk dropped, valid kept
+
+    Callers MUST NOT treat the ``([], False)`` return as a wildcard — that path
+    is reached by empty input AND by all-junk input. Promotion to ``trunk-all``
+    only happens when ``is_wildcard`` is True.
+    """
+    if not spec:
+        return [], False
+    raw = spec.strip().lower()
+    if raw == "all":
+        return [], True
+    if raw == "none":
+        return [], False
+
+    out: list[int] = []
+    for chunk in spec.split(","):
+        out.extend(_expand_range_chunk(chunk))
+
+    out = [v for v in out if 1 <= v <= 4094]
+    if _is_full_vlan_range(out):
+        return [], True
+    return out, False
+
+
+def _resolve_effective_mode(info: SwitchportInfo) -> Literal["access", "trunk"] | None:
+    """
+    Decide which mode to use, resolving DTP-negotiated ports via oper_mode.
+
+    Returns None to signal "routed/unknown"; classify_switchport converts
+    that to a routed entry.
+    """
+    if not info.enabled:
+        return None
+    admin = info.admin_mode
+    if admin in ("access", "trunk"):
+        return admin
+    # dynamic / None — fall back to oper_mode
+    oper = info.oper_mode
+    if oper in ("access", "trunk"):
+        return oper
+    return None  # routed / unknown
+
+
+def _normalize_allowed(
+    allowed: list[int] | str | None,
+) -> tuple[list[int], bool]:
+    """
+    Normalize a SwitchportInfo.allowed_vlans value into ``(vids, is_wildcard)``.
+
+    Accepts the literal ``"all"`` token (case-insensitive), a list of ints
+    (with bool/oob entries dropped), or None. List input is clamped to 1..4094
+    and de-booled. Empty list → ([], False) — NOT a wildcard.
+    """
+    if allowed is None:
+        return [], False
+    if isinstance(allowed, str):
+        if allowed.strip().lower() == "all":
+            return [], True
+        # any other string is treated as a comma-separated spec
+        return parse_vlan_range_string(allowed)
+    if isinstance(allowed, list):
+        cleaned = [coerce_vid(v) for v in allowed]
+        out = [v for v in cleaned if v is not None]
+        return ([], True) if _is_full_vlan_range(out) else (out, False)
+    return [], False
+
+
+def classify_switchport(info: SwitchportInfo) -> dict:
+    """
+    Map a SwitchportInfo to a switchport entry dict.
+
+    See module docstring for output shape and NetBox mapping.
+    """
+    effective = _resolve_effective_mode(info)
+    if effective is None:
+        return {"mode": "routed", "tagged": [], "untagged": None}
+
+    if effective == "access":
+        access = coerce_vid(info.access_vlan)
+        voice = coerce_vid(info.voice_vlan)
+        if voice is not None and voice != access:
+            # Voice-VLAN promotion: NetBox 'access' mode disallows tagged
+            # VLANs. Promote to trunk with the voice VLAN tagged + access
+            # as untagged. When voice == access (operator misconfig) keep
+            # plain access.
+            return {"mode": "trunk", "tagged": [voice], "untagged": access}
+        return {"mode": "access", "tagged": [], "untagged": access}
+
+    # effective == "trunk"
+    native = coerce_vid(info.native_vlan)
+    vids, is_wildcard = _normalize_allowed(info.allowed_vlans)
+    if is_wildcard:
+        return {"mode": "trunk-all", "tagged": [], "untagged": native}
+    tagged = [v for v in vids if v != native]
+    return {"mode": "trunk", "tagged": tagged, "untagged": native}

--- a/device-discovery/custom_napalm/cisco_s300.py
+++ b/device-discovery/custom_napalm/cisco_s300.py
@@ -159,6 +159,23 @@ def _parse_portchannel_status_raw(raw: str) -> dict[str, dict]:
 _S300_BLOCK_RE = re.compile(r"^Name:\s*(\S+)\s*$", re.MULTILINE)
 
 
+def _maybe_int(s: object) -> int | None:
+    """
+    Convert a string/int to int, returning None on failure.
+
+    Rejects ``bool`` explicitly: ``bool`` is a subclass of ``int`` in Python,
+    so ``int(True) == 1`` — without this guard a buggy upstream parser
+    passing a bool would slip past the classifier's bool-rejection in
+    ``_vlan.coerce_vid``.
+    """
+    if isinstance(s, bool):
+        return None
+    try:
+        return int(s)  # type: ignore[arg-type]
+    except (ValueError, TypeError):
+        return None
+
+
 def _s300_block_to_switchport_info(fields: dict[str, str]) -> SwitchportInfo:
     """
     Build a SwitchportInfo from one parsed ``show interfaces switchport`` block.
@@ -179,12 +196,6 @@ def _s300_block_to_switchport_info(fields: dict[str, str]) -> SwitchportInfo:
         admin = "trunk"  # 'general' collapses to trunk semantics
     else:
         admin = None
-
-    def _maybe_int(s: str) -> int | None:
-        try:
-            return int(s)
-        except (ValueError, TypeError):
-            return None
 
     access_vid = _maybe_int(fields.get("Access Mode VLAN", ""))
     native_vid = _maybe_int(fields.get("Trunking Native Mode VLAN", ""))

--- a/device-discovery/custom_napalm/cisco_s300.py
+++ b/device-discovery/custom_napalm/cisco_s300.py
@@ -196,11 +196,9 @@ def _s300_block_to_switchport_info(fields: dict[str, str]) -> SwitchportInfo:
             allowed: list[int] | str | None = "all"
         else:
             allowed = vids
-            # PR #375 contract: malformed trunk input must NOT silently
-            # widen to trunk-all. Warn from the cisco_s300 logger so
-            # operators can spot drift; existing test
-            # ``test_get_interfaces_vlans_malformed_trunk_does_not_promote``
-            # asserts this warning is emitted.
+            # Malformed trunk input must NOT silently widen to trunk-all.
+            # Warn from the cisco_s300 logger so operators can spot vendor
+            # output drift.
             raw_lower = trunk_spec.strip().lower()
             if raw_lower and raw_lower != "none" and not vids:
                 logger.warning(

--- a/device-discovery/custom_napalm/cisco_s300.py
+++ b/device-discovery/custom_napalm/cisco_s300.py
@@ -16,6 +16,8 @@ from napalm.base import models
 from napalm.base.netmiko_helpers import netmiko_args
 from ntc_templates.parse import parse_output as _parse_output_raw
 
+from custom_napalm._vlan import SwitchportInfo, classify_switchport, parse_vlan_range_string
+
 logger = logging.getLogger(__name__)
 
 # Config sanitization — S300 sensitive CLI fields:
@@ -154,101 +156,69 @@ def _parse_portchannel_status_raw(raw: str) -> dict[str, dict]:
     return result
 
 
-def _expand_s300_chunk(chunk: str) -> list[int]:
-    """
-    Expand a single S300 VLAN list chunk ("10" or "10-12") into VIDs.
-
-    Out-of-range / inverted / unparseable chunks return ``[]``. Lo/hi are
-    clamped to the dot1q range 1..4094 so callers can detect wildcards
-    on the aggregated output.
-    """
-    chunk = chunk.strip()
-    if not chunk:
-        return []
-    if "-" in chunk:
-        lo_s, hi_s = chunk.split("-", 1)
-        try:
-            lo, hi = int(lo_s), int(hi_s)
-        except ValueError:
-            return []
-        lo = max(lo, 1)
-        hi = min(hi, 4094)
-        if lo > hi:
-            return []
-        return list(range(lo, hi + 1))
-    try:
-        return [int(chunk)]
-    except ValueError:
-        return []
-
-
-def _parse_s300_vlan_list(value: str) -> tuple[list[int], bool]:
-    """
-    Expand "1,10-12,20" -> ``([1, 10, 11, 12, 20], False)``.
-
-    Returns ``([], True)`` for genuine wildcards: literal ``all`` /
-    ``"1-4094"`` / multi-range expansions covering the full 1-4094 dot1q
-    range. Returns ``([], False)`` for empty/none/unparseable input.
-    Callers must NOT treat the ``([], False)`` case as a wildcard, since
-    that path is reached by junk tokens too.
-    """
-    if not value:
-        return [], False
-    raw = value.strip().lower()
-    if raw == "all":
-        return [], True
-    if raw == "none":
-        return [], False
-    out: list[int] = []
-    for chunk in value.split(","):
-        out.extend(_expand_s300_chunk(chunk))
-    out = [v for v in out if 1 <= v <= 4094]
-    is_full_range = (
-        bool(out) and min(out) <= 1 and max(out) >= 4094 and len(set(out)) >= 4094
-    )
-    if is_full_range:
-        return [], True
-    return out, False
-
-
 _S300_BLOCK_RE = re.compile(r"^Name:\s*(\S+)\s*$", re.MULTILINE)
 
 
-def _s300_switchport_block_to_entry(fields: dict[str, str]) -> dict:
-    """Map a parsed ``show interfaces switchport`` block to the NAPALM #919 jobec shape."""
+def _s300_block_to_switchport_info(fields: dict[str, str]) -> SwitchportInfo:
+    """
+    Build a SwitchportInfo from one parsed ``show interfaces switchport`` block.
+
+    The S300 CLI emits multi-line key:value blocks per interface; this function
+    consumes the parsed dict (key strings exactly as printed by the device).
+    """
     if fields.get("Switchport", "").lower() != "enable":
-        return {"mode": "routed", "tagged": [], "untagged": None}
+        return SwitchportInfo(
+            enabled=False, admin_mode=None, oper_mode=None,
+            access_vlan=None, native_vlan=None, allowed_vlans=None,
+        )
 
-    admin_mode = fields.get("Administrative Mode", "").lower()
-    try:
-        access_vid: int | None = int(fields.get("Access Mode VLAN", ""))
-    except (ValueError, TypeError):
-        access_vid = None
-    try:
-        native_vid: int | None = int(fields.get("Trunking Native Mode VLAN", ""))
-    except (ValueError, TypeError):
-        native_vid = None
+    admin_raw = fields.get("Administrative Mode", "").lower()
+    if admin_raw == "access":
+        admin: str | None = "access"
+    elif admin_raw in ("trunk", "general"):
+        admin = "trunk"  # 'general' collapses to trunk semantics
+    else:
+        admin = None
 
-    if admin_mode == "access":
-        return {"mode": "access", "tagged": [], "untagged": access_vid}
-    if admin_mode in {"trunk", "general"}:
-        trunk_vlans = fields.get("Trunking VLANs Enabled", "")
-        expanded, is_wildcard = _parse_s300_vlan_list(trunk_vlans or "")
-        # Only promote to trunk-all when the helper signals a real wildcard
-        # (literal "all" or a numeric full-range expansion). Junk tokens
-        # collapse to ``([], False)`` and must NOT silently widen the trunk.
+    def _maybe_int(s: str) -> int | None:
+        try:
+            return int(s)
+        except (ValueError, TypeError):
+            return None
+
+    access_vid = _maybe_int(fields.get("Access Mode VLAN", ""))
+    native_vid = _maybe_int(fields.get("Trunking Native Mode VLAN", ""))
+
+    trunk_spec = fields.get("Trunking VLANs Enabled", "")
+    if trunk_spec:
+        vids, is_wildcard = parse_vlan_range_string(trunk_spec)
         if is_wildcard:
-            return {"mode": "trunk-all", "tagged": [], "untagged": native_vid}
-        raw = (trunk_vlans or "").strip().lower()
-        if raw and raw != "none" and not expanded:
-            logger.warning(
-                "Trunking VLANs Enabled=%r could not be parsed; "
-                "treating as plain trunk with no tagged VLANs",
-                trunk_vlans,
-            )
-        tagged = [v for v in expanded if v != native_vid]
-        return {"mode": "trunk", "tagged": tagged, "untagged": native_vid}
-    return {"mode": "routed", "tagged": [], "untagged": None}
+            allowed: list[int] | str | None = "all"
+        else:
+            allowed = vids
+            # PR #375 contract: malformed trunk input must NOT silently
+            # widen to trunk-all. Warn from the cisco_s300 logger so
+            # operators can spot drift; existing test
+            # ``test_get_interfaces_vlans_malformed_trunk_does_not_promote``
+            # asserts this warning is emitted.
+            raw_lower = trunk_spec.strip().lower()
+            if raw_lower and raw_lower != "none" and not vids:
+                logger.warning(
+                    "Trunking VLANs Enabled=%r could not be parsed; "
+                    "treating as plain trunk with no tagged VLANs",
+                    trunk_spec,
+                )
+    else:
+        allowed = None
+
+    return SwitchportInfo(
+        enabled=True,
+        admin_mode=admin,  # type: ignore[arg-type]
+        oper_mode=None,    # S300 doesn't expose oper-mode separately
+        access_vlan=access_vid,
+        native_vlan=native_vid,
+        allowed_vlans=allowed,
+    )
 
 
 def _parse_vlan_ports_raw(raw: str) -> dict[str, list[str]]:
@@ -508,10 +478,10 @@ class S300Driver(_napalm_base.NetworkDriver):
 
     def get_interfaces_vlans(self) -> dict[str, dict]:
         """
-        Return per-interface VLAN config (NAPALM #919 jobec shape).
+        Return per-interface VLAN config.
 
-        Parses ``show interfaces switchport`` from the S300 CLI.
-        Modes: access | trunk | trunk-all | routed (PVLAN/customer/etc. -> routed in v1).
+        Parses ``show interfaces switchport`` from the S300 CLI. Modes:
+        access | trunk | trunk-all | routed (PVLAN/customer/etc. → routed in v1).
         General mode collapses to trunk with explicit untagged + tagged sets.
         """
         output = self.device.send_command("show interfaces switchport")
@@ -536,11 +506,13 @@ class S300Driver(_napalm_base.NetworkDriver):
                 blocks[current][last_key] = v.strip()
             elif last_key is not None and line.strip():
                 # Continuation of the previous field's value. S300 wraps long
-                # `Trunking VLANs Enabled` values across indented lines; the
-                # downstream `_parse_s300_vlan_list` splits on commas and
-                # tolerates extra whitespace so we just concatenate.
+                # `Trunking VLANs Enabled` values across indented lines.
                 blocks[current][last_key] = (
                     blocks[current][last_key] + line.strip()
                 )
 
-        return {ifname: _s300_switchport_block_to_entry(fields) for ifname, fields in blocks.items()}
+        result: dict[str, dict] = {}
+        for ifname, fields in blocks.items():
+            info = _s300_block_to_switchport_info(fields)
+            result[ifname] = classify_switchport(info)
+        return result

--- a/device-discovery/custom_napalm/eos.py
+++ b/device-discovery/custom_napalm/eos.py
@@ -1,0 +1,118 @@
+# Copyright 2026 NetBox Labs Inc
+"""
+Arista EOS NAPALM driver subclass adding ``get_interfaces_vlans()``.
+
+Fetches structured switchport data via pyeapi (eAPI JSON-RPC) and maps
+each port into a :class:`custom_napalm._vlan.SwitchportInfo` for the
+generic classifier.
+"""
+
+import logging
+
+from napalm.eos.eos import EOSDriver as NapalmEOSDriver
+
+from custom_napalm._vlan import SwitchportInfo, classify_switchport, parse_vlan_range_string
+
+logger = logging.getLogger(__name__)
+
+
+def _maybe_int(v: object) -> int | None:
+    """Coerce to int, returning None for bools and non-numeric values."""
+    if isinstance(v, bool):
+        return None
+    try:
+        return int(v)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+def _eos_port_to_switchport_info(port_data: dict) -> SwitchportInfo:
+    """
+    Build a SwitchportInfo from one entry of eAPI ``show interfaces switchport`` output.
+
+    Arista eAPI per-port shape::
+
+        {
+            "enabled": true,
+            "switchportInfo": {
+                "mode": "access" | "trunk",
+                "accessVlanId": 100,
+                "trunkingNativeVlanId": 1,
+                "trunkAllowedVlans": "1-4094" | "10,20" | "ALL" | "NONE",
+                ...
+            }
+        }
+    """
+    if not port_data.get("enabled", True):
+        return SwitchportInfo(
+            enabled=False,
+            admin_mode=None,
+            oper_mode=None,
+            access_vlan=None,
+            native_vlan=None,
+            allowed_vlans=None,
+        )
+
+    sw = port_data.get("switchportInfo") or {}
+    mode_raw = (sw.get("mode") or "").lower()
+    if "access" in mode_raw:
+        admin: str | None = "access"
+    elif "trunk" in mode_raw:
+        admin = "trunk"
+    else:
+        # Includes "routed", empty, and any unknown mode — the generic
+        # classifier maps admin_mode=None to a routed entry.
+        admin = None
+
+    trunk_spec = sw.get("trunkAllowedVlans") or ""
+    if trunk_spec:
+        vids, is_wildcard = parse_vlan_range_string(trunk_spec)
+        allowed: list[int] | str | None = "all" if is_wildcard else vids
+    else:
+        allowed = None
+
+    return SwitchportInfo(
+        enabled=True,
+        admin_mode=admin,  # type: ignore[arg-type]
+        oper_mode=None,  # EOS does not expose DTP-style oper mode
+        access_vlan=_maybe_int(sw.get("accessVlanId")),
+        native_vlan=_maybe_int(sw.get("trunkingNativeVlanId")),
+        allowed_vlans=allowed,
+    )
+
+
+class EOSDriver(NapalmEOSDriver):
+    """Arista EOS NAPALM driver with VLAN-interface association support."""
+
+    def get_interfaces_vlans(self) -> dict[str, dict]:
+        """
+        Return per-interface VLAN config.
+
+        Output shape per interface::
+
+            {"mode": "access"|"trunk"|"trunk-all"|"routed",
+             "tagged": list[int], "untagged": int | None}
+
+        Uses ``self._run_commands`` (the upstream EOSDriver wrapper) — NOT
+        ``self.device.run_commands``. The wrapper bridges both eAPI
+        (pyeapi ``Node.run_commands``) and SSH (Netmiko ``send_command`` +
+        ``| json`` pipe). Calling pyeapi directly via ``self.device``
+        breaks deployments that configure ``transport=ssh``.
+        """
+        try:
+            response = self._run_commands(
+                ["show interfaces switchport"], encoding="json"
+            )
+        except Exception:
+            logger.debug("EOS show interfaces switchport failed", exc_info=True)
+            return {}
+
+        if not response:
+            return {}
+        switchports = (response[0] or {}).get("switchports") or {}
+
+        result: dict[str, dict] = {}
+        for ifname, port_data in switchports.items():
+            info = _eos_port_to_switchport_info(port_data or {})
+            result[ifname] = classify_switchport(info)
+        return result

--- a/device-discovery/custom_napalm/ios.py
+++ b/device-discovery/custom_napalm/ios.py
@@ -20,7 +20,17 @@ logger = logging.getLogger(__name__)
 
 
 def _maybe_int(v: object) -> int | None:
-    """Convert a string/int to int, returning None on failure."""
+    """
+    Convert a string/int to int, returning None on failure.
+
+    Explicitly rejects ``bool`` (which is a subclass of ``int`` in Python,
+    so ``int(True) == 1``). VLAN-ID fields populated from buggy upstream
+    parsers must NOT silently turn ``True``/``False`` into VID 1/0 — the
+    classifier's bool-rejection in ``_vlan.coerce_vid`` only fires if the
+    bool reaches it un-coerced.
+    """
+    if isinstance(v, bool):
+        return None
     try:
         return int(v)  # type: ignore[arg-type]
     except (TypeError, ValueError):

--- a/device-discovery/custom_napalm/ios.py
+++ b/device-discovery/custom_napalm/ios.py
@@ -1,5 +1,12 @@
 # Copyright 2026 NetBox Labs Inc
-"""IOS NAPALM driver subclass adding get_interfaces_vlans()."""
+"""
+IOS NAPALM driver subclass adding ``get_interfaces_vlans()``.
+
+Parses ``show interfaces switchport`` via ntc-templates, normalizes each
+row into a :class:`custom_napalm._vlan.SwitchportInfo`, and delegates to
+the generic classifier. The classifier handles voice promotion, DTP
+fallback, wildcard signaling, and clamping — none of that is duplicated here.
+"""
 
 import logging
 
@@ -7,146 +14,101 @@ from napalm.base.helpers import canonical_interface_name
 from napalm.ios.ios import IOSDriver as NapalmIOSDriver
 from ntc_templates.parse import parse_output
 
+from custom_napalm._vlan import SwitchportInfo, classify_switchport, parse_vlan_range_string
+
 logger = logging.getLogger(__name__)
 
 
-def _expand_ios_vlan_list(items: list[str]) -> tuple[list[int], bool]:
-    """
-    Expand ntc-templates trunking_vlans list into ``(vids, is_wildcard)``.
-
-    Each item is a digit ("10"), a range ("20-30"), "ALL", or "NONE".
-    Returns ``([], True)`` for genuine wildcards (literal ``ALL`` or any
-    expansion that covers the full 1-4094 dot1q range). Returns
-    ``([...], False)`` for explicit lists, ``([], False)`` for empty/NONE
-    input, and ``([], False)`` for unparseable input — callers must NOT
-    treat the False-with-empty-list case as a wildcard, since that path
-    can be entered by junk tokens (e.g. "5000-9000" clamped out, "junk"
-    failing int()).
-    """
-    if not items:
-        return [], False
-    has_explicit_all = any((tok or "").strip().upper() == "ALL" for tok in items)
-    out: list[int] = []
-    for item in items:
-        token = (item or "").strip().upper()
-        if not token or token in {"ALL", "NONE"}:
-            continue
-        if "-" in token:
-            lo_s, hi_s = token.split("-", 1)
-            try:
-                lo, hi = int(lo_s), int(hi_s)
-            except ValueError:
-                continue
-            lo = max(lo, 1)
-            hi = min(hi, 4094)
-            if lo > hi:
-                continue
-            out.extend(range(lo, hi + 1))
-        else:
-            try:
-                out.append(int(token))
-            except ValueError:
-                continue
-    out = [v for v in out if 1 <= v <= 4094]
-    is_full_range = (
-        bool(out) and min(out) <= 1 and max(out) >= 4094 and len(set(out)) >= 4094
-    )
-    if has_explicit_all or is_full_range:
-        return [], True
-    return out, False
+def _maybe_int(v: object) -> int | None:
+    """Convert a string/int to int, returning None on failure."""
+    try:
+        return int(v)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
 
 
-def _classify_ios_trunk(raw_trunking: list, native_vid: int | None) -> dict:
-    """
-    Classify the trunking_vlans portion of a trunk row into the jobec shape.
+def _normalize_admin_mode(raw: str) -> str | None:
+    """Map a raw IOS admin_mode string to 'access', 'trunk', 'dynamic', or None."""
+    if "access" in raw:
+        return "access"
+    if "trunk" in raw:
+        return "trunk"
+    if "dynamic" in raw:
+        return "dynamic"
+    return None
 
-    Returns the appropriate mode (``trunk`` / ``trunk-all``) based on the
-    typed wildcard signal from :func:`_expand_ios_vlan_list`. Logs a
-    warning when a non-empty, non-NONE input parses to an empty list
-    (likely malformed input), but does NOT promote to ``trunk-all`` in
-    that case — bad CLI rows yield a plain trunk with no tagged VLANs.
+
+def _normalize_oper_mode(raw: str) -> str | None:
+    """Map a raw IOS operational mode string to 'access', 'trunk', 'routed', or None."""
+    if "access" in raw:
+        return "access"
+    if "trunk" in raw:
+        return "trunk"
+    if "routed" in raw:
+        return "routed"
+    return None
+
+
+def _parse_trunking_vlans(raw_trunking: list) -> list[int] | str | None:
     """
-    expanded, is_wildcard = _expand_ios_vlan_list(raw_trunking)
+    Convert an ntc-templates trunking_vlans token list to allowed_vlans.
+
+    Returns ``"all"`` for wildcard inputs, a list of int VIDs for explicit
+    ranges, or None when the token list is empty. Logs a WARNING when the
+    caller supplied non-empty, non-NONE tokens that parsed to nothing — this
+    prevents silent trunk-all promotion on malformed CLI output.
+    """
+    if not raw_trunking:
+        return None
+    spec = ",".join(t for t in raw_trunking if t)
+    vids, is_wildcard = parse_vlan_range_string(spec)
     if is_wildcard:
-        return {"mode": "trunk-all", "tagged": [], "untagged": native_vid}
-    has_input = any((tok or "").strip() for tok in (raw_trunking or []))
-    has_none = any((tok or "").strip().upper() == "NONE" for tok in (raw_trunking or []))
-    if has_input and not has_none and not expanded:
+        return "all"
+    has_input = any((tok or "").strip() for tok in raw_trunking)
+    has_none = any((tok or "").strip().upper() == "NONE" for tok in raw_trunking)
+    if has_input and not has_none and not vids:
         logger.warning(
             "trunking_vlans=%r could not be parsed; "
             "treating as plain trunk with no tagged VLANs",
             raw_trunking,
         )
-    if native_vid is not None:
-        expanded = [v for v in expanded if v != native_vid]
-    return {"mode": "trunk", "tagged": expanded, "untagged": native_vid}
+    return vids
 
 
-def _classify_ios_switchport_row(row: dict) -> dict:
+def _ios_row_to_switchport_info(row: dict) -> SwitchportInfo:
     """
-    Map one ntc-templates parsed row to NAPALM #919 jobec shape.
+    Build a SwitchportInfo from one ntc-templates ``show interfaces switchport`` row.
 
-    Returns ``{"mode": "access"|"trunk"|"trunk-all"|"routed",
-    "tagged": list[int], "untagged": int | None}``.
-
-    Voice-VLAN promotion: an access port with a configured voice VLAN is
-    reported as ``mode=trunk, untagged=access_vid, tagged=[voice_vid]``
-    because NetBox's ``access`` mode disallows tagged VLANs.
-
-    DTP-negotiated ports (admin_mode = "dynamic auto" / "dynamic desirable")
-    fall back to operational ``mode`` for classification, since the admin
-    string itself contains neither "access" nor "trunk".
+    Field mapping rules:
+      - ``switchport`` "Disabled" / falsy   → enabled=False (routed downstream)
+      - ``admin_mode`` is the trusted intent signal; "dynamic auto" /
+        "dynamic desirable" map to ``"dynamic"`` so the classifier falls
+        back to oper_mode.
+      - ``mode`` (operational) is normalized similarly.
+      - ``trunking_vlans`` is a list of tokens — flattened via comma-join
+        and handed to ``parse_vlan_range_string``; literal "ALL" / "NONE"
+        tokens are detected by the helper.
     """
     switchport = (row.get("switchport") or "").lower()
-    admin_mode = (row.get("admin_mode") or "").lower()
-    oper_mode = (row.get("mode") or "").lower()
-
     if "disabled" in switchport:
-        return {"mode": "routed", "tagged": [], "untagged": None}
+        return SwitchportInfo(
+            enabled=False, admin_mode=None, oper_mode=None,
+            access_vlan=None, native_vlan=None, allowed_vlans=None,
+        )
 
-    # Pick the most useful mode signal. Admin tells us the user's intent;
-    # operational tells us what the port actually negotiated to. For DTP
-    # modes ("dynamic auto", "dynamic desirable") admin_mode is unhelpful,
-    # so fall back to oper_mode. If both are empty, treat as routed.
-    effective = admin_mode if (
-        "access" in admin_mode or "trunk" in admin_mode
-    ) else oper_mode
+    admin = _normalize_admin_mode((row.get("admin_mode") or "").lower())
+    oper = _normalize_oper_mode((row.get("mode") or "").lower())
+    allowed = _parse_trunking_vlans(row.get("trunking_vlans") or [])
 
-    if not effective or "routed" in effective:
-        return {"mode": "routed", "tagged": [], "untagged": None}
-
-    def _to_int(value: str) -> int | None:
-        try:
-            return int(value)
-        except (ValueError, TypeError):
-            return None
-
-    access_vid = _to_int(row.get("access_vlan", ""))
-    native_vid = _to_int(row.get("native_vlan", ""))
-    voice_vid = _to_int(row.get("voice_vlan", ""))
-
-    if "access" in effective:
-        # Voice-VLAN promotion: an access port with a *distinct* voice VLAN
-        # is reported as mode=trunk with the voice VLAN tagged. NetBox's
-        # `access` mode disallows tagged VLANs. When voice_vid equals
-        # access_vid (operator misconfiguration or coincidence), keep the
-        # interface as plain access — promoting would produce mode=tagged
-        # with an empty tagged list after the translator's defensive
-        # native-stripped-from-tagged filter.
-        if voice_vid and voice_vid != access_vid:
-            return {
-                "mode": "trunk",
-                "tagged": [voice_vid],
-                "untagged": access_vid,
-            }
-        return {
-            "mode": "access",
-            "tagged": [],
-            "untagged": access_vid,
-        }
-    if "trunk" in effective:
-        return _classify_ios_trunk(row.get("trunking_vlans") or [], native_vid)
-    return {"mode": "routed", "tagged": [], "untagged": None}
+    return SwitchportInfo(
+        enabled=True,
+        admin_mode=admin,  # type: ignore[arg-type]
+        oper_mode=oper,    # type: ignore[arg-type]
+        access_vlan=_maybe_int(row.get("access_vlan", "")),
+        native_vlan=_maybe_int(row.get("native_vlan", "")),
+        allowed_vlans=allowed,
+        voice_vlan=_maybe_int(row.get("voice_vlan", "")),
+    )
 
 
 class IOSDriver(NapalmIOSDriver):
@@ -154,9 +116,19 @@ class IOSDriver(NapalmIOSDriver):
 
     def get_interfaces_vlans(self) -> dict[str, dict]:
         """
-        Return per-interface VLAN config (NAPALM #919 jobec shape).
+        Return per-interface VLAN config.
 
-        Parses ``show interfaces switchport`` via ntc-templates.
+        Output shape per interface::
+
+            {"mode": "access"|"trunk"|"trunk-all"|"routed",
+             "tagged": list[int], "untagged": int | None}
+
+        Parses ``show interfaces switchport`` via ntc-templates. Always
+        canonicalizes interface names (``Gi1/0/1`` → ``GigabitEthernet1/0/1``)
+        because NAPALM IOS's default ``get_interfaces()`` returns long-form
+        from ``show interfaces``, while ``show interfaces switchport`` emits
+        short-form. Without canonicalization the translator's exact-name
+        match silently misses associations.
         """
         output = self._send_command("show interfaces switchport")
         if not output:
@@ -180,11 +152,7 @@ class IOSDriver(NapalmIOSDriver):
             ifname = row.get("interface")
             if not ifname:
                 continue
-            # Always canonicalize: NAPALM IOS's default get_interfaces() returns
-            # long-form names (GigabitEthernet1/0/1) parsed from `show interfaces`,
-            # but `show interfaces switchport` emits short-form (Gi1/0/1). Without
-            # this, apply_interface_vlans()'s exact-name match silently misses
-            # associations in the common default configuration.
             ifname = canonical_interface_name(ifname)
-            result[ifname] = _classify_ios_switchport_row(row)
+            info = _ios_row_to_switchport_info(row)
+            result[ifname] = classify_switchport(info)
         return result

--- a/device-discovery/custom_napalm/junos.py
+++ b/device-discovery/custom_napalm/junos.py
@@ -110,9 +110,9 @@ def _interface_to_switchport_info(intf_elem) -> SwitchportInfo:
         tagness = _text(_find_child(m, "interface-vlan-member-tagness")).lower()
         if vid is None:
             # Member emitted with only a name (no tagid). v1 doesn't resolve
-            # names → IDs via self.get_vlans(); skip and warn so the
-            # operator sees missing associations in logs.
-            logger.debug(
+            # names → IDs via self.get_vlans(); warn so operators see the
+            # missing association at default log levels.
+            logger.warning(
                 "Junos interface-vlan-member %r has no tagid; skipping (name resolution out-of-scope for v1)",
                 name,
             )

--- a/device-discovery/custom_napalm/junos.py
+++ b/device-discovery/custom_napalm/junos.py
@@ -8,9 +8,14 @@ Handles both ELS and non-ELS configuration models. v1 skips voice VLAN
 
 XML parsing notes
 -----------------
-- lxml only supports XPath 1.0, so the ``local-name()`` predicate is NOT
-  available. We compare ``etree.QName(child.tag).localname`` instead, which
-  is namespace-agnostic and works on every element lxml can produce.
+- ``Element.find()`` / ``Element.findall()`` use ElementPath, a simplified
+  subset of XPath that does NOT accept arbitrary predicates such as
+  ``local-name()``. (Full XPath 1.0 — including ``local-name()`` — is
+  available via ``Element.xpath()``, but it's heavier and namespace-aware
+  in ways that complicate ELS/non-ELS handling.) We compare
+  ``etree.QName(child.tag).localname`` directly instead — namespace-agnostic,
+  works on every element lxml can produce, and avoids the XPath dependency
+  altogether.
 - ELS responses wrap the per-interface list in
   ``<l2ng-l2ald-iff-information>`` and use ``<interface-mode>``.
 - Non-ELS responses wrap in ``<ethernet-switching-interface-information>``
@@ -77,7 +82,7 @@ def _interface_to_switchport_info(intf_elem) -> SwitchportInfo:
     ``<interface-vlan-member>`` entries with
     ``<interface-vlan-member-tagid>`` and
     ``<interface-vlan-member-tagness>`` ("tagged"|"untagged"). Members
-    with only a name (no tagid) are dropped with a debug log — VLAN-name
+    with only a name (no tagid) are dropped with a warning log — VLAN-name
     resolution against ``self.get_vlans()`` is out-of-scope for v1.
     """
     # Mode — read whichever element is present

--- a/device-discovery/custom_napalm/junos.py
+++ b/device-discovery/custom_napalm/junos.py
@@ -1,0 +1,194 @@
+# Copyright 2026 NetBox Labs Inc
+"""
+Juniper Junos NAPALM driver subclass adding ``get_interfaces_vlans()``.
+
+Fetches via PyEZ NETCONF RPC. Targets EX/QFX switching products.
+Handles both ELS and non-ELS configuration models. v1 skips voice VLAN
+(Junos voip semantics differ from the Cisco family).
+
+XML parsing notes
+-----------------
+- lxml only supports XPath 1.0, so the ``local-name()`` predicate is NOT
+  available. We compare ``etree.QName(child.tag).localname`` instead, which
+  is namespace-agnostic and works on every element lxml can produce.
+- ELS responses wrap the per-interface list in
+  ``<l2ng-l2ald-iff-information>`` and use ``<interface-mode>``.
+- Non-ELS responses wrap in ``<ethernet-switching-interface-information>``
+  and use ``<interface-port-mode>``.
+- Both share the per-``<interface>`` child shape, so the parser only needs
+  to recurse into direct ``interface`` children regardless of wrapper.
+"""
+
+import logging
+
+from lxml import etree
+from napalm.junos.junos import JunOSDriver as NapalmJunOSDriver
+
+from custom_napalm._vlan import SwitchportInfo, classify_switchport
+
+logger = logging.getLogger(__name__)
+
+
+def _localname(elem) -> str:
+    """Return the namespace-stripped local name of an element."""
+    return etree.QName(elem.tag).localname
+
+
+def _find_child(parent, name: str):
+    """Find the first direct child whose local-name matches ``name``."""
+    if parent is None:
+        return None
+    for child in parent:
+        if _localname(child) == name:
+            return child
+    return None
+
+
+def _find_children(parent, name: str) -> list:
+    """Return all direct children whose local-name matches ``name``."""
+    if parent is None:
+        return []
+    return [child for child in parent if _localname(child) == name]
+
+
+def _text(elem) -> str:
+    """Return stripped text or empty string."""
+    if elem is None or elem.text is None:
+        return ""
+    return elem.text.strip()
+
+
+def _maybe_int(s: str) -> int | None:
+    try:
+        return int(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def _interface_to_switchport_info(intf_elem) -> SwitchportInfo:
+    """
+    Build a SwitchportInfo from one ``<interface>`` element.
+
+    Tolerates both ELS (``<interface-mode>``) and non-ELS
+    (``<interface-port-mode>``) shapes — Junos emits one or the other but
+    never both, so we read whichever is present.
+
+    VLAN membership is in ``<interface-vlan-member-list>`` containing
+    ``<interface-vlan-member>`` entries with
+    ``<interface-vlan-member-tagid>`` and
+    ``<interface-vlan-member-tagness>`` ("tagged"|"untagged"). Members
+    with only a name (no tagid) are dropped with a debug log — VLAN-name
+    resolution against ``self.get_vlans()`` is out-of-scope for v1.
+    """
+    # Mode — read whichever element is present
+    mode_text = (
+        _text(_find_child(intf_elem, "interface-mode"))
+        or _text(_find_child(intf_elem, "interface-port-mode"))
+    ).lower()
+
+    if "trunk" in mode_text:
+        admin: str | None = "trunk"
+    elif "access" in mode_text:
+        admin = "access"
+    else:
+        admin = None
+
+    native_vid = _maybe_int(_text(_find_child(intf_elem, "interface-native-vlan-id")))
+
+    member_list = _find_child(intf_elem, "interface-vlan-member-list")
+    members = _find_children(member_list, "interface-vlan-member") if member_list is not None else []
+
+    untagged_vid: int | None = None
+    tagged_vids: list[int] = []
+    has_all_member = False
+    for m in members:
+        name = _text(_find_child(m, "interface-vlan-name"))
+        if name.lower() == "all":
+            has_all_member = True
+            continue
+        vid = _maybe_int(_text(_find_child(m, "interface-vlan-member-tagid")))
+        tagness = _text(_find_child(m, "interface-vlan-member-tagness")).lower()
+        if vid is None:
+            # Member emitted with only a name (no tagid). v1 doesn't resolve
+            # names → IDs via self.get_vlans(); skip and warn so the
+            # operator sees missing associations in logs.
+            logger.debug(
+                "Junos interface-vlan-member %r has no tagid; skipping (name resolution out-of-scope for v1)",
+                name,
+            )
+            continue
+        if "untagged" in tagness:
+            untagged_vid = vid
+        else:
+            tagged_vids.append(vid)
+
+    if admin == "trunk":
+        allowed: list[int] | str | None = "all" if has_all_member else tagged_vids
+        # Native VLAN preferred over untagged-from-membership
+        native_resolved = native_vid if native_vid is not None else untagged_vid
+        return SwitchportInfo(
+            enabled=True,
+            admin_mode="trunk",
+            oper_mode=None,
+            access_vlan=None,
+            native_vlan=native_resolved,
+            allowed_vlans=allowed,
+        )
+    if admin == "access":
+        return SwitchportInfo(
+            enabled=True,
+            admin_mode="access",
+            oper_mode=None,
+            access_vlan=untagged_vid,
+            native_vlan=None,
+            allowed_vlans=None,
+        )
+
+    # No VLAN config at all → routed
+    return SwitchportInfo(
+        enabled=False,
+        admin_mode=None,
+        oper_mode=None,
+        access_vlan=None,
+        native_vlan=None,
+        allowed_vlans=None,
+    )
+
+
+class JunOSDriver(NapalmJunOSDriver):
+    """Juniper Junos NAPALM driver with VLAN-interface association support."""
+
+    def get_interfaces_vlans(self) -> dict[str, dict]:
+        """
+        Return per-interface VLAN config (PyEZ NETCONF path).
+
+        Wraps the entire RPC + parse pipeline in try/except — any unexpected
+        XML shape returns an empty dict rather than crashing the discovery
+        cycle. This deliberately swallows exceptions because Junos releases
+        emit subtly-different XML and we'd rather skip VLAN ingest than fail
+        the whole device.
+        """
+        try:
+            reply = self.device.rpc.get_ethernet_switching_interface_information()
+        except Exception:
+            logger.debug("Junos get-ethernet-switching-interface-information failed", exc_info=True)
+            return {}
+
+        if reply is None:
+            return {}
+
+        # Wrapper element is <ethernet-switching-interface-information> (non-ELS)
+        # or <l2ng-l2ald-iff-information> (ELS). Each <interface> child has the
+        # same shape regardless of wrapper.
+        try:
+            result: dict[str, dict] = {}
+            for intf in _find_children(reply, "interface"):
+                ifname = _text(_find_child(intf, "interface-name"))
+                if not ifname:
+                    continue
+                info = _interface_to_switchport_info(intf)
+                result[ifname] = classify_switchport(info)
+            return result
+        except Exception:
+            logger.debug("Junos VLAN XML parse failed", exc_info=True)
+            return {}

--- a/device-discovery/custom_napalm/nxos.py
+++ b/device-discovery/custom_napalm/nxos.py
@@ -1,0 +1,54 @@
+# Copyright 2026 NetBox Labs Inc
+"""
+Cisco NX-OS NAPALM driver subclass adding ``get_interfaces_vlans()``.
+
+Fetches structured switchport data via NX-API (JSON) and maps each row
+through the shared NX-OS field-normalizer + generic classifier.
+"""
+
+import logging
+
+from napalm.nxos.nxos import NXOSDriver as NapalmNXOSDriver
+
+from custom_napalm._nxos_common import nxos_row_to_switchport_info
+from custom_napalm._vlan import classify_switchport
+
+logger = logging.getLogger(__name__)
+
+
+def _flatten_nxos_rows(payload: dict) -> list[dict]:
+    """
+    Flatten NX-API ``show interface switchport`` JSON into a list of row dicts.
+
+    NX-API wraps rows in ``TABLE_interface > ROW_interface``; ``ROW_interface``
+    is a dict for a single port and a list for multiple. Normalize to list.
+    """
+    table = (payload or {}).get("TABLE_interface") or {}
+    row = table.get("ROW_interface")
+    if row is None:
+        return []
+    if isinstance(row, list):
+        return row
+    return [row]
+
+
+class NXOSDriver(NapalmNXOSDriver):
+    """Cisco NX-OS NAPALM driver with VLAN-interface association support."""
+
+    def get_interfaces_vlans(self) -> dict[str, dict]:
+        """Return per-interface VLAN config (NX-API JSON path)."""
+        try:
+            payload = self.device.show("show interface switchport", raw_text=False)
+        except Exception:
+            logger.debug("NX-OS show interface switchport failed", exc_info=True)
+            return {}
+
+        rows = _flatten_nxos_rows(payload)
+        result: dict[str, dict] = {}
+        for row in rows:
+            ifname = row.get("interface")
+            if not ifname:
+                continue
+            info = nxos_row_to_switchport_info(row)
+            result[ifname] = classify_switchport(info)
+        return result

--- a/device-discovery/custom_napalm/nxos_ssh.py
+++ b/device-discovery/custom_napalm/nxos_ssh.py
@@ -1,0 +1,46 @@
+# Copyright 2026 NetBox Labs Inc
+"""
+Cisco NX-OS-SSH NAPALM driver subclass adding ``get_interfaces_vlans()``.
+
+Fetches ``show interface switchport`` over SSH (Netmiko), parses via
+ntc-templates ``cisco_nxos`` platform, and reuses the shared NX-OS
+field mapper so output is byte-identical with the NX-API path.
+"""
+
+import logging
+
+from napalm.nxos_ssh.nxos_ssh import NXOSSSHDriver as NapalmNXOSSSHDriver
+from ntc_templates.parse import parse_output
+
+from custom_napalm._nxos_common import nxos_row_to_switchport_info
+from custom_napalm._vlan import classify_switchport
+
+logger = logging.getLogger(__name__)
+
+
+class NXOSSSHDriver(NapalmNXOSSSHDriver):
+    """Cisco NX-OS-SSH NAPALM driver with VLAN-interface association support."""
+
+    def get_interfaces_vlans(self) -> dict[str, dict]:
+        """Return per-interface VLAN config (CLI scrape via ntc-templates)."""
+        output = self._send_command("show interface switchport")
+        if not output:
+            return {}
+        try:
+            rows = parse_output(
+                platform="cisco_nxos",
+                command="show interface switchport",
+                data=output,
+            )
+        except Exception:
+            logger.debug("ntc-templates failed to parse NX-OS switchport", exc_info=True)
+            return {}
+
+        result: dict[str, dict] = {}
+        for row in rows or []:
+            ifname = row.get("interface")
+            if not ifname:
+                continue
+            info = nxos_row_to_switchport_info(row)
+            result[ifname] = classify_switchport(info)
+        return result

--- a/device-discovery/tests/custom_drivers/arista_eos/__init__.py
+++ b/device-discovery/tests/custom_drivers/arista_eos/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Arista EOS custom NAPALM driver."""

--- a/device-discovery/tests/custom_drivers/arista_eos/conftest.py
+++ b/device-discovery/tests/custom_drivers/arista_eos/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest scenario discovery for arista_eos driver tests."""
+
+from pathlib import Path
+
+from tests.custom_drivers.base_test import parametrize_scenarios
+
+MOCK_DATA_ROOT = Path(__file__).parent / "mock_data"
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize the scenario fixture from sub-folders of each test method's mock dir."""
+    parametrize_scenarios(metafunc, MOCK_DATA_ROOT)

--- a/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/access_only/expected_result.json
+++ b/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/access_only/expected_result.json
@@ -1,0 +1,3 @@
+{
+  "Ethernet1": {"mode": "access", "tagged": [], "untagged": 100}
+}

--- a/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/access_only/show_interfaces_switchport.json
+++ b/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/access_only/show_interfaces_switchport.json
@@ -1,0 +1,13 @@
+{
+  "switchports": {
+    "Ethernet1": {
+      "enabled": true,
+      "switchportInfo": {
+        "mode": "access",
+        "accessVlanId": 100,
+        "trunkingNativeVlanId": 1,
+        "trunkAllowedVlans": "ALL"
+      }
+    }
+  }
+}

--- a/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/mixed/expected_result.json
+++ b/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/mixed/expected_result.json
@@ -1,0 +1,5 @@
+{
+  "Ethernet1": {"mode": "access", "tagged": [], "untagged": 100},
+  "Ethernet2": {"mode": "trunk", "tagged": [10, 20, 30], "untagged": 99},
+  "Ethernet5": {"mode": "routed", "tagged": [], "untagged": null}
+}

--- a/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/mixed/show_interfaces_switchport.json
+++ b/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/mixed/show_interfaces_switchport.json
@@ -1,0 +1,25 @@
+{
+  "switchports": {
+    "Ethernet1": {
+      "enabled": true,
+      "switchportInfo": {
+        "mode": "access",
+        "accessVlanId": 100,
+        "trunkingNativeVlanId": 1,
+        "trunkAllowedVlans": "ALL"
+      }
+    },
+    "Ethernet2": {
+      "enabled": true,
+      "switchportInfo": {
+        "mode": "trunk",
+        "trunkingNativeVlanId": 99,
+        "trunkAllowedVlans": "10,20,30"
+      }
+    },
+    "Ethernet5": {
+      "enabled": false,
+      "switchportInfo": {}
+    }
+  }
+}

--- a/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/routed/expected_result.json
+++ b/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/routed/expected_result.json
@@ -1,0 +1,3 @@
+{
+  "Ethernet4": {"mode": "routed", "tagged": [], "untagged": null}
+}

--- a/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/routed/show_interfaces_switchport.json
+++ b/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/routed/show_interfaces_switchport.json
@@ -1,0 +1,8 @@
+{
+  "switchports": {
+    "Ethernet4": {
+      "enabled": false,
+      "switchportInfo": {}
+    }
+  }
+}

--- a/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/trunk_all/expected_result.json
+++ b/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/trunk_all/expected_result.json
@@ -1,0 +1,3 @@
+{
+  "Ethernet3": {"mode": "trunk-all", "tagged": [], "untagged": 1}
+}

--- a/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/trunk_all/show_interfaces_switchport.json
+++ b/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/trunk_all/show_interfaces_switchport.json
@@ -1,0 +1,12 @@
+{
+  "switchports": {
+    "Ethernet3": {
+      "enabled": true,
+      "switchportInfo": {
+        "mode": "trunk",
+        "trunkingNativeVlanId": 1,
+        "trunkAllowedVlans": "1-4094"
+      }
+    }
+  }
+}

--- a/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/trunk_native/expected_result.json
+++ b/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/trunk_native/expected_result.json
@@ -1,0 +1,3 @@
+{
+  "Ethernet2": {"mode": "trunk", "tagged": [10, 20, 30], "untagged": 99}
+}

--- a/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/trunk_native/show_interfaces_switchport.json
+++ b/device-discovery/tests/custom_drivers/arista_eos/mock_data/test_get_interfaces_vlans/trunk_native/show_interfaces_switchport.json
@@ -1,0 +1,13 @@
+{
+  "switchports": {
+    "Ethernet2": {
+      "enabled": true,
+      "switchportInfo": {
+        "mode": "trunk",
+        "accessVlanId": 1,
+        "trunkingNativeVlanId": 99,
+        "trunkAllowedVlans": "10,20,30"
+      }
+    }
+  }
+}

--- a/device-discovery/tests/custom_drivers/arista_eos/test_driver.py
+++ b/device-discovery/tests/custom_drivers/arista_eos/test_driver.py
@@ -1,0 +1,57 @@
+"""
+Tests for the EOSDriver subclass — VLAN-association coverage only.
+
+The non-VLAN getters (get_facts, get_interfaces, etc.) are inherited unchanged
+from ``napalm.eos.eos.EOSDriver`` and covered by upstream NAPALM tests, so
+they are skipped here.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from custom_napalm.eos import EOSDriver
+from tests.custom_drivers.base_test import BaseDriverTest
+from tests.custom_drivers.mock_device import FakeJsonRpcDevice
+
+
+class TestEOSDriver(BaseDriverTest):
+    """Tests for the Arista EOS custom driver."""
+
+    driver_cls = EOSDriver
+    fake_device_cls = FakeJsonRpcDevice
+    mock_data_root = Path(__file__).parent / "mock_data"
+
+    def _build_driver(self, mock_dir):
+        """Build the driver with the eAPI transport path forced."""
+        # Upstream EOSDriver._run_commands branches on self.transport == "ssh".
+        # Force the eAPI path so it delegates to self.device.run_commands(...),
+        # which our FakeJsonRpcDevice implements.
+        driver = super()._build_driver(mock_dir)
+        driver.transport = "https"
+        return driver
+
+    # Skip inherited NAPALM getters — covered by upstream tests.
+    def test_get_facts(self, scenario):
+        """Skip: inherited from napalm.eos.eos.EOSDriver — covered upstream."""
+        pytest.skip("inherited from napalm.eos.eos.EOSDriver — covered upstream")
+
+    def test_get_interfaces(self, scenario):
+        """Skip: inherited from napalm.eos.eos.EOSDriver — covered upstream."""
+        pytest.skip("inherited from napalm.eos.eos.EOSDriver — covered upstream")
+
+    def test_get_interfaces_ip(self, scenario):
+        """Skip: inherited from napalm.eos.eos.EOSDriver — covered upstream."""
+        pytest.skip("inherited from napalm.eos.eos.EOSDriver — covered upstream")
+
+    def test_get_config(self, scenario):
+        """Skip: inherited from napalm.eos.eos.EOSDriver — covered upstream."""
+        pytest.skip("inherited from napalm.eos.eos.EOSDriver — covered upstream")
+
+    def test_get_config_sanitized(self, scenario):
+        """Skip: inherited from napalm.eos.eos.EOSDriver — covered upstream."""
+        pytest.skip("inherited from napalm.eos.eos.EOSDriver — covered upstream")
+
+    def test_get_vlans(self, scenario):
+        """Skip: inherited from napalm.eos.eos.EOSDriver — covered upstream."""
+        pytest.skip("inherited from napalm.eos.eos.EOSDriver — covered upstream")

--- a/device-discovery/tests/custom_drivers/base_test.py
+++ b/device-discovery/tests/custom_drivers/base_test.py
@@ -198,12 +198,20 @@ class BaseDriverTest:
             assert info.get("mode") in ("access", "trunk", "trunk-all", "routed"), (
                 f"{ifname}: invalid mode {info.get('mode')!r}"
             )
-            tagged = info.get("tagged", [])
+            assert "tagged" in info, f"{ifname}: missing 'tagged' key"
+            assert "untagged" in info, f"{ifname}: missing 'untagged' key"
+            tagged = info["tagged"]
             assert isinstance(tagged, list)
             for v in tagged:
-                assert isinstance(v, int) and 1 <= v <= 4094, f"{ifname}: bad tagged VID {v}"
-            untagged = info.get("untagged")
-            assert untagged is None or (isinstance(untagged, int) and 1 <= untagged <= 4094)
+                assert isinstance(v, int) and not isinstance(v, bool) and 1 <= v <= 4094, (
+                    f"{ifname}: bad tagged VID {v}"
+                )
+            untagged = info["untagged"]
+            assert untagged is None or (
+                isinstance(untagged, int)
+                and not isinstance(untagged, bool)
+                and 1 <= untagged <= 4094
+            )
 
         expected = _load_expected(mock_dir)
         if expected is not None:

--- a/device-discovery/tests/custom_drivers/cisco_ios/test_driver.py
+++ b/device-discovery/tests/custom_drivers/cisco_ios/test_driver.py
@@ -2,9 +2,24 @@
 
 from pathlib import Path
 
-from custom_napalm.ios import IOSDriver
+from custom_napalm.ios import IOSDriver, _maybe_int
 from tests.custom_drivers.base_test import BaseDriverTest
 from tests.custom_drivers.mock_device import FakeCLIDevice
+
+
+def test_ios_maybe_int_rejects_bool_true():
+    """Reject ``bool`` (int subclass) so it does not coerce to VID 1."""
+    assert _maybe_int(True) is None
+
+
+def test_ios_maybe_int_rejects_bool_false():
+    """Mirrors True case: False must not coerce to VID 0."""
+    assert _maybe_int(False) is None
+
+
+def test_ios_maybe_int_passes_through_string_int():
+    """Plain string-int still coerces normally."""
+    assert _maybe_int("42") == 42
 
 
 class TestIOSDriver(BaseDriverTest):

--- a/device-discovery/tests/custom_drivers/cisco_ios/test_driver.py
+++ b/device-discovery/tests/custom_drivers/cisco_ios/test_driver.py
@@ -32,15 +32,15 @@ class TestIOSDriver(BaseDriverTest):
         assert result["GigabitEthernet1/0/1"]["mode"] == "access"
         assert result["GigabitEthernet1/0/1"]["untagged"] == 10
 
-    def test_expand_ios_vlan_list_clamps_huge_range(self) -> None:
+    def test_expand_vlan_range_string_clamps_huge_range(self) -> None:
         """A range like 1-100000 is clamped to 1..4094 (then collapsed to wildcard)."""
-        from custom_napalm.ios import _expand_ios_vlan_list
+        from custom_napalm._vlan import parse_vlan_range_string
         # Single huge range whose hi is clamped to 4094 and lo is 1 → wildcard.
-        assert _expand_ios_vlan_list(["1-100000"]) == ([], True)
+        assert parse_vlan_range_string("1-100000") == ([], True)
         # Plain explicit list → not a wildcard, returns expanded VIDs.
-        assert _expand_ios_vlan_list(["10-12"]) == ([10, 11, 12], False)
+        assert parse_vlan_range_string("10-12") == ([10, 11, 12], False)
         # Out-of-range-only input → empty list, NOT a wildcard.
-        assert _expand_ios_vlan_list(["5000-9000"]) == ([], False)
+        assert parse_vlan_range_string("5000-9000") == ([], False)
 
     def test_get_interfaces_vlans_trunk_all_emits_distinct_mode(self) -> None:
         """A trunk advertising ALL VLANs emits mode='trunk-all', not 'trunk'."""
@@ -54,7 +54,8 @@ class TestIOSDriver(BaseDriverTest):
 
     def test_get_interfaces_vlans_numeric_full_range_is_trunk_all(self) -> None:
         """A numeric full-range trunk (e.g. 1-4094) collapses to trunk-all, same as literal ALL."""
-        from custom_napalm.ios import _classify_ios_switchport_row
+        from custom_napalm._vlan import classify_switchport
+        from custom_napalm.ios import _ios_row_to_switchport_info
         row = {
             "interface": "Gi1/0/48",
             "switchport": "Enabled",
@@ -65,12 +66,13 @@ class TestIOSDriver(BaseDriverTest):
             "voice_vlan": "none",
             "trunking_vlans": ["1-4094"],
         }
-        result = _classify_ios_switchport_row(row)
+        result = classify_switchport(_ios_row_to_switchport_info(row))
         assert result == {"mode": "trunk-all", "tagged": [], "untagged": 99}
 
     def test_get_interfaces_vlans_explicit_none_stays_plain_trunk(self) -> None:
         """A trunk explicitly with NONE allowed stays mode=trunk, not trunk-all."""
-        from custom_napalm.ios import _classify_ios_switchport_row
+        from custom_napalm._vlan import classify_switchport
+        from custom_napalm.ios import _ios_row_to_switchport_info
         row = {
             "interface": "Gi1/0/48",
             "switchport": "Enabled",
@@ -81,14 +83,15 @@ class TestIOSDriver(BaseDriverTest):
             "voice_vlan": "none",
             "trunking_vlans": ["NONE"],
         }
-        result = _classify_ios_switchport_row(row)
+        result = classify_switchport(_ios_row_to_switchport_info(row))
         assert result == {"mode": "trunk", "tagged": [], "untagged": 1}
 
     def test_get_interfaces_vlans_malformed_trunk_does_not_promote(self, caplog) -> None:
         """Junk trunking_vlans input must NOT silently widen the trunk to all VLANs."""
         import logging
 
-        from custom_napalm.ios import _classify_ios_switchport_row
+        from custom_napalm._vlan import classify_switchport
+        from custom_napalm.ios import _ios_row_to_switchport_info
         row = {
             "interface": "Gi1/0/48",
             "switchport": "Enabled",
@@ -100,14 +103,15 @@ class TestIOSDriver(BaseDriverTest):
             "trunking_vlans": ["5000-9000"],  # all out of range after clamp
         }
         with caplog.at_level(logging.WARNING, logger="custom_napalm.ios"):
-            result = _classify_ios_switchport_row(row)
+            result = classify_switchport(_ios_row_to_switchport_info(row))
         # NOT trunk-all — falls back to plain trunk with empty tagged list.
         assert result == {"mode": "trunk", "tagged": [], "untagged": 99}
         assert any("could not be parsed" in r.message for r in caplog.records)
 
     def test_get_interfaces_vlans_explicit_all_still_trunk_all(self) -> None:
         """Sanity: literal ALL still maps to trunk-all even with the typed-signal refactor."""
-        from custom_napalm.ios import _classify_ios_switchport_row
+        from custom_napalm._vlan import classify_switchport
+        from custom_napalm.ios import _ios_row_to_switchport_info
         row = {
             "interface": "Gi1/0/48",
             "switchport": "Enabled",
@@ -118,12 +122,13 @@ class TestIOSDriver(BaseDriverTest):
             "voice_vlan": "none",
             "trunking_vlans": ["ALL"],
         }
-        result = _classify_ios_switchport_row(row)
+        result = classify_switchport(_ios_row_to_switchport_info(row))
         assert result == {"mode": "trunk-all", "tagged": [], "untagged": 99}
 
     def test_get_interfaces_vlans_voice_equal_access_stays_access(self) -> None:
         """When voice VLAN equals access VLAN, keep mode=access (don't promote)."""
-        from custom_napalm.ios import _classify_ios_switchport_row
+        from custom_napalm._vlan import classify_switchport
+        from custom_napalm.ios import _ios_row_to_switchport_info
         row = {
             "interface": "Gi1/0/5",
             "switchport": "Enabled",
@@ -134,6 +139,6 @@ class TestIOSDriver(BaseDriverTest):
             "voice_vlan": "10",  # same as access_vlan — operator quirk
             "trunking_vlans": ["ALL"],
         }
-        result = _classify_ios_switchport_row(row)
+        result = classify_switchport(_ios_row_to_switchport_info(row))
         # NOT mode=trunk — promotion is suppressed when voice == access.
         assert result == {"mode": "access", "tagged": [], "untagged": 10}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/__init__.py
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Cisco NX-OS custom NAPALM driver."""

--- a/device-discovery/tests/custom_drivers/cisco_nxos/conftest.py
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest scenario discovery for cisco_nxos driver tests."""
+
+from pathlib import Path
+
+from tests.custom_drivers.base_test import parametrize_scenarios
+
+MOCK_DATA_ROOT = Path(__file__).parent / "mock_data"
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize the scenario fixture from sub-folders of each test method's mock dir."""
+    parametrize_scenarios(metafunc, MOCK_DATA_ROOT)

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/access_only/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/access_only/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "Ethernet1/1": {
+    "mode": "access",
+    "tagged": [],
+    "untagged": 100
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/access_only/show_interface_switchport.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/access_only/show_interface_switchport.json
@@ -1,0 +1,14 @@
+{
+  "TABLE_interface": {
+    "ROW_interface": {
+      "interface": "Ethernet1/1",
+      "switchport": "Enabled",
+      "admin_mode": "access",
+      "oper_mode": "access",
+      "access_vlan": "100",
+      "native_vlan": "1",
+      "voice_vlan": "none",
+      "trunk_vlans": "1-4094"
+    }
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/dynamic_auto/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/dynamic_auto/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "Ethernet1/5": {
+    "mode": "trunk",
+    "tagged": [10, 20],
+    "untagged": 1
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/dynamic_auto/show_interface_switchport.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/dynamic_auto/show_interface_switchport.json
@@ -1,0 +1,14 @@
+{
+  "TABLE_interface": {
+    "ROW_interface": {
+      "interface": "Ethernet1/5",
+      "switchport": "Enabled",
+      "admin_mode": "dynamic auto",
+      "oper_mode": "trunk",
+      "access_vlan": "1",
+      "native_vlan": "1",
+      "voice_vlan": "none",
+      "trunk_vlans": "10,20"
+    }
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/mixed/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/mixed/expected_result.json
@@ -1,0 +1,17 @@
+{
+  "Ethernet1/1": {
+    "mode": "access",
+    "tagged": [],
+    "untagged": 100
+  },
+  "Ethernet1/2": {
+    "mode": "trunk",
+    "tagged": [10, 20, 30],
+    "untagged": 1
+  },
+  "Ethernet1/3": {
+    "mode": "routed",
+    "tagged": [],
+    "untagged": null
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/mixed/show_interface_switchport.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/mixed/show_interface_switchport.json
@@ -1,0 +1,30 @@
+{
+  "TABLE_interface": {
+    "ROW_interface": [
+      {
+        "interface": "Ethernet1/1",
+        "switchport": "Enabled",
+        "admin_mode": "access",
+        "oper_mode": "access",
+        "access_vlan": "100",
+        "native_vlan": "1",
+        "voice_vlan": "none",
+        "trunk_vlans": "1-4094"
+      },
+      {
+        "interface": "Ethernet1/2",
+        "switchport": "Enabled",
+        "admin_mode": "trunk",
+        "oper_mode": "trunk",
+        "access_vlan": "1",
+        "native_vlan": "1",
+        "voice_vlan": "none",
+        "trunk_vlans": "10,20,30"
+      },
+      {
+        "interface": "Ethernet1/3",
+        "switchport": "Disabled"
+      }
+    ]
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/routed/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/routed/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "Ethernet1/6": {
+    "mode": "routed",
+    "tagged": [],
+    "untagged": null
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/routed/show_interface_switchport.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/routed/show_interface_switchport.json
@@ -1,0 +1,8 @@
+{
+  "TABLE_interface": {
+    "ROW_interface": {
+      "interface": "Ethernet1/6",
+      "switchport": "Disabled"
+    }
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/trunk_all/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/trunk_all/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "Ethernet1/4": {
+    "mode": "trunk-all",
+    "tagged": [],
+    "untagged": 1
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/trunk_all/show_interface_switchport.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/trunk_all/show_interface_switchport.json
@@ -1,0 +1,14 @@
+{
+  "TABLE_interface": {
+    "ROW_interface": {
+      "interface": "Ethernet1/4",
+      "switchport": "Enabled",
+      "admin_mode": "trunk",
+      "oper_mode": "trunk",
+      "access_vlan": "1",
+      "native_vlan": "1",
+      "voice_vlan": "none",
+      "trunk_vlans": "1-4094"
+    }
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/trunk_native/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/trunk_native/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "Ethernet1/3": {
+    "mode": "trunk",
+    "tagged": [10, 20, 30],
+    "untagged": 99
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/trunk_native/show_interface_switchport.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/trunk_native/show_interface_switchport.json
@@ -1,0 +1,14 @@
+{
+  "TABLE_interface": {
+    "ROW_interface": {
+      "interface": "Ethernet1/3",
+      "switchport": "Enabled",
+      "admin_mode": "trunk",
+      "oper_mode": "trunk",
+      "access_vlan": "1",
+      "native_vlan": "99",
+      "voice_vlan": "none",
+      "trunk_vlans": "10,20,30,99"
+    }
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/voice/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/voice/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "Ethernet1/2": {
+    "mode": "trunk",
+    "tagged": [200],
+    "untagged": 10
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/voice/show_interface_switchport.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/mock_data/test_get_interfaces_vlans/voice/show_interface_switchport.json
@@ -1,0 +1,14 @@
+{
+  "TABLE_interface": {
+    "ROW_interface": {
+      "interface": "Ethernet1/2",
+      "switchport": "Enabled",
+      "admin_mode": "access",
+      "oper_mode": "access",
+      "access_vlan": "10",
+      "native_vlan": "1",
+      "voice_vlan": "200",
+      "trunk_vlans": "1-4094"
+    }
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos/test_driver.py
+++ b/device-discovery/tests/custom_drivers/cisco_nxos/test_driver.py
@@ -1,0 +1,41 @@
+"""Tests for the NXOSDriver subclass — VLAN-association coverage only."""
+
+from pathlib import Path
+
+import pytest
+
+from custom_napalm.nxos import NXOSDriver
+from tests.custom_drivers.base_test import BaseDriverTest
+from tests.custom_drivers.mock_device import FakeJsonRpcDevice
+
+
+class TestNXOSDriver(BaseDriverTest):
+    """Tests for the Cisco NX-OS custom driver."""
+
+    driver_cls = NXOSDriver
+    fake_device_cls = FakeJsonRpcDevice
+    mock_data_root = Path(__file__).parent / "mock_data"
+
+    def test_get_facts(self, scenario):
+        """Skip: inherited from napalm.nxos.nxos.NXOSDriver."""
+        pytest.skip("inherited from napalm.nxos.nxos.NXOSDriver")
+
+    def test_get_interfaces(self, scenario):
+        """Skip: inherited from napalm.nxos.nxos.NXOSDriver."""
+        pytest.skip("inherited from napalm.nxos.nxos.NXOSDriver")
+
+    def test_get_interfaces_ip(self, scenario):
+        """Skip: inherited from napalm.nxos.nxos.NXOSDriver."""
+        pytest.skip("inherited from napalm.nxos.nxos.NXOSDriver")
+
+    def test_get_config(self, scenario):
+        """Skip: inherited from napalm.nxos.nxos.NXOSDriver."""
+        pytest.skip("inherited from napalm.nxos.nxos.NXOSDriver")
+
+    def test_get_config_sanitized(self, scenario):
+        """Skip: inherited from napalm.nxos.nxos.NXOSDriver."""
+        pytest.skip("inherited from napalm.nxos.nxos.NXOSDriver")
+
+    def test_get_vlans(self, scenario):
+        """Skip: inherited from napalm.nxos.nxos.NXOSDriver."""
+        pytest.skip("inherited from napalm.nxos.nxos.NXOSDriver")

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/__init__.py
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Cisco NX-OS-SSH custom NAPALM driver."""

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/conftest.py
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest scenario discovery for cisco_nxos_ssh driver tests."""
+
+from pathlib import Path
+
+from tests.custom_drivers.base_test import parametrize_scenarios
+
+MOCK_DATA_ROOT = Path(__file__).parent / "mock_data"
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize the scenario fixture from sub-folders of each test method's mock dir."""
+    parametrize_scenarios(metafunc, MOCK_DATA_ROOT)

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/access_only/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/access_only/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "Ethernet1/1": {
+    "mode": "access",
+    "tagged": [],
+    "untagged": 100
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/access_only/show_interface_switchport.txt
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/access_only/show_interface_switchport.txt
@@ -1,0 +1,8 @@
+Name: Ethernet1/1
+  Switchport: Enabled
+  Switchport Monitor: Not enabled
+  Operational Mode: access
+  Access Mode VLAN: 100 (users)
+  Trunking Native Mode VLAN: 1 (default)
+  Voice VLAN: none
+  Trunking VLANs Allowed: 1-4094

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/dynamic_negotiated/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/dynamic_negotiated/expected_result.json
@@ -1,0 +1,10 @@
+{
+  "Ethernet1/5": {
+    "mode": "trunk",
+    "tagged": [
+      10,
+      20
+    ],
+    "untagged": 1
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/dynamic_negotiated/show_interface_switchport.txt
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/dynamic_negotiated/show_interface_switchport.txt
@@ -1,0 +1,8 @@
+Name: Ethernet1/5
+  Switchport: Enabled
+  Switchport Monitor: Not enabled
+  Operational Mode: trunk
+  Access Mode VLAN: 1 (default)
+  Trunking Native Mode VLAN: 1 (default)
+  Voice VLAN: none
+  Trunking VLANs Allowed: 10,20

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/mixed/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/mixed/expected_result.json
@@ -1,0 +1,21 @@
+{
+  "Ethernet1/1": {
+    "mode": "access",
+    "tagged": [],
+    "untagged": 100
+  },
+  "Ethernet1/2": {
+    "mode": "trunk",
+    "tagged": [
+      10,
+      20,
+      30
+    ],
+    "untagged": 1
+  },
+  "Ethernet1/3": {
+    "mode": "routed",
+    "tagged": [],
+    "untagged": null
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/mixed/show_interface_switchport.txt
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/mixed/show_interface_switchport.txt
@@ -1,0 +1,20 @@
+Name: Ethernet1/1
+  Switchport: Enabled
+  Switchport Monitor: Not enabled
+  Operational Mode: access
+  Access Mode VLAN: 100 (users)
+  Trunking Native Mode VLAN: 1 (default)
+  Voice VLAN: none
+  Trunking VLANs Allowed: 1-4094
+
+Name: Ethernet1/2
+  Switchport: Enabled
+  Switchport Monitor: Not enabled
+  Operational Mode: trunk
+  Access Mode VLAN: 1 (default)
+  Trunking Native Mode VLAN: 1 (default)
+  Voice VLAN: none
+  Trunking VLANs Allowed: 10,20,30
+
+Name: Ethernet1/3
+  Switchport: Disabled

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/oper_down/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/oper_down/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "Ethernet1/7": {
+    "mode": "access",
+    "tagged": [],
+    "untagged": 100
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/oper_down/show_interface_switchport.txt
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/oper_down/show_interface_switchport.txt
@@ -1,0 +1,8 @@
+Name: Ethernet1/7
+  Switchport: Enabled
+  Switchport Monitor: Not enabled
+  Operational Mode: down
+  Access Mode VLAN: 100 (users)
+  Trunking Native Mode VLAN: 1 (default)
+  Voice VLAN: none
+  Trunking VLANs Allowed: 1-4094

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/routed/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/routed/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "Ethernet1/6": {
+    "mode": "routed",
+    "tagged": [],
+    "untagged": null
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/routed/show_interface_switchport.txt
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/routed/show_interface_switchport.txt
@@ -1,0 +1,2 @@
+Name: Ethernet1/6
+  Switchport: Disabled

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/trunk_all/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/trunk_all/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "Ethernet1/4": {
+    "mode": "trunk-all",
+    "tagged": [],
+    "untagged": 1
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/trunk_all/show_interface_switchport.txt
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/trunk_all/show_interface_switchport.txt
@@ -1,0 +1,8 @@
+Name: Ethernet1/4
+  Switchport: Enabled
+  Switchport Monitor: Not enabled
+  Operational Mode: trunk
+  Access Mode VLAN: 1 (default)
+  Trunking Native Mode VLAN: 1 (default)
+  Voice VLAN: none
+  Trunking VLANs Allowed: 1-4094

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/trunk_native/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/trunk_native/expected_result.json
@@ -1,0 +1,11 @@
+{
+  "Ethernet1/3": {
+    "mode": "trunk",
+    "tagged": [
+      10,
+      20,
+      30
+    ],
+    "untagged": 99
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/trunk_native/show_interface_switchport.txt
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/trunk_native/show_interface_switchport.txt
@@ -1,0 +1,8 @@
+Name: Ethernet1/3
+  Switchport: Enabled
+  Switchport Monitor: Not enabled
+  Operational Mode: trunk
+  Access Mode VLAN: 1 (default)
+  Trunking Native Mode VLAN: 99 (mgmt)
+  Voice VLAN: none
+  Trunking VLANs Allowed: 10,20,30

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/voice/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/voice/expected_result.json
@@ -1,0 +1,9 @@
+{
+  "Ethernet1/2": {
+    "mode": "trunk",
+    "tagged": [
+      200
+    ],
+    "untagged": 10
+  }
+}

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/voice/show_interface_switchport.txt
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/mock_data/test_get_interfaces_vlans/voice/show_interface_switchport.txt
@@ -1,0 +1,8 @@
+Name: Ethernet1/2
+  Switchport: Enabled
+  Switchport Monitor: Not enabled
+  Operational Mode: access
+  Access Mode VLAN: 10 (data)
+  Trunking Native Mode VLAN: 1 (default)
+  Voice VLAN: 200
+  Trunking VLANs Allowed: 1-4094

--- a/device-discovery/tests/custom_drivers/cisco_nxos_ssh/test_driver.py
+++ b/device-discovery/tests/custom_drivers/cisco_nxos_ssh/test_driver.py
@@ -1,0 +1,41 @@
+"""Tests for the NXOSSSHDriver subclass — VLAN-association coverage only."""
+
+from pathlib import Path
+
+import pytest
+
+from custom_napalm.nxos_ssh import NXOSSSHDriver
+from tests.custom_drivers.base_test import BaseDriverTest
+from tests.custom_drivers.mock_device import FakeCLIDevice
+
+
+class TestNXOSSSHDriver(BaseDriverTest):
+    """Tests for the Cisco NX-OS-SSH custom driver."""
+
+    driver_cls = NXOSSSHDriver
+    fake_device_cls = FakeCLIDevice
+    mock_data_root = Path(__file__).parent / "mock_data"
+
+    def test_get_facts(self, scenario):
+        """Skip: inherited from napalm.nxos_ssh.nxos_ssh.NXOSSSHDriver."""
+        pytest.skip("inherited from napalm.nxos_ssh.nxos_ssh.NXOSSSHDriver")
+
+    def test_get_interfaces(self, scenario):
+        """Skip: inherited from napalm.nxos_ssh.nxos_ssh.NXOSSSHDriver."""
+        pytest.skip("inherited from napalm.nxos_ssh.nxos_ssh.NXOSSSHDriver")
+
+    def test_get_interfaces_ip(self, scenario):
+        """Skip: inherited from napalm.nxos_ssh.nxos_ssh.NXOSSSHDriver."""
+        pytest.skip("inherited from napalm.nxos_ssh.nxos_ssh.NXOSSSHDriver")
+
+    def test_get_config(self, scenario):
+        """Skip: inherited from napalm.nxos_ssh.nxos_ssh.NXOSSSHDriver."""
+        pytest.skip("inherited from napalm.nxos_ssh.nxos_ssh.NXOSSSHDriver")
+
+    def test_get_config_sanitized(self, scenario):
+        """Skip: inherited from napalm.nxos_ssh.nxos_ssh.NXOSSSHDriver."""
+        pytest.skip("inherited from napalm.nxos_ssh.nxos_ssh.NXOSSSHDriver")
+
+    def test_get_vlans(self, scenario):
+        """Skip: inherited from napalm.nxos_ssh.nxos_ssh.NXOSSSHDriver."""
+        pytest.skip("inherited from napalm.nxos_ssh.nxos_ssh.NXOSSSHDriver")

--- a/device-discovery/tests/custom_drivers/cisco_s300/test_driver.py
+++ b/device-discovery/tests/custom_drivers/cisco_s300/test_driver.py
@@ -18,7 +18,8 @@ class TestS300Driver(BaseDriverTest):
         """Junk Trunking VLANs Enabled value must NOT silently widen the trunk."""
         import logging
 
-        from custom_napalm.cisco_s300 import _s300_switchport_block_to_entry
+        from custom_napalm._vlan import classify_switchport
+        from custom_napalm.cisco_s300 import _s300_block_to_switchport_info
         block = {
             "Switchport": "enable",
             "Administrative Mode": "trunk",
@@ -27,14 +28,15 @@ class TestS300Driver(BaseDriverTest):
             "Trunking VLANs Enabled": "not-a-vlan",
         }
         with caplog.at_level(logging.WARNING, logger="custom_napalm.cisco_s300"):
-            result = _s300_switchport_block_to_entry(block)
+            result = classify_switchport(_s300_block_to_switchport_info(block))
         # NOT trunk-all — fall back to plain trunk with empty tagged list.
         assert result == {"mode": "trunk", "tagged": [], "untagged": 99}
         assert any("could not be parsed" in r.message for r in caplog.records)
 
     def test_get_interfaces_vlans_explicit_all_still_trunk_all(self) -> None:
         """Sanity: literal "all" still maps to trunk-all after the typed-signal refactor."""
-        from custom_napalm.cisco_s300 import _s300_switchport_block_to_entry
+        from custom_napalm._vlan import classify_switchport
+        from custom_napalm.cisco_s300 import _s300_block_to_switchport_info
         block = {
             "Switchport": "enable",
             "Administrative Mode": "trunk",
@@ -42,5 +44,5 @@ class TestS300Driver(BaseDriverTest):
             "Trunking Native Mode VLAN": "99",
             "Trunking VLANs Enabled": "all",
         }
-        result = _s300_switchport_block_to_entry(block)
+        result = classify_switchport(_s300_block_to_switchport_info(block))
         assert result == {"mode": "trunk-all", "tagged": [], "untagged": 99}

--- a/device-discovery/tests/custom_drivers/cisco_s300/test_driver.py
+++ b/device-discovery/tests/custom_drivers/cisco_s300/test_driver.py
@@ -2,9 +2,24 @@
 
 from pathlib import Path
 
-from custom_napalm.cisco_s300 import S300Driver
+from custom_napalm.cisco_s300 import S300Driver, _maybe_int
 from tests.custom_drivers.base_test import BaseDriverTest
 from tests.custom_drivers.mock_device import FakeCLIDevice
+
+
+def test_s300_maybe_int_rejects_bool_true():
+    """Reject ``bool`` (int subclass) so it does not coerce to VID 1."""
+    assert _maybe_int(True) is None
+
+
+def test_s300_maybe_int_rejects_bool_false():
+    """Mirrors True case: False must not coerce to VID 0."""
+    assert _maybe_int(False) is None
+
+
+def test_s300_maybe_int_passes_through_string_int():
+    """Plain string-int still coerces normally."""
+    assert _maybe_int("42") == 42
 
 
 class TestS300Driver(BaseDriverTest):

--- a/device-discovery/tests/custom_drivers/juniper_junos/__init__.py
+++ b/device-discovery/tests/custom_drivers/juniper_junos/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Juniper Junos custom NAPALM driver."""

--- a/device-discovery/tests/custom_drivers/juniper_junos/conftest.py
+++ b/device-discovery/tests/custom_drivers/juniper_junos/conftest.py
@@ -1,0 +1,12 @@
+"""Pytest scenario discovery for juniper_junos driver tests."""
+
+from pathlib import Path
+
+from tests.custom_drivers.base_test import parametrize_scenarios
+
+MOCK_DATA_ROOT = Path(__file__).parent / "mock_data"
+
+
+def pytest_generate_tests(metafunc):
+    """Parametrize the scenario fixture from sub-folders of each test method's mock dir."""
+    parametrize_scenarios(metafunc, MOCK_DATA_ROOT)

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/access_only/expected_result.json
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/access_only/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "ge-0/0/1": {
+    "mode": "access",
+    "tagged": [],
+    "untagged": 100
+  }
+}

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/access_only/get-ethernet-switching-interface-information.xml
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/access_only/get-ethernet-switching-interface-information.xml
@@ -1,0 +1,13 @@
+<ethernet-switching-interface-information>
+  <interface>
+    <interface-name>ge-0/0/1</interface-name>
+    <interface-port-mode>Access</interface-port-mode>
+    <interface-vlan-member-list>
+      <interface-vlan-member>
+        <interface-vlan-name>vlan100</interface-vlan-name>
+        <interface-vlan-member-tagid>100</interface-vlan-member-tagid>
+        <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+      </interface-vlan-member>
+    </interface-vlan-member-list>
+  </interface>
+</ethernet-switching-interface-information>

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/els/expected_result.json
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/els/expected_result.json
@@ -1,0 +1,12 @@
+{
+  "xe-0/0/0": {
+    "mode": "access",
+    "tagged": [],
+    "untagged": 50
+  },
+  "xe-0/0/1": {
+    "mode": "trunk",
+    "tagged": [100, 200],
+    "untagged": 1
+  }
+}

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/els/get-ethernet-switching-interface-information.xml
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/els/get-ethernet-switching-interface-information.xml
@@ -1,0 +1,30 @@
+<l2ng-l2ald-iff-information>
+  <interface>
+    <interface-name>xe-0/0/0</interface-name>
+    <interface-mode>access</interface-mode>
+    <interface-vlan-member-list>
+      <interface-vlan-member>
+        <interface-vlan-name>vlan50</interface-vlan-name>
+        <interface-vlan-member-tagid>50</interface-vlan-member-tagid>
+        <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+      </interface-vlan-member>
+    </interface-vlan-member-list>
+  </interface>
+  <interface>
+    <interface-name>xe-0/0/1</interface-name>
+    <interface-mode>trunk</interface-mode>
+    <interface-native-vlan-id>1</interface-native-vlan-id>
+    <interface-vlan-member-list>
+      <interface-vlan-member>
+        <interface-vlan-name>vlan100</interface-vlan-name>
+        <interface-vlan-member-tagid>100</interface-vlan-member-tagid>
+        <interface-vlan-member-tagness>tagged</interface-vlan-member-tagness>
+      </interface-vlan-member>
+      <interface-vlan-member>
+        <interface-vlan-name>vlan200</interface-vlan-name>
+        <interface-vlan-member-tagid>200</interface-vlan-member-tagid>
+        <interface-vlan-member-tagness>tagged</interface-vlan-member-tagness>
+      </interface-vlan-member>
+    </interface-vlan-member-list>
+  </interface>
+</l2ng-l2ald-iff-information>

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/mixed/expected_result.json
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/mixed/expected_result.json
@@ -1,0 +1,17 @@
+{
+  "ge-0/0/1": {
+    "mode": "access",
+    "tagged": [],
+    "untagged": 200
+  },
+  "ge-0/0/2": {
+    "mode": "trunk",
+    "tagged": [10, 20],
+    "untagged": 1
+  },
+  "ge-0/0/3": {
+    "mode": "routed",
+    "tagged": [],
+    "untagged": null
+  }
+}

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/mixed/get-ethernet-switching-interface-information.xml
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/mixed/get-ethernet-switching-interface-information.xml
@@ -1,0 +1,33 @@
+<ethernet-switching-interface-information>
+  <interface>
+    <interface-name>ge-0/0/1</interface-name>
+    <interface-port-mode>Access</interface-port-mode>
+    <interface-vlan-member-list>
+      <interface-vlan-member>
+        <interface-vlan-name>vlan200</interface-vlan-name>
+        <interface-vlan-member-tagid>200</interface-vlan-member-tagid>
+        <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+      </interface-vlan-member>
+    </interface-vlan-member-list>
+  </interface>
+  <interface>
+    <interface-name>ge-0/0/2</interface-name>
+    <interface-port-mode>Trunk</interface-port-mode>
+    <interface-native-vlan-id>1</interface-native-vlan-id>
+    <interface-vlan-member-list>
+      <interface-vlan-member>
+        <interface-vlan-name>vlan10</interface-vlan-name>
+        <interface-vlan-member-tagid>10</interface-vlan-member-tagid>
+        <interface-vlan-member-tagness>tagged</interface-vlan-member-tagness>
+      </interface-vlan-member>
+      <interface-vlan-member>
+        <interface-vlan-name>vlan20</interface-vlan-name>
+        <interface-vlan-member-tagid>20</interface-vlan-member-tagid>
+        <interface-vlan-member-tagness>tagged</interface-vlan-member-tagness>
+      </interface-vlan-member>
+    </interface-vlan-member-list>
+  </interface>
+  <interface>
+    <interface-name>ge-0/0/3</interface-name>
+  </interface>
+</ethernet-switching-interface-information>

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/non_els/expected_result.json
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/non_els/expected_result.json
@@ -1,0 +1,12 @@
+{
+  "ge-0/0/10": {
+    "mode": "access",
+    "tagged": [],
+    "untagged": 300
+  },
+  "ge-0/0/11": {
+    "mode": "trunk",
+    "tagged": [30],
+    "untagged": null
+  }
+}

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/non_els/get-ethernet-switching-interface-information.xml
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/non_els/get-ethernet-switching-interface-information.xml
@@ -1,0 +1,24 @@
+<ethernet-switching-interface-information>
+  <interface>
+    <interface-name>ge-0/0/10</interface-name>
+    <interface-port-mode>Access</interface-port-mode>
+    <interface-vlan-member-list>
+      <interface-vlan-member>
+        <interface-vlan-name>mgmt</interface-vlan-name>
+        <interface-vlan-member-tagid>300</interface-vlan-member-tagid>
+        <interface-vlan-member-tagness>untagged</interface-vlan-member-tagness>
+      </interface-vlan-member>
+    </interface-vlan-member-list>
+  </interface>
+  <interface>
+    <interface-name>ge-0/0/11</interface-name>
+    <interface-port-mode>Trunk</interface-port-mode>
+    <interface-vlan-member-list>
+      <interface-vlan-member>
+        <interface-vlan-name>vlan30</interface-vlan-name>
+        <interface-vlan-member-tagid>30</interface-vlan-member-tagid>
+        <interface-vlan-member-tagness>tagged</interface-vlan-member-tagness>
+      </interface-vlan-member>
+    </interface-vlan-member-list>
+  </interface>
+</ethernet-switching-interface-information>

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/routed/expected_result.json
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/routed/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "ge-0/0/4": {
+    "mode": "routed",
+    "tagged": [],
+    "untagged": null
+  }
+}

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/routed/get-ethernet-switching-interface-information.xml
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/routed/get-ethernet-switching-interface-information.xml
@@ -1,0 +1,5 @@
+<ethernet-switching-interface-information>
+  <interface>
+    <interface-name>ge-0/0/4</interface-name>
+  </interface>
+</ethernet-switching-interface-information>

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/trunk_all/expected_result.json
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/trunk_all/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "ge-0/0/3": {
+    "mode": "trunk-all",
+    "tagged": [],
+    "untagged": null
+  }
+}

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/trunk_all/get-ethernet-switching-interface-information.xml
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/trunk_all/get-ethernet-switching-interface-information.xml
@@ -1,0 +1,11 @@
+<ethernet-switching-interface-information>
+  <interface>
+    <interface-name>ge-0/0/3</interface-name>
+    <interface-port-mode>Trunk</interface-port-mode>
+    <interface-vlan-member-list>
+      <interface-vlan-member>
+        <interface-vlan-name>all</interface-vlan-name>
+      </interface-vlan-member>
+    </interface-vlan-member-list>
+  </interface>
+</ethernet-switching-interface-information>

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/trunk_native/expected_result.json
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/trunk_native/expected_result.json
@@ -1,0 +1,7 @@
+{
+  "ge-0/0/2": {
+    "mode": "trunk",
+    "tagged": [10, 20],
+    "untagged": 99
+  }
+}

--- a/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/trunk_native/get-ethernet-switching-interface-information.xml
+++ b/device-discovery/tests/custom_drivers/juniper_junos/mock_data/test_get_interfaces_vlans/trunk_native/get-ethernet-switching-interface-information.xml
@@ -1,0 +1,19 @@
+<ethernet-switching-interface-information>
+  <interface>
+    <interface-name>ge-0/0/2</interface-name>
+    <interface-port-mode>Trunk</interface-port-mode>
+    <interface-native-vlan-id>99</interface-native-vlan-id>
+    <interface-vlan-member-list>
+      <interface-vlan-member>
+        <interface-vlan-name>vlan10</interface-vlan-name>
+        <interface-vlan-member-tagid>10</interface-vlan-member-tagid>
+        <interface-vlan-member-tagness>tagged</interface-vlan-member-tagness>
+      </interface-vlan-member>
+      <interface-vlan-member>
+        <interface-vlan-name>vlan20</interface-vlan-name>
+        <interface-vlan-member-tagid>20</interface-vlan-member-tagid>
+        <interface-vlan-member-tagness>tagged</interface-vlan-member-tagness>
+      </interface-vlan-member>
+    </interface-vlan-member-list>
+  </interface>
+</ethernet-switching-interface-information>

--- a/device-discovery/tests/custom_drivers/juniper_junos/test_driver.py
+++ b/device-discovery/tests/custom_drivers/juniper_junos/test_driver.py
@@ -1,0 +1,41 @@
+"""Tests for the JunOSDriver subclass — VLAN-association coverage only."""
+
+from pathlib import Path
+
+import pytest
+
+from custom_napalm.junos import JunOSDriver
+from tests.custom_drivers.base_test import BaseDriverTest
+from tests.custom_drivers.mock_device import FakePyEZDevice
+
+
+class TestJunOSDriver(BaseDriverTest):
+    """Tests for the Juniper Junos custom NAPALM driver."""
+
+    driver_cls = JunOSDriver
+    fake_device_cls = FakePyEZDevice
+    mock_data_root = Path(__file__).parent / "mock_data"
+
+    def test_get_facts(self, scenario):
+        """Skip: inherited from napalm.junos.junos.JunOSDriver."""
+        pytest.skip("inherited from napalm.junos.junos.JunOSDriver")
+
+    def test_get_interfaces(self, scenario):
+        """Skip: inherited from napalm.junos.junos.JunOSDriver."""
+        pytest.skip("inherited from napalm.junos.junos.JunOSDriver")
+
+    def test_get_interfaces_ip(self, scenario):
+        """Skip: inherited from napalm.junos.junos.JunOSDriver."""
+        pytest.skip("inherited from napalm.junos.junos.JunOSDriver")
+
+    def test_get_config(self, scenario):
+        """Skip: inherited from napalm.junos.junos.JunOSDriver."""
+        pytest.skip("inherited from napalm.junos.junos.JunOSDriver")
+
+    def test_get_config_sanitized(self, scenario):
+        """Skip: inherited from napalm.junos.junos.JunOSDriver."""
+        pytest.skip("inherited from napalm.junos.junos.JunOSDriver")
+
+    def test_get_vlans(self, scenario):
+        """Skip: inherited from napalm.junos.junos.JunOSDriver."""
+        pytest.skip("inherited from napalm.junos.junos.JunOSDriver")

--- a/device-discovery/tests/custom_drivers/mock_device.py
+++ b/device-discovery/tests/custom_drivers/mock_device.py
@@ -342,3 +342,113 @@ class FakeRestDevice:
 
     def close_session(self) -> None:
         """No-op stub — no real session to close."""
+
+
+class FakeJsonRpcDevice:
+    """
+    Drop-in replacement for pyeapi (Arista EOS) and NX-API (Cisco NX-OS) clients.
+
+    Both vendors expose a "send a command, get JSON back" surface, just under
+    different method names. This fake serves both shapes from the same JSON
+    file convention so EOS and NX-OS tests share infrastructure.
+
+    File-name mapping reuses ``_cli_filename`` from the CLI fake — i.e. the
+    command string is sanitized into a filename and ``.json`` appended.
+
+    Methods
+    -------
+    run_commands(commands, encoding="json")
+        EOS shape. ``commands`` is a list of strings. Returns a list of dicts,
+        one per command, each loaded from ``<sanitized>.json`` or ``{}`` if
+        missing.
+
+    show(command, raw_text=False)
+        NX-OS shape. Single-command. Returns a dict loaded from
+        ``<sanitized>.json`` or ``{}`` if missing.
+
+    cli(command)
+        NX-OS-SSH compatibility hook (rarely used by NX-API drivers — present
+        for completeness). Returns the loaded dict directly.
+
+    """
+
+    def __init__(self, mock_dir: Path) -> None:
+        """Store the directory containing mock JSON response files."""
+        self._mock_dir = mock_dir
+
+    def _load_json(self, command: str) -> dict:
+        filename = _cli_filename(command).replace(".txt", ".json")
+        path = self._mock_dir / filename
+        if not path.exists():
+            return {}
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def run_commands(self, commands: list[str], encoding: str = "json", **kwargs) -> list[dict]:
+        """Pyeapi-shaped multi-command call. Returns list of per-command results."""
+        return [self._load_json(cmd) for cmd in commands]
+
+    def show(self, command: str, raw_text: bool = False, **kwargs) -> dict:
+        """NX-API-shaped single-command call."""
+        return self._load_json(command)
+
+    def cli(self, command: str, **kwargs) -> dict:
+        """NX-API ``cli()`` alias used by some drivers — returns the same dict."""
+        return self._load_json(command)
+
+
+class _FakePyEZRpc:
+    """Backing object for FakePyEZDevice.rpc — turns attribute access into RPC calls."""
+
+    def __init__(self, mock_dir: Path) -> None:
+        self._mock_dir = mock_dir
+
+    def __getattr__(self, name: str):
+        if name.startswith("__") and name.endswith("__"):
+            # Don't intercept dunder lookups — let Python fall back to the
+            # default AttributeError so introspection (deepcopy, repr, etc.)
+            # behaves correctly and isn't accidentally turned into a callable
+            # that returns <data/>.
+            raise AttributeError(name)
+        # PyEZ converts python_name → rpc-name. We accept both "snake_name" and
+        # "rpc-name". Try the kebab-case form first (matches PyEZ wire names),
+        # fall back to the underscore form.
+        from lxml import etree  # local import: lxml is a junos/pyez dep already
+
+        kebab = name.replace("_", "-")
+        candidates = [f"{kebab}.xml", f"{name}.xml"]
+
+        def _call(*_args, **_kwargs):
+            for fname in candidates:
+                path = self._mock_dir / fname
+                if path.exists():
+                    return etree.fromstring(path.read_text(encoding="utf-8").encode("utf-8"))
+            return etree.fromstring(b"<data/>")
+
+        return _call
+
+
+class FakePyEZDevice:
+    """
+    Drop-in replacement for ``napalm.junos.junos.JunOSDriver.device`` (a PyEZ Device).
+
+    Exposes ``.rpc.<rpc_name>(...)`` whose attribute access is mapped to
+    ``<rpc-name>.xml`` files in the scenario directory (snake_case → kebab-case
+    conversion, matching PyEZ's wire convention). Returns an lxml ``Element``
+    parsed from the file content, or ``<data/>`` when the file is missing.
+
+    File-name mapping example::
+
+        device.rpc.get_ethernet_switching_interface_information()
+            → get-ethernet-switching-interface-information.xml
+    """
+
+    def __init__(self, mock_dir: Path) -> None:
+        """Store the directory and create the RPC proxy."""
+        self._mock_dir = mock_dir
+        self.rpc = _FakePyEZRpc(mock_dir)
+
+    def cli(self, command: str = "", **kwargs) -> str:
+        """Optional CLI fallback — reads ``<sanitized>.txt`` like FakeCLIDevice."""
+        filename = _cli_filename(command)
+        path = self._mock_dir / filename
+        return path.read_text(encoding="utf-8") if path.exists() else ""

--- a/device-discovery/tests/custom_drivers/test_mock_device.py
+++ b/device-discovery/tests/custom_drivers/test_mock_device.py
@@ -1,0 +1,65 @@
+"""Sanity tests for FakeJsonRpcDevice and FakePyEZDevice mock helpers."""
+
+import json
+from pathlib import Path
+
+from tests.custom_drivers.mock_device import FakeJsonRpcDevice, FakePyEZDevice
+
+# ----- FakeJsonRpcDevice ----------------------------------------------
+
+
+def test_fake_jsonrpc_run_commands_loads_json(tmp_path: Path):
+    """JSON file is loaded and returned as a dict in the result list."""
+    (tmp_path / "show_interfaces_switchport.json").write_text(
+        json.dumps({"switchports": {"Et1": {"switchportInfo": {"mode": "access"}}}})
+    )
+    fake = FakeJsonRpcDevice(tmp_path)
+    out = fake.run_commands(["show interfaces switchport"], encoding="json")
+    assert out == [{"switchports": {"Et1": {"switchportInfo": {"mode": "access"}}}}]
+
+
+def test_fake_jsonrpc_run_commands_missing_returns_empty_dict(tmp_path: Path):
+    """Missing fixture silently returns an empty dict in the result list."""
+    fake = FakeJsonRpcDevice(tmp_path)
+    out = fake.run_commands(["show foo"], encoding="json")
+    assert out == [{}]
+
+
+def test_fake_jsonrpc_show_loads_json(tmp_path: Path):
+    """show() loads the matching JSON fixture and returns a dict."""
+    (tmp_path / "show_interface_switchport.json").write_text(
+        json.dumps({"TABLE_interface": {"ROW_interface": []}})
+    )
+    fake = FakeJsonRpcDevice(tmp_path)
+    out = fake.show("show interface switchport", raw_text=False)
+    assert out == {"TABLE_interface": {"ROW_interface": []}}
+
+
+def test_fake_jsonrpc_show_missing_returns_empty(tmp_path: Path):
+    """show() returns an empty dict when the fixture file is absent."""
+    fake = FakeJsonRpcDevice(tmp_path)
+    out = fake.show("show foo bar", raw_text=False)
+    assert out == {}
+
+
+# ----- FakePyEZDevice -------------------------------------------------
+
+
+def test_fake_pyez_rpc_call_loads_xml(tmp_path: Path):
+    """rpc.<name>() returns an lxml Element parsed from the matching XML fixture."""
+    (tmp_path / "get-ethernet-switching-interface-information.xml").write_text(
+        "<ethernet-switching-interface-information><interface/></ethernet-switching-interface-information>"
+    )
+    fake = FakePyEZDevice(tmp_path)
+    out = fake.rpc.get_ethernet_switching_interface_information()
+    # PyEZ returns lxml.etree._Element; we expose .tag / .findall like real lxml
+    assert out.tag == "ethernet-switching-interface-information"
+
+
+def test_fake_pyez_rpc_call_missing_returns_empty(tmp_path: Path):
+    """rpc.<name>() returns an empty <data/> element when the fixture is absent."""
+    fake = FakePyEZDevice(tmp_path)
+    out = fake.rpc.get_something_unmocked()
+    # Empty <data/> element when fixture absent
+    assert out is not None
+    assert len(out) == 0

--- a/device-discovery/tests/custom_drivers/test_nxos_common.py
+++ b/device-discovery/tests/custom_drivers/test_nxos_common.py
@@ -1,6 +1,26 @@
 """Unit tests for custom_napalm._nxos_common shared NX-OS field mapper."""
 
-from custom_napalm._nxos_common import nxos_row_to_switchport_info
+from custom_napalm._nxos_common import _maybe_int, nxos_row_to_switchport_info
+
+
+def test_maybe_int_rejects_bool_true():
+    """Reject ``bool`` (int subclass) so it does not coerce to VID 1."""
+    assert _maybe_int(True) is None
+
+
+def test_maybe_int_rejects_bool_false():
+    """Mirrors True case: False must not coerce to VID 0."""
+    assert _maybe_int(False) is None
+
+
+def test_maybe_int_passes_through_string_int():
+    """Plain string-int still coerces normally."""
+    assert _maybe_int("42") == 42
+
+
+def test_maybe_int_treats_none_sentinel_as_none():
+    """NX-OS emits 'none' for absent voice VLAN; mapper returns None."""
+    assert _maybe_int("none") is None
 
 
 def test_nxos_disabled_switchport_is_routed():

--- a/device-discovery/tests/custom_drivers/test_nxos_common.py
+++ b/device-discovery/tests/custom_drivers/test_nxos_common.py
@@ -1,0 +1,141 @@
+"""Unit tests for custom_napalm._nxos_common shared NX-OS field mapper."""
+
+from custom_napalm._nxos_common import nxos_row_to_switchport_info
+
+
+def test_nxos_disabled_switchport_is_routed():
+    """Switchport 'Disabled' means the port is in routed (L3) mode."""
+    info = nxos_row_to_switchport_info({"switchport": "Disabled"})
+    assert info.enabled is False
+
+
+def test_nxos_access_basic():
+    """NX-API access row produces correct access_vlan and voice_vlan=None for 'none'."""
+    info = nxos_row_to_switchport_info({
+        "switchport": "Enabled",
+        "admin_mode": "access",
+        "oper_mode": "access",
+        "access_vlan": "100",
+        "native_vlan": "1",
+        "voice_vlan": "none",
+        "trunk_vlans": "1-4094",
+    })
+    assert info.enabled is True
+    assert info.admin_mode == "access"
+    assert info.access_vlan == 100
+    assert info.voice_vlan is None  # "none" string → None
+
+
+def test_nxos_voice_vlan_extracted():
+    """Numeric voice_vlan string is coerced to int."""
+    info = nxos_row_to_switchport_info({
+        "switchport": "Enabled",
+        "admin_mode": "access",
+        "access_vlan": "100",
+        "voice_vlan": "200",
+    })
+    assert info.voice_vlan == 200
+
+
+def test_nxos_trunk_with_explicit_list():
+    """Trunk row with comma-separated VIDs produces an explicit allowed_vlans list."""
+    info = nxos_row_to_switchport_info({
+        "switchport": "Enabled",
+        "admin_mode": "trunk",
+        "oper_mode": "trunk",
+        "native_vlan": "1",
+        "trunk_vlans": "10,20,30",
+    })
+    assert info.admin_mode == "trunk"
+    assert info.allowed_vlans == [10, 20, 30]
+
+
+def test_nxos_trunk_full_range_is_wildcard():
+    """'1-4094' trunk_vlans collapses to the 'all' wildcard sentinel."""
+    info = nxos_row_to_switchport_info({
+        "switchport": "Enabled",
+        "admin_mode": "trunk",
+        "native_vlan": "1",
+        "trunk_vlans": "1-4094",
+    })
+    assert info.allowed_vlans == "all"
+
+
+def test_nxos_dynamic_admin_falls_through_to_oper():
+    """'dynamic auto' admin_mode normalizes to 'dynamic'; oper_mode is preserved."""
+    info = nxos_row_to_switchport_info({
+        "switchport": "Enabled",
+        "admin_mode": "dynamic auto",
+        "oper_mode": "trunk",
+        "native_vlan": "1",
+        "trunk_vlans": "10",
+    })
+    assert info.admin_mode == "dynamic"
+    assert info.oper_mode == "trunk"
+
+
+def test_nxos_missing_keys_safe():
+    """Row with only 'switchport: Enabled' and no other keys is handled gracefully."""
+    info = nxos_row_to_switchport_info({"switchport": "Enabled"})
+    assert info.enabled is True
+    assert info.admin_mode is None
+    assert info.access_vlan is None
+
+
+# ----- ntc-templates alias paths (cisco_nxos template emits 'mode' / 'trunking_vlans') -----
+
+def test_nxos_ntc_template_mode_alias_access():
+    """ntc-templates row uses 'mode' (operational), no admin_mode key."""
+    info = nxos_row_to_switchport_info({
+        "switchport": "Enabled",
+        "mode": "access",  # alias for both admin_mode AND oper_mode
+        "access_vlan": "100",
+        "native_vlan": "1",
+        "voice_vlan": "none",
+        "trunking_vlans": "1-4094",  # alias for trunk_vlans
+    })
+    assert info.enabled is True
+    assert info.admin_mode == "access"
+    assert info.oper_mode == "access"
+    assert info.access_vlan == 100
+
+
+def test_nxos_ntc_template_mode_alias_trunk():
+    """ntc-templates trunk row via 'mode' alias with 'trunking_vlans' list."""
+    info = nxos_row_to_switchport_info({
+        "switchport": "Enabled",
+        "mode": "trunk",
+        "access_vlan": "1",
+        "native_vlan": "99",
+        "voice_vlan": "none",
+        "trunking_vlans": "10,20,30",
+    })
+    assert info.admin_mode == "trunk"
+    assert info.oper_mode == "trunk"
+    assert info.allowed_vlans == [10, 20, 30]
+    assert info.native_vlan == 99
+
+
+def test_nxos_ntc_template_trunking_vlans_full_range_wildcard():
+    """ntc-templates 'trunking_vlans: 1-4094' collapses to the 'all' wildcard."""
+    info = nxos_row_to_switchport_info({
+        "switchport": "Enabled",
+        "mode": "trunk",
+        "trunking_vlans": "1-4094",
+        "native_vlan": "1",
+    })
+    assert info.allowed_vlans == "all"
+
+
+def test_nxos_nxapi_keys_take_priority_over_aliases():
+    """When both 'admin_mode' (NX-API) and 'mode' (ntc) are present, prefer NX-API."""
+    info = nxos_row_to_switchport_info({
+        "switchport": "Enabled",
+        "admin_mode": "trunk",
+        "mode": "access",  # ntc alias — must NOT override admin_mode
+        "trunk_vlans": "10",
+        "trunking_vlans": "999",  # alias — must be ignored
+        "native_vlan": "1",
+    })
+    assert info.admin_mode == "trunk"
+    assert info.allowed_vlans == [10]

--- a/device-discovery/tests/custom_drivers/test_nxos_common.py
+++ b/device-discovery/tests/custom_drivers/test_nxos_common.py
@@ -94,12 +94,40 @@ def test_nxos_dynamic_admin_falls_through_to_oper():
     assert info.oper_mode == "trunk"
 
 
-def test_nxos_missing_keys_safe():
-    """Row with only 'switchport: Enabled' and no other keys is handled gracefully."""
+def test_nxos_missing_keys_safe_defaults_to_access():
+    """Row with only 'switchport: Enabled' resolves to access via the SSH oper-down heuristic."""
     info = nxos_row_to_switchport_info({"switchport": "Enabled"})
     assert info.enabled is True
-    assert info.admin_mode is None
+    assert info.admin_mode == "access"
     assert info.access_vlan is None
+
+
+def test_nxos_oper_down_defaults_to_access_to_preserve_vlan_data():
+    """Down switchport on the SSH path defaults to access so access_vlan still drives classification."""
+    info = nxos_row_to_switchport_info({
+        "switchport": "Enabled",
+        "mode": "down",
+        "access_vlan": "100",
+        "native_vlan": "1",
+        "voice_vlan": "none",
+        "trunking_vlans": "1-4094",
+    })
+    assert info.enabled is True
+    assert info.admin_mode == "access"
+    assert info.access_vlan == 100
+
+
+def test_nxos_oper_down_inference_does_not_override_explicit_admin():
+    """Heuristic must NOT fire when admin_mode is explicitly set (NX-API path)."""
+    info = nxos_row_to_switchport_info({
+        "switchport": "Enabled",
+        "admin_mode": "trunk",
+        "oper_mode": "down",
+        "native_vlan": "99",
+        "trunk_vlans": "10,20",
+    })
+    assert info.admin_mode == "trunk"
+    assert info.oper_mode is None  # "down" is not a recognized oper-mode value
 
 
 # ----- ntc-templates alias paths (cisco_nxos template emits 'mode' / 'trunking_vlans') -----

--- a/device-discovery/tests/custom_drivers/test_vlan_classify.py
+++ b/device-discovery/tests/custom_drivers/test_vlan_classify.py
@@ -1,0 +1,300 @@
+"""Unit tests for custom_napalm._vlan generic classifier."""
+
+from custom_napalm._vlan import (
+    SwitchportInfo,
+    classify_switchport,
+    coerce_vid,
+    parse_vlan_range_string,
+)
+
+# ----- coerce_vid -------------------------------------------------------
+
+
+def test_coerce_vid_int_passthrough():
+    """Plain int in range is returned unchanged."""
+    assert coerce_vid(100) == 100
+
+
+def test_coerce_vid_string_int():
+    """Numeric string is coerced to int."""
+    assert coerce_vid("100") == 100
+
+
+def test_coerce_vid_rejects_bool_true():
+    """Bool is subclass of int — must be rejected explicitly."""
+    assert coerce_vid(True) is None
+
+
+def test_coerce_vid_rejects_bool_false():
+    """False must be rejected even though int(False) == 0."""
+    assert coerce_vid(False) is None
+
+
+def test_coerce_vid_clamps_below():
+    """VID 0 is out of range."""
+    assert coerce_vid(0) is None
+
+
+def test_coerce_vid_clamps_above():
+    """VID 4095 is out of range."""
+    assert coerce_vid(4095) is None
+
+
+def test_coerce_vid_accepts_min():
+    """VID 1 is the minimum valid value."""
+    assert coerce_vid(1) == 1
+
+
+def test_coerce_vid_accepts_max():
+    """VID 4094 is the maximum valid value."""
+    assert coerce_vid(4094) == 4094
+
+
+def test_coerce_vid_none():
+    """None input returns None."""
+    assert coerce_vid(None) is None
+
+
+def test_coerce_vid_garbage():
+    """Non-numeric garbage returns None."""
+    assert coerce_vid("foo") is None
+    assert coerce_vid([]) is None
+    assert coerce_vid({}) is None
+
+
+# ----- parse_vlan_range_string -----------------------------------------
+
+
+def test_parse_range_empty():
+    """Empty string returns empty list, no wildcard."""
+    assert parse_vlan_range_string("") == ([], False)
+
+
+def test_parse_range_none_token():
+    """'none' / 'NONE' is a valid empty signal, NOT a wildcard."""
+    assert parse_vlan_range_string("none") == ([], False)
+    assert parse_vlan_range_string("NONE") == ([], False)
+
+
+def test_parse_range_literal_all():
+    """'all' / 'ALL' is the wildcard token."""
+    assert parse_vlan_range_string("all") == ([], True)
+    assert parse_vlan_range_string("ALL") == ([], True)
+
+
+def test_parse_range_single_vid():
+    """Single VID returns a one-element list."""
+    assert parse_vlan_range_string("100") == ([100], False)
+
+
+def test_parse_range_simple_range():
+    """Simple hyphen-delimited range is expanded."""
+    assert parse_vlan_range_string("10-12") == ([10, 11, 12], False)
+
+
+def test_parse_range_comma_list():
+    """Comma-separated list is returned in order."""
+    assert parse_vlan_range_string("1,10,20") == ([1, 10, 20], False)
+
+
+def test_parse_range_mixed():
+    """Mixed comma list and ranges are combined correctly."""
+    assert parse_vlan_range_string("1,10-12,20") == ([1, 10, 11, 12, 20], False)
+
+
+def test_parse_range_full_range_is_wildcard():
+    """1-4094 covers the whole VID space and is promoted to wildcard."""
+    vids, is_wildcard = parse_vlan_range_string("1-4094")
+    assert vids == []
+    assert is_wildcard is True
+
+
+def test_parse_range_clamps_above():
+    """Tokens above 4094 are clamped out and must NOT widen to wildcard."""
+    # Tokens above 4094 are clamped out, never returned, AND must NOT widen to wildcard
+    vids, is_wildcard = parse_vlan_range_string("5000-9000")
+    assert vids == []
+    assert is_wildcard is False
+
+
+def test_parse_range_clamps_partial():
+    """Range that starts in-band and ends out-of-band is clamped."""
+    vids, is_wildcard = parse_vlan_range_string("4090-9000")
+    assert vids == [4090, 4091, 4092, 4093, 4094]
+    assert is_wildcard is False  # only because it doesn't start at 1
+
+
+def test_parse_range_inverted_range_dropped():
+    """Inverted range (hi < lo) is silently dropped."""
+    assert parse_vlan_range_string("100-50") == ([], False)
+
+
+def test_parse_range_junk_dropped():
+    """Junk tokens are dropped; valid adjacent tokens are kept."""
+    assert parse_vlan_range_string("junk,10,bad-bad") == ([10], False)
+
+
+def test_parse_range_all_junk_not_wildcard():
+    """All-junk input returns ([], False) — NOT a wildcard."""
+    assert parse_vlan_range_string("junk,nonsense") == ([], False)
+
+
+# ----- classify_switchport ---------------------------------------------
+
+
+def _info(**kwargs) -> SwitchportInfo:
+    """Build a SwitchportInfo with sensible defaults for tests."""
+    return SwitchportInfo(
+        enabled=kwargs.pop("enabled", True),
+        admin_mode=kwargs.pop("admin_mode", None),
+        oper_mode=kwargs.pop("oper_mode", None),
+        access_vlan=kwargs.pop("access_vlan", None),
+        native_vlan=kwargs.pop("native_vlan", None),
+        allowed_vlans=kwargs.pop("allowed_vlans", None),
+        voice_vlan=kwargs.pop("voice_vlan", None),
+    )
+
+
+def test_classify_routed_when_disabled():
+    """Disabled interface always resolves to routed."""
+    out = classify_switchport(_info(enabled=False))
+    assert out == {"mode": "routed", "tagged": [], "untagged": None}
+
+
+def test_classify_routed_when_no_mode():
+    """No admin or oper mode resolves to routed."""
+    out = classify_switchport(_info(admin_mode=None, oper_mode=None))
+    assert out == {"mode": "routed", "tagged": [], "untagged": None}
+
+
+def test_classify_routed_when_oper_routed():
+    """DTP dynamic port with oper_mode=routed resolves to routed."""
+    out = classify_switchport(_info(admin_mode="dynamic", oper_mode="routed"))
+    assert out == {"mode": "routed", "tagged": [], "untagged": None}
+
+
+def test_classify_access():
+    """Basic access port returns access mode with correct untagged VID."""
+    out = classify_switchport(_info(admin_mode="access", access_vlan=100))
+    assert out == {"mode": "access", "tagged": [], "untagged": 100}
+
+
+def test_classify_access_with_voice_promoted_to_trunk():
+    """Voice VLAN on an access port is promoted to trunk."""
+    out = classify_switchport(_info(admin_mode="access", access_vlan=100, voice_vlan=200))
+    # NetBox 'access' mode disallows tagged VLANs, so we promote
+    assert out == {"mode": "trunk", "tagged": [200], "untagged": 100}
+
+
+def test_classify_access_voice_equal_to_access_no_promotion():
+    """Voice VLAN equal to access VLAN does not trigger promotion."""
+    out = classify_switchport(
+        _info(admin_mode="access", access_vlan=100, voice_vlan=100)
+    )
+    # Voice == access (operator misconfig). Promoting would put voice in
+    # `tagged` and access in `untagged`, but they're the same VID — that
+    # produces a degenerate trunk. Keep plain access instead.
+    assert out == {"mode": "access", "tagged": [], "untagged": 100}
+
+
+def test_classify_trunk_explicit_list():
+    """Trunk with explicit allowed list returns all VIDs as tagged."""
+    out = classify_switchport(_info(admin_mode="trunk", native_vlan=1, allowed_vlans=[10, 20, 30]))
+    assert out == {"mode": "trunk", "tagged": [10, 20, 30], "untagged": 1}
+
+
+def test_classify_trunk_strips_native_from_tagged():
+    """Native VLAN is excluded from the tagged list."""
+    out = classify_switchport(_info(admin_mode="trunk", native_vlan=10, allowed_vlans=[10, 20]))
+    assert out == {"mode": "trunk", "tagged": [20], "untagged": 10}
+
+
+def test_classify_trunk_all_via_wildcard():
+    """String 'all' for allowed_vlans produces trunk-all mode."""
+    out = classify_switchport(_info(admin_mode="trunk", native_vlan=1, allowed_vlans="all"))
+    assert out == {"mode": "trunk-all", "tagged": [], "untagged": 1}
+
+
+def test_classify_dtp_fallback_to_oper_trunk():
+    """DTP dynamic port with oper_mode=trunk is treated as trunk."""
+    out = classify_switchport(
+        _info(admin_mode="dynamic", oper_mode="trunk", native_vlan=1, allowed_vlans=[10])
+    )
+    assert out == {"mode": "trunk", "tagged": [10], "untagged": 1}
+
+
+def test_classify_dtp_fallback_to_oper_access():
+    """DTP dynamic port with oper_mode=access is treated as access."""
+    out = classify_switchport(_info(admin_mode="dynamic", oper_mode="access", access_vlan=100))
+    assert out == {"mode": "access", "tagged": [], "untagged": 100}
+
+
+def test_classify_rejects_bool_vlan_inputs():
+    """Bool values passed as VIDs are rejected by coerce_vid."""
+    out = classify_switchport(
+        _info(
+            admin_mode="trunk",
+            native_vlan=True,  # bool — should drop
+            allowed_vlans=[10, False, 20],  # bool in list — should drop
+        )
+    )
+    # native_vlan rejected → None; tagged keeps only valid ints
+    assert out == {"mode": "trunk", "tagged": [10, 20], "untagged": None}
+
+
+def test_classify_clamps_oob_vids_in_tagged():
+    """Out-of-band VIDs in the allowed list are clamped out."""
+    out = classify_switchport(_info(admin_mode="trunk", native_vlan=1, allowed_vlans=[0, 10, 4095, 20]))
+    assert out == {"mode": "trunk", "tagged": [10, 20], "untagged": 1}
+
+
+# ----- additional classifier edges (Codex review P1#8) -----
+
+
+def test_classify_trunk_all_via_full_range_list():
+    """List form covering 1..4094 must promote to trunk-all, not stay as a list."""
+    full_range = list(range(1, 4095))
+    out = classify_switchport(_info(admin_mode="trunk", native_vlan=1, allowed_vlans=full_range))
+    assert out == {"mode": "trunk-all", "tagged": [], "untagged": 1}
+
+
+def test_classify_trunk_junk_string_falls_back_to_plain_trunk():
+    """All-junk string for allowed_vlans must NOT widen to trunk-all."""
+    out = classify_switchport(_info(admin_mode="trunk", native_vlan=1, allowed_vlans="junk,nonsense"))
+    assert out == {"mode": "trunk", "tagged": [], "untagged": 1}
+
+
+def test_classify_trunk_with_no_allowed_vlans():
+    """admin_mode=trunk with allowed_vlans=None → plain trunk, empty tagged."""
+    out = classify_switchport(_info(admin_mode="trunk", native_vlan=99, allowed_vlans=None))
+    assert out == {"mode": "trunk", "tagged": [], "untagged": 99}
+
+
+def test_classify_dtp_with_no_oper_signal_is_routed():
+    """admin=dynamic with oper=None resolves to routed (no useful info)."""
+    out = classify_switchport(_info(admin_mode="dynamic", oper_mode=None))
+    assert out == {"mode": "routed", "tagged": [], "untagged": None}
+
+
+def test_classify_unknown_admin_mode_with_no_oper_routed():
+    """Unrecognized admin_mode string + no oper_mode → routed."""
+    out = classify_switchport(_info(admin_mode=None, oper_mode=None, access_vlan=100))
+    assert out == {"mode": "routed", "tagged": [], "untagged": None}
+
+
+def test_classify_access_with_oob_access_vlan_drops_untagged():
+    """Out-of-range access_vlan coerces to None, leaving untagged=None."""
+    out = classify_switchport(_info(admin_mode="access", access_vlan=4095))
+    assert out == {"mode": "access", "tagged": [], "untagged": None}
+
+
+def test_classify_access_with_zero_access_vlan_drops_untagged():
+    """VID 0 is out of range and produces untagged=None."""
+    out = classify_switchport(_info(admin_mode="access", access_vlan=0))
+    assert out == {"mode": "access", "tagged": [], "untagged": None}
+
+
+def test_classify_trunk_native_oob_drops_native():
+    """Out-of-range native_vlan coerces to None."""
+    out = classify_switchport(_info(admin_mode="trunk", native_vlan=9999, allowed_vlans=[10, 20]))
+    assert out == {"mode": "trunk", "tagged": [10, 20], "untagged": None}

--- a/device-discovery/tests/custom_drivers/test_vlan_classify.py
+++ b/device-discovery/tests/custom_drivers/test_vlan_classify.py
@@ -248,7 +248,7 @@ def test_classify_clamps_oob_vids_in_tagged():
     assert out == {"mode": "trunk", "tagged": [10, 20], "untagged": 1}
 
 
-# ----- additional classifier edges (Codex review P1#8) -----
+# ----- additional classifier edge cases -----
 
 
 def test_classify_trunk_all_via_full_range_list():

--- a/device-discovery/tests/test_discovery.py
+++ b/device-discovery/tests/test_discovery.py
@@ -517,9 +517,13 @@ def test_discover_device_driver_defaults_to_standard_napalm_only(mock_get_networ
 
     driver = discover_device_driver(info)  # no drivers= arg
     assert driver in _default_discovery_drivers
-    # custom_napalm drivers must not be tried by default
-    custom_drivers = custom_napalm_driver_list()
+    # custom_napalm-ONLY drivers (not also in the standard NAPALM list) must not
+    # be tried by default.  Drivers like 'eos' and 'ios' appear in both lists
+    # because custom_napalm ships subclasses that override the upstream driver;
+    # those are intentionally included in _default_discovery_drivers.
+    custom_drivers = set(custom_napalm_driver_list())
+    custom_only_drivers = custom_drivers - set(_default_discovery_drivers)
     for call in mock_get_network_driver.call_args_list:
-        assert call.args[0] not in custom_drivers, (
+        assert call.args[0] not in custom_only_drivers, (
             f"Custom driver '{call.args[0]}' was tried during default auto-discovery"
         )


### PR DESCRIPTION
## Summary

Adds `get_interfaces_vlans()` to four NAPALM-native subclass drivers (Arista EOS, Cisco NX-OS via NX-API, Cisco NX-OS-SSH, Juniper Junos via PyEZ) backed by a new generic NetBox-aligned classifier. Refactors the existing IOS and Cisco S300 drivers to consume the same shared classifier, removing duplicated logic. Strips upstream "jobec / NAPALM #919" naming.

Builds on top of #375.

## What changed

**New shared module** — `custom_napalm/_vlan.py`:
- Vendor-neutral `SwitchportInfo` dataclass (intermediate representation)
- Pure-function `classify_switchport(info) -> dict` — single source of truth for voice-VLAN promotion, DTP fallback, wildcard signaling, VID range clamping, bool rejection
- 44 unit tests in `test_vlan_classify.py`

**Shared NX-OS field mapper** — `custom_napalm/_nxos_common.py`:
- `nxos_row_to_switchport_info()` consumed by both NX-API and SSH paths
- Accepts both NX-API field names (`admin_mode`, `oper_mode`, `trunk_vlans`) and ntc-templates aliases (`mode`, `trunking_vlans`)
- 11 unit tests

**Four new NAPALM-native subclass drivers:**
| Driver | Transport | Coverage |
|---|---|---|
| `eos` | pyeapi (eAPI JSON-RPC), SSH-fallback via upstream `_run_commands` | 5 scenarios |
| `nxos` | NX-API (JSON-RPC) | 7 scenarios incl. voice-VLAN promotion + DTP fallback |
| `nxos_ssh` | Netmiko + ntc-templates `cisco_nxos` | 7 scenarios |
| `junos` | PyEZ NETCONF, lxml QName-based parsing (handles ELS + non-ELS) | 7 scenarios incl. ``vlan members all`` wildcard |

**Refactored existing drivers** — `ios.py` and `cisco_s300.py`:
- Driver-local classification helpers deleted; both now consume `_vlan.classify_switchport`
- Existing scenario fixtures and `expected_result.json` files **byte-identical** (zero diff)
- Two retargeted helper-level tests still assert malformed-trunk warnings via `caplog`

**Test harness extensions** — `tests/custom_drivers/mock_device.py`:
- `FakeJsonRpcDevice` — serves both pyeapi `run_commands()` and NX-API `show()` from per-command `.json` files
- `FakePyEZDevice` — exposes `.rpc.<name>(...)` returning lxml elements from `<rpc-name>.xml` files (snake → kebab conversion); guards dunders against introspection
- 6 sanity tests

**Tightened `BaseDriverTest.test_get_interfaces_vlans`** — now requires `tagged`/`untagged` keys explicitly and rejects bool VIDs.

**Repo-wide scrub** of `jobec` / `NAPALM #919` references (5 occurrences in PR #375's docstrings).

**CLAUDE.md** — new section documenting the `get_interfaces_vlans` pattern + a transport→fake table.

## Architecture

The classifier acts as the single source of truth: every driver does only field extraction (vendor JSON/XML → `SwitchportInfo`) and delegates classification. Adding a fifth VLAN-aware driver is now ~30 lines of vendor-specific code plus fixtures.

NetBox 4.5.9 mapping (unchanged from #375):
| Driver output mode | NetBox `Interface.mode` |
|---|---|
| `access` | `access` |
| `trunk` | `tagged` |
| `trunk-all` | `tagged-all` |
| `routed` | no change (Diode PATCH semantics) |

Q-in-Q (`qinq_svlan`) and VLAN translation policies are explicitly out of scope for v1.

## Out of scope (deferred)

- IOS-XR (different L2 model — sub-interfaces / L2VPN)
- Junos voice-VLAN promotion (Junos `voip` semantics differ from Cisco)
- Q-in-Q modeling
- Retrofitting other custom drivers (aruba_aoscx, dell_sonic, extreme_exos, etc.) — each becomes a follow-up ~30-line PR

## Test plan

- [x] All 682 tests pass (595 baseline + 87 new). 64 skipped.
- [x] Ruff clean across whole `device-discovery/` tree.
- [x] Zero `jobec` / `NAPALM #919` references repo-wide.
- [x] All 6 drivers (`eos`, `nxos`, `nxos_ssh`, `junos`, `ios`, `cisco_s300`) resolve to `custom_napalm.*` subclasses via `napalm.get_network_driver()`.
- [x] Existing IOS + S300 fixtures byte-identical (refactor preserves output).
- [x] Codex normal review against `develop`: CLEAN — zero P0/P1 findings.
- [ ] mockit E2E for `nxos_ssh` (CLI fallback path) — to validate during merge prep.
- [ ] Schema validation for `eos.py` against a real EOS device (eAPI Command Explorer reference) — defensive parsing means key-name drift produces wrong-but-not-crashing output.

Companion docs PR in orb-agent: netboxlabs/orb-agent#341 (will be updated to add the four new drivers to the supported list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)