### PR TITLE
feat(discovery): set scope_site on VLAN group from defaults.site

### DIFF
--- a/device-discovery/device_discovery/translate.py
+++ b/device-discovery/device_discovery/translate.py
@@ -21,6 +21,8 @@ from netboxlabs.diode.sdk.ingester import (
     Rack,
     Tenant,
     TenantGroup,
+    VLANGroup,
+    slugify,
 )
 
 from device_discovery.interface import build_interface_entities
@@ -192,6 +194,10 @@ def translate_vlan(vid: str, vlan_name: str, defaults: Defaults) -> VLAN | None:
         group = defaults.vlan.group
         tenant = translate_tenant(defaults.vlan.tenant)
         role = defaults.vlan.role
+        if group:
+            group = VLANGroup(
+                name=group, slug=slugify(group), scope_site=defaults.site
+            )
 
     clean_name = " ".join(vlan_name.strip().split())
     vlan = VLAN(

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -657,6 +657,54 @@ def test_translate_vlan_with_defaults(sample_defaults):
     assert len(vlan.tags) == 3
 
 
+def test_translate_vlan_group_scope_site_set_when_site_defined(sample_defaults):
+    """VLAN group is wrapped with slug + scope_site when defaults.site is a real value."""
+    sample_defaults.site = "New York"
+    sample_defaults.vlan = VlanParameters(group="Default Group")
+
+    vlan = translate_vlan("10", "V10", sample_defaults)
+
+    assert vlan.group.name == "Default Group"
+    assert vlan.group.slug == "default-group"
+    assert vlan.group.scope_site.name == "New York"
+
+
+def test_translate_vlan_group_scope_site_set_when_site_undefined(sample_defaults):
+    """scope_site is still populated when defaults.site is the sentinel 'undefined'."""
+    sample_defaults.site = "undefined"
+    sample_defaults.vlan = VlanParameters(group="Default Group")
+
+    vlan = translate_vlan("11", "V11", sample_defaults)
+
+    assert vlan.group.name == "Default Group"
+    assert vlan.group.slug == "default-group"
+    assert vlan.group.scope_site.name == "undefined"
+
+
+def test_translate_vlan_group_no_scope_site_when_site_none(sample_defaults):
+    """VLAN group has slug but no scope_site when defaults.site is None."""
+    sample_defaults.site = None
+    sample_defaults.vlan = VlanParameters(group="Default Group")
+
+    vlan = translate_vlan("12", "V12", sample_defaults)
+
+    assert vlan.group.name == "Default Group"
+    assert vlan.group.slug == "default-group"
+    assert vlan.group.scope_site.name == ""
+
+
+def test_translate_vlan_no_group_unaffected_by_site(sample_defaults):
+    """When no group is set, scope_site is not applied (group stays unset)."""
+    sample_defaults.site = "New York"
+    sample_defaults.vlan = VlanParameters(comments="no group")
+
+    vlan = translate_vlan("13", "V13", sample_defaults)
+
+    assert vlan.group.name == ""
+    assert vlan.group.slug == ""
+    assert vlan.group.scope_site.name == ""
+
+
 def test_translate_vlan_with_tenant_parameters(
     sample_defaults, sample_tenant_parameters
 ):

--- a/snmp-discovery/mapping/vlan_mapper.go
+++ b/snmp-discovery/mapping/vlan_mapper.go
@@ -246,7 +246,12 @@ func applyVLANDefaults(v *diode.VLAN, defaults *config.Defaults) {
 		v.Tenant = &diode.Tenant{Name: StringPtr(vd.Tenant)}
 	}
 	if vd.Group != "" {
-		v.Group = &diode.VLANGroup{Name: StringPtr(vd.Group)}
+		name := vd.Group
+		group := &diode.VLANGroup{Name: &name, Slug: toSlug(&name)}
+		if defaults.Site != "" {
+			group.Scope = &diode.Site{Name: StringPtr(defaults.Site)}
+		}
+		v.Group = group
 	}
 	if vd.Status != "" {
 		v.Status = StringPtr(vd.Status)

--- a/snmp-discovery/mapping/vlan_mapper_test.go
+++ b/snmp-discovery/mapping/vlan_mapper_test.go
@@ -355,3 +355,96 @@ func TestVlanMapper_EmitVLANs_AppliesDefaults(t *testing.T) {
 		t.Errorf("Group.Name: got %v, want \"campus-vlans\"", got.Group)
 	}
 }
+
+// applyVLANDefaults: when defaults.Site is a real value and a VLAN Group is
+// configured, the Group must carry Name + Slug + Scope = Site{Name: defaults.Site}.
+func TestApplyVLANDefaults_GroupScopeSite_WhenSiteDefined(t *testing.T) {
+	v := &diode.VLAN{}
+	defaults := &config.Defaults{
+		Site: "NYC",
+		VLAN: config.VLANDefaults{Group: "Lab VLAN Group"},
+	}
+
+	applyVLANDefaults(v, defaults)
+
+	if v.Group == nil {
+		t.Fatal("Group: got nil, want non-nil")
+	}
+	if v.Group.Name == nil || *v.Group.Name != "Lab VLAN Group" {
+		t.Errorf("Group.Name: got %v, want \"Lab VLAN Group\"", v.Group.Name)
+	}
+	if v.Group.Slug == nil || *v.Group.Slug != "lab-vlan-group" {
+		t.Errorf("Group.Slug: got %v, want \"lab-vlan-group\"", v.Group.Slug)
+	}
+	site, ok := v.Group.Scope.(*diode.Site)
+	if !ok {
+		t.Fatalf("Group.Scope: got %T, want *diode.Site", v.Group.Scope)
+	}
+	if site.Name == nil || *site.Name != "NYC" {
+		t.Errorf("Group.Scope.Site.Name: got %v, want \"NYC\"", site.Name)
+	}
+}
+
+// applyVLANDefaults: when defaults.Site is the sentinel "undefined" string,
+// scope_site is still populated (the value "undefined" is treated like any
+// other site name so the scoped-slug dedup path keeps working).
+func TestApplyVLANDefaults_GroupScopeSite_WhenSiteUndefined(t *testing.T) {
+	v := &diode.VLAN{}
+	defaults := &config.Defaults{
+		Site: "undefined",
+		VLAN: config.VLANDefaults{Group: "campus-vlans"},
+	}
+
+	applyVLANDefaults(v, defaults)
+
+	if v.Group == nil {
+		t.Fatal("Group: got nil, want non-nil")
+	}
+	if v.Group.Slug == nil || *v.Group.Slug != "campus-vlans" {
+		t.Errorf("Group.Slug: got %v, want \"campus-vlans\"", v.Group.Slug)
+	}
+	site, ok := v.Group.Scope.(*diode.Site)
+	if !ok {
+		t.Fatalf("Group.Scope: got %T, want *diode.Site", v.Group.Scope)
+	}
+	if site.Name == nil || *site.Name != "undefined" {
+		t.Errorf("Group.Scope.Site.Name: got %v, want \"undefined\"", site.Name)
+	}
+}
+
+// applyVLANDefaults: when defaults.Site is empty, the Group must still carry
+// Slug but no scope_site.
+func TestApplyVLANDefaults_GroupNoScopeSite_WhenSiteEmpty(t *testing.T) {
+	v := &diode.VLAN{}
+	defaults := &config.Defaults{
+		VLAN: config.VLANDefaults{Group: "campus-vlans"},
+	}
+
+	applyVLANDefaults(v, defaults)
+
+	if v.Group == nil {
+		t.Fatal("Group: got nil, want non-nil")
+	}
+	if v.Group.Slug == nil || *v.Group.Slug != "campus-vlans" {
+		t.Errorf("Group.Slug: got %v, want \"campus-vlans\"", v.Group.Slug)
+	}
+	if v.Group.Scope != nil {
+		t.Errorf("Group.Scope: got %v, want nil (site is empty)", v.Group.Scope)
+	}
+}
+
+// applyVLANDefaults: when no VLAN Group default is set, defaults.Site must not
+// synthesize a Group out of thin air.
+func TestApplyVLANDefaults_NoGroup_SiteIgnored(t *testing.T) {
+	v := &diode.VLAN{}
+	defaults := &config.Defaults{
+		Site: "NYC",
+		VLAN: config.VLANDefaults{},
+	}
+
+	applyVLANDefaults(v, defaults)
+
+	if v.Group != nil {
+		t.Errorf("Group: got %v, want nil (no group configured)", v.Group)
+	}
+}


### PR DESCRIPTION
## Summary
- `device-discovery` and `snmp-discovery` now emit a fully-qualified `VLANGroup` (`name` + `slug` + `scope_site`) whenever `defaults.vlan.group` is configured. The scope is taken from `defaults.site` and is applied even when the value is the `"undefined"` sentinel.
- Slug is computed deterministically via the Diode Python SDK's `slugify` helper (device-discovery) and the project's existing `toSlug` helper (snmp-discovery), so the value matches what NetBox would auto-generate.
- Without scope, the Diode reconciler's `AutoSlugMatcher` falls back to a path that creates a fresh `ipam.vlangroup` on every run; with `name + slug + scope` populated, the scoped-slug matcher dedupes cleanly across runs.

## Why
Repeated ingestion against the same policy was creating duplicate VLAN groups in NetBox because the group payload only carried a name. The reconciler relies on the `(name, slug, scope_type, scope_id)` tuple to match an existing `ipam.vlangroup`; if any of those are absent, the match key collapses and a new group is inserted on each run.

## Test plan
- [x] `device-discovery`: `pytest tests/test_translate.py` — 87 passed (4 new VLAN-group scope/slug tests).
- [x] `snmp-discovery`: `go test ./...` — all packages green; 4 new `TestApplyVLANDefaults_*` cases.
- [x] End-to-end against a local Diode → NetBox 4.5 stack via the `orb-test-lab` `cisco-router` mockit (cisco_ios driver):
  - Policy with `defaults.site: Lab Site`, `defaults.vlan.group: Lab VLAN Group` →
    one `ipam.vlangroup` (`slug=lab-vlan-group`, `scope_type=dcim.site`, `scope=Lab Site`). A second run reuses the same record (deduped).
  - Policy with `defaults.site: undefined`, `defaults.vlan.group: Lab Unscoped Group` →
    one `ipam.vlangroup` (`slug=lab-unscoped-group`, `scope_type=dcim.site`, `scope=undefined`). A second run reuses the same record (deduped). Previously, this case created a fresh group per VLAN per run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)