### PR TITLE
feat(device-discovery): MAC address support for 5 custom NAPALM drivers

### DIFF
--- a/device-discovery/custom_napalm/CLAUDE.md
+++ b/device-discovery/custom_napalm/CLAUDE.md
@@ -90,9 +90,16 @@ from napalm.base.helpers import mac as normalize_mac
 try:
     mac_address = normalize_mac(mac_raw) if mac_raw else ""
 except Exception:
-    # napalm.mac() raises on malformed values; keep the raw value so
-    # debuggers can see the source of truth rather than dropping the row.
-    mac_address = mac_raw
+    # napalm.mac() rejected the value — log at WARNING and emit an
+    # empty MAC. Keeping the malformed raw string would lead NetBox's
+    # unique_primary_mac_address matcher to treat it as a distinct
+    # interface, which is worse than the missing-MAC behaviour callers
+    # already handle gracefully.
+    logger.warning(
+        "%s: normalize_mac rejected %r for interface %s — emitting empty MAC",
+        DRIVER_NAME, mac_raw, name,
+    )
+    mac_address = ""
 ```
 
 **Set `mac_address = ""` only when the platform genuinely doesn't

--- a/device-discovery/custom_napalm/CLAUDE.md
+++ b/device-discovery/custom_napalm/CLAUDE.md
@@ -64,6 +64,48 @@ must return the correct empty type so the rest of the pipeline doesn't break.
 hostname, vendor, model, os_version, serial_number, uptime (float, seconds), fqdn, interface_list (list[str])
 ```
 
+### `get_interfaces()` — `mac_address` field
+
+Each per-interface dict carries a `mac_address` string. The translator
+emits it as `Interface.primary_mac_address` and NetBox matches the
+interface via its `unique_primary_mac_address` matcher, so populating
+it is highly valuable to operators.
+
+**Populate it whenever the platform exposes a per-port MAC.** Acceptable
+sources:
+- SSH CLI: a `show interfaces`-style command that prints a per-port MAC
+  (Cisco-family `Hardware ... address`, Dell `Burned MAC`, Mellanox
+  `HW address`, etc.).
+- Structured API: a field in the same payload the driver already
+  pulls (AOS-CX `hw_intf_info.mac_addr`, PAN-OS `mac`, etc.).
+- gNMI / NETCONF state tree: e.g. SR Linux's
+  `interface[name=*]/ethernet/hw-mac-address`, SR OS NETCONF's
+  `state_ns:hardware-mac-address`.
+
+**Normalise through `napalm.base.helpers.mac`** before returning:
+
+```python
+from napalm.base.helpers import mac as normalize_mac
+
+try:
+    mac_address = normalize_mac(mac_raw) if mac_raw else ""
+except Exception:
+    # napalm.mac() raises on malformed values; keep the raw value so
+    # debuggers can see the source of truth rather than dropping the row.
+    mac_address = mac_raw
+```
+
+**Set `mac_address = ""` only when the platform genuinely doesn't
+expose per-port MAC.** Two real cases exist:
+- Cisco Small Business SG300 / SG350 / SG550 — one chassis MAC across
+  all ports; no per-port concept.
+- Cisco AireOS WLC — most "interfaces" are virtual (mgmt / dynamic
+  VLANs / AP-manager) with no L2 MAC.
+
+For every other driver, an unsupported (`""`) MAC field is a feature
+gap, not the intended steady state — track in the supported-platforms
+table and follow up with a driver-specific fix.
+
 ---
 
 ## Optional method: `get_interfaces_vlans`

