### PR TITLE
fix: quiet APScheduler INFO for one-shot policy jobs

### DIFF
--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -104,6 +104,9 @@ class PolicyRunner:
         self.config.defaults = self.config.defaults or Defaults()
         self.config.options = self.config.options or Options()
 
+        # APScheduler logs one-shot job removal at INFO; keep library chatter off default logs (OBS-2581).
+        logging.getLogger("apscheduler").setLevel(logging.WARNING)
+
         self.scheduler.start()
         self._validate_discovery_drivers()
 

--- a/device-discovery/device_discovery/policy/runner.py
+++ b/device-discovery/device_discovery/policy/runner.py
@@ -104,8 +104,10 @@ class PolicyRunner:
         self.config.defaults = self.config.defaults or Defaults()
         self.config.options = self.config.options or Options()
 
-        # APScheduler logs one-shot job removal at INFO; keep library chatter off default logs (OBS-2581).
-        logging.getLogger("apscheduler").setLevel(logging.WARNING)
+        # One-shot jobs make APScheduler emit INFO when removing the ephemeral job after run.
+        # Cron policies keep default APScheduler INFO so library scheduling detail stays visible.
+        if self.config.schedule is None:
+            logging.getLogger("apscheduler").setLevel(logging.WARNING)
 
         self.scheduler.start()
         self._validate_discovery_drivers()

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -97,6 +97,9 @@ class PolicyRunner:
         self.policy = policy
         self.run_store = run_store
 
+        # APScheduler logs one-shot job removal at INFO; keep library chatter off default logs (OBS-2581).
+        logging.getLogger("apscheduler").setLevel(logging.WARNING)
+
         self.scheduler.start()
 
         if self.policy.config.schedule is not None:

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -97,8 +97,10 @@ class PolicyRunner:
         self.policy = policy
         self.run_store = run_store
 
-        # APScheduler logs one-shot job removal at INFO; keep library chatter off default logs (OBS-2581).
-        logging.getLogger("apscheduler").setLevel(logging.WARNING)
+        # One-shot jobs make APScheduler emit INFO when removing the ephemeral job after run.
+        # Cron policies keep default APScheduler INFO so library scheduling detail stays visible.
+        if self.policy.config.schedule is None:
+            logging.getLogger("apscheduler").setLevel(logging.WARNING)
 
         self.scheduler.start()
 


### PR DESCRIPTION
## Summary
Cuts noisy APScheduler INFO when **one-shot** jobs finish (the library logs removal of ephemeral jobs after a `DateTrigger` run). When the policy has **no** cron schedule, we set the `apscheduler` logger to `WARNING` before `BackgroundScheduler.start()`. **Cron** policies keep the default library log level so APScheduler INFO related to scheduling—including next-run detail—still appears.

## What changed
- **worker** (`worker/worker/policy/runner.py`): apply the logger tweak only if `policy.config.schedule` is unset.
- **device-discovery** (`device_discovery/policy/runner.py`): same when `config.schedule` is unset.

## How tested
- Not run locally; CI runs pytest on push.