### PR TITLE
chore: silence uvicorn access logs in device-discovery and worker

### DIFF
--- a/device-discovery/device_discovery/main.py
+++ b/device-discovery/device_discovery/main.py
@@ -176,6 +176,7 @@ def main():
             app,
             host=args.host,
             port=args.port,
+            access_log=False,
         )
     except (KeyboardInterrupt, RuntimeError):
         pass

--- a/worker/worker/main.py
+++ b/worker/worker/main.py
@@ -207,6 +207,7 @@ def main():
             app,
             host=args.host,
             port=args.port,
+            access_log=False,
         )
     except (KeyboardInterrupt, RuntimeError):
         pass


### PR DESCRIPTION
## Summary
- Pass `access_log=False` to `uvicorn.run` in both `device-discovery` and `worker` services so per-request access lines (e.g. `INFO: 127.0.0.1:xxxxx - \"GET /api/v1/status HTTP/1.1\" 200 OK`) stop flooding stdout.
- Startup, shutdown, and error logs from uvicorn remain unaffected.

## Test plan
- [x] `pytest tests/test_main.py` passes for `device-discovery`
- [x] `pytest tests/test_main.py` passes for `worker`
- [x] Manual: run each service and confirm `/api/v1/status` polling no longer emits access log lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)