--- a/device-discovery/custom_napalm/CLAUDE.md
+++ b/device-discovery/custom_napalm/CLAUDE.md
@@ -96,11 +96,13 @@ except Exception:
 ```
 
 **Set `mac_address = ""` only when the platform genuinely doesn't
-expose per-port MAC.** Two real cases exist:
+expose per-port MAC.** Real cases:
 - Cisco Small Business SG300 / SG350 / SG550 — one chassis MAC across
   all ports; no per-port concept.
 - Cisco AireOS WLC — most "interfaces" are virtual (mgmt / dynamic
   VLANs / AP-manager) with no L2 MAC.
+- Extreme EXOS — all ports share the system MAC by design; no
+  per-port MAC field in any standard ``show ports*`` command.
 
 For every other driver, an unsupported (`""`) MAC field is a feature
 gap, not the intended steady state — track in the supported-platforms

--- a/device-discovery/custom_napalm/extreme_slx.py
+++ b/device-discovery/custom_napalm/extreme_slx.py
@@ -187,7 +187,11 @@ _INTF_HEADER_RE = re.compile(
     re.M | re.IGNORECASE,
 )
 _INTF_HW_ADDR_RE = re.compile(
-    r"^\s*Hardware\s+is\s+\S+,\s+address\s+is\s+([0-9a-fA-F:.\-]{12,17})",
+    # End-of-token boundary (\b) prevents the capture group from greedily
+    # absorbing an adjacent string that happens to start with hex chars.
+    # SLX-OS emits a trailing ``(bia <mac>)`` after the configured address
+    # so we need to stop at the boundary, not the end of line.
+    r"^\s*Hardware\s+is\s+\S+,\s+address\s+is\s+([0-9a-fA-F:.\-]{12,17})\b",
     re.M | re.IGNORECASE,
 )
 
@@ -214,10 +218,17 @@ def _parse_intf_hw_addresses(text: str) -> dict[str, str]:
         mac_m = _INTF_HW_ADDR_RE.search(block)
         if not mac_m:
             continue
+        raw = mac_m.group(1)
         try:
-            result[name] = normalize_mac(mac_m.group(1))
+            result[name] = normalize_mac(raw)
         except Exception:
-            result[name] = mac_m.group(1)
+            # napalm normalize_mac rejected the value — log and skip rather
+            # than emit a malformed MAC string that downstream NetBox matching
+            # would silently treat as a distinct interface.
+            logger.warning(
+                "extreme_slx: normalize_mac rejected %r for interface %s — emitting empty MAC",
+                raw, name,
+            )
     return result
 
 # --- vlan brief parsing ---------------------------------------------------- #

--- a/device-discovery/custom_napalm/extreme_slx.py
+++ b/device-discovery/custom_napalm/extreme_slx.py
@@ -15,6 +15,7 @@ import re
 
 import napalm.base as _napalm_base
 from napalm.base import models
+from napalm.base.helpers import mac as normalize_mac
 from napalm.base.netmiko_helpers import netmiko_args
 from ntc_templates.parse import ParsingException, parse_output
 from textfsm import TextFSMError
@@ -166,6 +167,58 @@ _INTF_BRIEF_RE = re.compile(
     r"^((?:Ethernet|Management|Port-channel|Loopback|Ve)\s+\S+)\s+(\S+)\s+(\S+)",
     re.M | re.IGNORECASE,
 )
+
+# --- show interface (no-arg) MAC parser ------------------------------------ #
+# SLX-OS ``show interface ethernet`` emits one multi-line block per port:
+#
+#   Ethernet 0/1 is up, line protocol is up (connected)
+#   Hardware is Ethernet, address is 6cb1.580f.b900 (bia 6cb1.580f.b900)
+#   Description: ...
+#   ...
+#
+# We pair each ``<Type> <id>`` header line with the next ``address is <mac>``
+# line in the same block. The MAC capture is permissive — napalm.mac() does
+# the actual validation/normalisation so dotted (``xxxx.xxxx.xxxx``), dashed,
+# and colon-separated forms all resolve. ``bia <mac>`` (burned-in address)
+# appears in parentheses after the configured address; we always take the
+# FIRST ``address is`` value, which is the operational MAC NetBox expects.
+_INTF_HEADER_RE = re.compile(
+    r"^((?:Ethernet|Management|Port-channel|Loopback|Ve)\s+\S+)\s+is\s+\S+",
+    re.M | re.IGNORECASE,
+)
+_INTF_HW_ADDR_RE = re.compile(
+    r"^\s*Hardware\s+is\s+\S+,\s+address\s+is\s+([0-9a-fA-F:.\-]{12,17})",
+    re.M | re.IGNORECASE,
+)
+
+
+def _parse_intf_hw_addresses(text: str) -> dict[str, str]:
+    """
+    Parse ``show interface`` (no port-arg) multi-block output → ``{name: mac}``.
+
+    Iterates over interface-header positions and, for each one, looks for
+    the next ``Hardware is ..., address is <mac>`` line before the next
+    header. Blocks without a Hardware/address line are silently skipped
+    (loopbacks, VEs, port-channels often lack a per-port burned-in MAC).
+    """
+    result: dict[str, str] = {}
+    if not text:
+        return result
+    headers = list(_INTF_HEADER_RE.finditer(text))
+    for i, hdr in enumerate(headers):
+        name = re.sub(r"\s+", " ", hdr.group(1).strip())
+        # Restrict MAC search to this block: from after the header to the start
+        # of the next header (or end of text for the last block).
+        block_end = headers[i + 1].start() if i + 1 < len(headers) else len(text)
+        block = text[hdr.end():block_end]
+        mac_m = _INTF_HW_ADDR_RE.search(block)
+        if not mac_m:
+            continue
+        try:
+            result[name] = normalize_mac(mac_m.group(1))
+        except Exception:
+            result[name] = mac_m.group(1)
+    return result
 
 # --- vlan brief parsing ---------------------------------------------------- #
 # Matches leading VLAN row.  The name capture uses a greedy (.+) so that VLAN
@@ -487,10 +540,20 @@ class SLXOSDriver(_napalm_base.NetworkDriver):
         }
 
     def get_interfaces(self) -> dict:
-        """Return interface details keyed by interface name."""
+        """
+        Return interface details keyed by interface name.
+
+        Per-port MAC is sourced from ``show interface`` (no port-arg) —
+        SLX-OS emits one block per port in a single command, so MAC fetch
+        is one extra round-trip regardless of port count.
+        """
         output = self.device.send_command("show interface brief")
         if not output:
             return {}
+
+        mac_by_intf = _parse_intf_hw_addresses(
+            self.device.send_command("show interface")
+        )
 
         interfaces = {}
         for m in _INTF_BRIEF_RE.finditer(output):
@@ -506,7 +569,7 @@ class SLXOSDriver(_napalm_base.NetworkDriver):
                 "last_flapped": -1.0,
                 "mtu": -1,
                 "speed": _speed_mbps(m.group(3)),
-                "mac_address": "",
+                "mac_address": mac_by_intf.get(name, ""),
             }
         return interfaces
 

--- a/device-discovery/custom_napalm/extreme_slx.py
+++ b/device-discovery/custom_napalm/extreme_slx.py
@@ -169,7 +169,8 @@ _INTF_BRIEF_RE = re.compile(
 )
 
 # --- show interface (no-arg) MAC parser ------------------------------------ #
-# SLX-OS ``show interface ethernet`` emits one multi-line block per port:
+# SLX-OS ``show interface`` (no port-arg — the command get_interfaces issues)
+# emits one multi-line block per port:
 #
 #   Ethernet 0/1 is up, line protocol is up (connected)
 #   Hardware is Ethernet, address is 6cb1.580f.b900 (bia 6cb1.580f.b900)

--- a/device-discovery/custom_napalm/fortinet_fortios_ssh.py
+++ b/device-discovery/custom_napalm/fortinet_fortios_ssh.py
@@ -70,7 +70,10 @@ def _parse_uptime(output: str) -> int:
 # permanent MAC but is per-port. The current MAC is what NetBox matches
 # against L2 neighbours so we accept it as the right value.
 _FNSYSCTL_IFACE_RE = re.compile(
-    r"^(\S+)\s+Link\s+encap:Ethernet\s+HWaddr\s+([0-9a-fA-F:.\-]{12,17})",
+    # End-of-token boundary (\b) prevents the capture group from greedily
+    # absorbing trailing trash on the same line. ifconfig output ends the
+    # HWaddr line at the MAC, but the explicit boundary is defensive.
+    r"^(\S+)\s+Link\s+encap:Ethernet\s+HWaddr\s+([0-9a-fA-F:.\-]{12,17})\b",
     re.M,
 )
 
@@ -91,7 +94,13 @@ def _parse_fnsysctl_mac_addresses(text: str) -> dict[str, str]:
         try:
             result[name] = normalize_mac(raw)
         except Exception:
-            result[name] = raw
+            # napalm normalize_mac rejected the value — log and skip rather
+            # than emit a malformed MAC string that downstream NetBox matching
+            # would silently treat as a distinct interface.
+            logger.warning(
+                "fortinet_fortios_ssh: normalize_mac rejected %r for interface %s — emitting empty MAC",
+                raw, name,
+            )
     return result
 
 

--- a/device-discovery/custom_napalm/fortinet_fortios_ssh.py
+++ b/device-discovery/custom_napalm/fortinet_fortios_ssh.py
@@ -14,6 +14,7 @@ import re
 
 import napalm.base as _napalm_base
 from napalm.base import models
+from napalm.base.helpers import mac as normalize_mac
 from napalm.base.netmiko_helpers import netmiko_args
 from ntc_templates.parse import parse_output
 
@@ -46,6 +47,52 @@ def _parse_uptime(output: str) -> int:
         return 0
     days, hours, minutes = int(m.group(1)), int(m.group(2)), int(m.group(3))
     return days * 86400 + hours * 3600 + minutes * 60
+
+
+# --- fnsysctl ifconfig MAC parser ------------------------------------------ #
+# FortiOS ``fnsysctl ifconfig`` is a shell-passthrough wrapper for Linux
+# ifconfig. It emits all NICs in one shot, e.g.::
+#
+#   port1   Link encap:Ethernet  HWaddr 00:09:0F:09:00:01
+#           inet addr:192.168.1.1  Bcast:192.168.1.255  Mask:255.255.255.0
+#           UP BROADCAST RUNNING ALLMULTI MULTICAST  MTU:1500  Metric:1
+#           ...
+#
+#   port2   Link encap:Ethernet  HWaddr 00:09:0F:09:00:02
+#           ...
+#
+# Pairs ``<name> Link encap:Ethernet`` header with the ``HWaddr`` value on
+# the same line. Loopback / non-ethernet interfaces emit a different encap
+# (``Link encap:Local Loopback``) and don't carry HWaddr — silently skipped.
+#
+# HA caveat: FortiGate HA-secondary nodes report the *current* (operational)
+# MAC rather than the burned-in MAC. ``get hardware nic <port>`` returns
+# permanent MAC but is per-port. The current MAC is what NetBox matches
+# against L2 neighbours so we accept it as the right value.
+_FNSYSCTL_IFACE_RE = re.compile(
+    r"^(\S+)\s+Link\s+encap:Ethernet\s+HWaddr\s+([0-9a-fA-F:.\-]{12,17})",
+    re.M,
+)
+
+
+def _parse_fnsysctl_mac_addresses(text: str) -> dict[str, str]:
+    """
+    Parse ``fnsysctl ifconfig`` output → ``{interface_name: normalised_mac}``.
+
+    Loopback / non-ethernet interfaces (``Link encap:Local Loopback``,
+    GRE tunnels, etc.) don't match the Ethernet-only header and are
+    silently skipped. Empty / None input is tolerated.
+    """
+    result: dict[str, str] = {}
+    if not text:
+        return result
+    for m in _FNSYSCTL_IFACE_RE.finditer(text):
+        name, raw = m.group(1), m.group(2)
+        try:
+            result[name] = normalize_mac(raw)
+        except Exception:
+            result[name] = raw
+    return result
 
 
 def _netmask_to_prefix(netmask: str) -> int:
@@ -135,7 +182,17 @@ class FortiOSSSHDriver(_napalm_base.NetworkDriver):
         }
 
     def get_interfaces(self) -> dict:
-        """Return interface details keyed by interface name."""
+        """
+        Return interface details keyed by interface name.
+
+        Per-port MAC is sourced from ``fnsysctl ifconfig`` — a single shell
+        passthrough call that lists every Ethernet NIC with HWaddr. Non-
+        Ethernet interfaces (Loopback, tunnels) and admin profiles without
+        shell access return no MAC; the field stays ``"" `` for those.
+
+        HA caveat: secondary HA nodes report the *current* (operational) MAC
+        rather than the burned-in MAC — see _parse_fnsysctl_mac_addresses.
+        """
         raw = self.device.send_command("get system interface physical")
         try:
             parsed = parse_output(
@@ -144,6 +201,10 @@ class FortiOSSSHDriver(_napalm_base.NetworkDriver):
         except Exception:
             logger.debug("Failed to parse 'get system interface physical' output", exc_info=True)
             return {}
+
+        mac_by_intf = _parse_fnsysctl_mac_addresses(
+            self.device.send_command("fnsysctl ifconfig")
+        )
 
         interfaces = {}
         for row in parsed:
@@ -165,7 +226,7 @@ class FortiOSSSHDriver(_napalm_base.NetworkDriver):
                 "last_flapped": -1.0,
                 "mtu": 0,
                 "speed": speed,
-                "mac_address": "",
+                "mac_address": mac_by_intf.get(name, ""),
             }
 
         return interfaces

--- a/device-discovery/custom_napalm/hp_procurve.py
+++ b/device-discovery/custom_napalm/hp_procurve.py
@@ -276,11 +276,33 @@ def _parse_procurve_intf_mac_addresses(text: str) -> dict[str, str]:
         mac_m = _PROCURVE_MAC_RE.search(text[hdr.end():block_end])
         if not mac_m:
             continue
+        raw = mac_m.group(1)
         try:
-            result[port] = normalize_mac(mac_m.group(1))
+            result[port] = normalize_mac(raw)
         except Exception:
-            result[port] = mac_m.group(1)
+            # napalm normalize_mac rejected the value — log and skip rather
+            # than emit a malformed MAC string that downstream NetBox matching
+            # would silently treat as a distinct interface.
+            logger.warning(
+                "hp_procurve: normalize_mac rejected %r for port %s — emitting empty MAC",
+                raw, port,
+            )
     return result
+
+
+# Conservative chunk size for the ``show interfaces <port-list>`` batched
+# call. A 24-port comma-separated list is well under ProCurve / AOS-S CLI
+# input limits (typically ~255 chars) even with longest port-name forms
+# (``A1,A2,...,Trk24``). Larger chassis / stacks fall into multiple chunks
+# of this size, costing one extra round-trip per chunk rather than the
+# per-port iteration the platform-MAC docs warn against.
+_PROCURVE_PORTLIST_CHUNK_SIZE = 24
+
+
+def _chunked(seq: list, size: int):
+    """Yield ``seq`` in fixed-size chunks. Last chunk may be smaller."""
+    for i in range(0, len(seq), size):
+        yield seq[i:i + size]
 
 
 class ProcurveDriver(_napalm_base.NetworkDriver):
@@ -416,8 +438,12 @@ class ProcurveDriver(_napalm_base.NetworkDriver):
                 "mac_address": "",
             }
 
-        if interfaces:
-            port_list = ",".join(interfaces.keys())
+        # Chunked port-list batching: comma-separated lists longer than ~255
+        # chars can exceed ProCurve / AOS-S CLI input limits on large chassis
+        # / stacks. Issuing ceil(N/24) commands keeps each call well under
+        # the limit while still amortising the per-port iteration cost.
+        for chunk in _chunked(list(interfaces.keys()), _PROCURVE_PORTLIST_CHUNK_SIZE):
+            port_list = ",".join(chunk)
             mac_by_port = _parse_procurve_intf_mac_addresses(
                 self.device.send_command(f"show interfaces {port_list}")
             )

--- a/device-discovery/custom_napalm/hp_procurve.py
+++ b/device-discovery/custom_napalm/hp_procurve.py
@@ -21,6 +21,7 @@ import re
 
 import napalm.base as _napalm_base
 from napalm.base import models
+from napalm.base.helpers import mac as normalize_mac
 from napalm.base.netmiko_helpers import netmiko_args
 from ntc_templates.parse import parse_output
 
@@ -231,6 +232,57 @@ def _procurve_aggregate_to_switchport(per_port: dict) -> SwitchportInfo:
     )
 
 
+# --- show interfaces <port-list> MAC parser -------------------------------- #
+# ``show interfaces <port-or-list>`` emits one detail block per port::
+#
+#   Status and Counters - Port Counters for port 1
+#
+#    Name (intended)        : Uplink
+#    MAC Address            : 001234-567890
+#    Link Status            : Up
+#    ...
+#
+# We pair the ``port <name>`` header with the first ``MAC Address`` line in
+# the same block. The MAC capture is permissive — napalm.mac() handles the
+# ProCurve ``xxxxxx-xxxxxx`` form alongside the standard colon-separated
+# variants. Trunk ports (``Trk1``) and other logical interfaces lack a MAC
+# row and are silently skipped.
+_PROCURVE_PORT_HEADER_RE = re.compile(
+    r"^\s*Status\s+and\s+Counters\s*-\s*Port\s+Counters\s+for\s+port\s+(\S+)",
+    re.M | re.IGNORECASE,
+)
+_PROCURVE_MAC_RE = re.compile(
+    r"^\s*MAC\s+Address\s*:\s*([0-9a-fA-F:.\-]{12,17})\s*$",
+    re.M | re.IGNORECASE,
+)
+
+
+def _parse_procurve_intf_mac_addresses(text: str) -> dict[str, str]:
+    """
+    Parse ``show interfaces <port-list>`` multi-block output → ``{port: mac}``.
+
+    Iterates over port-header positions and, for each one, looks for the
+    next ``MAC Address`` line before the next header. Logical interfaces
+    (trunks, VLANs) lack the MAC row and are silently skipped — the caller
+    treats a missing key as ``"" ``.
+    """
+    result: dict[str, str] = {}
+    if not text:
+        return result
+    headers = list(_PROCURVE_PORT_HEADER_RE.finditer(text))
+    for i, hdr in enumerate(headers):
+        port = hdr.group(1).strip()
+        block_end = headers[i + 1].start() if i + 1 < len(headers) else len(text)
+        mac_m = _PROCURVE_MAC_RE.search(text[hdr.end():block_end])
+        if not mac_m:
+            continue
+        try:
+            result[port] = normalize_mac(mac_m.group(1))
+        except Exception:
+            result[port] = mac_m.group(1)
+    return result
+
+
 class ProcurveDriver(_napalm_base.NetworkDriver):
     """
     HP/Aruba ProCurve NAPALM driver (read-only subset for device-discovery).
@@ -332,7 +384,16 @@ class ProcurveDriver(_napalm_base.NetworkDriver):
         }
 
     def get_interfaces(self) -> dict:
-        """Return interface details keyed by interface name."""
+        """
+        Return interface details keyed by interface name.
+
+        Per-port MAC is sourced from one batched ``show interfaces
+        <port-list>`` call — ProCurve accepts a comma-separated port
+        list, so a single round-trip covers every port discovered by
+        ``show interfaces brief`` regardless of port count. Logical
+        interfaces (trunks, VLANs, etc.) emit no MAC row and stay
+        ``mac_address=""``.
+        """
         raw = self.device.send_command("show interfaces brief")
         if not raw:
             return {}
@@ -354,6 +415,15 @@ class ProcurveDriver(_napalm_base.NetworkDriver):
                 "speed": _parse_speed(row.get("mode", "")),
                 "mac_address": "",
             }
+
+        if interfaces:
+            port_list = ",".join(interfaces.keys())
+            mac_by_port = _parse_procurve_intf_mac_addresses(
+                self.device.send_command(f"show interfaces {port_list}")
+            )
+            for port, mac in mac_by_port.items():
+                if port in interfaces:
+                    interfaces[port]["mac_address"] = mac
 
         return interfaces
 

--- a/device-discovery/custom_napalm/hp_procurve.py
+++ b/device-discovery/custom_napalm/hp_procurve.py
@@ -409,12 +409,14 @@ class ProcurveDriver(_napalm_base.NetworkDriver):
         """
         Return interface details keyed by interface name.
 
-        Per-port MAC is sourced from one batched ``show interfaces
-        <port-list>`` call — ProCurve accepts a comma-separated port
-        list, so a single round-trip covers every port discovered by
-        ``show interfaces brief`` regardless of port count. Logical
-        interfaces (trunks, VLANs, etc.) emit no MAC row and stay
-        ``mac_address=""``.
+        Per-port MAC is sourced from batched ``show interfaces
+        <port-list>`` calls — ProCurve accepts a comma-separated port
+        list. To stay under ProCurve / AOS-S CLI input limits on large
+        chassis or stacks we chunk the list at
+        ``_PROCURVE_PORTLIST_CHUNK_SIZE`` ports per call, costing
+        ceil(N/chunk_size) round-trips instead of N per-port commands.
+        Logical interfaces (trunks, VLANs, etc.) emit no MAC row and
+        stay ``mac_address=""``.
         """
         raw = self.device.send_command("show interfaces brief")
         if not raw:

--- a/device-discovery/custom_napalm/nokia_srl.py
+++ b/device-discovery/custom_napalm/nokia_srl.py
@@ -22,12 +22,15 @@ SR Linux commands used:
   admin display-config      — running configuration (YANG flat format)
 """
 
+import logging
 import re
 
 import napalm.base as _napalm_base
 from napalm.base import models
 from napalm.base.helpers import mac as normalize_mac
 from napalm.base.netmiko_helpers import netmiko_args
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Config sanitization — Nokia SR Linux sensitive fields
@@ -129,10 +132,13 @@ def _parse_hw_mac_addresses(text: str) -> dict[str, str]:
         try:
             result[name] = normalize_mac(raw)
         except Exception:
-            # napalm normalize_mac raises on malformed values; keep the
-            # raw value rather than dropping the row so debuggers still
-            # see the source of truth.
-            result[name] = raw
+            # napalm normalize_mac rejected the value — log and skip rather
+            # than emit a malformed MAC string that downstream NetBox matching
+            # would silently treat as a distinct interface.
+            logger.warning(
+                "nokia_srl: normalize_mac rejected %r for interface %s — emitting empty MAC",
+                raw, name,
+            )
     return result
 
 

--- a/device-discovery/custom_napalm/nokia_srl.py
+++ b/device-discovery/custom_napalm/nokia_srl.py
@@ -14,6 +14,11 @@ SR Linux commands used:
   show version              — hostname, software version, chassis type
   show system information   — uptime, serial number
   show interface all        — interface status, speed, IP addresses
+  info from state interface * ethernet hw-mac-address
+                            — per-interface hardware MAC (single shot,
+                              wildcard expands across every physical
+                              interface; YANG path is
+                              /interface[name=*]/ethernet/hw-mac-address)
   admin display-config      — running configuration (YANG flat format)
 """
 
@@ -21,6 +26,7 @@ import re
 
 import napalm.base as _napalm_base
 from napalm.base import models
+from napalm.base.helpers import mac as normalize_mac
 from napalm.base.netmiko_helpers import netmiko_args
 
 # ---------------------------------------------------------------------------
@@ -75,6 +81,44 @@ def _parse_speed(speed_str: str) -> float:
         return -1.0
     value, unit = float(m.group(1)), m.group(2).lower()
     return value * _SPEED_MULT.get(unit, 1.0)
+
+
+# ---------------------------------------------------------------------------
+# Hardware MAC parser — ``info from state interface * ethernet hw-mac-address``
+# ---------------------------------------------------------------------------
+
+# SR Linux emits one block per interface, e.g.::
+#
+#     interface ethernet-1/1 {
+#         ethernet {
+#             hw-mac-address 1A:CD:EE:FF:00:01
+#         }
+#     }
+#
+# Capture the (name, mac) pair across the braces — interfaces without an
+# ethernet/hw-mac-address leaf (e.g. loopbacks, system) won't match and are
+# silently skipped. The MAC value is required to be 17 chars (xx:xx:...).
+_HW_MAC_BLOCK_RE = re.compile(
+    r"interface\s+(\S+)\s*\{[^}]*?ethernet\s*\{[^}]*?hw-mac-address\s+([0-9A-Fa-f:]{17})",
+    re.DOTALL,
+)
+
+
+def _parse_hw_mac_addresses(text: str) -> dict[str, str]:
+    """Return ``{interface_name: normalized_mac}`` parsed from the YANG state output."""
+    result: dict[str, str] = {}
+    if not text:
+        return result
+    for m in _HW_MAC_BLOCK_RE.finditer(text):
+        name, raw = m.group(1), m.group(2)
+        try:
+            result[name] = normalize_mac(raw)
+        except Exception:
+            # napalm normalize_mac raises on malformed values; keep the
+            # raw value rather than dropping the row so debuggers still
+            # see the source of truth.
+            result[name] = raw
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -348,10 +392,21 @@ class SRLDriver(_napalm_base.NetworkDriver):
         sub-interface (e.g. ``mgmt0`` and ``mgmt0.0``). The translator
         maps sub-interface names to NetBox ``virtual`` interfaces with
         parent linkage automatically.
+
+        Physical interface MACs are sourced from
+        ``info from state interface * ethernet hw-mac-address`` (one
+        wildcard call covers every port). Sub-interfaces inherit no
+        L2 identity in SR Linux and remain MAC-less.
         """
         intf_out = self.device.send_command("show interface all")
         if not intf_out:
             return {}
+
+        mac_by_intf = _parse_hw_mac_addresses(
+            self.device.send_command(
+                "info from state interface * ethernet hw-mac-address"
+            )
+        )
 
         parsed = _parse_interface_output(intf_out)
         interfaces: dict = {}
@@ -363,7 +418,7 @@ class SRLDriver(_napalm_base.NetworkDriver):
                 "last_flapped": -1.0,
                 "mtu": entry["mtu"],
                 "speed": entry["speed"],
-                "mac_address": "",
+                "mac_address": mac_by_intf.get(entry["name"], ""),
             }
             for sub in entry["subs"]:
                 interfaces[sub["name"]] = {

--- a/device-discovery/custom_napalm/nokia_srl.py
+++ b/device-discovery/custom_napalm/nokia_srl.py
@@ -97,9 +97,24 @@ def _parse_speed(speed_str: str) -> float:
 #
 # Capture the (name, mac) pair across the braces — interfaces without an
 # ethernet/hw-mac-address leaf (e.g. loopbacks, system) won't match and are
-# silently skipped. The MAC value is required to be 17 chars (xx:xx:...).
+# silently skipped.
+#
+# The MAC capture group accepts colon-, dot-, or dash-separated forms and a
+# wider length range (12-17 chars) so `napalm.base.helpers.mac()` — not the
+# regex — does the format validation. This catches non-padded variants like
+# `aa:bb:cc:dd:ee:1` that napalm normalises to `AA:BB:CC:DD:EE:01`.
+#
+# NOTE: the ``[^}]*?`` spans are NOT brace-aware — they stop at the first
+# closing brace. The targeted query `info from state interface *
+# ethernet hw-mac-address` keeps the ethernet sub-block flat (just the
+# requested leaf), so this is safe today. If future SR Linux versions emit
+# extra nested blocks inside ``ethernet { ... }`` before hw-mac-address
+# (e.g. flow-control { }), the regex would silently miss those interfaces
+# and the MAC field would fall back to empty string. Mitigation if that
+# happens: request JSON output via ``| as json`` and switch to a structured
+# parser.
 _HW_MAC_BLOCK_RE = re.compile(
-    r"interface\s+(\S+)\s*\{[^}]*?ethernet\s*\{[^}]*?hw-mac-address\s+([0-9A-Fa-f:]{17})",
+    r"interface\s+(\S+)\s*\{[^}]*?ethernet\s*\{[^}]*?hw-mac-address\s+([0-9A-Fa-f:.\-]{12,17})",
     re.DOTALL,
 )
 

