### PR TITLE
feat(OBS-2820): expose resolved NAPALM driver on status runs

### DIFF
--- a/device-discovery/device_discovery/policy/models.py
+++ b/device-discovery/device_discovery/policy/models.py
@@ -280,6 +280,10 @@ class Run(BaseModel):
     status: RunStatus
     reason: str = ""
     entity_count: int = 0
+    driver: str | None = Field(
+        default=None,
+        description="Resolved NAPALM driver after a successful device session",
+    )
     metadata: dict[str, str] = Field(default_factory=dict)
     created_at: int = Field(default_factory=time.time_ns)
     updated_at: int = Field(default_factory=time.time_ns)

--- a/device-discovery/device_discovery/policy/run.py
+++ b/device-discovery/device_discovery/policy/run.py
@@ -6,11 +6,15 @@ import ipaddress
 import json
 import threading
 import time
+from typing import Any
 
 from device_discovery.policy.models import Run, RunStatus
 
 # Maximum number of runs to keep per target
 MAX_RUNS_PER_TARGET = 3
+
+# Sentinel: omit ``driver`` argument to ``update_run`` to leave the field unchanged.
+_MISSING_DRIVER = object()
 
 
 class RunStore:
@@ -128,6 +132,7 @@ class RunStore:
         status: RunStatus,
         error: Exception | None,
         entity_count: int,
+        driver: Any = _MISSING_DRIVER,
     ) -> None:
         """
         Update an existing run's status.
@@ -140,6 +145,8 @@ class RunStore:
             status: New status.
             error: Error if failed, None otherwise.
             entity_count: Number of entities discovered.
+            driver: Resolved NAPALM driver after a successful session; None clears
+                the field. Omit (use default) to leave the existing value unchanged.
 
         """
         with self._lock:
@@ -161,6 +168,9 @@ class RunStore:
                         run.reason = str(error)
                     else:
                         run.reason = ""  # Clear reason when no error
+
+                    if driver is not _MISSING_DRIVER:
+                        run.driver = driver
 
                     return
 

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -347,6 +347,7 @@ class PolicyRunner:
                     status=RunStatus.FAILED,
                     error=Exception("No reachable hosts found in range"),
                     entity_count=0,
+                    driver=None,
                 )
                 return
 
@@ -397,6 +398,7 @@ class PolicyRunner:
                 status=RunStatus.FAILED,
                 error=e,
                 entity_count=0,
+                driver=None,
             )
 
     def run(self, id: str, scope: Napalm, config: Config):
@@ -431,6 +433,7 @@ class PolicyRunner:
                 status=RunStatus.FAILED,
                 error=Exception("Not able to discover device driver"),
                 entity_count=0,
+                driver=None,
             )
             return
 
@@ -454,6 +457,7 @@ class PolicyRunner:
                 status=RunStatus.COMPLETED,
                 error=None,
                 entity_count=entity_count,
+                driver=scope.driver,
             )
 
             # Record total discovery duration
@@ -478,6 +482,7 @@ class PolicyRunner:
                 status=RunStatus.FAILED,
                 error=e,
                 entity_count=0,
+                driver=None,
             )
 
             discovery_failure = get_metric("discovery_failure")
@@ -538,6 +543,7 @@ class PolicyRunner:
                 status=RunStatus.FAILED,
                 error=Exception("Not able to discover device driver"),
                 entity_count=0,
+                driver=None,
             )
             return
 
@@ -561,6 +567,7 @@ class PolicyRunner:
                 status=RunStatus.COMPLETED,
                 error=None,
                 entity_count=entity_count,
+                driver=scope.driver,
             )
 
             # Record total discovery duration
@@ -585,6 +592,7 @@ class PolicyRunner:
                 status=RunStatus.FAILED,
                 error=e,
                 entity_count=0,
+                driver=None,
             )
 
             discovery_failure = get_metric("discovery_failure")

