### PR TITLE
feat(snmp-discovery): literal-or-OID-ref defaults for location and asset_tag

### DIFF
--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -84,6 +84,7 @@ type Defaults struct {
 	Site                     string             `yaml:"site,omitempty"`
 	Location                 string             `yaml:"location,omitempty"`
 	Role                     string             `yaml:"role,omitempty"`
+	AssetTag                 string             `yaml:"asset_tag,omitempty"`
 	IPAddress                IPAddressDefaults  `yaml:"ip_address,omitempty"`
 	Interface                InterfaceDefaults  `yaml:"interface,omitempty"`
 	Device                   DeviceDefaults     `yaml:"device,omitempty"`
@@ -111,6 +112,9 @@ func MergeDefaults(policyDefaults, overrideDefaults *Defaults) *Defaults {
 	}
 	if overrideDefaults.Role != "" {
 		merged.Role = overrideDefaults.Role
+	}
+	if overrideDefaults.AssetTag != "" {
+		merged.AssetTag = overrideDefaults.AssetTag
 	}
 	if len(overrideDefaults.Tags) > 0 {
 		merged.Tags = overrideDefaults.Tags

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -448,3 +448,48 @@ entity: "interface"
 		t.Errorf("Vendor: got %q, want empty (generic)", m.Vendor)
 	}
 }
+
+func TestDefaults_AssetTag_ParsesFromYAML(t *testing.T) {
+	yamlContent := []byte(`
+defaults:
+  site: dc1
+  asset_tag: "ASSET-007"
+`)
+	var parsed struct {
+		Defaults Defaults `yaml:"defaults"`
+	}
+	require.NoError(t, yaml.Unmarshal(yamlContent, &parsed))
+	assert.Equal(t, "ASSET-007", parsed.Defaults.AssetTag)
+}
+
+func TestDefaults_AssetTag_ParsesOIDReference(t *testing.T) {
+	yamlContent := []byte(`
+defaults:
+  asset_tag: ".1.3.6.1.2.1.1.4.0"
+`)
+	var parsed struct {
+		Defaults Defaults `yaml:"defaults"`
+	}
+	require.NoError(t, yaml.Unmarshal(yamlContent, &parsed))
+	assert.Equal(t, ".1.3.6.1.2.1.1.4.0", parsed.Defaults.AssetTag)
+}
+
+func TestMergeDefaults_AssetTag_OverrideWins(t *testing.T) {
+	policy := &Defaults{AssetTag: "POLICY-TAG"}
+	override := &Defaults{AssetTag: "OVERRIDE-TAG"}
+	merged := MergeDefaults(policy, override)
+	assert.Equal(t, "OVERRIDE-TAG", merged.AssetTag)
+}
+
+func TestMergeDefaults_AssetTag_EmptyOverrideKeepsPolicy(t *testing.T) {
+	policy := &Defaults{AssetTag: "POLICY-TAG"}
+	override := &Defaults{AssetTag: ""}
+	merged := MergeDefaults(policy, override)
+	assert.Equal(t, "POLICY-TAG", merged.AssetTag)
+}
+
+func TestMergeDefaults_AssetTag_NoOverride(t *testing.T) {
+	policy := &Defaults{AssetTag: "POLICY-TAG"}
+	merged := MergeDefaults(policy, nil)
+	assert.Equal(t, "POLICY-TAG", merged.AssetTag)
+}

--- a/snmp-discovery/data/lookup_extensions.go
+++ b/snmp-discovery/data/lookup_extensions.go
@@ -455,3 +455,55 @@ func loadYAMLFile(data []byte, devicesByVendor map[string]deviceRef) error {
 
 	return nil
 }