--- a/device-discovery/custom_napalm/nokia_sros_ssh.py
+++ b/device-discovery/custom_napalm/nokia_sros_ssh.py
@@ -123,7 +123,8 @@ def _parse_port_hw_mac_addresses(text: str) -> dict[str, str]:
     result: dict[str, str] = {}
     if not text:
         return result
-    # SR-OS uses ===== banners between port blocks. Split on a run of >=5 = chars.
+    # SR-OS uses ``=`` banners between port blocks; split on any run of one
+    # or more ``=`` characters on a line by themselves.
     for block in re.split(r"^=+\s*$", text, flags=re.MULTILINE):
         iface_m = _PORT_INTERFACE_RE.search(block)
         mac_m = _PORT_HW_MAC_RE.search(block)
@@ -133,7 +134,13 @@ def _parse_port_hw_mac_addresses(text: str) -> dict[str, str]:
         try:
             result[port_id] = normalize_mac(mac_raw)
         except Exception:
-            result[port_id] = mac_raw
+            # napalm normalize_mac rejected the value — log and skip rather
+            # than emit a malformed MAC string that downstream NetBox matching
+            # would silently treat as a distinct interface.
+            logger.warning(
+                "nokia_sros_ssh: normalize_mac rejected %r for port %s — emitting empty MAC",
+                mac_raw, port_id,
+            )
     return result
 
 