--- a/device-discovery/device_discovery/server.py
+++ b/device-discovery/device_discovery/server.py
@@ -144,7 +144,7 @@ def read_status():
         policies=policy_statuses,
     )
 
-    return response.model_dump()
+    return response.model_dump(mode="json", exclude_none=True)
 
 
 @app.get("/api/v1/capabilities")

--- a/device-discovery/tests/policy/test_run.py
+++ b/device-discovery/tests/policy/test_run.py
@@ -24,6 +24,7 @@ def test_run_creation():
     assert run.metadata["targets"] == '["router1.example.com"]'
     assert run.created_at
     assert run.updated_at
+    assert run.driver is None
 
 
 def test_run_with_parent():
@@ -76,6 +77,52 @@ def test_update_run_success():
     assert updated.status == RunStatus.COMPLETED
     assert updated.entity_count == 42
     assert updated.reason == ""
+    assert updated.driver is None
+
+
+def test_update_run_sets_driver():
+    """Resolved NAPALM driver is persisted when passed to update_run."""
+    store = RunStore()
+    run = store.create_run("policy1", "router1.example.com", "")
+
+    store.update_run(
+        "policy1",
+        "router1.example.com",
+        run.id,
+        RunStatus.COMPLETED,
+        None,
+        3,
+        driver="eos",
+    )
+
+    updated = store.get_runs_for_target("policy1", "router1.example.com")[0]
+    assert updated.driver == "eos"
+
+
+def test_update_run_omit_driver_preserves_existing():
+    """Omitting driver leaves the previous value unchanged."""
+    store = RunStore()
+    run = store.create_run("policy1", "192.168.1.1", "")
+    store.update_run(
+        "policy1",
+        "192.168.1.1",
+        run.id,
+        RunStatus.COMPLETED,
+        None,
+        1,
+        driver="junos",
+    )
+    store.update_run(
+        "policy1",
+        "192.168.1.1",
+        run.id,
+        RunStatus.FAILED,
+        Exception("device closed"),
+        0,
+    )
+
+    updated = store.get_runs_for_target("policy1", "192.168.1.1")[0]
+    assert updated.driver == "junos"
 
 
 def test_update_run_failure():
@@ -92,6 +139,61 @@ def test_update_run_failure():
     assert updated.status == RunStatus.FAILED
     assert updated.entity_count == 0
     assert "Connection timeout" in updated.reason
+
+
+def test_update_run_sets_and_preserves_driver():
+    """Resolved driver is stored; omitting driver on a later update preserves it."""
+    store = RunStore()
+    run = store.create_run("policy1", "router1.example.com", "")
+
+    store.update_run(
+        "policy1",
+        "router1.example.com",
+        run.id,
+        RunStatus.COMPLETED,
+        None,
+        5,
+        driver="ios",
+    )
+    updated = store.get_runs_for_target("policy1", "router1.example.com")[0]
+    assert updated.driver == "ios"
+
+    store.update_run(
+        "policy1",
+        "router1.example.com",
+        run.id,
+        RunStatus.COMPLETED,
+        None,
+        7,
+    )
+    updated = store.get_runs_for_target("policy1", "router1.example.com")[0]
+    assert updated.driver == "ios"
+    assert updated.entity_count == 7
+
+
+def test_update_run_clears_driver_with_none():
+    store = RunStore()
+    run = store.create_run("policy1", "router1.example.com", "")
+    store.update_run(
+        "policy1",
+        "router1.example.com",
+        run.id,
+        RunStatus.COMPLETED,
+        None,
+        1,
+        driver="ios",
+    )
+    store.update_run(
+        "policy1",
+        "router1.example.com",
+        run.id,
+        RunStatus.FAILED,
+        Exception("fail"),
+        0,
+        driver=None,
+    )
+    updated = store.get_runs_for_target("policy1", "router1.example.com")[0]
+    assert updated.driver is None
 
 
 def test_normalize_target_ip():