+
+// defaultOIDPattern matches OIDs rooted at the standard SNMP Internet
+// sub-tree (.1.3.6.1.*). This is intentionally stricter than oidPattern:
+// PolicyConfig defaults like defaults.location may already contain
+// dotted-decimal literals (e.g. "3.14.159" as a room number, or
+// "10.0.0.1"), and silently re-classifying them as OID references would
+// be a backward-compat break.
+var defaultOIDPattern = regexp.MustCompile(`^\.1\.3\.6\.1\.(\d+\.)+\d+$`)
+
+// ResolveDefault classifies raw as either a literal value or an SNMP OID
+// reference and resolves it against the walked map.
+//
+// If raw matches defaultOIDPattern, it is treated as an OID reference:
+// the function returns the corresponding value from walked, with NULL
+// bytes and surrounding whitespace trimmed from both ends. Both
+// leading-dot and no-leading-dot spellings are tolerated on the lookup
+// side.
+//
+// If raw is not an OID, it is treated as a literal and returned after
+// trimming surrounding whitespace.
+//
+// ok is false when:
+//   - raw is empty or whitespace-only,
+//   - raw is an OID reference and the OID is missing from walked,
+//   - raw is an OID reference and the resolved value is empty after
+//     trimming.
+//
+// The regex requires the .1.3.6.1.* root so legitimate non-SNMP
+// dotted-decimal literals (room numbers, IPs) cannot collide with the
+// OID-reference syntax. This is stricter than the lookup_extensions
+// oidPattern used by GetDeviceModel.
+func ResolveDefault(raw string, walked map[string]string) (string, bool) {
+	if defaultOIDPattern.MatchString(raw) {
+		if walked == nil {
+			return "", false
+		}
+		value, ok := lookupOIDBothSpellings(walked, raw)
+		if !ok {
+			return "", false
+		}
+		trimmed := strings.Trim(value, "\x00 \t\n\r")
+		if trimmed == "" {
+			return "", false
+		}
+		return trimmed, true
+	}
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", false
+	}
+	return trimmed, true
+}

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -865,3 +865,88 @@ func TestLoadYAMLFile(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveDefault_Literal(t *testing.T) {
+	v, ok := ResolveDefault("DC1-Building-A", nil)
+	assert.True(t, ok)
+	assert.Equal(t, "DC1-Building-A", v)
+}
+
+func TestResolveDefault_LiteralTrimsWhitespace(t *testing.T) {
+	v, ok := ResolveDefault("  DC1  ", nil)
+	assert.True(t, ok)
+	assert.Equal(t, "DC1", v)
+}
+
+func TestResolveDefault_LiteralEmptyAfterTrim(t *testing.T) {
+	_, ok := ResolveDefault("   ", nil)
+	assert.False(t, ok)
+}
+
+func TestResolveDefault_EmptyRaw(t *testing.T) {
+	_, ok := ResolveDefault("", nil)
+	assert.False(t, ok)
+}
+
+func TestResolveDefault_NonSNMPDottedDecimalIsLiteral(t *testing.T) {
+	v, ok := ResolveDefault("3.14.159", map[string]string{".1.3.6.1.2.1.1.6.0": "ignored"})
+	assert.True(t, ok)
+	assert.Equal(t, "3.14.159", v)
+}
+
+func TestResolveDefault_IPLikeLiteralIsLiteral(t *testing.T) {
+	v, ok := ResolveDefault("10.0.0.1", nil)
+	assert.True(t, ok)
+	assert.Equal(t, "10.0.0.1", v)
+}
+
+func TestResolveDefault_OIDReferenceHit(t *testing.T) {
+	walked := map[string]string{".1.3.6.1.2.1.1.6.0": "Data Center 01"}
+	v, ok := ResolveDefault(".1.3.6.1.2.1.1.6.0", walked)
+	assert.True(t, ok)
+	assert.Equal(t, "Data Center 01", v)
+}
+
+func TestResolveDefault_OIDReferenceBothSpellingsTolerated(t *testing.T) {
+	walked := map[string]string{"1.3.6.1.2.1.1.6.0": "Data Center 01"}
+	v, ok := ResolveDefault(".1.3.6.1.2.1.1.6.0", walked)
+	assert.True(t, ok)
+	assert.Equal(t, "Data Center 01", v)
+}
+
+func TestResolveDefault_OIDReferenceMissing(t *testing.T) {
+	_, ok := ResolveDefault(".1.3.6.1.2.1.1.6.0", map[string]string{})
+	assert.False(t, ok)
+}
+
+func TestResolveDefault_OIDReferenceEmptyValue(t *testing.T) {
+	walked := map[string]string{".1.3.6.1.2.1.1.6.0": "   "}
+	_, ok := ResolveDefault(".1.3.6.1.2.1.1.6.0", walked)
+	assert.False(t, ok)
+}
+
+func TestResolveDefault_OIDReferenceStripsLeadingNullByte(t *testing.T) {
+	walked := map[string]string{".1.3.6.1.2.1.1.6.0": "\x00Data Center 01"}
+	v, ok := ResolveDefault(".1.3.6.1.2.1.1.6.0", walked)
+	assert.True(t, ok)
+	assert.Equal(t, "Data Center 01", v)
+}
+
+func TestResolveDefault_OIDReferenceStripsTrailingNullByte(t *testing.T) {
+	walked := map[string]string{".1.3.6.1.2.1.1.6.0": "Data Center 01\x00"}
+	v, ok := ResolveDefault(".1.3.6.1.2.1.1.6.0", walked)
+	assert.True(t, ok)
+	assert.Equal(t, "Data Center 01", v)
+}
+
+func TestResolveDefault_OIDReferenceNilWalked(t *testing.T) {
+	_, ok := ResolveDefault(".1.3.6.1.2.1.1.6.0", nil)
+	assert.False(t, ok)
+}
+
+func TestResolveDefault_ExistingOIDPatternUnchanged(t *testing.T) {
+	// Regression guard: the looser oidPattern used by GetDeviceModel must
+	// not be tightened by this change.
+	assert.True(t, oidPattern.MatchString(".1.3.6.1.4.1.14988.1"))
+	assert.True(t, oidPattern.MatchString("3.14.159"))
+}

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
@@ -983,6 +984,12 @@ func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defa
 
 	if defaults.Location != "" {
 		if resolved, ok := data.ResolveDefault(defaults.Location, walked); ok {
+			// Builds a fresh Location, overriding anything a future
+			// mapper may have set on entity.Location. Site is taken from
+			// defaults.Site only; a Site that was previously attached to
+			// entity.Location is not preserved. No mapper sets
+			// entity.Location today, so this is a documented forward
+			// invariant rather than an observable change.
 			loc := &diode.Location{Name: &resolved}
 			if defaults.Site != "" {
 				loc.Site = &diode.Site{Name: &defaults.Site}
@@ -993,11 +1000,15 @@ func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defa
 
 	if defaults.AssetTag != "" {
 		if resolved, ok := data.ResolveDefault(defaults.AssetTag, walked); ok {
-			if len(resolved) > assetTagMaxLen {
+			// NetBox CharField(max_length=N) counts characters, not bytes;
+			// use rune count so non-ASCII tags at exactly 50 chars are
+			// accepted instead of being skipped on byte count alone.
+			runeCount := utf8.RuneCountInString(resolved)
+			if runeCount > assetTagMaxLen {
 				m.logger.Warn(
 					"defaults.asset_tag resolved value exceeds NetBox max length; skipping",
 					"max_length", assetTagMaxLen,
-					"value_length", len(resolved),
+					"value_length", runeCount,
 				)
 			} else {
 				entity.AssetTag = &resolved
@@ -1138,10 +1149,16 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 					fieldFound = true
 				case "sysContact":
 					// Walked solely so defaults can reference this OID;
-					// no direct mapper consumption.
+					// no direct mapper consumption. Mark fieldFound so
+					// applyDefaults still runs for devices that respond
+					// to sysContact but not to name/description/platform.
+					fieldFound = true
 				case "sysLocation":
 					// Walked solely so defaults can reference this OID;
-					// no direct mapper consumption.
+					// no direct mapper consumption. Mark fieldFound so
+					// applyDefaults still runs for devices that respond
+					// to sysLocation but not to name/description/platform.
+					fieldFound = true
 				default:
 					m.logger.Warn("unknown field", "field", propertyMappingEntry.Field)
 				}

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -975,14 +975,13 @@ func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defa
 		}
 	}
 
-	if entity.Location == nil && defaults.Location != "" {
-		entity.Location = &diode.Location{
-			Name: &defaults.Location,
-		}
-		if entity.Location.Site == nil && defaults.Site != "" {
-			entity.Location.Site = &diode.Site{
-				Name: &defaults.Site,
+	if defaults.Location != "" {
+		if resolved, ok := data.ResolveDefault(defaults.Location, walked); ok {
+			loc := &diode.Location{Name: &resolved}
+			if defaults.Site != "" {
+				loc.Site = &diode.Site{Name: &defaults.Site}
 			}
+			entity.Location = loc
 		}
 	}
 }

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -923,6 +923,12 @@ func (m *InterfaceMapper) FormatMACAddress(input string) (string, error) {
 	return output, nil
 }
 
+// assetTagMaxLen mirrors NetBox's dcim.Device.asset_tag column
+// (CharField(max_length=50)). Resolved AssetTag values that exceed
+// this length are warn-skipped rather than truncated so we don't
+// introduce silent uniqueness collisions.
+const assetTagMaxLen = 50
+
 // DeviceMapper is a struct that maps devices to entities
 type DeviceMapper struct {
 	manufacturers data.ManufacturerRetriever
@@ -982,6 +988,20 @@ func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defa
 				loc.Site = &diode.Site{Name: &defaults.Site}
 			}
 			entity.Location = loc
+		}
+	}
+
+	if defaults.AssetTag != "" {
+		if resolved, ok := data.ResolveDefault(defaults.AssetTag, walked); ok {
+			if len(resolved) > assetTagMaxLen {
+				m.logger.Warn(
+					"defaults.asset_tag resolved value exceeds NetBox max length; skipping",
+					"max_length", assetTagMaxLen,
+					"value_length", len(resolved),
+				)
+			} else {
+				entity.AssetTag = &resolved
+			}
 		}
 	}
 }

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -1117,6 +1117,12 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 					}
 					deviceEntity.Serial = &serial
 					fieldFound = true
+				case "sysContact":
+					// Walked solely so defaults can reference this OID;
+					// no direct mapper consumption.
+				case "sysLocation":
+					// Walked solely so defaults can reference this OID;
+					// no direct mapper consumption.
 				default:
 					m.logger.Warn("unknown field", "field", propertyMappingEntry.Field)
 				}

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -931,7 +931,7 @@ type DeviceMapper struct {
 }
 
 // applyDefaults applies default values to a device entity
-func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defaults) {
+func (m *DeviceMapper) applyDefaults(entity *diode.Device, defaults *config.Defaults, walked map[string]string) {
 	if defaults == nil {
 		return
 	}
@@ -1132,7 +1132,7 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 
 	// Apply defaults if available
 	if fieldFound {
-		m.applyDefaults(deviceEntity, defaults)
+		m.applyDefaults(deviceEntity, defaults, walked)
 		if deviceEntity.Name != nil {
 			m.logger.Debug("successfully mapped device", "name", *deviceEntity.Name)
 		} else {

--- a/snmp-discovery/mapping/mappers_defaults_test.go
+++ b/snmp-discovery/mapping/mappers_defaults_test.go
@@ -12,9 +12,6 @@ import (
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 )
 
-// strPtr is declared in stubs_test.go (same package mapping), so it
-// is reachable from here without redeclaration.
-
 func newTestDeviceMapper() *DeviceMapper {
 	return &DeviceMapper{logger: slog.Default()}
 }
@@ -134,13 +131,17 @@ func TestDeviceMapper_applyDefaults_AssetTagEmptyConfigIsNoop(t *testing.T) {
 func TestDeviceMapper_applyDefaults_AssetTagExceedsMaxLengthSkips(t *testing.T) {
 	// NetBox asset_tag is CharField(max_length=50). The diode SDK does
 	// not validate; we warn-skip rather than truncate to avoid silent
-	// uniqueness collisions.
+	// uniqueness collisions. Start with a non-nil AssetTag so the test
+	// observes "skipped" as "did not overwrite" rather than the trivial
+	// "stayed nil because no path writes it" assertion.
 	m := newTestDeviceMapper()
-	entity := &diode.Device{}
+	preset := "ORIGINAL"
+	entity := &diode.Device{AssetTag: &preset}
 	tooLong := strings.Repeat("x", 51)
 	defaults := &config.Defaults{AssetTag: tooLong}
 	m.applyDefaults(entity, defaults, nil)
-	assert.Nil(t, entity.AssetTag)
+	require.NotNil(t, entity.AssetTag)
+	assert.Equal(t, "ORIGINAL", *entity.AssetTag)
 }
 
 func TestDeviceMapper_applyDefaults_AssetTagExactlyMaxLengthSet(t *testing.T) {
@@ -151,4 +152,28 @@ func TestDeviceMapper_applyDefaults_AssetTagExactlyMaxLengthSet(t *testing.T) {
 	m.applyDefaults(entity, defaults, nil)
 	require.NotNil(t, entity.AssetTag)
 	assert.Equal(t, exact, *entity.AssetTag)
+}
+
+func TestDeviceMapper_applyDefaults_AssetTagFiftyRunesNonASCIISet(t *testing.T) {
+	// NetBox CharField(max_length=N) counts characters. A string of 50
+	// non-ASCII runes is exactly 50 characters (and 150 bytes in UTF-8)
+	// and must be accepted, not rejected on byte length.
+	m := newTestDeviceMapper()
+	entity := &diode.Device{}
+	exact := strings.Repeat("é", 50) // 50 runes, 100 bytes
+	defaults := &config.Defaults{AssetTag: exact}
+	m.applyDefaults(entity, defaults, nil)
+	require.NotNil(t, entity.AssetTag)
+	assert.Equal(t, exact, *entity.AssetTag)
+}
+
+func TestDeviceMapper_applyDefaults_AssetTagFiftyOneRunesNonASCIISkips(t *testing.T) {
+	m := newTestDeviceMapper()
+	preset := "ORIGINAL"
+	entity := &diode.Device{AssetTag: &preset}
+	tooLong := strings.Repeat("é", 51) // 51 runes
+	defaults := &config.Defaults{AssetTag: tooLong}
+	m.applyDefaults(entity, defaults, nil)
+	require.NotNil(t, entity.AssetTag)
+	assert.Equal(t, "ORIGINAL", *entity.AssetTag)
 }

--- a/snmp-discovery/mapping/mappers_defaults_test.go
+++ b/snmp-discovery/mapping/mappers_defaults_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 )
 
 func newTestDeviceMapper() *DeviceMapper {

--- a/snmp-discovery/mapping/mappers_defaults_test.go
+++ b/snmp-discovery/mapping/mappers_defaults_test.go
@@ -1,0 +1,86 @@
+package mapping
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+)
+
+// strPtr is declared in stubs_test.go (same package mapping), so it
+// is reachable from here without redeclaration.
+
+func newTestDeviceMapper() *DeviceMapper {
+	return &DeviceMapper{logger: slog.Default()}
+}
+
+func TestDeviceMapper_applyDefaults_LocationLiteral(t *testing.T) {
+	m := newTestDeviceMapper()
+	entity := &diode.Device{}
+	defaults := &config.Defaults{Location: "DC1-Building-A", Site: "dc1"}
+	m.applyDefaults(entity, defaults, nil)
+	require.NotNil(t, entity.Location)
+	require.NotNil(t, entity.Location.Name)
+	assert.Equal(t, "DC1-Building-A", *entity.Location.Name)
+	require.NotNil(t, entity.Location.Site)
+	require.NotNil(t, entity.Location.Site.Name)
+	assert.Equal(t, "dc1", *entity.Location.Site.Name)
+}
+
+func TestDeviceMapper_applyDefaults_LocationNonSNMPDecimalIsLiteral(t *testing.T) {
+	// "3.14.159" is a literal (room number), not an OID — must not be
+	// re-classified even if a walked map is present.
+	m := newTestDeviceMapper()
+	entity := &diode.Device{}
+	defaults := &config.Defaults{Location: "3.14.159", Site: "dc1"}
+	walked := map[string]string{".1.3.6.1.2.1.1.6.0": "Data Center 01"}
+	m.applyDefaults(entity, defaults, walked)
+	require.NotNil(t, entity.Location)
+	require.NotNil(t, entity.Location.Name)
+	assert.Equal(t, "3.14.159", *entity.Location.Name)
+}
+
+func TestDeviceMapper_applyDefaults_LocationOIDReferenceResolves(t *testing.T) {
+	m := newTestDeviceMapper()
+	entity := &diode.Device{}
+	defaults := &config.Defaults{Location: ".1.3.6.1.2.1.1.6.0", Site: "dc1"}
+	walked := map[string]string{".1.3.6.1.2.1.1.6.0": "Data Center 01"}
+	m.applyDefaults(entity, defaults, walked)
+	require.NotNil(t, entity.Location)
+	require.NotNil(t, entity.Location.Name)
+	assert.Equal(t, "Data Center 01", *entity.Location.Name)
+	require.NotNil(t, entity.Location.Site)
+	assert.Equal(t, "dc1", *entity.Location.Site.Name)
+}
+
+func TestDeviceMapper_applyDefaults_LocationOIDReferenceMissingSkips(t *testing.T) {
+	m := newTestDeviceMapper()
+	entity := &diode.Device{}
+	defaults := &config.Defaults{Location: ".1.3.6.1.2.1.1.6.0", Site: "dc1"}
+	m.applyDefaults(entity, defaults, map[string]string{})
+	assert.Nil(t, entity.Location)
+}
+
+func TestDeviceMapper_applyDefaults_LocationOIDReferenceEmptySkips(t *testing.T) {
+	m := newTestDeviceMapper()
+	entity := &diode.Device{}
+	defaults := &config.Defaults{Location: ".1.3.6.1.2.1.1.6.0", Site: "dc1"}
+	walked := map[string]string{".1.3.6.1.2.1.1.6.0": "   "}
+	m.applyDefaults(entity, defaults, walked)
+	assert.Nil(t, entity.Location)
+}
+
+func TestDeviceMapper_applyDefaults_LocationOverridesPreSetValue(t *testing.T) {
+	m := newTestDeviceMapper()
+	existing := "pre-existing"
+	entity := &diode.Device{Location: &diode.Location{Name: &existing}}
+	defaults := &config.Defaults{Location: "DC1-Building-A", Site: "dc1"}
+	m.applyDefaults(entity, defaults, nil)
+	require.NotNil(t, entity.Location)
+	require.NotNil(t, entity.Location.Name)
+	assert.Equal(t, "DC1-Building-A", *entity.Location.Name)
+}

--- a/snmp-discovery/mapping/mappers_defaults_test.go
+++ b/snmp-discovery/mapping/mappers_defaults_test.go
@@ -155,7 +155,7 @@ func TestDeviceMapper_applyDefaults_AssetTagExactlyMaxLengthSet(t *testing.T) {
 
 func TestDeviceMapper_applyDefaults_AssetTagFiftyRunesNonASCIISet(t *testing.T) {
 	// NetBox CharField(max_length=N) counts characters. A string of 50
-	// non-ASCII runes is exactly 50 characters (and 150 bytes in UTF-8)
+	// non-ASCII runes is exactly 50 characters (and 100 bytes in UTF-8)
 	// and must be accepted, not rejected on byte length.
 	m := newTestDeviceMapper()
 	entity := &diode.Device{}

--- a/snmp-discovery/mapping/mappers_defaults_test.go
+++ b/snmp-discovery/mapping/mappers_defaults_test.go
@@ -2,6 +2,7 @@ package mapping
 
 import (
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
@@ -83,4 +84,71 @@ func TestDeviceMapper_applyDefaults_LocationOverridesPreSetValue(t *testing.T) {
 	require.NotNil(t, entity.Location)
 	require.NotNil(t, entity.Location.Name)
 	assert.Equal(t, "DC1-Building-A", *entity.Location.Name)
+}
+
+func TestDeviceMapper_applyDefaults_AssetTagLiteral(t *testing.T) {
+	m := newTestDeviceMapper()
+	entity := &diode.Device{}
+	defaults := &config.Defaults{AssetTag: "ASSET-007"}
+	m.applyDefaults(entity, defaults, nil)
+	require.NotNil(t, entity.AssetTag)
+	assert.Equal(t, "ASSET-007", *entity.AssetTag)
+}
+
+func TestDeviceMapper_applyDefaults_AssetTagOIDReferenceResolves(t *testing.T) {
+	m := newTestDeviceMapper()
+	entity := &diode.Device{}
+	defaults := &config.Defaults{AssetTag: ".1.3.6.1.2.1.1.4.0"}
+	walked := map[string]string{".1.3.6.1.2.1.1.4.0": "asset-12345"}
+	m.applyDefaults(entity, defaults, walked)
+	require.NotNil(t, entity.AssetTag)
+	assert.Equal(t, "asset-12345", *entity.AssetTag)
+}
+
+func TestDeviceMapper_applyDefaults_AssetTagOIDReferenceMissingSkips(t *testing.T) {
+	m := newTestDeviceMapper()
+	entity := &diode.Device{}
+	defaults := &config.Defaults{AssetTag: ".1.3.6.1.2.1.1.4.0"}
+	m.applyDefaults(entity, defaults, map[string]string{})
+	assert.Nil(t, entity.AssetTag)
+}
+
+func TestDeviceMapper_applyDefaults_AssetTagOverridesPreSetValue(t *testing.T) {
+	m := newTestDeviceMapper()
+	existing := "PRE-EXISTING"
+	entity := &diode.Device{AssetTag: &existing}
+	defaults := &config.Defaults{AssetTag: "FROM-CONFIG"}
+	m.applyDefaults(entity, defaults, nil)
+	require.NotNil(t, entity.AssetTag)
+	assert.Equal(t, "FROM-CONFIG", *entity.AssetTag)
+}
+
+func TestDeviceMapper_applyDefaults_AssetTagEmptyConfigIsNoop(t *testing.T) {
+	m := newTestDeviceMapper()
+	entity := &diode.Device{}
+	defaults := &config.Defaults{}
+	m.applyDefaults(entity, defaults, nil)
+	assert.Nil(t, entity.AssetTag)
+}
+
+func TestDeviceMapper_applyDefaults_AssetTagExceedsMaxLengthSkips(t *testing.T) {
+	// NetBox asset_tag is CharField(max_length=50). The diode SDK does
+	// not validate; we warn-skip rather than truncate to avoid silent
+	// uniqueness collisions.
+	m := newTestDeviceMapper()
+	entity := &diode.Device{}
+	tooLong := strings.Repeat("x", 51)
+	defaults := &config.Defaults{AssetTag: tooLong}
+	m.applyDefaults(entity, defaults, nil)
+	assert.Nil(t, entity.AssetTag)
+}
+
+func TestDeviceMapper_applyDefaults_AssetTagExactlyMaxLengthSet(t *testing.T) {
+	m := newTestDeviceMapper()
+	entity := &diode.Device{}
+	exact := strings.Repeat("x", 50)
+	defaults := &config.Defaults{AssetTag: exact}
+	m.applyDefaults(entity, defaults, nil)
+	require.NotNil(t, entity.AssetTag)
+	assert.Equal(t, exact, *entity.AssetTag)
 }

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -3,6 +3,7 @@ package mapping_test
 import (
 	"fmt"
 	"log/slog"
+	"os"
 	"strings"
 	"testing"
 
@@ -11,6 +12,8 @@ import (
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/mapping"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestIPAddressMapper_Map(t *testing.T) {
@@ -4514,4 +4517,44 @@ func TestIPAddressMapper_LegacyTable_StillIPv4Only(t *testing.T) {
 	got := mapper.Map(pdus, entry, registry, nil)
 	ip := got.(*diode.IPAddress)
 	assert.Equal(t, "10.0.0.1/32", *ip.Address)
+}
+
+// TestDeviceMapping_WalksSysContactAndSysLocation confirms that the
+// two OIDs needed for OID-ref defaults are direct children of the
+// device system-group block (.1.3.6.1.2.1.1) in mapping.yaml, with the
+// expected field names. Anchoring at the system-group block (not a
+// recursive search across the whole file) ensures the OIDs are in the
+// per-Map() walked snapshot that applyDefaults consumes.
+func TestDeviceMapping_WalksSysContactAndSysLocation(t *testing.T) {
+	data, err := os.ReadFile("../policy/mapping.yaml")
+	require.NoError(t, err)
+
+	var m config.Mapping
+	require.NoError(t, yaml.Unmarshal(data, &m))
+
+	var sysGroup *config.MappingEntry
+	for i := range m.Entries {
+		if m.Entries[i].OID == ".1.3.6.1.2.1.1" && m.Entries[i].Entity == "device" {
+			sysGroup = &m.Entries[i]
+			break
+		}
+	}
+	require.NotNil(t, sysGroup, "device system-group block .1.3.6.1.2.1.1 not found in mapping.yaml")
+
+	wantOIDs := map[string]string{
+		".1.3.6.1.2.1.1.4.0": "sysContact",
+		".1.3.6.1.2.1.1.6.0": "sysLocation",
+	}
+	found := map[string]string{}
+	for _, child := range sysGroup.MappingEntries {
+		if expectedField, want := wantOIDs[child.OID]; want {
+			found[child.OID] = child.Field
+			assert.Equal(t, expectedField, child.Field,
+				"OID %s should have field=%q", child.OID, expectedField)
+		}
+	}
+	for oid := range wantOIDs {
+		_, present := found[oid]
+		assert.True(t, present, "expected %s as a direct child of the device system-group block", oid)
+	}
 }

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -4558,3 +4558,117 @@ func TestDeviceMapping_WalksSysContactAndSysLocation(t *testing.T) {
 		assert.True(t, present, "expected %s as a direct child of the device system-group block", oid)
 	}
 }
+
+// TestDeviceMapper_Map_DefaultsResolveFromWalkedSnapshot is an end-to-end
+// integration test for the OID-reference defaults path. It exercises the
+// full DeviceMapper.Map flow with a synthetic system-group walk that
+// contains sysName, sysContact, and sysLocation, then verifies that
+// defaults.{location,asset_tag} pointing at those OIDs are resolved
+// against the walked snapshot built inside Map() — closing the gap
+// between the structural mapping.yaml assertion and the internal
+// applyDefaults tests.
+func TestDeviceMapper_Map_DefaultsResolveFromWalkedSnapshot(t *testing.T) {
+	logger := slog.Default()
+	mockDeviceLookup := &MockDeviceLookup{}
+	mockManufacturers := &MockManufacturerDataRetriever{}
+	mapper := mapping.NewDeviceMapper(mockManufacturers, mockDeviceLookup, logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.1.5.0": {
+			OID:    "1.3.6.1.2.1.1.5.0",
+			Index:  "0",
+			Parent: "1.3.6.1.2.1.1.5",
+			Value:  "router1",
+			Type:   mapping.OctetString,
+		},
+		"1.3.6.1.2.1.1.4.0": {
+			OID:    "1.3.6.1.2.1.1.4.0",
+			Index:  "0",
+			Parent: "1.3.6.1.2.1.1.4",
+			Value:  "asset-12345",
+			Type:   mapping.OctetString,
+		},
+		"1.3.6.1.2.1.1.6.0": {
+			OID:    "1.3.6.1.2.1.1.6.0",
+			Index:  "0",
+			Parent: "1.3.6.1.2.1.1.6",
+			Value:  "Data Center 01",
+			Type:   mapping.OctetString,
+		},
+	}
+	mappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.1",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{OID: "1.3.6.1.2.1.1.5", Entity: "device", Field: "name"},
+			{OID: "1.3.6.1.2.1.1.4", Entity: "device", Field: "sysContact"},
+			{OID: "1.3.6.1.2.1.1.6", Entity: "device", Field: "sysLocation"},
+		},
+	}
+	// Defaults use the leading-dot OID spelling. Walked map keys are
+	// stored without leading dot (matching the test fixture convention
+	// elsewhere in this file). data.ResolveDefault must therefore
+	// tolerate both spellings — this also exercises that path
+	// end-to-end.
+	defaults := &config.Defaults{
+		Site:     "dc1",
+		Location: ".1.3.6.1.2.1.1.6.0",
+		AssetTag: ".1.3.6.1.2.1.1.4.0",
+	}
+
+	registry := mapping.NewEntityRegistry(logger)
+	entity := mapper.Map(values, mappingEntry, registry, defaults)
+	require.NotNil(t, entity)
+	device, ok := entity.(*diode.Device)
+	require.True(t, ok)
+
+	require.NotNil(t, device.Location)
+	require.NotNil(t, device.Location.Name)
+	assert.Equal(t, "Data Center 01", *device.Location.Name)
+	require.NotNil(t, device.Location.Site)
+	assert.Equal(t, "dc1", *device.Location.Site.Name)
+
+	require.NotNil(t, device.AssetTag)
+	assert.Equal(t, "asset-12345", *device.AssetTag)
+}
+
+// TestDeviceMapper_Map_DefaultsResolveFromSysContactOnly covers the
+// edge case where a device responds to sysContact/sysLocation but not
+// to name/description/platform. The no-op switch cases set fieldFound
+// so applyDefaults still runs, and OID-ref defaults resolve normally.
+func TestDeviceMapper_Map_DefaultsResolveFromSysContactOnly(t *testing.T) {
+	logger := slog.Default()
+	mapper := mapping.NewDeviceMapper(&MockManufacturerDataRetriever{}, &MockDeviceLookup{}, logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.1.4.0": {
+			OID:    "1.3.6.1.2.1.1.4.0",
+			Index:  "0",
+			Parent: "1.3.6.1.2.1.1.4",
+			Value:  "asset-from-contact",
+			Type:   mapping.OctetString,
+		},
+	}
+	mappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.1",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{OID: "1.3.6.1.2.1.1.4", Entity: "device", Field: "sysContact"},
+		},
+	}
+	defaults := &config.Defaults{
+		Site:     "dc1",
+		AssetTag: ".1.3.6.1.2.1.1.4.0",
+	}
+
+	registry := mapping.NewEntityRegistry(logger)
+	entity := mapper.Map(values, mappingEntry, registry, defaults)
+	require.NotNil(t, entity)
+	device, ok := entity.(*diode.Device)
+	require.True(t, ok)
+
+	require.NotNil(t, device.AssetTag)
+	assert.Equal(t, "asset-from-contact", *device.AssetTag)
+}

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -4633,6 +4633,49 @@ func TestDeviceMapper_Map_DefaultsResolveFromWalkedSnapshot(t *testing.T) {
 	assert.Equal(t, "asset-12345", *device.AssetTag)
 }
 
+// TestDeviceMapper_Map_DefaultsResolveFromSysLocationOnly is the
+// symmetric partial-walk test for sysLocation: a device that responds
+// only to sysLocation (no name/description/platform/sysContact) must
+// still apply defaults via the no-op switch case's fieldFound=true.
+func TestDeviceMapper_Map_DefaultsResolveFromSysLocationOnly(t *testing.T) {
+	logger := slog.Default()
+	mapper := mapping.NewDeviceMapper(&MockManufacturerDataRetriever{}, &MockDeviceLookup{}, logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.1.6.0": {
+			OID:    "1.3.6.1.2.1.1.6.0",
+			Index:  "0",
+			Parent: "1.3.6.1.2.1.1.6",
+			Value:  "Data Center 02",
+			Type:   mapping.OctetString,
+		},
+	}
+	mappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.1",
+		Entity: "device",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{OID: "1.3.6.1.2.1.1.6", Entity: "device", Field: "sysLocation"},
+		},
+	}
+	defaults := &config.Defaults{
+		Site:     "dc2",
+		Location: ".1.3.6.1.2.1.1.6.0",
+	}
+
+	registry := mapping.NewEntityRegistry(logger)
+	entity := mapper.Map(values, mappingEntry, registry, defaults)
+	require.NotNil(t, entity)
+	device, ok := entity.(*diode.Device)
+	require.True(t, ok)
+
+	require.NotNil(t, device.Location)
+	require.NotNil(t, device.Location.Name)
+	assert.Equal(t, "Data Center 02", *device.Location.Name)
+	require.NotNil(t, device.Location.Site)
+	assert.Equal(t, "dc2", *device.Location.Site.Name)
+}
+
 // TestDeviceMapper_Map_DefaultsResolveFromSysContactOnly covers the
 // edge case where a device responds to sysContact/sysLocation but not
 // to name/description/platform. The no-op switch cases set fieldFound

--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -54,13 +54,14 @@ func newMACMatchStub(mac *diode.MACAddress) *diode.MACAddress {
 // INVARIANT: the fields here must be a superset of (a) every
 // dcim.device matcher field that snmp-discovery currently populates
 // on the rich Device, and (b) every dcim.device field NetBox treats
-// as required for create. As of the spec date, snmp-discovery does
-// NOT populate AssetTag, OobIp, Rack, Position, Face, VirtualChassis,
-// or VcPosition (matcher fields not used today). If a new mapper
-// starts setting any of those, or if NetBox adds new required fields
-// for dcim.device, this stub must grow to match — otherwise the rich
-// entity and the stub will resolve via different matcher precedence
-// paths or fail validation on the first cycle.
+// as required for create. As of the spec date, snmp-discovery
+// populates AssetTag via PolicyConfig.Defaults.AssetTag (literal or
+// OID reference). The stub must carry it through so rich and stub
+// resolve via the same matcher precedence path. OobIp, Rack,
+// Position, Face, VirtualChassis, and VcPosition remain
+// not-populated. If a new mapper starts setting any of those, or if
+// NetBox adds new required fields for dcim.device, this stub must
+// grow to match.
 //
 // Metadata.source_match (e.g. netbox_id) is the diode-netbox-plugin's
 // PK-based match path, so it must not diverge between rich and stub.
@@ -76,6 +77,7 @@ func newDeviceStub(d *diode.Device) *diode.Device {
 		Tenant:     d.Tenant,
 		DeviceType: d.DeviceType,
 		Role:       d.Role,
+		AssetTag:   d.AssetTag,
 		PrimaryIp4: newIPMatchStub(d.PrimaryIp4),
 		PrimaryIp6: newIPMatchStub(d.PrimaryIp6),
 	}

--- a/snmp-discovery/mapping/stubs_test.go
+++ b/snmp-discovery/mapping/stubs_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func strPtr(s string) *string { return &s }
@@ -105,10 +106,15 @@ func TestNewDeviceStub_KeepsMatcherAndRequiredFieldsDropsRest(t *testing.T) {
 	assert.NotNil(t, stub.PrimaryIp6)
 	assert.Equal(t, &v6, stub.PrimaryIp6.Address)
 
+	// AssetTag propagates — it is populated via
+	// PolicyConfig.Defaults.AssetTag and the stub must carry it so
+	// matcher precedence stays consistent between rich and stub.
+	require.NotNil(t, stub.AssetTag)
+	assert.Equal(t, "ASSET-001", *stub.AssetTag)
+
 	// All non-matcher / non-required fields cleared.
 	assert.Nil(t, stub.Platform)
 	assert.Nil(t, stub.Serial)
-	assert.Nil(t, stub.AssetTag)
 	assert.Nil(t, stub.Status)
 	assert.Nil(t, stub.Description)
 }

--- a/snmp-discovery/policy/mapping.yaml
+++ b/snmp-discovery/policy/mapping.yaml
@@ -77,7 +77,21 @@ entries:
         entity: "ipAddress"
         field: "addressRowStatus"
 
-  # Device mappings
+  # Device mappings.
+  #
+  # sysContact (.1.3.6.1.2.1.1.4.0) and sysLocation (.1.3.6.1.2.1.1.6.0)
+  # are walked but not consumed directly by the device mapper. They are
+  # available for PolicyConfig.Defaults.{Location,AssetTag} to reference
+  # by OID, e.g.:
+  #
+  #   defaults:
+  #     location: ".1.3.6.1.2.1.1.6.0"   # populate from sysLocation
+  #     asset_tag: ".1.3.6.1.2.1.1.4.0"  # populate from sysContact
+  #
+  # See data.ResolveDefault for the resolution semantics. OID references
+  # in defaults can resolve only against the walked snapshot of this
+  # system-group Map() call — references to OIDs in other mapping groups
+  # (interfaces, ENTITY-MIB rows, etc.) will not resolve.
   - oid: ".1.3.6.1.2.1.1"
     entity: "device"
     field: "_id"
@@ -88,9 +102,17 @@ entries:
       - oid: ".1.3.6.1.2.1.1.2.0"
         entity: "device"
         field: "platform"
+      - oid: ".1.3.6.1.2.1.1.4.0"
+        entity: "device"
+        field: "sysContact"
+        description: "Walked solely so defaults.asset_tag or defaults.location can reference it via OID. Not consumed by the mapper directly."
       - oid: ".1.3.6.1.2.1.1.5.0"
         entity: "device"
         field: "name"
+      - oid: ".1.3.6.1.2.1.1.6.0"
+        entity: "device"
+        field: "sysLocation"
+        description: "Walked solely so defaults.location or defaults.asset_tag can reference it via OID. Not consumed by the mapper directly."
 
   # Device serial number (ENTITY-MIB entPhysicalSerialNum).
   # identifier_size: 2 uses the last two OID components (column.row,


### PR DESCRIPTION
## Summary

- Operators can now write either a literal string **or** an SNMP OID reference (`.1.3.6.1.*`) in `defaults.location` and the new `defaults.asset_tag`. OID-syntax values are dereferenced from the walked map at apply-time; everything else stays a literal.
- Walks `sysContact` (`.1.3.6.1.2.1.1.4.0`) and `sysLocation` (`.1.3.6.1.2.1.1.6.0`) on every device so operators can reference them from defaults (e.g. `defaults.location: ".1.3.6.1.2.1.1.6.0"`).
- The pattern reuses the existing literal-or-OID primitive already used for `lookup_extensions` device-model resolution, but with a stricter regex (`^\.1\.3\.6\.1\.(\d+\.)+\d+$`) so non-SNMP dotted-decimal literals like `"3.14.159"` (a room number) keep working unchanged. The existing `oidPattern` used by `GetDeviceModel` is untouched.

## Why not the obvious mapping

A customer asked for `sysContact → asset_tag` as default behavior. We pushed back: `sysContact` is RFC 3418's "contact person", not an inventory tag, and forcing that mapping on every operator would create asset_tag uniqueness collisions (`admin@example.com`, `noc@company.tld`, vendor defaults). Instead this PR ships the primitive — the customer gets their mapping in **their** policy with one config line, without affecting anyone else.

## Out of scope (deferred)

- `entPhysicalAssetID` as an asset_tag source. The mapping framework groups walked PDUs per `Map()` call, so a column at `.1.3.6.1.2.1.47.1.1.1.1.15.<row>` is never visible to the system-group `applyDefaults` snapshot. Correct support needs row-aware chassis selection (`entPhysicalClass = chassis(3)`) and is tracked as a follow-up.

## Test plan

- [x] Unit tests for `ResolveDefault` (14 cases): literal pass-through, non-SNMP-decimal stays literal, OID-ref resolves, both-spelling tolerance, leading/trailing NUL trim, empty/missing/nil-walked → ok=false, regression-guard that existing `oidPattern` is unchanged.
- [x] Config tests: `AssetTag` parses + merges.
- [x] Mapper unit tests (internal-package `mappers_defaults_test.go`): literal Location, OID-ref Location, override semantics, Site inheritance, AssetTag literal + OID-ref + override + empty-config no-op + length cap (>50 runes warn-skips, ==50 ASCII sets, ==50 non-ASCII sets, ==51 non-ASCII skips — `utf8.RuneCountInString`, matches NetBox `CharField(max_length=50)` character semantics).
- [x] Mapper integration tests (`mappers_test.go`): `Map()` end-to-end with synthetic walk; partial-walk edge cases for sysContact-only and sysLocation-only (no-op switch arms set `fieldFound=true` so defaults still apply).
- [x] `go test ./... -count=1 -race` clean.
- [x] `go vet ./...` and `go build ./...` clean.
- [x] **Dry-run validation** via orb-test-lab snmpsim (cisco-csr1000v at 172.28.0.24): policy with `defaults.location: ".1.3.6.1.2.1.1.6.0"` and `defaults.asset_tag: ".1.3.6.1.2.1.1.4.0"`. Dry-run JSON shows `device.asset_tag = "admin@example.com"`, `device.location.name = "orb-test-lab"`, and the nested `interface.device` stub also carries `asset_tag` (stub propagation confirmed).
- [x] **Real ingestion validation** via Diode → NetBox: same policy ingested cleanly; NetBox API confirms `asset_tag: admin@example.com`, `location: orb-test-lab`, `site: orb-test-lab`.