--- a/device-discovery/custom_napalm/nokia_sros_ssh.py
+++ b/device-discovery/custom_napalm/nokia_sros_ssh.py
@@ -15,6 +15,7 @@ import re
 
 import napalm.base as _napalm_base
 from napalm.base import models
+from napalm.base.helpers import mac as normalize_mac
 from napalm.base.netmiko_helpers import netmiko_args
 from ntc_templates.parse import parse_output
 
@@ -72,6 +73,53 @@ def _parse_uptime(uptime_str: str) -> float:
         int(m.group(4)),
     )
     return float(days * 86400 + hours * 3600 + minutes * 60 + secs)
+
+
+# ---------------------------------------------------------------------------
+# Per-port hardware MAC parser — ``show port detail`` output
+# ---------------------------------------------------------------------------
+
+# SR-OS prints one block per port under `show port detail`, separated by
+# `=====...` banner lines. Within each block:
+#     Interface          : 1/1/1
+#     ...
+#     Hardware Mac       : 90:ec:00:00:00:00
+# The Hardware-Mac row reports the burned-in MAC; the Configured-Mac row
+# above it is the operator-overridden MAC. NetBox interface MAC matches the
+# burned-in MAC by convention.
+_PORT_INTERFACE_RE = re.compile(
+    r"^\s*Interface\s*:\s*(\S+)", re.MULTILINE,
+)
+_PORT_HW_MAC_RE = re.compile(
+    r"^\s*Hardware\s+Mac\s*:\s*([0-9a-fA-F:]{17})", re.MULTILINE,
+)
+
+
+def _parse_port_hw_mac_addresses(text: str) -> dict[str, str]:
+    """
+    Return ``{port_id: normalized_mac}`` parsed from ``show port detail``.
+
+    The command emits one block per port. We split on the SR-OS banner
+    (a run of `=` characters) and look for an ``Interface`` line + a
+    ``Hardware Mac`` line within the same block. Blocks without both
+    (e.g. summary banner, totals footer) are silently skipped — the
+    caller treats a missing key as ``"" `` (no MAC).
+    """
+    result: dict[str, str] = {}
+    if not text:
+        return result
+    # SR-OS uses ===== banners between port blocks. Split on a run of >=5 = chars.
+    for block in re.split(r"^=+\s*$", text, flags=re.MULTILINE):
+        iface_m = _PORT_INTERFACE_RE.search(block)
+        mac_m = _PORT_HW_MAC_RE.search(block)
+        if not iface_m or not mac_m:
+            continue
+        port_id, mac_raw = iface_m.group(1), mac_m.group(1)
+        try:
+            result[port_id] = normalize_mac(mac_raw)
+        except Exception:
+            result[port_id] = mac_raw
+    return result
 
 
 class SROSSSHDriver(_napalm_base.NetworkDriver):
@@ -166,9 +214,19 @@ class SROSSSHDriver(_napalm_base.NetworkDriver):
         }
 
     def get_interfaces(self) -> dict:
-        """Return interface details keyed by interface name."""
+        """
+        Return interface details keyed by interface name.
+
+        Per-port MAC is sourced from ``show port detail`` (no port-id) —
+        SR-OS emits one block per port in a single command, so the
+        join cost is one extra round-trip regardless of port count.
+        """
         port_out = self.device.send_command("show port")
         parsed = parse_output(platform="alcatel_sros", command="show port", data=port_out)
+
+        mac_by_port = _parse_port_hw_mac_addresses(
+            self.device.send_command("show port detail")
+        )
 
         interfaces = {}
         for row in parsed:
@@ -192,7 +250,7 @@ class SROSSSHDriver(_napalm_base.NetworkDriver):
                 "last_flapped": -1.0,
                 "mtu": mtu,
                 "speed": 0.0,
-                "mac_address": "",
+                "mac_address": mac_by_port.get(port_id, ""),
             }
 
         return interfaces