--- a/device-discovery/tests/policy/test_run.py
+++ b/device-discovery/tests/policy/test_run.py
@@ -172,6 +172,7 @@ def test_update_run_sets_and_preserves_driver():
 
 
 def test_update_run_clears_driver_with_none():
+    """Clearing driver with None sets driver to None."""
     store = RunStore()
     run = store.create_run("policy1", "router1.example.com", "")
     store.update_run(

--- a/device-discovery/tests/policy/test_runner.py
+++ b/device-discovery/tests/policy/test_runner.py
@@ -245,6 +245,7 @@ def test_run_device_with_discovered_driver(
         }
         run = run_store.get_runs_for_policy(policy_runner.name)[0]
         assert kwargs["run_id"] == run.id
+        assert run.driver == "ios"
         assert data["driver"] == "ios"
         assert data["device"] == {"model": "SampleModel"}
         assert data["interface"] == {"eth0": "up"}
@@ -273,6 +274,8 @@ def test_run_discovered_driver_error(
         mock_logger_error.assert_called_once()
         assert "Not able to discover device driver" in mock_logger_error.call_args[0][0]
         assert policy_runner.status == Status.FAILED
+        failed_run = run_store.get_runs_for_policy(policy_runner.name)[0]
+        assert failed_run.driver is None
 
 
 def test_run_driver_failure_does_not_remove_job(policy_runner, sample_scopes, sample_config, run_store):
@@ -669,6 +672,7 @@ def test_run_uses_entity_count_from_collect(policy_runner, run_store):
     mock_update.assert_called_once()
     call_kwargs = mock_update.call_args[1]
     assert call_kwargs["entity_count"] == 5
+    assert call_kwargs["driver"] == "ios"
 
 
 def test_run_with_parent_uses_entity_count_from_collect(policy_runner, run_store):
@@ -691,6 +695,7 @@ def test_run_with_parent_uses_entity_count_from_collect(policy_runner, run_store
     mock_update.assert_called_once()
     call_kwargs = mock_update.call_args[1]
     assert call_kwargs["entity_count"] == 12
+    assert call_kwargs["driver"] == "ios"
 
 
 def test_run_with_parent_driver_failure_does_not_remove_job(policy_runner, run_store, sample_config):

--- a/device-discovery/tests/test_server.py
+++ b/device-discovery/tests/test_server.py
@@ -423,6 +423,7 @@ def test_read_status_with_policies(mock_version_semver):
         policy_id="test_policy",
         status=RunStatus.COMPLETED,
         entity_count=10,
+        driver="ios",
         created_at=int(datetime(2026, 1, 27, 10, 0, 0).timestamp() * 1e9),
         updated_at=int(datetime(2026, 1, 27, 10, 5, 0).timestamp() * 1e9),
     )
@@ -456,6 +457,7 @@ def test_read_status_with_policies(mock_version_semver):
         assert run["policy_id"] == "test_policy"
         assert run["status"] == "completed"
         assert run["entity_count"] == 10
+        assert run["driver"] == "ios"
         assert "id" in run
         assert "created_at" in run
         assert "updated_at" in run


### PR DESCRIPTION
## Summary
Adds optional run-level `driver` to device-discovery `/api/v1/status` after a successful NAPALM session, aligned with the orb-agent heartbeat field (same JSON key).

## What changed
- `Run` model: optional `driver` (resolved NAPALM driver name).
- `RunStore.update_run` accepts optional `driver`; omitting it preserves the previous value; `None` clears.
- `PolicyRunner` sets `driver` on completed device runs and clears it on failures; port-scan runs unchanged.
- Status response uses `model_dump(mode="json", exclude_none=True)` so absent drivers stay off the wire.

## How tested
- Not run in this environment (full suite needs project venv / napalm). Intended: targeted `pytest` on `tests/policy/test_run.py`, `test_runner.py`, `tests/test_server.py::test_read_status_with_policies`, then CI.

## Companion
- **orb-agent:** https://github.com/netboxlabs/orb-agent/pull/343