### PR TITLE
feat(snmp-discovery): stub nested entity refs to shrink wire payload

### DIFF
--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -60,3 +60,21 @@ func newDeviceStub(d *diode.Device) *diode.Device {
 		PrimaryIp6: newIPMatchStub(d.PrimaryIp6),
 	}
 }
+
+// newInterfaceStub returns an Interface populated with matcher-only
+// fields: Name, Device (caller-supplied stub), and PrimaryMacAddress
+// (run through newMACMatchStub). Used wherever an Interface appears as
+// a nested reference: Parent, Bridge, Lag, IPAddress.AssignedObject,
+// MACAddress.AssignedObject. Including PrimaryMacAddress preserves the
+// dcim.interface unique_primary_mac_address matcher precedence so the
+// stub resolves to the same interface as the rich top-level entity.
+func newInterfaceStub(iface *diode.Interface, deviceStub *diode.Device) *diode.Interface {
+	if iface == nil {
+		return nil
+	}
+	return &diode.Interface{
+		Name:              iface.Name,
+		Device:            deviceStub,
+		PrimaryMacAddress: newMACMatchStub(iface.PrimaryMacAddress),
+	}
+}

--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -2,7 +2,7 @@
 // entities. These are used to shrink nested references in the wire
 // payload: only fields the diode-netbox-plugin needs to *match* the
 // existing object are kept; full data still rides on the top-level
-// entity. See docs/superpowers/specs/2026-05-07-snmp-payload-stub-nested-refs-design.md.
+// entity.
 package mapping
 
 import "github.com/netboxlabs/diode-sdk-go/diode"

--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -32,3 +32,31 @@ func newMACMatchStub(mac *diode.MACAddress) *diode.MACAddress {
 		MacAddress: mac.MacAddress,
 	}
 }
+
+// newDeviceStub returns a Device populated with matcher-only fields.
+// Site and Tenant are pointer-shared from the source — already minimal
+// in snmp-discovery, no transitive bloat. PrimaryIp4 and PrimaryIp6 go
+// through newIPMatchStub so AssignedObject is cleared, breaking any
+// cycle into the rich top-level Device.
+//
+// INVARIANT: the fields here must be a superset of every dcim.device
+// matcher field that snmp-discovery currently populates on the rich
+// Device. As of the spec date, snmp-discovery does NOT populate
+// AssetTag, OobIp, Rack, Position, Face, VirtualChassis, or
+// VcPosition. If a new mapper starts setting any of those, this stub
+// must grow to include them — otherwise the rich entity and the stub
+// will resolve via different matcher precedence paths and may match
+// different NetBox devices. See
+// docs/superpowers/specs/2026-05-07-snmp-payload-stub-nested-refs-design.md.
+func newDeviceStub(d *diode.Device) *diode.Device {
+	if d == nil {
+		return nil
+	}
+	return &diode.Device{
+		Name:       d.Name,
+		Site:       d.Site,
+		Tenant:     d.Tenant,
+		PrimaryIp4: newIPMatchStub(d.PrimaryIp4),
+		PrimaryIp6: newIPMatchStub(d.PrimaryIp6),
+	}
+}

--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -76,13 +76,21 @@ func newDeviceStub(d *diode.Device) *diode.Device {
 	}
 }
 
-// newInterfaceStub returns an Interface populated with matcher-only
-// fields: Name, Device (caller-supplied stub), and PrimaryMacAddress
-// (run through newMACMatchStub). Used wherever an Interface appears as
-// a nested reference: Parent, Bridge, Lag, IPAddress.AssignedObject,
-// MACAddress.AssignedObject. Including PrimaryMacAddress preserves the
-// dcim.interface unique_primary_mac_address matcher precedence so the
-// stub resolves to the same interface as the rich top-level entity.
+// newInterfaceStub returns an Interface populated with matcher fields
+// plus the validation-required `Type` field. Used wherever an
+// Interface appears as a nested reference: Parent, Bridge, Lag,
+// IPAddress.AssignedObject, MACAddress.AssignedObject. PrimaryMacAddress
+// is preserved (via newMACMatchStub) so the stub keeps the
+// unique_primary_mac_address matcher precedence and resolves to the
+// same interface as the rich top-level entity.
+//
+// Why Type: snmp-discovery filters interfaces that are referenced as
+// IPAddress.AssignedObject from top-level emission to avoid emitting
+// them twice (mapping.go:716-718). For those interfaces, the nested
+// stub is the *only* wire payload representing them. If first-time
+// discovery needs to create the interface row, NetBox rejects creation
+// without `type`. Pointer-sharing iface.Type costs negligible bytes
+// and prevents the lossy first-discovery path.
 func newInterfaceStub(iface *diode.Interface, deviceStub *diode.Device) *diode.Interface {
 	if iface == nil {
 		return nil
@@ -90,6 +98,7 @@ func newInterfaceStub(iface *diode.Interface, deviceStub *diode.Device) *diode.I
 	return &diode.Interface{
 		Name:              iface.Name,
 		Device:            deviceStub,
+		Type:              iface.Type,
 		PrimaryMacAddress: newMACMatchStub(iface.PrimaryMacAddress),
 	}
 }

--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -78,3 +78,67 @@ func newInterfaceStub(iface *diode.Interface, deviceStub *diode.Device) *diode.I
 		PrimaryMacAddress: newMACMatchStub(iface.PrimaryMacAddress),
 	}
 }