--- a/device-discovery/custom_napalm/nokia_sros_ssh.py
+++ b/device-discovery/custom_napalm/nokia_sros_ssh.py
@@ -81,17 +81,32 @@ def _parse_uptime(uptime_str: str) -> float:
 
 # SR-OS prints one block per port under `show port detail`, separated by
 # `=====...` banner lines. Within each block:
-#     Interface          : 1/1/1
-#     ...
-#     Hardware Mac       : 90:ec:00:00:00:00
-# The Hardware-Mac row reports the burned-in MAC; the Configured-Mac row
-# above it is the operator-overridden MAC. NetBox interface MAC matches the
-# burned-in MAC by convention.
+#
+#     Classic CLI (older releases):
+#         Interface          : 1/1/1
+#         ...
+#         Hardware Mac       : 90:ec:00:00:00:00
+#
+#     MD-CLI (SR-OS 19+):
+#         Interface         : 1/1/c2/1
+#         ...
+#         Hardware Address  : 90:ec:00:00:00:00
+#
+# The Hardware row reports the burned-in MAC; the Configured row above it
+# is the operator-overridden MAC. NetBox interface MAC matches the burned-in
+# MAC by convention.
+#
+# The MAC capture group accepts colon-, dot-, or dash-separated forms and a
+# wider length range so `napalm.base.helpers.mac()` (not the regex) does the
+# validation. Length 12-17 chars covers `aabbccddeeff`, `aabb.ccdd.eeff`,
+# `aa-bb-cc-dd-ee-ff`, and non-padded variants like `aa:bb:cc:dd:ee:1` that
+# napalm normalises.
 _PORT_INTERFACE_RE = re.compile(
     r"^\s*Interface\s*:\s*(\S+)", re.MULTILINE,
 )
 _PORT_HW_MAC_RE = re.compile(
-    r"^\s*Hardware\s+Mac\s*:\s*([0-9a-fA-F:]{17})", re.MULTILINE,
+    r"^\s*Hardware\s+(?:Mac|Address)\s*:\s*([0-9a-fA-F:.\-]{12,17})\s*$",
+    re.MULTILINE,
 )
 
 

--- a/device-discovery/tests/custom_drivers/extreme_slx/mock_data/test_get_interfaces/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/extreme_slx/mock_data/test_get_interfaces/normal/expected_result.json
@@ -6,7 +6,7 @@
     "last_flapped": -1.0,
     "mtu": -1,
     "speed": 1000.0,
-    "mac_address": ""
+    "mac_address": "6C:B1:58:0F:B9:00"
   },
   "Ethernet 0/1": {
     "is_up": true,
@@ -15,7 +15,7 @@
     "last_flapped": -1.0,
     "mtu": -1,
     "speed": 10000.0,
-    "mac_address": ""
+    "mac_address": "6C:B1:58:0F:B9:01"
   },
   "Ethernet 0/2": {
     "is_up": false,
@@ -24,7 +24,7 @@
     "last_flapped": -1.0,
     "mtu": -1,
     "speed": 1000.0,
-    "mac_address": ""
+    "mac_address": "6C:B1:58:0F:B9:02"
   },
   "Ethernet 0/3": {
     "is_up": false,
@@ -33,7 +33,7 @@
     "last_flapped": -1.0,
     "mtu": -1,
     "speed": 1000.0,
-    "mac_address": ""
+    "mac_address": "6C:B1:58:0F:B9:03"
   },
   "Port-channel 1": {
     "is_up": true,

--- a/device-discovery/tests/custom_drivers/extreme_slx/mock_data/test_get_interfaces/normal/show_interface.txt
+++ b/device-discovery/tests/custom_drivers/extreme_slx/mock_data/test_get_interfaces/normal/show_interface.txt
@@ -1,0 +1,34 @@
+Management 1 is up, line protocol is up
+Hardware is Ethernet, address is 6cb1.580f.b900 (bia 6cb1.580f.b900)
+Description: Out-of-band management
+Internet address is 192.0.2.1/24
+MTU 1500 bytes
+
+Ethernet 0/1 is up, line protocol is up (connected)
+Hardware is Ethernet, address is 6cb1.580f.b901 (bia 6cb1.580f.b901)
+Description: uplink
+MTU 9216 bytes
+LineSpeed Actual    : 10000 Mbit, Mode of Operation: Full duplex
+
+Ethernet 0/2 is down, line protocol is down (link down)
+Hardware is Ethernet, address is 6cb1.580f.b902 (bia 6cb1.580f.b902)
+Description:
+MTU 9216 bytes
+LineSpeed Actual    : Nil
+
+Ethernet 0/3 is down, line protocol is down (link down)
+Hardware is Ethernet, address is 6cb1.580f.b903 (bia 6cb1.580f.b903)
+Description:
+MTU 9216 bytes
+LineSpeed Actual    : Nil
+
+Port-channel 1 is up, line protocol is up
+Description:
+MTU 9216 bytes
+
+Loopback 1 is up, line protocol is up
+Internet address is 10.0.0.1/32
+
+Ve 10 is up, line protocol is up
+Description: SVI for vlan 10
+Internet address is 192.168.10.1/24

--- a/device-discovery/tests/custom_drivers/extreme_slx/test_driver.py
+++ b/device-discovery/tests/custom_drivers/extreme_slx/test_driver.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from custom_napalm.extreme_slx import SLXOSDriver
+from custom_napalm.extreme_slx import SLXOSDriver, _parse_intf_hw_addresses
 from tests.custom_drivers.base_test import BaseDriverTest
 from tests.custom_drivers.mock_device import FakeCLIDevice
 
@@ -13,3 +13,56 @@ class TestSLXOSDriver(BaseDriverTest):
     driver_cls = SLXOSDriver
     fake_device_cls = FakeCLIDevice
     mock_data_root = Path(__file__).parent / "mock_data"
+
+
+# ---------------------------------------------------------------------------
+# _parse_intf_hw_addresses — parser unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_intf_hw_addresses_typical_multi_block():
+    """Multi-port `show interface` output → {name: normalised_mac}."""
+    text = """\
+Ethernet 0/1 is up, line protocol is up (connected)
+Hardware is Ethernet, address is 6cb1.580f.b901 (bia 6cb1.580f.b901)
+Description: uplink
+MTU 9216 bytes
+
+Ethernet 0/2 is down, line protocol is down (link down)
+Hardware is Ethernet, address is 6cb1.580f.b902 (bia 6cb1.580f.b902)
+"""
+    # napalm.mac() converts SLX-OS dotted form to canonical colon form, uppercase.
+    assert _parse_intf_hw_addresses(text) == {
+        "Ethernet 0/1": "6C:B1:58:0F:B9:01",
+        "Ethernet 0/2": "6C:B1:58:0F:B9:02",
+    }
+
+
+def test_parse_intf_hw_addresses_skips_block_without_hw_address():
+    """Loopback / VE / port-channel blocks lacking ``Hardware ... address`` are skipped."""
+    text = """\
+Ethernet 0/1 is up, line protocol is up
+Hardware is Ethernet, address is 6cb1.580f.b901 (bia 6cb1.580f.b901)
+
+Loopback 1 is up, line protocol is up
+Internet address is 10.0.0.1/32
+
+Port-channel 1 is up, line protocol is up
+Description: aggregate
+"""
+    assert _parse_intf_hw_addresses(text) == {"Ethernet 0/1": "6C:B1:58:0F:B9:01"}
+
+
+def test_parse_intf_hw_addresses_empty_and_none():
+    """Empty / None input → empty dict, never raises."""
+    assert _parse_intf_hw_addresses("") == {}
+    assert _parse_intf_hw_addresses(None) == {}  # type: ignore[arg-type]
+
+
+def test_parse_intf_hw_addresses_management_interface_included():
+    """Management 1 interface block is captured the same as Ethernet ports."""
+    text = """\
+Management 1 is up, line protocol is up
+Hardware is Ethernet, address is 6cb1.580f.b900 (bia 6cb1.580f.b900)
+"""
+    assert _parse_intf_hw_addresses(text) == {"Management 1": "6C:B1:58:0F:B9:00"}

--- a/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces/normal/expected_result.json
@@ -6,7 +6,7 @@
     "last_flapped": -1.0,
     "mtu": 0,
     "speed": 1000.0,
-    "mac_address": ""
+    "mac_address": "00:09:0F:09:00:01"
   },
   "port2": {
     "is_up": false,
@@ -15,6 +15,6 @@
     "last_flapped": -1.0,
     "mtu": 0,
     "speed": 0.0,
-    "mac_address": ""
+    "mac_address": "00:09:0F:09:00:02"
   }
 }

--- a/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces/normal/fnsysctl_ifconfig.txt
+++ b/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/mock_data/test_get_interfaces/normal/fnsysctl_ifconfig.txt
@@ -1,0 +1,13 @@
+port1   Link encap:Ethernet  HWaddr 00:09:0F:09:00:01
+        inet addr:192.168.1.1  Bcast:192.168.1.255  Mask:255.255.255.0
+        UP BROADCAST RUNNING ALLMULTI MULTICAST  MTU:1500  Metric:1
+        RX packets:1234 errors:0 dropped:0 overruns:0 frame:0
+        TX packets:5678 errors:0 dropped:0 overruns:0 carrier:0
+
+port2   Link encap:Ethernet  HWaddr 00:09:0F:09:00:02
+        BROADCAST MULTICAST  MTU:1500  Metric:1
+        RX packets:0 errors:0 dropped:0 overruns:0 frame:0
+
+lo      Link encap:Local Loopback
+        inet addr:127.0.0.1  Mask:255.0.0.0
+        UP LOOPBACK RUNNING  MTU:65536  Metric:1

