### PR TITLE
fix(snmp-discovery): preserve metadata.source_match on Device stub

### DIFF
--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -61,11 +61,16 @@ func newMACMatchStub(mac *diode.MACAddress) *diode.MACAddress {
 // for dcim.device, this stub must grow to match — otherwise the rich
 // entity and the stub will resolve via different matcher precedence
 // paths or fail validation on the first cycle.
+//
+// Metadata.source_match (e.g. netbox_id) is the diode-netbox-plugin's
+// PK-based match path, so it must not diverge between rich and stub.
+// Annotation metadata such as run_id is intentionally NOT copied —
+// stubs are matcher-only.
 func newDeviceStub(d *diode.Device) *diode.Device {
 	if d == nil {
 		return nil
 	}
-	return &diode.Device{
+	stub := &diode.Device{
 		Name:       d.Name,
 		Site:       d.Site,
 		Tenant:     d.Tenant,
@@ -74,6 +79,10 @@ func newDeviceStub(d *diode.Device) *diode.Device {
 		PrimaryIp4: newIPMatchStub(d.PrimaryIp4),
 		PrimaryIp6: newIPMatchStub(d.PrimaryIp6),
 	}
+	if sm, ok := d.Metadata["source_match"]; ok {
+		stub.Metadata = diode.Metadata{"source_match": sm}
+	}
+	return stub
 }
 
 // newInterfaceStub returns an Interface populated with matcher fields

--- a/snmp-discovery/mapping/stubs_test.go
+++ b/snmp-discovery/mapping/stubs_test.go
@@ -121,6 +121,40 @@ func TestNewDeviceStub_NilPrimaryIPs(t *testing.T) {
 	assert.Nil(t, stub.PrimaryIp6)
 }
 
+func TestNewDeviceStub_PreservesSourceMatchDropsRunID(t *testing.T) {
+	rich := &diode.Device{
+		Name: strPtr("sw1"),
+		Metadata: diode.Metadata{
+			"source_match": diode.Metadata{"netbox_id": 42},
+			"run_id":       "run-abc",
+		},
+	}
+
+	stub := newDeviceStub(rich)
+
+	// source_match is the diode-netbox-plugin's PK-based match path —
+	// MUST flow to the stub or rich and stub diverge.
+	assert.NotNil(t, stub.Metadata)
+	sm, ok := stub.Metadata["source_match"].(diode.Metadata)
+	assert.True(t, ok, "source_match must be a nested Metadata map on the stub")
+	assert.Equal(t, 42, sm["netbox_id"])
+
+	// Annotation metadata (run_id) is intentionally NOT on the stub —
+	// stubs are matcher-only and must not carry per-run annotation.
+	_, hasRunID := stub.Metadata["run_id"]
+	assert.False(t, hasRunID, "stub must not carry run_id annotation")
+}
+
+func TestNewDeviceStub_NoMetadataWhenSourceMatchAbsent(t *testing.T) {
+	rich := &diode.Device{
+		Name:     strPtr("sw1"),
+		Metadata: diode.Metadata{"run_id": "run-abc"}, // only annotation
+	}
+	stub := newDeviceStub(rich)
+	// run_id is annotation, not a matcher — stub stays metadata-free.
+	assert.Nil(t, stub.Metadata)
+}
+
 func TestNewInterfaceStub_Nil(t *testing.T) {
 	assert.Nil(t, newInterfaceStub(nil, nil))
 }

--- a/snmp-discovery/policy/runner_internal_test.go
+++ b/snmp-discovery/policy/runner_internal_test.go
@@ -812,8 +812,22 @@ func TestRunnerAnnotateThenPrune(t *testing.T) {
 	assert.Nil(t, stubIface.Metadata, "stub Interface must not carry annotation Metadata")
 	require.NotNil(t, stubIface.Device, "Interface stub must keep a Device reference for matching")
 	assert.NotSame(t, richDevice, stubIface.Device, "nested Device must be a stub, not the rich pointer")
-	assert.Nil(t, stubIface.Device.Metadata, "stub Device must not carry annotation Metadata")
 	assert.Nil(t, stubIface.Device.Serial, "stub Device must not carry rich fields")
+
+	// stub Device may carry source_match (PK-based match path — preserved
+	// intentionally) but must never carry run_id annotation.
+	if stubIface.Device.Metadata != nil {
+		_, hasRunID := stubIface.Device.Metadata["run_id"]
+		assert.False(t, hasRunID, "stub Device must not carry run_id annotation")
+		// source_match is allowed: when annotateDeviceWithSourceMatch
+		// runs first (NetboxID != nil), the stub carries it for the
+		// plugin's PK-based matcher.
+		if sm, ok := stubIface.Device.Metadata["source_match"]; ok {
+			smMap, isMap := sm.(diode.Metadata)
+			assert.True(t, isMap, "source_match value must be a Metadata map")
+			assert.Equal(t, netboxID, smMap["netbox_id"])
+		}
+	}
 
 	// PrimaryIp4 cycle-break: only exercised if the rich Device's PrimaryIp4 was set
 	// by mappers. This walker doesn't populate it (no SNMP target IP / interface match


### PR DESCRIPTION
Tiny follow-up to #392. Mirror of the same fix landed in #394 for device-discovery.

When the runner sets `source_match.netbox_id` on the rich Device (via `annotateDeviceWithSourceMatch` when `target.NetboxID` is set), the stub must carry it too — `source_match` is the diode-netbox-plugin's PK-based match path and must not diverge between rich and stub. Annotation metadata such as `run_id` is intentionally NOT copied: stubs are matcher-only.

Runner-level integration test relaxed to allow `source_match` on the stub Device while still asserting `run_id` is absent.

## Changes

- `snmp-discovery/mapping/stubs.go`: `_device_match_stub` copies `Metadata["source_match"]` when set; INVARIANT comment extended.
- `snmp-discovery/mapping/stubs_test.go`: 2 new unit tests (`TestNewDeviceStub_PreservesSourceMatchDropsRunID`, `TestNewDeviceStub_NoMetadataWhenSourceMatchAbsent`).
- `snmp-discovery/policy/runner_internal_test.go`: existing integration test updated to allow `source_match` on the stub but still assert `run_id` is absent.

## Test plan

- [x] `go test ./...` from `snmp-discovery/` — all packages green
- [x] New unit tests cover both source_match preservation and run_id exclusion

## Out of scope

The Interface dedup-by-name change explored earlier in this PR was dropped because E2E showed the duplicate-MAC issue we observed in cumulus_bgp comes from a different root cause (one interface with multiple IPs each carrying the MAC sub-object, not duplicate-name interfaces). That investigation will be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)