### PR TITLE
fix(device-discovery): IOS short-form "Fi" expands to FiveGigabitEthernet (ENGHLP-1279)

### DIFF
--- a/device-discovery/custom_napalm/ios.py
+++ b/device-discovery/custom_napalm/ios.py
@@ -21,6 +21,23 @@ from custom_napalm._vlan import SwitchportInfo, classify_switchport, parse_vlan_
 logger = logging.getLogger(__name__)
 
 
+# Cisco IOS / IOS-XE Catalyst multigig short-form override.
+#
+# netutils.constants.BASE_INTERFACES (the table backing
+# napalm.base.helpers.canonical_interface_name) maps "Fi" to
+# "FiftyGigabitEthernet". On the IOS Catalyst platforms this driver targets,
+# "Fi" is the short form of FiveGigabitEthernet (5GBASE-T multigig). Without
+# this override, `show interfaces switchport` rows for 5G ports canonicalize
+# to "FiftyGigabitEthernet*/..." and fail to match the long-form
+# "FiveGigabitEthernet*/..." names emitted by NAPALM's get_interfaces(), so
+# the translator silently drops VLAN data for every 5G port.
+_IOS_ADDL_NAME_MAP = {
+    "Fi": "FiveGigabitEthernet",
+    "FI": "FiveGigabitEthernet",
+    "fi": "FiveGigabitEthernet",
+}
+
+
 def _maybe_int(v: object) -> int | None:
     """
     Convert a string/int to int, returning None on failure.
@@ -164,7 +181,7 @@ class IOSDriver(NapalmIOSDriver):
             ifname = row.get("interface")
             if not ifname:
                 continue
-            ifname = canonical_interface_name(ifname)
+            ifname = canonical_interface_name(ifname, addl_name_map=_IOS_ADDL_NAME_MAP)
             info = _ios_row_to_switchport_info(row)
             result[ifname] = classify_switchport(info)
         return result

--- a/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_interfaces_vlans/multigig_fivegig/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_interfaces_vlans/multigig_fivegig/expected_result.json
@@ -1,0 +1,6 @@
+{
+  "FiveGigabitEthernet3/0/1": {"mode": "access", "tagged": [], "untagged": 148},
+  "FiveGigabitEthernet3/0/2": {"mode": "trunk", "tagged": [190, 191, 251, 261], "untagged": 999},
+  "TwoGigabitEthernet2/0/1": {"mode": "access", "tagged": [], "untagged": 20},
+  "GigabitEthernet1/0/1": {"mode": "access", "tagged": [], "untagged": 10}
+}

--- a/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_interfaces_vlans/multigig_fivegig/show_interfaces_switchport.txt
+++ b/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_interfaces_vlans/multigig_fivegig/show_interfaces_switchport.txt
@@ -1,0 +1,49 @@
+Name: Fi3/0/1
+Switchport: Enabled
+Administrative Mode: static access
+Operational Mode: static access
+Administrative Trunking Encapsulation: dot1q
+Negotiation of Trunking: Off
+Access Mode VLAN: 148 (PC_VLAN)
+Trunking Native Mode VLAN: 1 (default)
+Administrative Native VLAN tagging: enabled
+Voice VLAN: none
+Trunking VLANs Enabled: ALL
+Pruning VLANs Enabled: 2-1001
+
+Name: Fi3/0/2
+Switchport: Enabled
+Administrative Mode: trunk
+Operational Mode: trunk
+Administrative Trunking Encapsulation: dot1q
+Operational Trunking Encapsulation: dot1q
+Negotiation of Trunking: On
+Access Mode VLAN: 1 (default)
+Trunking Native Mode VLAN: 999 (TrunkNative)
+Administrative Native VLAN tagging: enabled
+Voice VLAN: none
+Trunking VLANs Enabled: 190,191,251,261
+
+Name: Tw2/0/1
+Switchport: Enabled
+Administrative Mode: static access
+Operational Mode: static access
+Administrative Trunking Encapsulation: dot1q
+Negotiation of Trunking: Off
+Access Mode VLAN: 20 (USERS)
+Trunking Native Mode VLAN: 1 (default)
+Administrative Native VLAN tagging: enabled
+Voice VLAN: none
+Trunking VLANs Enabled: ALL
+
+Name: Gi1/0/1
+Switchport: Enabled
+Administrative Mode: static access
+Operational Mode: static access
+Administrative Trunking Encapsulation: dot1q
+Negotiation of Trunking: Off
+Access Mode VLAN: 10 (DATA)
+Trunking Native Mode VLAN: 1 (default)
+Administrative Native VLAN tagging: enabled
+Voice VLAN: none
+Trunking VLANs Enabled: ALL

--- a/device-discovery/tests/custom_drivers/cisco_ios/test_driver.py
+++ b/device-discovery/tests/custom_drivers/cisco_ios/test_driver.py
@@ -47,6 +47,72 @@ class TestIOSDriver(BaseDriverTest):
         assert result["GigabitEthernet1/0/1"]["mode"] == "access"
         assert result["GigabitEthernet1/0/1"]["untagged"] == 10
 
+    def test_get_interfaces_vlans_fi_shortform_expands_to_fivegig(self) -> None:
+        """
+        ``Fi*`` short-form expands to FiveGigabitEthernet, not FiftyGigabitEthernet.
+
+        Regression for ENGHLP-1279: netutils.BASE_INTERFACES maps ``"Fi"`` to
+        ``"FiftyGigabitEthernet"``, which is wrong for Cisco IOS Catalyst
+        multigig hardware. Without the IOS-specific ``addl_name_map`` override,
+        every ``Fi*`` port returned by ``show interfaces switchport`` ended up
+        with a key that didn't match the ``FiveGigabitEthernet*`` long form
+        emitted by ``get_interfaces()``, and ``apply_interface_vlans()``
+        silently dropped the association for every 5G port on the device.
+        """
+        mock_dir = self.mock_data_root / "test_get_interfaces_vlans" / "multigig_fivegig"
+        driver = self._build_driver(mock_dir)
+        result = driver.get_interfaces_vlans()
+        # The buggy expansion would have produced "FiftyGigabitEthernet3/0/1".
+        # Assert both the positive (correct expansion present) and negative
+        # (wrong expansion absent) so a future regression on the netutils
+        # mapping is caught even if FiveGig happens to also be inserted.
+        assert "FiveGigabitEthernet3/0/1" in result, (
+            f"expected FiveGigabitEthernet3/0/1 key, got {sorted(result)}"
+        )
+        assert "FiveGigabitEthernet3/0/2" in result
+        assert not any(k.startswith("FiftyGigabitEthernet") for k in result), (
+            f"unexpected FiftyGigabitEthernet key in {sorted(result)}"
+        )
+        assert result["FiveGigabitEthernet3/0/1"] == {
+            "mode": "access", "tagged": [], "untagged": 148,
+        }
+        assert result["FiveGigabitEthernet3/0/2"] == {
+            "mode": "trunk", "tagged": [190, 191, 251, 261], "untagged": 999,
+        }
+        # Sanity: other short-forms (Tw, Gi) keep working alongside the override.
+        assert result["TwoGigabitEthernet2/0/1"]["untagged"] == 20
+        assert result["GigabitEthernet1/0/1"]["untagged"] == 10
+
+    def test_canonical_interface_name_fi_override(self) -> None:
+        """
+        Lock the BASE_INTERFACES override at the function-call level.
+
+        If netutils ever flips ``"Fi"`` to mean something else, or a future
+        refactor drops ``addl_name_map`` from the driver call site, this
+        narrower assertion fires before the integration test does — making
+        the root cause obvious from the failure alone.
+        """
+        from napalm.base.helpers import canonical_interface_name
+
+        from custom_napalm.ios import _IOS_ADDL_NAME_MAP
+
+        assert canonical_interface_name(
+            "Fi3/0/1", addl_name_map=_IOS_ADDL_NAME_MAP
+        ) == "FiveGigabitEthernet3/0/1"
+        assert canonical_interface_name(
+            "FI3/0/1", addl_name_map=_IOS_ADDL_NAME_MAP
+        ) == "FiveGigabitEthernet3/0/1"
+        assert canonical_interface_name(
+            "fi3/0/1", addl_name_map=_IOS_ADDL_NAME_MAP
+        ) == "FiveGigabitEthernet3/0/1"
+        # Sanity: prefixes we did NOT override still resolve via BASE_INTERFACES.
+        assert canonical_interface_name(
+            "Gi1/0/1", addl_name_map=_IOS_ADDL_NAME_MAP
+        ) == "GigabitEthernet1/0/1"
+        assert canonical_interface_name(
+            "Twe1/0/1", addl_name_map=_IOS_ADDL_NAME_MAP
+        ) == "TwentyFiveGigE1/0/1"
+
     def test_expand_vlan_range_string_clamps_huge_range(self) -> None:
         """A range like 1-100000 is clamped to 1..4094 (then collapsed to wildcard)."""
         from custom_napalm._vlan import parse_vlan_range_string


### PR DESCRIPTION
## Summary

- Fixes: VLAN associations missing from 5GBASE-T interfaces ingested via `orb-agent:develop` (Cisco IOS NAPALM driver). On the reporting customer's Catalyst 9410R, **all 144 of 144** `FiveGigabitEthernet*` interfaces lost their `mode`/`untagged_vlan`/`tagged_vlans`, while `GigabitEthernet*` was unaffected.
- Passes `addl_name_map={"Fi"/"FI"/"fi": "FiveGigabitEthernet"}` to `canonical_interface_name()` inside `IOSDriver.get_interfaces_vlans()` only.

## Root cause

`netutils.constants.BASE_INTERFACES` (backing `napalm.base.helpers.canonical_interface_name`) maps `"Fi"` → `"FiftyGigabitEthernet"`. That choice is wrong for Cisco Catalyst multigig hardware, where `Fi` is the short form of FiveGigabitEthernet.

`show interfaces switchport` emits the short form (`Fi3/0/1`) in its `Name:` field, while NAPALM's stock `get_interfaces()` returns the long form (`FiveGigabitEthernet3/0/1`) from `show interfaces`. The driver canonicalized the switchport key to `FiftyGigabitEthernet3/0/1`, which never matched any Interface entity, and `translate.apply_interface_vlans()`'s exact-name lookup silently dropped the association for every 5G port (debug log only — no warning).

Scope is intentionally IOS-only:
- There is no `cisco_xe.py` driver in the repo; `discovery.py` registers `ios` for IOS / IOS-XE.
- `nxos.py` / `nxos_ssh.py` do not canonicalize interface names, so the `Fi` ambiguity does not reach them. NX-OS platforms may legitimately ship 50G optics; we do not want to mis-resolve there.

## Tests

- New scenario fixture: [`tests/custom_drivers/cisco_ios/mock_data/test_get_interfaces_vlans/multigig_fivegig/`](https://github.com/netboxlabs/orb-discovery/tree/fix/ios-fi-shortform-fivegig/device-discovery/tests/custom_drivers/cisco_ios/mock_data/test_get_interfaces_vlans/multigig_fivegig) — `Fi3/0/1` (access), `Fi3/0/2` (trunk-native), `Tw2/0/1`, `Gi1/0/1`. Auto-discovered by `BaseDriverTest.test_get_interfaces_vlans`.
- `test_get_interfaces_vlans_fi_shortform_expands_to_fivegig` — integration: asserts both the positive (`FiveGigabitEthernet*` present) and negative (no `FiftyGigabitEthernet*` keys) outcomes.
- `test_canonical_interface_name_fi_override` — unit test pinning all three casings (`Fi`/`FI`/`fi`) at the function-call boundary so any future drop of `addl_name_map` fails cleanly with a narrow signal.

## Test plan

- [x] `pytest tests/custom_drivers/cisco_ios/` — 35/35 pass (including 3 new tests + 1 new scenario).
- [x] `pytest tests/test_translate.py -k "vlan or apply_interface"` — 35/35 pass (translator path unaffected).
- [x] `ruff check custom_napalm/ios.py tests/custom_drivers/cisco_ios/` — clean.
- [x] End-to-end script driving real `IOSDriver.get_interfaces_vlans()` + `translate._apply_interface_vlan_associations()` with a Catalyst-shaped fixture:
  - **With fix:** all `FiveGigabitEthernet*` interfaces carry the expected `mode`/`untagged`/`tagged` refs.
  - **With fix reverted (HEAD~1 of branch):** Step-1 keys flip back to `FiftyGigabitEthernet*`, by-name lookup misses, and 5G ports leave with empty `mode` and no VLAN refs — exact reproduction of the customer JSON symptom.
- [x] Codex review against `develop` — clean, no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)