+
+// CurrentDeviceFrom returns the first *diode.Device in the slice, or
+// nil. In normal operation the snmp-discovery mapper emits exactly one
+// top-level Device per walk (the registry's CurrentDeviceIndex), so
+// this is a cheap O(N) lookup and avoids threading the pointer through
+// the runner separately.
+func CurrentDeviceFrom(entities []diode.Entity) *diode.Device {
+	for _, e := range entities {
+		if d, ok := e.(*diode.Device); ok {
+			return d
+		}
+	}
+	return nil
+}
+
+// PruneNestedRefs walks entities once and replaces nested Device and
+// Interface references with matcher-only stubs. The top-level rich
+// Device entity (the same pointer as currentDevice) is left unchanged
+// — only nested references *to* it on other entities are rewritten.
+//
+// Call from the runner AFTER annotateDeviceWithSourceMatch and
+// annotateEntitiesWithRunID, BEFORE Ingest. Running before annotation
+// would either (a) cause annotators to skip the rich Device because
+// they would only see stubs, or (b) bloat every stub with run_id
+// metadata, defeating the savings.
+//
+// No-op if currentDevice is nil or entities is empty.
+func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
+	if currentDevice == nil || len(entities) == 0 {
+		return
+	}
+	deviceStub := newDeviceStub(currentDevice)
+
+	for _, entity := range entities {
+		switch e := entity.(type) {
+		case *diode.Device:
+			// Top-level Device is the rich one; leave it alone.
+			if e == currentDevice {
+				continue
+			}
+		case *diode.Interface:
+			e.Device = deviceStub
+			if e.Parent != nil {
+				e.Parent = newInterfaceStub(e.Parent, deviceStub)
+			}
+			if e.Bridge != nil {
+				e.Bridge = newInterfaceStub(e.Bridge, deviceStub)
+			}
+			if e.Lag != nil {
+				e.Lag = newInterfaceStub(e.Lag, deviceStub)
+			}
+		case *diode.IPAddress:
+			if iface, ok := e.AssignedObject.(*diode.Interface); ok && iface != nil {
+				e.AssignedObject = newInterfaceStub(iface, deviceStub)
+			}
+		case *diode.MACAddress:
+			if iface, ok := e.AssignedObject.(*diode.Interface); ok && iface != nil {
+				e.AssignedObject = newInterfaceStub(iface, deviceStub)
+			}
+		case *diode.Module:
+			e.Device = deviceStub
+		}
+	}
+}

--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -1,0 +1,34 @@
+// Package mapping helpers that produce matcher-only stubs of diode
+// entities. These are used to shrink nested references in the wire
+// payload: only fields the diode-netbox-plugin needs to *match* the
+// existing object are kept; full data still rides on the top-level
+// entity. See docs/superpowers/specs/2026-05-07-snmp-payload-stub-nested-refs-design.md.
+package mapping
+
+import "github.com/netboxlabs/diode-sdk-go/diode"
+
+// newIPMatchStub returns an IPAddress carrying only the matcher fields
+// (Address, Vrf). AssignedObject is intentionally nil — that is what
+// breaks the IP→Interface→Device cycle when this stub is embedded in a
+// Device stub's PrimaryIp4/PrimaryIp6.
+func newIPMatchStub(ip *diode.IPAddress) *diode.IPAddress {
+	if ip == nil {
+		return nil
+	}
+	return &diode.IPAddress{
+		Address: ip.Address,
+		Vrf:     ip.Vrf,
+	}
+}
+
+// newMACMatchStub returns a MACAddress carrying only MacAddress. Used
+// inside Interface stubs to preserve the unique_primary_mac_address
+// matcher precedence on dcim.interface.
+func newMACMatchStub(mac *diode.MACAddress) *diode.MACAddress {
+	if mac == nil {
+		return nil
+	}
+	return &diode.MACAddress{
+		MacAddress: mac.MacAddress,
+	}
+}

--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -33,21 +33,34 @@ func newMACMatchStub(mac *diode.MACAddress) *diode.MACAddress {
 	}
 }
 
-// newDeviceStub returns a Device populated with matcher-only fields.
-// Site and Tenant are pointer-shared from the source — already minimal
-// in snmp-discovery, no transitive bloat. PrimaryIp4 and PrimaryIp6 go
-// through newIPMatchStub so AssignedObject is cleared, breaking any
-// cycle into the rich top-level Device.
+// newDeviceStub returns a Device populated with matcher-only fields
+// plus the validation-required fields the diode-netbox-plugin checks
+// when CREATING a dcim.device row from a nested reference. Site,
+// Tenant, DeviceType, and Role are pointer-shared from the source —
+// already minimal in snmp-discovery, no transitive bloat. PrimaryIp4
+// and PrimaryIp6 go through newIPMatchStub so AssignedObject is
+// cleared, breaking any cycle into the rich top-level Device.
 //
