### PR TITLE
fix(snmp-discovery): propagate master.Location to stack member devices

### DIFF
--- a/snmp-discovery/mapping/chassis.go
+++ b/snmp-discovery/mapping/chassis.go
@@ -273,12 +273,21 @@ func buildMemberDevice(master *diode.Device, member ChassisMember, masterRef *di
 	name := fmt.Sprintf("%s-%d", vcName, member.ID)
 	pos := int64(member.ID)
 	dev := &diode.Device{
-		Name:       &name,
-		Serial:     &member.Serial,
+		Name:   &name,
+		Serial: &member.Serial,
+		// Inherit policy-scoped attributes from the master. Location
+		// is carried alongside Site/Tenant/Role/Platform because
+		// defaults.location applies to the whole discovery scope —
+		// without this, members would be ingested into NetBox without
+		// the configured location even though the master has it.
+		// Pointer-shared (matches how Site/Tenant/Role/Platform are
+		// shared); each member's Device.location FK resolves to the
+		// same NetBox Location object.
 		Site:       master.Site,
 		Tenant:     master.Tenant,
 		Role:       master.Role,
 		Platform:   master.Platform,
+		Location:   master.Location,
 		VcPosition: &pos,
 		VirtualChassis: &diode.VirtualChassis{
 			Name:   &vcName,

--- a/snmp-discovery/mapping/chassis.go
+++ b/snmp-discovery/mapping/chassis.go
@@ -268,21 +268,13 @@ func buildMasterRef(master *diode.Device) *diode.Device {
 //     applied to N members would collapse them onto one NetBox row).
 //   - VcPosition = member.ID; VirtualChassis = {Name: vcName, Master: masterRef}.
 //   - DeviceType from member.Model when populated, else inherit master's.
-//   - Site / Tenant / Role / Platform inherited from master.
+//   - Site / Tenant / Role / Platform / Location inherited from master.
 func buildMemberDevice(master *diode.Device, member ChassisMember, masterRef *diode.Device, vcName string) *diode.Device {
 	name := fmt.Sprintf("%s-%d", vcName, member.ID)
 	pos := int64(member.ID)
 	dev := &diode.Device{
-		Name:   &name,
-		Serial: &member.Serial,
-		// Inherit policy-scoped attributes from the master. Location
-		// is carried alongside Site/Tenant/Role/Platform because
-		// defaults.location applies to the whole discovery scope —
-		// without this, members would be ingested into NetBox without
-		// the configured location even though the master has it.
-		// Pointer-shared (matches how Site/Tenant/Role/Platform are
-		// shared); each member's Device.location FK resolves to the
-		// same NetBox Location object.
+		Name:       &name,
+		Serial:     &member.Serial,
 		Site:       master.Site,
 		Tenant:     master.Tenant,
 		Role:       master.Role,

--- a/snmp-discovery/mapping/chassis_test.go
+++ b/snmp-discovery/mapping/chassis_test.go
@@ -450,6 +450,33 @@ func TestBuildMemberDevice_CarriesVcPositionAndMatcherBlock(t *testing.T) {
 	assert.Equal(t, "WS-C3850-12X", *dev.DeviceType.Model)
 }
 
+// TestBuildMemberDevice_InheritsMasterLocation guards finding #16:
+// when DeviceMapper.applyDefaults attaches `defaults.location` to the
+// master Device (which happens BEFORE TranslateAsStack builds the
+// non-master member devices), every member must also carry that
+// Location. Without this propagation, members would be ingested into
+// NetBox without the operator-configured location while the master /
+// standalone case has it — silently splitting one logical stack
+// across multiple NetBox locations.
+func TestBuildMemberDevice_InheritsMasterLocation(t *testing.T) {
+	site := &diode.Site{Name: strPtr("dc1")}
+	loc := &diode.Location{Name: strPtr("rack-42"), Site: site}
+	master := &diode.Device{
+		Name:     strPtr("stack"),
+		Site:     site,
+		Location: loc,
+	}
+	masterRef := buildMasterRef(master)
+	member := ChassisMember{ID: 2, Serial: "X", Model: "ModelB"}
+
+	dev := buildMemberDevice(master, member, masterRef, "stack")
+
+	require.NotNil(t, dev.Location, "members must inherit master.Location")
+	assert.Same(t, loc, dev.Location,
+		"Location is pointer-shared with master (mirrors Site/Tenant/Role/Platform sharing)")
+	assert.Equal(t, "rack-42", *dev.Location.Name)
+}
+
 func TestBuildMemberDevice_FallsBackToMasterDeviceTypeWhenModelEmpty(t *testing.T) {
 	master := &diode.Device{
 		Name: strPtr("stack"),


### PR DESCRIPTION
## Summary

Follow-up fix to [#404](https://github.com/netboxlabs/orb-discovery/pull/404). When a target is configured with `defaults.location`, `DeviceMapper.applyDefaults` attaches the resolved `Location` to the master Device — but `buildMemberDevice` (in `TranslateAsStack`) copied only `Site`, `Tenant`, `Role`, `Platform`, and `DeviceType` from the master. Members ended up ingested into NetBox without the operator-configured location while the master/standalone path had it, silently splitting one logical stack across multiple NetBox locations.

Adds `Location: master.Location` to the `buildMemberDevice` constructor. Pointer-shared, mirroring how `Site`/`Tenant`/`Role`/`Platform` are shared — each member's `Device.location` FK resolves to the same NetBox `Location` object as the master.

## Test plan

- [x] New regression test `TestBuildMemberDevice_InheritsMasterLocation` — asserts members carry `master.Location` via pointer identity.
- [x] `go test ./... -count=1` from `snmp-discovery/` — full suite green.
- [x] `golangci-lint run ./...` — 0 issues.
- [x] `go build ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)