--- a/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/test_driver.py
+++ b/device-discovery/tests/custom_drivers/fortinet_fortios_ssh/test_driver.py
@@ -2,7 +2,10 @@
 
 from pathlib import Path
 
-from custom_napalm.fortinet_fortios_ssh import FortiOSSSHDriver
+from custom_napalm.fortinet_fortios_ssh import (
+    FortiOSSSHDriver,
+    _parse_fnsysctl_mac_addresses,
+)
 from tests.custom_drivers.base_test import BaseDriverTest
 from tests.custom_drivers.mock_device import FakeCLIDevice
 
@@ -13,3 +16,41 @@ class TestFortiOSSSHDriver(BaseDriverTest):
     driver_cls = FortiOSSSHDriver
     fake_device_cls = FakeCLIDevice
     mock_data_root = Path(__file__).parent / "mock_data"
+
+
+# ---------------------------------------------------------------------------
+# _parse_fnsysctl_mac_addresses — parser unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_fnsysctl_mac_addresses_typical_two_ports():
+    """Two-NIC ``fnsysctl ifconfig`` output → {port: normalised MAC}."""
+    text = """\
+port1   Link encap:Ethernet  HWaddr 00:09:0F:09:00:01
+        inet addr:192.168.1.1  Mask:255.255.255.0
+        UP BROADCAST RUNNING
+
+port2   Link encap:Ethernet  HWaddr 00:09:0F:09:00:02
+        BROADCAST MULTICAST
+"""
+    assert _parse_fnsysctl_mac_addresses(text) == {
+        "port1": "00:09:0F:09:00:01",
+        "port2": "00:09:0F:09:00:02",
+    }
+
+
+def test_parse_fnsysctl_mac_addresses_skips_loopback():
+    """``Link encap:Local Loopback`` doesn't match the Ethernet-only header."""
+    text = """\
+port1   Link encap:Ethernet  HWaddr 00:09:0F:09:00:01
+
+lo      Link encap:Local Loopback
+        inet addr:127.0.0.1  Mask:255.0.0.0
+"""
+    assert _parse_fnsysctl_mac_addresses(text) == {"port1": "00:09:0F:09:00:01"}
+
+
+def test_parse_fnsysctl_mac_addresses_empty_and_none():
+    """Empty / None input → empty dict, never raises (admin without shell access)."""
+    assert _parse_fnsysctl_mac_addresses("") == {}
+    assert _parse_fnsysctl_mac_addresses(None) == {}  # type: ignore[arg-type]

--- a/device-discovery/tests/custom_drivers/hp_procurve/mock_data/test_get_interfaces/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/hp_procurve/mock_data/test_get_interfaces/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
-  "1": {"is_up": true, "is_enabled": true, "description": "", "last_flapped": -1.0, "mtu": -1, "speed": 1000.0, "mac_address": ""},
-  "2": {"is_up": false, "is_enabled": true, "description": "", "last_flapped": -1.0, "mtu": -1, "speed": 1000.0, "mac_address": ""},
-  "3": {"is_up": false, "is_enabled": false, "description": "", "last_flapped": -1.0, "mtu": -1, "speed": -1.0, "mac_address": ""},
-  "A1": {"is_up": true, "is_enabled": true, "description": "", "last_flapped": -1.0, "mtu": -1, "speed": 1000.0, "mac_address": ""}
+  "1": {"is_up": true, "is_enabled": true, "description": "", "last_flapped": -1.0, "mtu": -1, "speed": 1000.0, "mac_address": "00:12:34:56:78:01"},
+  "2": {"is_up": false, "is_enabled": true, "description": "", "last_flapped": -1.0, "mtu": -1, "speed": 1000.0, "mac_address": "00:12:34:56:78:02"},
+  "3": {"is_up": false, "is_enabled": false, "description": "", "last_flapped": -1.0, "mtu": -1, "speed": -1.0, "mac_address": "00:12:34:56:78:03"},
+  "A1": {"is_up": true, "is_enabled": true, "description": "", "last_flapped": -1.0, "mtu": -1, "speed": 1000.0, "mac_address": "00:12:34:56:78:A1"}
 }

--- a/device-discovery/tests/custom_drivers/hp_procurve/mock_data/test_get_interfaces/normal/show_interfaces_1_2_3_A1.txt
+++ b/device-discovery/tests/custom_drivers/hp_procurve/mock_data/test_get_interfaces/normal/show_interfaces_1_2_3_A1.txt
@@ -1,0 +1,32 @@
+ Status and Counters - Port Counters for port 1
+
+  Name (intended)                  : Uplink
+  MAC Address                      : 001234-567801
+  Link Status                      : Up
+  Totals (Since boot or last clear) :
+   Bytes Rx        : 1,234,567          Bytes Tx        : 7,654,321
+   Unicast Rx      : 100                Unicast Tx      : 200
+
+ Status and Counters - Port Counters for port 2
+
+  Name (intended)                  :
+  MAC Address                      : 001234-567802
+  Link Status                      : Down
+  Totals (Since boot or last clear) :
+   Bytes Rx        : 0                  Bytes Tx        : 0
+
+ Status and Counters - Port Counters for port 3
+
+  Name (intended)                  :
+  MAC Address                      : 001234-567803
+  Link Status                      : Down
+  Totals (Since boot or last clear) :
+   Bytes Rx        : 0                  Bytes Tx        : 0
+
+ Status and Counters - Port Counters for port A1
+
+  Name (intended)                  : SFP-uplink
+  MAC Address                      : 001234-5678A1
+  Link Status                      : Up
+  Totals (Since boot or last clear) :
+   Bytes Rx        : 50                 Bytes Tx        : 60

--- a/device-discovery/tests/custom_drivers/hp_procurve/test_driver.py
+++ b/device-discovery/tests/custom_drivers/hp_procurve/test_driver.py
@@ -2,7 +2,10 @@
 
 from pathlib import Path
 
-from custom_napalm.hp_procurve import ProcurveDriver
+from custom_napalm.hp_procurve import (
+    ProcurveDriver,
+    _parse_procurve_intf_mac_addresses,
+)
 from tests.custom_drivers.base_test import BaseDriverTest
 from tests.custom_drivers.mock_device import FakeCLIDevice
 
@@ -13,3 +16,62 @@ class TestProcurveDriver(BaseDriverTest):
     driver_cls = ProcurveDriver
     fake_device_cls = FakeCLIDevice
     mock_data_root = Path(__file__).parent / "mock_data"
+
+
+# ---------------------------------------------------------------------------
+# _parse_procurve_intf_mac_addresses — parser unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_procurve_intf_mac_addresses_typical_multi_block():
+    """Two-port ``show interfaces <port-list>`` output → {port: normalised mac}."""
+    text = """\
+ Status and Counters - Port Counters for port 1
+
+  Name (intended)                  : Uplink
+  MAC Address                      : 001234-567801
+  Link Status                      : Up
+
+ Status and Counters - Port Counters for port 2
+
+  Name (intended)                  :
+  MAC Address                      : 001234-567802
+  Link Status                      : Down
+"""
+    # napalm.mac() converts ProCurve dashed-pair form to canonical colon form.
+    assert _parse_procurve_intf_mac_addresses(text) == {
+        "1": "00:12:34:56:78:01",
+        "2": "00:12:34:56:78:02",
+    }
+
+
+def test_parse_procurve_intf_mac_addresses_module_port_id():
+    """Module-style port IDs like ``A1`` parse the same as plain numeric ports."""
+    text = """\
+ Status and Counters - Port Counters for port A1
+
+  MAC Address                      : 001234-5678A1
+  Link Status                      : Up
+"""
+    assert _parse_procurve_intf_mac_addresses(text) == {"A1": "00:12:34:56:78:A1"}
+
+
+def test_parse_procurve_intf_mac_addresses_skips_block_without_mac():
+    """A port block missing the MAC Address row is silently skipped (e.g. logical ports)."""
+    text = """\
+ Status and Counters - Port Counters for port 99
+
+  Name (intended)                  :
+  Link Status                      : Up
+
+ Status and Counters - Port Counters for port 100
+
+  MAC Address                      : 001234-567064
+"""
+    assert _parse_procurve_intf_mac_addresses(text) == {"100": "00:12:34:56:70:64"}
+
+
+def test_parse_procurve_intf_mac_addresses_empty_and_none():
+    """Empty / None input → empty dict, never raises."""
+    assert _parse_procurve_intf_mac_addresses("") == {}
+    assert _parse_procurve_intf_mac_addresses(None) == {}  # type: ignore[arg-type]

--- a/device-discovery/tests/custom_drivers/nokia_srl/mock_data/test_get_interfaces/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/nokia_srl/mock_data/test_get_interfaces/normal/expected_result.json
@@ -6,7 +6,7 @@
     "last_flapped": -1.0,
     "mtu": -1,
     "speed": 25000.0,