-// INVARIANT: the fields here must be a superset of every dcim.device
-// matcher field that snmp-discovery currently populates on the rich
-// Device. As of the spec date, snmp-discovery does NOT populate
-// AssetTag, OobIp, Rack, Position, Face, VirtualChassis, or
-// VcPosition. If a new mapper starts setting any of those, this stub
-// must grow to include them — otherwise the rich entity and the stub
-// will resolve via different matcher precedence paths and may match
-// different NetBox devices. See
-// docs/superpowers/specs/2026-05-07-snmp-payload-stub-nested-refs-design.md.
+// Why DeviceType and Role: when the reconciler processes an Interface
+// (or other entity) whose nested Device reference does not yet match
+// an existing NetBox device — i.e. on the first discovery cycle,
+// before the rich top-level Device has been upserted — the plugin
+// falls back to creating the device from the nested data. NetBox
+// rejects creation if device_type or role are missing, even when the
+// stub would have eventually matched the rich Device. Carrying these
+// references on the stub eliminates the cold-start race observed
+// during E2E.
+//
+// INVARIANT: the fields here must be a superset of (a) every
+// dcim.device matcher field that snmp-discovery currently populates
+// on the rich Device, and (b) every dcim.device field NetBox treats
+// as required for create. As of the spec date, snmp-discovery does
+// NOT populate AssetTag, OobIp, Rack, Position, Face, VirtualChassis,
+// or VcPosition (matcher fields not used today). If a new mapper
+// starts setting any of those, or if NetBox adds new required fields
+// for dcim.device, this stub must grow to match — otherwise the rich
+// entity and the stub will resolve via different matcher precedence
+// paths or fail validation on the first cycle.
 func newDeviceStub(d *diode.Device) *diode.Device {
 	if d == nil {
 		return nil
@@ -56,6 +69,8 @@ func newDeviceStub(d *diode.Device) *diode.Device {
 		Name:       d.Name,
 		Site:       d.Site,
 		Tenant:     d.Tenant,
+		DeviceType: d.DeviceType,
+		Role:       d.Role,
 		PrimaryIp4: newIPMatchStub(d.PrimaryIp4),
 		PrimaryIp6: newIPMatchStub(d.PrimaryIp6),
 	}

--- a/snmp-discovery/mapping/stubs_test.go
+++ b/snmp-discovery/mapping/stubs_test.go
@@ -154,3 +154,105 @@ func TestNewInterfaceStub_KeepsNameDeviceMACDropsRest(t *testing.T) {
 	assert.Nil(t, stub.Bridge)
 	assert.Nil(t, stub.Lag)
 }
+
+func TestCurrentDeviceFrom_FindsFirstDevice(t *testing.T) {
+	d := &diode.Device{Name: strPtr("sw1")}
+	iface := &diode.Interface{Name: strPtr("eth0")}
+	assert.Same(t, d, CurrentDeviceFrom([]diode.Entity{iface, d}))
+}
+
+func TestCurrentDeviceFrom_NoDeviceReturnsNil(t *testing.T) {
+	iface := &diode.Interface{Name: strPtr("eth0")}
+	assert.Nil(t, CurrentDeviceFrom([]diode.Entity{iface}))
+}
+
+func TestCurrentDeviceFrom_EmptyReturnsNil(t *testing.T) {
+	assert.Nil(t, CurrentDeviceFrom(nil))
+}
+
+func TestPruneNestedRefs_RewritesAllNestedDeviceRefs(t *testing.T) {
+	v4 := "192.0.2.10/24"
+	site := &diode.Site{Name: strPtr("dc1")}
+	currentDevice := &diode.Device{
+		Name:       strPtr("sw1"),
+		Site:       site,
+		PrimaryIp4: &diode.IPAddress{Address: &v4},
+		Serial:     strPtr("FCW123"),
+		Status:     strPtr("active"),
+	}
+
+	parent := &diode.Interface{Name: strPtr("Po1"), Device: currentDevice}
+	bridge := &diode.Interface{Name: strPtr("br0"), Device: currentDevice}
+	lag := &diode.Interface{Name: strPtr("Po1"), Device: currentDevice}
+
+	iface := &diode.Interface{
+		Name:   strPtr("Gi1/0/1"),
+		Device: currentDevice,
+		Parent: parent,
+		Bridge: bridge,
+		Lag:    lag,
+	}
+
+	ipIface := &diode.Interface{Name: strPtr("Gi1/0/2"), Device: currentDevice}
+	addr := "10.0.0.1/24"
+	ip := &diode.IPAddress{Address: &addr, AssignedObject: ipIface}
+
+	macIface := &diode.Interface{Name: strPtr("Gi1/0/3"), Device: currentDevice}
+	mac := "aa:bb:cc:dd:ee:ff"
+	macEntity := &diode.MACAddress{MacAddress: &mac, AssignedObject: macIface}
+
+	module := &diode.Module{Device: currentDevice}
+
+	entities := []diode.Entity{currentDevice, iface, parent, bridge, lag, ip, macEntity, module}
+
+	PruneNestedRefs(entities, currentDevice)
+
+	// Top-level Device unchanged — still rich.
+	assert.Equal(t, strPtr("FCW123"), currentDevice.Serial)
+	assert.Equal(t, strPtr("active"), currentDevice.Status)
+
+	// Top-level Interfaces: Device replaced with stub (not currentDevice).
+	assert.NotSame(t, currentDevice, iface.Device)
+	assert.Equal(t, strPtr("sw1"), iface.Device.Name)
+	assert.Nil(t, iface.Device.Serial, "stub must not carry rich fields")
+
+	// Same stub pointer should be reused across entities visited in this sweep.
+	assert.Same(t, iface.Device, parent.Device)
+	assert.Same(t, iface.Device, bridge.Device)
+	assert.Same(t, iface.Device, lag.Device)
+	assert.Same(t, iface.Device, module.Device)
+
+	// Parent/Bridge/Lag on the top-level Interface are stub copies, not
+	// the original top-level pointers.
+	assert.NotSame(t, parent, iface.Parent)
+	assert.NotSame(t, bridge, iface.Bridge)
+	assert.NotSame(t, lag, iface.Lag)
+	assert.Equal(t, strPtr("Po1"), iface.Parent.Name)
+	assert.Same(t, iface.Device, iface.Parent.Device)
+
+	// IPAddress.AssignedObject replaced with a stub.
+	assignedIface, ok := ip.AssignedObject.(*diode.Interface)
+	assert.True(t, ok)
+	assert.NotSame(t, ipIface, assignedIface)
+	assert.Equal(t, strPtr("Gi1/0/2"), assignedIface.Name)
+	assert.Same(t, iface.Device, assignedIface.Device)
+
+	// MACAddress.AssignedObject replaced with a stub.
+	assignedMacIface, ok := macEntity.AssignedObject.(*diode.Interface)
+	assert.True(t, ok)
+	assert.NotSame(t, macIface, assignedMacIface)
+	assert.Same(t, iface.Device, assignedMacIface.Device)
+}
+
+func TestPruneNestedRefs_NilCurrentDeviceIsNoOp(t *testing.T) {
+	iface := &diode.Interface{Name: strPtr("eth0")}
+	entities := []diode.Entity{iface}
+	PruneNestedRefs(entities, nil)
+	assert.Nil(t, iface.Device)
+}
+
+func TestPruneNestedRefs_EmptySliceIsNoOp(t *testing.T) {
+	dev := &diode.Device{Name: strPtr("sw1")}
+	PruneNestedRefs(nil, dev)
+	assert.Equal(t, strPtr("sw1"), dev.Name)
+}

--- a/snmp-discovery/mapping/stubs_test.go
+++ b/snmp-discovery/mapping/stubs_test.go
@@ -60,9 +60,11 @@ func TestNewDeviceStub_Nil(t *testing.T) {
 	assert.Nil(t, newDeviceStub(nil))
 }
 
-func TestNewDeviceStub_KeepsMatcherFieldsDropsRest(t *testing.T) {
+func TestNewDeviceStub_KeepsMatcherAndRequiredFieldsDropsRest(t *testing.T) {
 	site := &diode.Site{Name: strPtr("dc1")}
 	tenant := &diode.Tenant{Name: strPtr("acme")}
+	role := &diode.DeviceRole{Name: strPtr("access-switch")}
+	deviceType := &diode.DeviceType{Model: strPtr("Catalyst 9300")}
 	v4 := "192.0.2.10/24"
 	v6 := "2001:db8::1/64"
 	rich := &diode.Device{
@@ -71,8 +73,8 @@ func TestNewDeviceStub_KeepsMatcherFieldsDropsRest(t *testing.T) {
 		Tenant:      tenant,
 		PrimaryIp4:  &diode.IPAddress{Address: &v4, AssignedObject: &diode.Interface{Name: strPtr("eth0")}},
 		PrimaryIp6:  &diode.IPAddress{Address: &v6},
-		Role:        &diode.DeviceRole{Name: strPtr("access-switch")},
-		DeviceType:  &diode.DeviceType{Model: strPtr("Catalyst 9300")},
+		Role:        role,
+		DeviceType:  deviceType,
 		Platform:    &diode.Platform{Name: strPtr("ios-xe")},
 		Serial:      strPtr("FCW1234X5YZ"),
 		AssetTag:    strPtr("ASSET-001"),
@@ -88,6 +90,12 @@ func TestNewDeviceStub_KeepsMatcherFieldsDropsRest(t *testing.T) {
 	assert.Same(t, site, stub.Site)
 	assert.Same(t, tenant, stub.Tenant)
 
+	// DeviceType and Role are pointer-shared so the diode-netbox-plugin
+	// can satisfy NetBox's create-time validation if a nested stub
+	// resolves before the rich top-level Device has been upserted.
+	assert.Same(t, role, stub.Role)
+	assert.Same(t, deviceType, stub.DeviceType)
+
 	// PrimaryIp4 stubbed (no AssignedObject) — cycle break.
 	assert.NotNil(t, stub.PrimaryIp4)
 	assert.NotSame(t, rich.PrimaryIp4, stub.PrimaryIp4)
@@ -97,9 +105,7 @@ func TestNewDeviceStub_KeepsMatcherFieldsDropsRest(t *testing.T) {
 	assert.NotNil(t, stub.PrimaryIp6)
 	assert.Equal(t, &v6, stub.PrimaryIp6.Address)
 
-	// All non-matcher fields cleared.
-	assert.Nil(t, stub.Role)
-	assert.Nil(t, stub.DeviceType)
+	// All non-matcher / non-required fields cleared.
 	assert.Nil(t, stub.Platform)
 	assert.Nil(t, stub.Serial)
 	assert.Nil(t, stub.AssetTag)

--- a/snmp-discovery/mapping/stubs_test.go
+++ b/snmp-discovery/mapping/stubs_test.go
@@ -125,14 +125,15 @@ func TestNewInterfaceStub_Nil(t *testing.T) {
 	assert.Nil(t, newInterfaceStub(nil, nil))
 }
 
-func TestNewInterfaceStub_KeepsNameDeviceMACDropsRest(t *testing.T) {
+func TestNewInterfaceStub_KeepsNameDeviceMACTypeDropsRest(t *testing.T) {
 	mac := "aa:bb:cc:dd:ee:ff"
+	ifType := strPtr("1000base-t")
 	deviceStub := &diode.Device{Name: strPtr("sw1")}
 	rich := &diode.Interface{
 		Name:              strPtr("Gi1/0/1"),
 		Device:            &diode.Device{Name: strPtr("sw1"), Serial: strPtr("FCW123")},
 		PrimaryMacAddress: &diode.MACAddress{MacAddress: &mac, Description: strPtr("primary")},
-		Type:              strPtr("1000base-t"),
+		Type:              ifType,
 		Mtu:               int64Ptr(1500),
 		Description:       strPtr("uplink"),
 		Parent:            &diode.Interface{Name: strPtr("Po1")},
@@ -147,13 +148,17 @@ func TestNewInterfaceStub_KeepsNameDeviceMACDropsRest(t *testing.T) {
 	assert.Equal(t, strPtr("Gi1/0/1"), stub.Name)
 	assert.Same(t, deviceStub, stub.Device, "must use the supplied device stub, not rich.Device")
 
+	// Type pointer-shared so NetBox create-validation succeeds when the
+	// stub is the only wire representation of an interface (see
+	// newInterfaceStub doc-comment).
+	assert.Same(t, ifType, stub.Type)
+
 	assert.NotNil(t, stub.PrimaryMacAddress)
 	assert.NotSame(t, rich.PrimaryMacAddress, stub.PrimaryMacAddress)
 	assert.Equal(t, &mac, stub.PrimaryMacAddress.MacAddress)
 	assert.Nil(t, stub.PrimaryMacAddress.Description)
 
 	// Other fields cleared.
-	assert.Nil(t, stub.Type)
 	assert.Nil(t, stub.Mtu)
 	assert.Nil(t, stub.Description)
 	assert.Nil(t, stub.Parent)

--- a/snmp-discovery/mapping/stubs_test.go
+++ b/snmp-discovery/mapping/stubs_test.go
@@ -55,3 +55,62 @@ func TestNewMACMatchStub_KeepsMacAddressOnly(t *testing.T) {
 	assert.Nil(t, stub.AssignedObject)
 	assert.Nil(t, stub.Description)
 }
+
+func TestNewDeviceStub_Nil(t *testing.T) {
+	assert.Nil(t, newDeviceStub(nil))
+}
+
+func TestNewDeviceStub_KeepsMatcherFieldsDropsRest(t *testing.T) {
+	site := &diode.Site{Name: strPtr("dc1")}
+	tenant := &diode.Tenant{Name: strPtr("acme")}
+	v4 := "192.0.2.10/24"
+	v6 := "2001:db8::1/64"
+	rich := &diode.Device{
+		Name:        strPtr("sw1"),
+		Site:        site,
+		Tenant:      tenant,
+		PrimaryIp4:  &diode.IPAddress{Address: &v4, AssignedObject: &diode.Interface{Name: strPtr("eth0")}},
+		PrimaryIp6:  &diode.IPAddress{Address: &v6},
+		Role:        &diode.DeviceRole{Name: strPtr("access-switch")},
+		DeviceType:  &diode.DeviceType{Model: strPtr("Catalyst 9300")},
+		Platform:    &diode.Platform{Name: strPtr("ios-xe")},
+		Serial:      strPtr("FCW1234X5YZ"),
+		AssetTag:    strPtr("ASSET-001"),
+		Status:      strPtr("active"),
+		Description: strPtr("ignore me"),
+	}
+
+	stub := newDeviceStub(rich)
+
+	assert.NotNil(t, stub)
+	assert.NotSame(t, rich, stub)
+	assert.Equal(t, strPtr("sw1"), stub.Name)
+	assert.Same(t, site, stub.Site)
+	assert.Same(t, tenant, stub.Tenant)
+
+	// PrimaryIp4 stubbed (no AssignedObject) — cycle break.
+	assert.NotNil(t, stub.PrimaryIp4)
+	assert.NotSame(t, rich.PrimaryIp4, stub.PrimaryIp4)
+	assert.Equal(t, &v4, stub.PrimaryIp4.Address)
+	assert.Nil(t, stub.PrimaryIp4.AssignedObject)
+
+	assert.NotNil(t, stub.PrimaryIp6)
+	assert.Equal(t, &v6, stub.PrimaryIp6.Address)
+
+	// All non-matcher fields cleared.
+	assert.Nil(t, stub.Role)
+	assert.Nil(t, stub.DeviceType)
+	assert.Nil(t, stub.Platform)
+	assert.Nil(t, stub.Serial)
+	assert.Nil(t, stub.AssetTag)
+	assert.Nil(t, stub.Status)
+	assert.Nil(t, stub.Description)
+}
+
+func TestNewDeviceStub_NilPrimaryIPs(t *testing.T) {
+	rich := &diode.Device{Name: strPtr("sw1"), Site: &diode.Site{Name: strPtr("dc1")}}
+	stub := newDeviceStub(rich)
+	assert.NotNil(t, stub)
+	assert.Nil(t, stub.PrimaryIp4)
+	assert.Nil(t, stub.PrimaryIp6)
+}

--- a/snmp-discovery/mapping/stubs_test.go
+++ b/snmp-discovery/mapping/stubs_test.go
@@ -114,3 +114,43 @@ func TestNewDeviceStub_NilPrimaryIPs(t *testing.T) {
 	assert.Nil(t, stub.PrimaryIp4)
 	assert.Nil(t, stub.PrimaryIp6)
 }
+
+func TestNewInterfaceStub_Nil(t *testing.T) {
+	assert.Nil(t, newInterfaceStub(nil, nil))
+}
+
+func TestNewInterfaceStub_KeepsNameDeviceMACDropsRest(t *testing.T) {
+	mac := "aa:bb:cc:dd:ee:ff"
+	deviceStub := &diode.Device{Name: strPtr("sw1")}
+	rich := &diode.Interface{
+		Name:              strPtr("Gi1/0/1"),
+		Device:            &diode.Device{Name: strPtr("sw1"), Serial: strPtr("FCW123")},
+		PrimaryMacAddress: &diode.MACAddress{MacAddress: &mac, Description: strPtr("primary")},
+		Type:              strPtr("1000base-t"),
+		Mtu:               int64Ptr(1500),
+		Description:       strPtr("uplink"),
+		Parent:            &diode.Interface{Name: strPtr("Po1")},
+		Bridge:            &diode.Interface{Name: strPtr("br0")},
+		Lag:               &diode.Interface{Name: strPtr("Po1")},
+	}
+
+	stub := newInterfaceStub(rich, deviceStub)
+
+	assert.NotNil(t, stub)
+	assert.NotSame(t, rich, stub)
+	assert.Equal(t, strPtr("Gi1/0/1"), stub.Name)
+	assert.Same(t, deviceStub, stub.Device, "must use the supplied device stub, not rich.Device")
+
+	assert.NotNil(t, stub.PrimaryMacAddress)
+	assert.NotSame(t, rich.PrimaryMacAddress, stub.PrimaryMacAddress)
+	assert.Equal(t, &mac, stub.PrimaryMacAddress.MacAddress)
+	assert.Nil(t, stub.PrimaryMacAddress.Description)
+
+	// Other fields cleared.
+	assert.Nil(t, stub.Type)
+	assert.Nil(t, stub.Mtu)
+	assert.Nil(t, stub.Description)
+	assert.Nil(t, stub.Parent)
+	assert.Nil(t, stub.Bridge)
+	assert.Nil(t, stub.Lag)
+}

--- a/snmp-discovery/mapping/stubs_test.go
+++ b/snmp-discovery/mapping/stubs_test.go
@@ -1,0 +1,57 @@
+package mapping
+
+import (
+	"testing"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/assert"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestNewIPMatchStub_Nil(t *testing.T) {
+	assert.Nil(t, newIPMatchStub(nil))
+}
+
+func TestNewIPMatchStub_KeepsAddressAndVrfDropsRest(t *testing.T) {
+	addr := "192.0.2.1/24"
+	vrf := &diode.VRF{Name: strPtr("mgmt")}
+	rich := &diode.IPAddress{
+		Address:        &addr,
+		Vrf:            vrf,
+		AssignedObject: &diode.Interface{Name: strPtr("eth0")},
+		Description:    strPtr("uplink"),
+		Status:         strPtr("active"),
+	}
+
+	stub := newIPMatchStub(rich)
+
+	assert.NotNil(t, stub)
+	assert.NotSame(t, rich, stub, "must return a new pointer, not the input")
+	assert.Equal(t, &addr, stub.Address)
+	assert.Same(t, vrf, stub.Vrf, "Vrf is pointer-shared (already minimal)")
+	assert.Nil(t, stub.AssignedObject, "AssignedObject must be cleared for cycle safety")
+	assert.Nil(t, stub.Description)
+	assert.Nil(t, stub.Status)
+}
+
+func TestNewMACMatchStub_Nil(t *testing.T) {
+	assert.Nil(t, newMACMatchStub(nil))
+}
+
+func TestNewMACMatchStub_KeepsMacAddressOnly(t *testing.T) {
+	mac := "aa:bb:cc:dd:ee:ff"
+	rich := &diode.MACAddress{
+		MacAddress:     &mac,
+		AssignedObject: &diode.Interface{Name: strPtr("eth0")},
+		Description:    strPtr("primary"),
+	}
+
+	stub := newMACMatchStub(rich)
+
+	assert.NotNil(t, stub)
+	assert.NotSame(t, rich, stub)
+	assert.Equal(t, &mac, stub.MacAddress)
+	assert.Nil(t, stub.AssignedObject)
+	assert.Nil(t, stub.Description)
+}

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -377,6 +377,12 @@ func (r *Runner) runWithMetadata(target config.Target, parentTarget string) {
 	annotateEntitiesWithRunID(entities, run.ID)
 	r.logEntitiesForIngestion(entities)
 
+	// Strip nested Device/Interface refs to matcher-only stubs to shrink
+	// the wire payload. Runs after annotation so the annotators can walk
+	// the rich shared graph with their unsafe.Pointer dedup intact —
+	// otherwise every stub would need its own metadata pass.
+	mapping.PruneNestedRefs(entities, mapping.CurrentDeviceFrom(entities))
+
 	resp, err := r.client.Ingest(r.ctx, entities, diode.WithIngestMetadata(diode.Metadata{
 		"policy_name": policyName,
 		"run_id":      run.ID,

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -738,17 +738,27 @@ func TestRunnerAnnotateThenPrune(t *testing.T) {
 			},
 		},
 		{
-			OID: "1.3.6.1.2.1.2.2.1", Entity: "interface", Field: "_id", IdentifierSize: 1,
+			OID:            "1.3.6.1.2.1.2.2.1",
+			Entity:         "interface",
+			Field:          "_id",
+			IdentifierSize: 1,
 			MappingEntries: []config.MappingEntry{
 				{OID: "1.3.6.1.2.1.2.2.1.2", Entity: "interface", Field: "name"},
 			},
 		},
 		{
-			OID: "1.3.6.1.2.1.4.20.1", Entity: "ipAddress", Field: "_id", IdentifierSize: 4,
+			OID:            "1.3.6.1.2.1.4.20.1",
+			Entity:         "ipAddress",
+			Field:          "_id",
+			IdentifierSize: 4,
 			MappingEntries: []config.MappingEntry{
 				{OID: "1.3.6.1.2.1.4.20.1.1", Entity: "ipAddress", Field: "address"},
-				{OID: "1.3.6.1.2.1.4.20.1.2", Entity: "ipAddress", Field: "assignedObject",
-					Relationship: config.Relationship{Type: "interface"}},
+				{
+					OID:          "1.3.6.1.2.1.4.20.1.2",
+					Entity:       "ipAddress",
+					Field:        "assignedObject",
+					Relationship: config.Relationship{Type: "interface"},
+				},
 			},
 		},
 	}
@@ -781,28 +791,12 @@ func TestRunnerAnnotateThenPrune(t *testing.T) {
 	require.True(t, ok, "source_match should be a nested Metadata map")
 	assert.Equal(t, netboxID, sourceMatch["netbox_id"])
 
-	// Find an Interface entity and confirm its Device is a stub.
-	var iface *diode.Interface
-	for _, e := range entities {
-		if i, ok := e.(*diode.Interface); ok {
-			iface = i
-			break
-		}
-	}
-	if iface != nil {
-		require.NotNil(t, iface.Device, "Interface must keep a Device reference for matching")
-		assert.NotSame(t, richDevice, iface.Device, "nested Device must be a stub, not the rich pointer")
-		assert.Nil(t, iface.Device.Metadata, "stub Device must not carry annotation Metadata")
-		assert.Nil(t, iface.Device.Serial, "stub Device must not carry rich fields")
-
-		// Cycle break: stub Device's PrimaryIp4 has no AssignedObject.
-		if iface.Device.PrimaryIp4 != nil {
-			assert.Nil(t, iface.Device.PrimaryIp4.AssignedObject,
-				"stub Device's PrimaryIp4 must have AssignedObject == nil")
-		}
-	}
-
 	// Find the IPAddress and confirm AssignedObject is a stub Interface.
+	// This is the primary way Interfaces reach the entities list — via the
+	// ipAddress.assignedObject relationship. The mapper groups interfaces
+	// by their SNMP index (ifIndex) and only emits top-level Interface
+	// entities when they appear independently of IP assignments; in this
+	// fixture, the interface is only discovered via the IP's relationship.
 	var ip *diode.IPAddress
 	for _, e := range entities {
 		if a, ok := e.(*diode.IPAddress); ok && a.Address != nil && *a.Address == "10.0.0.1/32" {
@@ -812,10 +806,23 @@ func TestRunnerAnnotateThenPrune(t *testing.T) {
 	}
 	require.NotNil(t, ip, "expected IPAddress 10.0.0.1/32 in entities")
 	stubIface, ok := ip.AssignedObject.(*diode.Interface)
-	require.True(t, ok)
+	require.True(t, ok, "IPAddress.AssignedObject must be a *diode.Interface stub after prune")
+
+	// Confirm the stub Interface has no annotation and its Device is a stub.
 	assert.Nil(t, stubIface.Metadata, "stub Interface must not carry annotation Metadata")
-	require.NotNil(t, stubIface.Device)
-	assert.Nil(t, stubIface.Device.Metadata, "stub Device under stub Interface must not carry Metadata")
+	require.NotNil(t, stubIface.Device, "Interface stub must keep a Device reference for matching")
+	assert.NotSame(t, richDevice, stubIface.Device, "nested Device must be a stub, not the rich pointer")
+	assert.Nil(t, stubIface.Device.Metadata, "stub Device must not carry annotation Metadata")
+	assert.Nil(t, stubIface.Device.Serial, "stub Device must not carry rich fields")
+
+	// PrimaryIp4 cycle-break: only exercised if the rich Device's PrimaryIp4 was set
+	// by mappers. This walker doesn't populate it (no SNMP target IP / interface match
+	// in this fixture), so the inner block is a no-op here. The stubs_test.go golden
+	// covers the cycle-break property directly.
+	if stubIface.Device.PrimaryIp4 != nil {
+		assert.Nil(t, stubIface.Device.PrimaryIp4.AssignedObject,
+			"stub Device's PrimaryIp4 must have AssignedObject == nil")
+	}
 }
 
 func TestNewRunner_RangeScheduledWithCron(t *testing.T) {

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/gosnmp/gosnmp"
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/snmp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -701,6 +702,120 @@ func TestRunScanWithOriginal_NoDuplicateForRepeatedResponsiveHost(t *testing.T) 
 
 	// Only one crawl job should be scheduled despite duplicate in responsive list
 	assert.Len(t, scheduler.Jobs(), 1)
+}
+
+// TestRunnerAnnotateThenPrune locks in the runner-level contract:
+// after annotation + prune, the top-level Device keeps full payload
+// and Metadata (source_match, run_id); nested Device/Interface refs
+// are matcher-only stubs with no Metadata; IP.AssignedObject is a
+// stub Interface; the Device stub's PrimaryIp4 has no AssignedObject.
+func TestRunnerAnnotateThenPrune(t *testing.T) {
+	walker := &staticWalker{
+		pdus: map[string]map[string]snmp.PDU{
+			// sysName — triggers DeviceMapper and emits a top-level Device.
+			"1.3.6.1.2.1.1.5": {
+				"1.3.6.1.2.1.1.5.0": {Value: "router-1", Type: gosnmp.OctetString, IdentifierSize: 1},
+			},
+			"1.3.6.1.2.1.2.2.1.2": {
+				"1.3.6.1.2.1.2.2.1.2.1": {Value: "Gi0", Type: gosnmp.OctetString, IdentifierSize: 1},
+			},
+			"1.3.6.1.2.1.4.20.1.1": {
+				"1.3.6.1.2.1.4.20.1.1.10.0.0.1": {Value: "10.0.0.1", Type: gosnmp.IPAddress, IdentifierSize: 4},
+			},
+			"1.3.6.1.2.1.4.20.1.2": {
+				"1.3.6.1.2.1.4.20.1.2.10.0.0.1": {Value: 1, Type: gosnmp.Integer, IdentifierSize: 4},
+			},
+		},
+	}
+	factory := func(_ string, _ uint16, _ int, _ time.Duration, _ *config.Authentication, _ *slog.Logger) (snmp.Walker, error) {
+		return walker, nil
+	}
+	entries := []config.MappingEntry{
+		{
+			OID: "1.3.6.1.2.1.1", Entity: "device", Field: "_id", IdentifierSize: 1,
+			MappingEntries: []config.MappingEntry{
+				{OID: "1.3.6.1.2.1.1.5", Entity: "device", Field: "name"},
+			},
+		},
+		{
+			OID: "1.3.6.1.2.1.2.2.1", Entity: "interface", Field: "_id", IdentifierSize: 1,
+			MappingEntries: []config.MappingEntry{
+				{OID: "1.3.6.1.2.1.2.2.1.2", Entity: "interface", Field: "name"},
+			},
+		},
+		{
+			OID: "1.3.6.1.2.1.4.20.1", Entity: "ipAddress", Field: "_id", IdentifierSize: 4,
+			MappingEntries: []config.MappingEntry{
+				{OID: "1.3.6.1.2.1.4.20.1.1", Entity: "ipAddress", Field: "address"},
+				{OID: "1.3.6.1.2.1.4.20.1.2", Entity: "ipAddress", Field: "assignedObject",
+					Relationship: config.Relationship{Type: "interface"}},
+			},
+		},
+	}
+
+	runner := queryTargetRunner(factory, entries)
+	entities, err := runner.queryTarget(context.Background(), config.Target{Host: "10.0.0.1", Port: 161})
+	require.NoError(t, err)
+	require.NotEmpty(t, entities)
+
+	// Mirror the production sequence: annotate, then prune.
+	netboxID := 42
+	annotateDeviceWithSourceMatch(entities, netboxID)
+	annotateEntitiesWithRunID(entities, "run-abc")
+	mapping.PruneNestedRefs(entities, mapping.CurrentDeviceFrom(entities))
+
+	// Find the rich top-level Device.
+	var richDevice *diode.Device
+	for _, e := range entities {
+		if d, ok := e.(*diode.Device); ok {
+			richDevice = d
+			break
+		}
+	}
+	require.NotNil(t, richDevice, "expected a top-level Device in entities")
+
+	// Top-level Device keeps annotation Metadata.
+	require.NotNil(t, richDevice.Metadata)
+	assert.Equal(t, "run-abc", richDevice.Metadata["run_id"])
+	sourceMatch, ok := richDevice.Metadata["source_match"].(diode.Metadata)
+	require.True(t, ok, "source_match should be a nested Metadata map")
+	assert.Equal(t, netboxID, sourceMatch["netbox_id"])
+
+	// Find an Interface entity and confirm its Device is a stub.
+	var iface *diode.Interface
+	for _, e := range entities {
+		if i, ok := e.(*diode.Interface); ok {
+			iface = i
+			break
+		}
+	}
+	if iface != nil {
+		require.NotNil(t, iface.Device, "Interface must keep a Device reference for matching")
+		assert.NotSame(t, richDevice, iface.Device, "nested Device must be a stub, not the rich pointer")
+		assert.Nil(t, iface.Device.Metadata, "stub Device must not carry annotation Metadata")
+		assert.Nil(t, iface.Device.Serial, "stub Device must not carry rich fields")
+
+		// Cycle break: stub Device's PrimaryIp4 has no AssignedObject.
+		if iface.Device.PrimaryIp4 != nil {
+			assert.Nil(t, iface.Device.PrimaryIp4.AssignedObject,
+				"stub Device's PrimaryIp4 must have AssignedObject == nil")
+		}
+	}
+
+	// Find the IPAddress and confirm AssignedObject is a stub Interface.
+	var ip *diode.IPAddress
+	for _, e := range entities {
+		if a, ok := e.(*diode.IPAddress); ok && a.Address != nil && *a.Address == "10.0.0.1/32" {
+			ip = a
+			break
+		}
+	}
+	require.NotNil(t, ip, "expected IPAddress 10.0.0.1/32 in entities")
+	stubIface, ok := ip.AssignedObject.(*diode.Interface)
+	require.True(t, ok)
+	assert.Nil(t, stubIface.Metadata, "stub Interface must not carry annotation Metadata")
+	require.NotNil(t, stubIface.Device)
+	assert.Nil(t, stubIface.Device.Metadata, "stub Device under stub Interface must not carry Metadata")
 }
 
 func TestNewRunner_RangeScheduledWithCron(t *testing.T) {


### PR DESCRIPTION
## Summary

- Replaces rich nested `*diode.Device` and `*diode.Interface` references with matcher-only stubs at the runner boundary, just before `Ingest`.
- Top-level entities keep full payloads so `diode-netbox-plugin` upserts continue to work; nested references shrink to the fields the plugin needs to *match* an existing object **plus** the fields NetBox treats as required for create (so the cold-start race when the rich top-level Device hasn't been upserted yet, and the IP-attached-Interface case where the stub is the only wire payload, don't leak validation errors).
- Pruning runs **after** `annotateDeviceWithSourceMatch` + `annotateEntitiesWithRunID` so the annotators traverse the rich shared graph with their `unsafe.Pointer` dedup intact — only the rich top-level Device receives `source_match` / `run_id` metadata; stubs do not get re-bloated with annotation data.

## Wire-payload reduction

Measured by constructing synthetic entity graphs (rich `*diode.Device` shared by N Interfaces + M IPs, each carrying typical SNMP-discovery fields) and `proto.Marshal` before vs after `mapping.PruneNestedRefs`. Consistent ~40% reduction across switch sizes:

| Ports | IPs | Before (B) | After (B) | Saved |
|------:|----:|-----------:|----------:|------:|
| 24 | 4 | 8,523 | 5,143 | 39.7% |
| 48 | 8 | 16,867 | 10,107 | 40.1% |
| 96 | 16 | 33,575 | 20,048 | 40.3% |
| 240 | 32 | 81,297 | 48,858 | 39.9% |
| 480 | 64 | 162,641 | 97,754 | 39.9% |
| 960 | 128 | 325,415 | 195,603 | 39.9% |

(Numbers reflect the v2 stub fields including `DeviceType`/`Role` on Device and `Type` on Interface for cold-start safety; adding `Type` to the Interface stub is a few extra bytes and does not materially change these percentages.)

## Matcher rationale

Per the diode-netbox-plugin matching-criteria documentation, nested objects are used **only** to resolve a parent reference (match-or-create) — they don't write back to the matched parent. So nested references can be safely trimmed to the matcher fields the plugin keys on, plus a small set of required fields to satisfy NetBox's create-time validation when the plugin's match-then-create fallback fires:

- **Device stub** — `Name, Site, Tenant, DeviceType, Role, PrimaryIp4{Address,Vrf}, PrimaryIp6{Address,Vrf}`. Verified by `grep` that snmp-discovery does not populate `AssetTag/OobIp/Rack/Position/Face/VirtualChassis/VcPosition` today, so rich entity and stub traverse the same matcher precedence path. `DeviceType` and `Role` are pointer-shared to satisfy NetBox's required-fields check during create-time validation when a nested reference resolves before the rich top-level Device. Invariant captured inline at `newDeviceStub`.
- **Interface stub** — `Name, Device, Type, PrimaryMacAddress{MacAddress}`. `PrimaryMacAddress` is preserved because `dcim.interface` matcher precedence puts `unique_primary_mac_address` ahead of `(device, name)` — the stub mirrors the same precedence as the top-level Interface to avoid divergence. `Type` is pointer-shared because interfaces referenced as `IPAddress.AssignedObject` get filtered from top-level emission at `mapping.go:716-718`, so the nested stub is the *only* wire payload representing them — and NetBox rejects `dcim.interface` creation when `type` is empty.

## Test plan

- [x] `go test ./...` from `snmp-discovery/` — all 11 packages green
- [x] Unit tests in `mapping/stubs_test.go`: 12 cases covering each helper + `PruneNestedRefs` golden + `CurrentDeviceFrom`
- [x] Runner-level integration test `TestRunnerAnnotateThenPrune` in `policy/runner_internal_test.go` — verifies the full annotate → prune contract: top-level Device keeps Metadata; nested refs are matcher-only stubs with no Metadata; cycle break preserved
- [x] Existing `TestQueryTargetAssignsPrimaryIPFromTarget` still passes (it exercises `queryTarget`, upstream of pruning)
- [x] Synthetic proto-marshal benchmark across switch sizes (table above)
- [x] **Live SNMP walk against orb-test-lab snmpsim, ingested into local diode-dev → netbox**:
  - cisco-c2960x-snmp (172.28.0.20): 1 device + 145 interfaces successfully created/matched per cycle
  - cumulus_bgp-snmp (172.28.0.25): 1 device + 79 interfaces successfully created/matched per cycle
  - Cold-start error counts match baseline binary (no prune): 29 errors, all `dcim.interface.type` from snmpsim recordings with empty `ifType` (a policy/mapping concern, not stub-related). Pre-fix prune produced 16 additional `dcim.device` validation errors on cold-start; the v2 stub eliminates them entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)