### PR TITLE
fix(OBS-2834): omit SNMP port from run target metadata

### DIFF
--- a/snmp-discovery/policy/run.go
+++ b/snmp-discovery/policy/run.go
@@ -3,10 +3,8 @@ package policy
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/netip"
 	"sort"
-	"strconv"
 	"sync"
 	"time"
 
@@ -52,19 +50,21 @@ func NewRunStore() *RunStore {
 	}
 }
 
-// normalizeTarget normalizes target strings to canonical form and includes port
-// Returns format "host:port" (e.g., "192.168.1.10:161")
-func normalizeTarget(host string, port uint16) string {
-	normalizedHost := host
-	// Try to parse as IP address
+// normalizedHostString returns canonical host or CIDR for display and metadata;
+// hostnames and other literals are returned unchanged.
+func normalizedHostString(host string) string {
 	if addr, err := netip.ParseAddr(host); err == nil {
-		normalizedHost = addr.String()
-	} else if prefix, err := netip.ParsePrefix(host); err == nil {
-		// Try to parse as IP prefix (CIDR)
-		normalizedHost = prefix.String()
+		return addr.String()
 	}
-	// Return composite identifier "host:port"
-	return fmt.Sprintf("%s:%d", normalizedHost, port)
+	if prefix, err := netip.ParsePrefix(host); err == nil {
+		return prefix.String()
+	}
+	return host
+}
+
+// normalizeTarget returns a stable map key "host:port" for per-target run storage.
+func normalizeTarget(host string, port uint16) string {
+	return fmt.Sprintf("%s:%d", normalizedHostString(host), port)
 }
 
 // copyRun creates a deep copy of a Run to avoid race conditions
@@ -104,9 +104,8 @@ func (rs *RunStore) CreateRun(policyName string, target string, port uint16, par
 	// Normalize target for consistent storage (includes port)
 	normalizedTarget := normalizeTarget(target, port)
 
-	// Create metadata with targets as JSON array of host:port strings
-	hostPort := net.JoinHostPort(target, strconv.FormatUint(uint64(port), 10))
-	targetsJSON, _ := json.Marshal([]string{hostPort})
+	// Report targets without port (UI shows policy/defaults elsewhere); align with device/network discovery.
+	targetsJSON, _ := json.Marshal([]string{normalizedHostString(target)})
 	metadata := map[string]string{
 		"targets": string(targetsJSON),
 	}

--- a/snmp-discovery/policy/run_test.go
+++ b/snmp-discovery/policy/run_test.go
@@ -29,7 +29,7 @@ func TestRunStore_CreateRun(t *testing.T) {
 
 	// Verify metadata
 	assert.NotNil(t, run.Metadata)
-	assert.Equal(t, `["192.168.1.10:161"]`, run.Metadata["targets"])
+	assert.Equal(t, `["192.168.1.10"]`, run.Metadata["targets"])
 	assert.NotContains(t, run.Metadata, "target")
 	assert.NotContains(t, run.Metadata, "port")
 	assert.Equal(t, parentTarget, run.Metadata["parent_target"])
@@ -54,7 +54,7 @@ func TestRunStore_CreateRun_NoParentTarget(t *testing.T) {
 
 	// Verify metadata has targets but not parent_target, target, or port
 	assert.NotNil(t, run.Metadata)
-	assert.Equal(t, `["192.168.1.10:161"]`, run.Metadata["targets"])
+	assert.Equal(t, `["192.168.1.10"]`, run.Metadata["targets"])
 	assert.NotContains(t, run.Metadata, "target")
 	assert.NotContains(t, run.Metadata, "port")
 	assert.NotContains(t, run.Metadata, "parent_target")
@@ -148,11 +148,11 @@ func TestRunStore_MaxThreeRunsPerTarget_MultipleTargets(t *testing.T) {
 
 	// Verify runs have correct metadata
 	for _, run := range runs1 {
-		assert.Equal(t, `["192.168.1.10:161"]`, run.Metadata["targets"])
+		assert.Equal(t, `["192.168.1.10"]`, run.Metadata["targets"])
 		assert.Equal(t, parentTarget, run.Metadata["parent_target"])
 	}
 	for _, run := range runs2 {
-		assert.Equal(t, `["192.168.1.11:161"]`, run.Metadata["targets"])
+		assert.Equal(t, `["192.168.1.11"]`, run.Metadata["targets"])
 		assert.Equal(t, parentTarget, run.Metadata["parent_target"])
 	}
 
@@ -186,10 +186,10 @@ func TestRunStore_GetRunsForTarget(t *testing.T) {
 
 	// Verify runs are for correct target
 	for _, run := range runs1 {
-		assert.Equal(t, `["192.168.1.10:161"]`, run.Metadata["targets"])
+		assert.Equal(t, `["192.168.1.10"]`, run.Metadata["targets"])
 	}
 	for _, run := range runs2 {
-		assert.Equal(t, `["192.168.1.11:161"]`, run.Metadata["targets"])
+		assert.Equal(t, `["192.168.1.11"]`, run.Metadata["targets"])
 	}
 }
 
@@ -389,8 +389,8 @@ func TestRunStore_TargetNormalization(t *testing.T) {
 	assert.Len(t, runs2, 1, "Second target should have one run")
 
 	// Verify metadata contains correct targets
-	assert.Equal(t, `["192.168.1.10:161"]`, run1.Metadata["targets"])
-	assert.Equal(t, `["192.168.1.11:161"]`, run2.Metadata["targets"])
+	assert.Equal(t, `["192.168.1.10"]`, run1.Metadata["targets"])
+	assert.Equal(t, `["192.168.1.11"]`, run2.Metadata["targets"])
 
 	// Test that same IP in different notation normalizes correctly
 	target3 := "192.168.1.10" // Same as target1
@@ -410,7 +410,7 @@ func TestRunStore_ScanRunWithRange(t *testing.T) {
 	// Create scan run (no parent_target)
 	scanRun := store.CreateRun(policyName, scanTarget, port, "")
 
-	assert.Equal(t, `["192.168.1.0/24:161"]`, scanRun.Metadata["targets"])
+	assert.Equal(t, `["192.168.1.0/24"]`, scanRun.Metadata["targets"])
 	assert.NotContains(t, scanRun.Metadata, "parent_target")
 
 	// Create individual target runs from scan
@@ -420,10 +420,10 @@ func TestRunStore_ScanRunWithRange(t *testing.T) {
 	run1 := store.CreateRun(policyName, target1, port, scanTarget)
 	run2 := store.CreateRun(policyName, target2, port, scanTarget)
 
-	assert.Equal(t, `["192.168.1.10:161"]`, run1.Metadata["targets"])
+	assert.Equal(t, `["192.168.1.10"]`, run1.Metadata["targets"])
 	assert.Equal(t, scanTarget, run1.Metadata["parent_target"])
 
-	assert.Equal(t, `["192.168.1.11:161"]`, run2.Metadata["targets"])
+	assert.Equal(t, `["192.168.1.11"]`, run2.Metadata["targets"])
 	assert.Equal(t, scanTarget, run2.Metadata["parent_target"])
 
 	// Verify scan run is tracked separately (with its own port)
@@ -490,27 +490,24 @@ func TestRunStore_SameHostDifferentPorts(t *testing.T) {
 	allRuns := store.GetRunsForPolicy(policyName)
 	assert.Len(t, allRuns, 6, "Should have 3 runs from each port")
 
-	// Verify metadata has correct targets values (host:port format)
 	for _, run := range runsPort161 {
-		assert.Equal(t, `["192.168.1.10:161"]`, run.Metadata["targets"], "Port 161 runs should embed port in targets")
+		assert.Equal(t, `["192.168.1.10"]`, run.Metadata["targets"], "reported targets omit port")
 	}
 	for _, run := range runsPort162 {
-		assert.Equal(t, `["192.168.1.10:162"]`, run.Metadata["targets"], "Port 162 runs should embed port in targets")
+		assert.Equal(t, `["192.168.1.10"]`, run.Metadata["targets"], "reported targets omit port")
 	}
 }
 
-func TestRunStore_PortInTargets(t *testing.T) {
+func TestRunStore_TargetsMetadataOmitsPort(t *testing.T) {
 	store := policy.NewRunStore()
 	policyName := "test-policy"
 	target := "192.168.1.10"
 	port := uint16(162)
 
-	// Create run with non-default port
 	run := store.CreateRun(policyName, target, port, "")
 
-	// Verify metadata contains port embedded in targets as host:port JSON array
 	assert.NotNil(t, run.Metadata, "Metadata should not be nil")
-	assert.Equal(t, `["192.168.1.10:162"]`, run.Metadata["targets"], "Metadata should have targets as JSON [host:port]")
+	assert.Equal(t, `["192.168.1.10"]`, run.Metadata["targets"])
 	assert.NotContains(t, run.Metadata, "target", "Metadata should not have separate target field")
 	assert.NotContains(t, run.Metadata, "port", "Metadata should not have separate port field")
 }

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -257,7 +257,7 @@ func TestRunScanSchedulesResponsiveTargets(t *testing.T) {
 	// Verify scan run was created
 	runs := runStore.GetRunsForTarget("test-policy", "192.168.1.0/24", 161)
 	require.Len(t, runs, 1, "Scan run should be created")
-	assert.Equal(t, `["192.168.1.0/24:161"]`, runs[0].Metadata["targets"])
+	assert.Equal(t, `["192.168.1.0/24"]`, runs[0].Metadata["targets"])
 	assert.Equal(t, RunStatusCompleted, runs[0].Status)
 }
 


### PR DESCRIPTION
## Summary
SNMP discovery run rows showed targets like `172.28.0.1:161` because `metadata["targets"]` embedded the SNMP port. Device and network discovery do not show the port in that column; this change makes SNMP consistent.

## What changed
- `CreateRun` now sets `targets` metadata to a JSON array of normalized host/CIDR strings only (no `:port`).
- The in-memory run store still keys runs by `host:port` so different SNMP ports on the same host keep separate histories.

## How tested
- `cd snmp-discovery && go test ./policy/... -count=1 -short` (135 tests passed)

## Linear
OBS-2834 — https://linear.app/netboxlabs/issue/OBS-2834/snmp-discovery-run-history-displays-port-161-appended-to-targets-port

Made with [Cursor](https://cursor.com)