-    "mac_address": ""
+    "mac_address": "1A:CD:EE:FF:00:01"
   },
   "ethernet-1/1.0": {
     "is_up": true,
@@ -24,7 +24,7 @@
     "last_flapped": -1.0,
     "mtu": -1,
     "speed": -1.0,
-    "mac_address": ""
+    "mac_address": "1A:CD:EE:FF:00:02"
   },
   "mgmt0": {
     "is_up": true,
@@ -33,7 +33,7 @@
     "last_flapped": -1.0,
     "mtu": -1,
     "speed": 1000.0,
-    "mac_address": ""
+    "mac_address": "02:42:AC:12:00:06"
   },
   "mgmt0.0": {
     "is_up": true,

--- a/device-discovery/tests/custom_drivers/nokia_srl/mock_data/test_get_interfaces/normal/info_from_state_interface_ethernet_hw-mac-address.txt
+++ b/device-discovery/tests/custom_drivers/nokia_srl/mock_data/test_get_interfaces/normal/info_from_state_interface_ethernet_hw-mac-address.txt
@@ -1,0 +1,15 @@
+    interface ethernet-1/1 {
+        ethernet {
+            hw-mac-address 1A:CD:EE:FF:00:01
+        }
+    }
+    interface ethernet-1/2 {
+        ethernet {
+            hw-mac-address 1A:CD:EE:FF:00:02
+        }
+    }
+    interface mgmt0 {
+        ethernet {
+            hw-mac-address 02:42:AC:12:00:06
+        }
+    }

--- a/device-discovery/tests/custom_drivers/nokia_srl/test_driver.py
+++ b/device-discovery/tests/custom_drivers/nokia_srl/test_driver.py
@@ -91,3 +91,15 @@ def test_parse_hw_mac_addresses_skips_interfaces_without_ethernet_block():
 def test_parse_hw_mac_addresses_no_matches_returns_empty():
     """A blob with zero MAC blocks (e.g. error banner) returns an empty dict."""
     assert _parse_hw_mac_addresses("Error: invalid path\n") == {}
+
+
+def test_parse_hw_mac_addresses_accepts_non_padded_mac():
+    """napalm.mac() accepts ``aa:bb:cc:dd:ee:1`` and pads to ``AA:BB:CC:DD:EE:01`` — regex must allow shorter form too."""
+    text = """\
+    interface ethernet-1/1 {
+        ethernet {
+            hw-mac-address aa:bb:cc:dd:ee:1
+        }
+    }
+"""
+    assert _parse_hw_mac_addresses(text) == {"ethernet-1/1": "AA:BB:CC:DD:EE:01"}

--- a/device-discovery/tests/custom_drivers/nokia_srl/test_driver.py
+++ b/device-discovery/tests/custom_drivers/nokia_srl/test_driver.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from custom_napalm.nokia_srl import SRLDriver
+from custom_napalm.nokia_srl import SRLDriver, _parse_hw_mac_addresses
 from tests.custom_drivers.base_test import BaseDriverTest
 from tests.custom_drivers.mock_device import FakeCLIDevice
 
@@ -13,3 +13,81 @@ class TestSRLDriver(BaseDriverTest):
     driver_cls = SRLDriver
     fake_device_cls = FakeCLIDevice
     mock_data_root = Path(__file__).parent / "mock_data"
+
+
+# ---------------------------------------------------------------------------
+# _parse_hw_mac_addresses — parser unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_parse_hw_mac_addresses_typical_output():
+    """Three-interface YANG block → name→MAC dict, normalised to colon form."""
+    text = """\
+    interface ethernet-1/1 {
+        ethernet {
+            hw-mac-address 1A:CD:EE:FF:00:01
+        }
+    }
+    interface ethernet-1/2 {
+        ethernet {
+            hw-mac-address 1A:CD:EE:FF:00:02
+        }
+    }
+    interface mgmt0 {
+        ethernet {
+            hw-mac-address 02:42:AC:12:00:06
+        }
+    }
+"""
+    result = _parse_hw_mac_addresses(text)
+    assert result == {
+        "ethernet-1/1": "1A:CD:EE:FF:00:01",
+        "ethernet-1/2": "1A:CD:EE:FF:00:02",
+        "mgmt0": "02:42:AC:12:00:06",
+    }
+
+
+def test_parse_hw_mac_addresses_lowercase_normalised_to_canonical():
+    """Lowercase hex digits in source still resolve via napalm normalize_mac."""
+    text = """\
+    interface ethernet-1/3 {
+        ethernet {
+            hw-mac-address aa:bb:cc:dd:ee:ff
+        }
+    }
+"""
+    result = _parse_hw_mac_addresses(text)
+    # napalm.base.helpers.mac() upper-cases the canonical form.
+    assert result == {"ethernet-1/3": "AA:BB:CC:DD:EE:FF"}
+
+
+def test_parse_hw_mac_addresses_empty_and_none_inputs():
+    """Empty string and None inputs return empty dict — never raise."""
+    assert _parse_hw_mac_addresses("") == {}
+    assert _parse_hw_mac_addresses(None) == {}  # type: ignore[arg-type]
+
+
+def test_parse_hw_mac_addresses_skips_interfaces_without_ethernet_block():
+    """Loopback / system interfaces have no ethernet/hw-mac-address — silently skipped."""
+    text = """\
+    interface system0 {
+        admin-state enable
+    }
+    interface lo0 {
+        subinterface 0 {
+            admin-state enable
+        }
+    }
+    interface ethernet-1/1 {
+        ethernet {
+            hw-mac-address 1A:CD:EE:FF:00:01
+        }
+    }
+"""
+    # Only the ethernet-1/1 block matches.
+    assert _parse_hw_mac_addresses(text) == {"ethernet-1/1": "1A:CD:EE:FF:00:01"}
+
+
+def test_parse_hw_mac_addresses_no_matches_returns_empty():
+    """A blob with zero MAC blocks (e.g. error banner) returns an empty dict."""
+    assert _parse_hw_mac_addresses("Error: invalid path\n") == {}

--- a/device-discovery/tests/custom_drivers/nokia_sros_ssh/mock_data/test_get_interfaces/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/nokia_sros_ssh/mock_data/test_get_interfaces/normal/expected_result.json
@@ -6,7 +6,7 @@
     "last_flapped": -1.0,
     "mtu": 9212,
     "speed": 0.0,
-    "mac_address": ""
+    "mac_address": "90:EC:00:00:00:01"
   },
   "1/1/2": {
     "is_enabled": true,
@@ -15,7 +15,7 @@
     "last_flapped": -1.0,
     "mtu": 1518,
     "speed": 0.0,
-    "mac_address": ""
+    "mac_address": "90:EC:00:00:00:02"
   },
   "1/1/3": {
     "is_enabled": true,
@@ -24,6 +24,6 @@
     "last_flapped": -1.0,
     "mtu": 1518,
     "speed": 0.0,
-    "mac_address": ""
+    "mac_address": "90:EC:00:00:00:03"
   }
 }

--- a/device-discovery/tests/custom_drivers/nokia_sros_ssh/mock_data/test_get_interfaces/normal/show_port_detail.txt
+++ b/device-discovery/tests/custom_drivers/nokia_sros_ssh/mock_data/test_get_interfaces/normal/show_port_detail.txt
@@ -1,0 +1,42 @@
+===============================================================================
+Ethernet Interface
+===============================================================================
+Description        : 10/100/Gig Ethernet SFP
+Interface          : 1/1/1                      Oper Speed       : 1 Gbps
+Link-level         : Ethernet                   Config Speed     : 1 Gbps
+Admin State        : up                         Oper Duplex      : full
+Oper State         : up                         Config Duplex    : full
+Physical Link      : Yes                        MTU              : 9212
+IfIndex            : 35684352                   Hold time up     : 0 seconds
+Last State Change  : 12d 7h 23m 38s             Hold time down   : 0 seconds
+Configured Mac     : 90:ec:00:00:00:01
+Hardware Mac       : 90:ec:00:00:00:01
+===============================================================================
+===============================================================================
+Ethernet Interface
+===============================================================================
+Description        : 10/100/Gig Ethernet SFP
+Interface          : 1/1/2                      Oper Speed       : 1 Gbps
+Link-level         : Ethernet                   Config Speed     : 1 Gbps
+Admin State        : up                         Oper Duplex      : full
+Oper State         : up                         Config Duplex    : full
+Physical Link      : Yes                        MTU              : 1518
+IfIndex            : 35684608                   Hold time up     : 0 seconds
+Last State Change  : 12d 7h 23m 38s             Hold time down   : 0 seconds
+Configured Mac     : 90:ec:00:00:00:02
+Hardware Mac       : 90:ec:00:00:00:02
+===============================================================================
+===============================================================================
+Ethernet Interface
+===============================================================================
+Description        :
+Interface          : 1/1/3                      Oper Speed       : N/A
+Link-level         : Ethernet                   Config Speed     : 1 Gbps
+Admin State        : up                         Oper Duplex      : N/A
+Oper State         : down                       Config Duplex    : full
+Physical Link      : No                         MTU              : 1518
+IfIndex            : 35684864                   Hold time up     : 0 seconds
+Last State Change  : 12d 7h 23m 38s             Hold time down   : 0 seconds
+Configured Mac     : 90:ec:00:00:00:03
+Hardware Mac       : 90:ec:00:00:00:03
+===============================================================================

--- a/device-discovery/tests/custom_drivers/nokia_sros_ssh/test_driver.py
+++ b/device-discovery/tests/custom_drivers/nokia_sros_ssh/test_driver.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from custom_napalm.nokia_sros_ssh import SROSSSHDriver
+from custom_napalm.nokia_sros_ssh import SROSSSHDriver, _parse_port_hw_mac_addresses
 from tests.custom_drivers.base_test import BaseDriverTest
 from tests.custom_drivers.mock_device import FakeCLIDevice
 
@@ -13,3 +13,78 @@ class TestSROSSSHDriver(BaseDriverTest):
     driver_cls = SROSSSHDriver
     fake_device_cls = FakeCLIDevice
     mock_data_root = Path(__file__).parent / "mock_data"
+
+
+# ---------------------------------------------------------------------------
+# _parse_port_hw_mac_addresses — parser unit tests
+# ---------------------------------------------------------------------------
+
+
+_SHOW_PORT_DETAIL_TWO_PORTS = """\
+===============================================================================
+Ethernet Interface
+===============================================================================
+Interface          : 1/1/1                      Oper Speed       : 1 Gbps
+Admin State        : up                         Oper Duplex      : full
+Configured Mac     : 90:ec:00:00:00:01
+Hardware Mac       : 90:ec:00:00:00:01
+===============================================================================
+===============================================================================
+Ethernet Interface
+===============================================================================
+Interface          : 1/1/2                      Oper Speed       : 1 Gbps
+Admin State        : up                         Oper Duplex      : full
+Configured Mac     : 90:ec:00:00:00:02
+Hardware Mac       : 90:ec:00:00:00:02
+===============================================================================
+"""
+
+
+def test_parse_port_hw_mac_addresses_typical_multi_block():
+    """Two consecutive port blocks → port_id → normalised MAC dict."""
+    result = _parse_port_hw_mac_addresses(_SHOW_PORT_DETAIL_TWO_PORTS)
+    assert result == {
+        "1/1/1": "90:EC:00:00:00:01",
+        "1/1/2": "90:EC:00:00:00:02",
+    }
+
+
+def test_parse_port_hw_mac_addresses_empty_input_returns_empty():
+    """Empty / None input never raises — empty dict result."""
+    assert _parse_port_hw_mac_addresses("") == {}
+    assert _parse_port_hw_mac_addresses(None) == {}  # type: ignore[arg-type]
+
+
+def test_parse_port_hw_mac_addresses_skips_block_without_hw_mac():
+    """A block with Interface but no Hardware Mac row is silently skipped."""
+    text = """\
+===============================================================================
+Ethernet Interface
+===============================================================================
+Interface          : 1/1/9                      Oper Speed       : N/A
+Admin State        : down
+Configured Mac     : N/A
+===============================================================================
+===============================================================================
+Ethernet Interface
+===============================================================================
+Interface          : 1/1/10                     Oper Speed       : 10 Gbps
+Hardware Mac       : 90:ec:00:00:00:0a
+===============================================================================
+"""
+    # 1/1/9 lacks a Hardware Mac row → skipped. 1/1/10 still resolves.
+    assert _parse_port_hw_mac_addresses(text) == {"1/1/10": "90:EC:00:00:00:0A"}
+
+
+def test_parse_port_hw_mac_addresses_prefers_hardware_over_configured():
+    """When both ``Configured Mac`` and ``Hardware Mac`` are present, only Hardware is taken."""
+    text = """\
+===============================================================================
+Ethernet Interface
+===============================================================================
+Interface          : 1/1/1
+Configured Mac     : aa:bb:cc:dd:ee:ff
+Hardware Mac       : 90:ec:00:00:00:01
+===============================================================================
+"""
+    assert _parse_port_hw_mac_addresses(text) == {"1/1/1": "90:EC:00:00:00:01"}

--- a/device-discovery/tests/custom_drivers/nokia_sros_ssh/test_driver.py
+++ b/device-discovery/tests/custom_drivers/nokia_sros_ssh/test_driver.py
@@ -88,3 +88,28 @@ Hardware Mac       : 90:ec:00:00:00:01
 ===============================================================================
 """
     assert _parse_port_hw_mac_addresses(text) == {"1/1/1": "90:EC:00:00:00:01"}
+
+
+def test_parse_port_hw_mac_addresses_md_cli_hardware_address_label():
+    """MD-CLI (SR-OS 19+) uses ``Hardware Address`` instead of ``Hardware Mac``."""
+    text = """\
+===============================================================================
+Ethernet Interface
+===============================================================================
+Interface         : 1/1/c2/1                   Oper Speed         : 10 Gbps
+Configured Address: aa:bb:cc:dd:ee:42
+Hardware Address  : 90:ec:00:00:00:42
+===============================================================================
+"""
+    assert _parse_port_hw_mac_addresses(text) == {"1/1/c2/1": "90:EC:00:00:00:42"}
+
+
+def test_parse_port_hw_mac_addresses_accepts_non_padded_mac():
+    """napalm.mac() accepts ``aa:bb:cc:dd:ee:1`` and pads to ``AA:BB:CC:DD:EE:01`` — regex must allow shorter form too."""
+    text = """\
+===============================================================================
+Interface          : 1/1/1
+Hardware Mac       : aa:bb:cc:dd:ee:1
+===============================================================================
+"""
+    assert _parse_port_hw_mac_addresses(text) == {"1/1/1": "AA:BB:CC:DD:EE:01"}


### PR DESCRIPTION
## Summary

Populates `Interface.mac_address` on five custom NAPALM drivers that previously emitted empty strings. Each driver gains MAC support via a **single additional SSH round-trip** (no per-port iteration) so the discovery-cycle cost is bounded regardless of port count.

| Driver | Source command | Pattern |
|---|---|---|
| **`nokia_srl`** | `info from state interface * ethernet hw-mac-address` | Single wildcard YANG-state call. Mirrors the community napalm-srlinux driver which reads the same field via gNMI. |
| **`nokia_sros_ssh`** | `show port detail` (no port-id) | One command, multi-block output, one block per port. Accepts both Classic-CLI (`Hardware Mac`) and MD-CLI 19+ (`Hardware Address`) labels. Mirrors the NETCONF sibling driver. |
| **`extreme_slx`** | `show interface` (no port-arg) | One command, multi-block per-port output. Parses `Hardware is Ethernet, address is xxxx.xxxx.xxxx`. |
| **`hp_procurve`** | `show interfaces <port-list>` | Comma-separated port list (chunked at 24 ports per call to stay under CLI input limits on large chassis). Parses `MAC Address` row per block. |
| **`fortinet_fortios_ssh`** | `fnsysctl ifconfig` | Single shell-passthrough call. Parses `HWaddr` on Ethernet-encap lines. Loopback/tunnel blocks skipped. Admin profiles without shell access degrade silently to empty MAC. |

All five drivers normalise through `napalm.base.helpers.mac()` so vendor-specific MAC formats (`xxxx.xxxx.xxxx`, `xxxxxx-xxxxxx`, padded/non-padded, dashed/colon/dotted) emit canonical uppercase colon form to NetBox.

### CLAUDE.md (custom_napalm guide)
- New "`get_interfaces()` — `mac_address` field" section documenting when to populate, acceptable sources (CLI / structured API / gNMI / NETCONF), normalization through `napalm.mac()`, and the legitimate "no per-port MAC" platforms.
- Three platforms documented as intentionally `mac_address=""`: **Cisco SG300/SG350/SG550** (chassis-only MAC), **AireOS WLC** (mostly virtual interfaces), **Extreme EXOS** (all ports share the system MAC by design).

### Out of scope (deferred)

The remaining unsupported drivers all require **per-port SSH iteration** (N extra round-trips per discovery cycle) and were not included in this batch:

- `aruba_os`, `aruba_osswitch`, `ciena_saos`, `dell_powerconnect`, `dell_sonic`, `ericsson_ipos`, `ubiquiti_edgerouter`, `ubiquiti_edgeswitch`, `ubiquiti_unifiswitch`.

Each would be a clean per-driver follow-up if a customer asks; the implementation pattern is established by this PR.

## Codex review

Branch was reviewed by `codex` twice — once after the Nokia pair and once after the Extreme/HP/Fortinet additions. All findings addressed:

- **P1 (Nokia SR-OS)**: MD-CLI 19+ uses `Hardware Address` not `Hardware Mac` — regex now accepts both.
- **P2 (HP ProCurve)**: port-list could exceed CLI input limits on large chassis — now chunked at 24 ports per call.
- **P3 (multiple)**: MAC capture group lacked end-of-token anchor on SLX-OS and FortiOS — added `\b`. Silent fallback on `normalize_mac()` failure replaced with WARNING log + empty MAC.
- **Non-padded MAC**: SR Linux + SR-OS regex relaxed from `{17}` to `{12,17}` so `napalm.mac()` — not the regex — validates the format. Covers shortened variants like `aa:bb:cc:dd:ee:1`.

## Test plan
- [x] `pytest tests/` — 1383 passed, 128 skipped (added 16 new parser-focused unit tests across the 5 drivers).
- [x] `ruff check device_discovery/ custom_napalm/ tests/` clean.
- [x] Fixture-based `test_get_interfaces` paths for all 5 drivers now assert populated MAC values against new mock fixtures.
- [x] Each parser unit-tested for: typical multi-port output, vendor-specific MAC formats, empty/None inputs, blocks-missing-MAC, MD-CLI vs Classic CLI variants (SR-OS), non-padded MAC variants (SR Linux, SR-OS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)