### PR TITLE
feat(snmp-discovery): Module/ModuleBay discovery via ENTITY-MIB (OBS-1828)

### DIFF
--- a/snmp-discovery/README.md
+++ b/snmp-discovery/README.md
@@ -373,6 +373,42 @@ This means subinterfaces **always** receive the "virtual" type, even if:
 - Speed-based detection would assign a different type
 
 
+### Module / ModuleBay Discovery
+
+Opt-in emission of NetBox `Module` and `ModuleBay` entities on modular chassis, sourced from the standard ENTITY-MIB `entPhysicalTable`. Vendor-neutral — works on any device that populates the MIB (Cisco IOS / IOS-XE / NX-OS, Juniper, Arista, Aruba CX, Nokia SROS, and others).
+
+Controlled by the `discover_modules` option under `config.options`:
+
+| Mode | Behaviour |
+|---|---|
+| `off` *(default)* | No module / module-bay entities emitted. Zero behaviour change versus prior releases. |
+| `linecards` | One `ModuleBay` + `Module` per top-level chassis slot — line cards and supervisors only. PSU and fan modules are classified for metric labelling but NOT emitted. |
+| `full` | Everything `linecards` emits, plus one `ModuleBay` + `Module` per transceiver sub-bay. Physical interfaces backed by a transceiver carry an `Interface.Module` reference for per-port optic visibility. |
+
+Virtual-chassis-of-modular targets are supported from day one: when the device reports 2+ chassis members, modules are dispatched per-member using the same chassis inventory the VC path produces.
+
+**Sub-bay rendering note (transient, `full` mode only).** Transceiver sub-bays are currently emitted device-rooted rather than nested under the parent line card, due to a Diode reconciler limitation. The transceiver `Module` still installs into the sub-bay via `Module.ModuleBay`, so per-port optic visibility is preserved; only the bay-under-linecard visual hierarchy is missing. This will be restored once the reconciler supports single-batch plan-and-apply.
+
+#### Example
+
+```yaml
+policies:
+  snmp_modular_chassis:
+    config:
+      schedule: "0 */6 * * *"
+      options:
+        discover_modules: linecards   # off | linecards | full
+      defaults:
+        site: "datacenter-01"
+    scope:
+      targets:
+        - host: "10.0.0.1"
+      authentication:
+        protocol_version: "v2c"
+        community: "public"
+```
+
+
 ### Device Model Lookup
 The `lookup_extensions_dir` specifies a directory containing device data YAML files that map SNMP device OIDs to human-readable device names. This allows snmp-discovery to provide meaningful device identification instead of raw OID values. This only needs to be set if additional or modified files are being provided instead of the ones that are included with orb-discovery and orb-agent.
 

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -204,6 +204,25 @@ func MergeDefaults(policyDefaults, overrideDefaults *Defaults) *Defaults {
 // Options represents per-policy global behavior toggles peer to Defaults.
 type Options struct {
 	CreateUnknownVlans *bool `yaml:"create_unknown_vlans,omitempty"`
+
+	// Tri-state pointer so we can distinguish unset (default = "off") from
+	// explicit "off". Values:
+	//   nil         → treat as "off" (default; zero behaviour change)
+	//   "off"       → no module / module bay entities emitted
+	//   "linecards" → top-level chassis-slot modules (linecards + supervisors;
+	//                 PSU/fan classified for labelling but NOT emitted);
+	//                 transceiver sub-bays dropped
+	//   "full"      → linecards plus per-transceiver sub-bays; populates
+	//                 Interface.Module on physical ports
+	DiscoverModules *string `yaml:"discover_modules,omitempty"`
+}
+
+// ModuleDiscoveryMode returns the effective mode, defaulting to "off".
+func (o *Options) ModuleDiscoveryMode() string {
+	if o == nil || o.DiscoverModules == nil {
+		return "off"
+	}
+	return *o.DiscoverModules
 }
 
 // PolicyConfig represents the configuration of a policy

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -201,6 +201,14 @@ func MergeDefaults(policyDefaults, overrideDefaults *Defaults) *Defaults {
 	return &merged
 }
 
+// DiscoverModules* are the accepted values for options.discover_modules.
+// Off is the default when the field is unset.
+const (
+	DiscoverModulesOff       = "off"
+	DiscoverModulesLinecards = "linecards"
+	DiscoverModulesFull      = "full"
+)
+
 // Options represents per-policy global behavior toggles peer to Defaults.
 type Options struct {
 	CreateUnknownVlans *bool `yaml:"create_unknown_vlans,omitempty"`
@@ -220,7 +228,7 @@ type Options struct {
 // ModuleDiscoveryMode returns the effective mode, defaulting to "off".
 func (o *Options) ModuleDiscoveryMode() string {
 	if o == nil || o.DiscoverModules == nil {
-		return "off"
+		return DiscoverModulesOff
 	}
 	return *o.DiscoverModules
 }

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -493,3 +493,33 @@ func TestMergeDefaults_AssetTag_NoOverride(t *testing.T) {
 	merged := MergeDefaults(policy, nil)
 	assert.Equal(t, "POLICY-TAG", merged.AssetTag)
 }
+
+func TestPolicyOptions_DiscoverModulesDefaultsToOff(t *testing.T) {
+	raw := []byte(`
+options:
+  create_unknown_vlans: true
+`)
+	var pc PolicyConfig
+	require.NoError(t, yaml.Unmarshal(raw, &pc))
+	assert.Equal(t, "off", pc.Options.ModuleDiscoveryMode(),
+		"DiscoverModules should default to off when omitted")
+}
+
+func TestPolicyOptions_DiscoverModulesParsed(t *testing.T) {
+	cases := []struct {
+		in  string
+		out string
+	}{
+		{"off", "off"},
+		{"linecards", "linecards"},
+		{"full", "full"},
+	}
+	for _, c := range cases {
+		t.Run(c.in, func(t *testing.T) {
+			raw := []byte("options:\n  discover_modules: " + c.in + "\n")
+			var pc PolicyConfig
+			require.NoError(t, yaml.Unmarshal(raw, &pc))
+			assert.Equal(t, c.out, pc.Options.ModuleDiscoveryMode())
+		})
+	}
+}

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -506,13 +506,16 @@ options:
 }
 
 func TestPolicyOptions_DiscoverModulesParsed(t *testing.T) {
+	// YAML wire format stays as literal strings (that's what we test);
+	// expected outputs use the package constants so the test fails
+	// loudly if a constant value ever drifts.
 	cases := []struct {
 		in  string
 		out string
 	}{
-		{"off", "off"},
-		{"linecards", "linecards"},
-		{"full", "full"},
+		{"off", DiscoverModulesOff},
+		{"linecards", DiscoverModulesLinecards},
+		{"full", DiscoverModulesFull},
 	}
 	for _, c := range cases {
 		t.Run(c.in, func(t *testing.T) {

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -501,7 +501,7 @@ options:
 `)
 	var pc PolicyConfig
 	require.NoError(t, yaml.Unmarshal(raw, &pc))
-	assert.Equal(t, "off", pc.Options.ModuleDiscoveryMode(),
+	assert.Equal(t, DiscoverModulesOff, pc.Options.ModuleDiscoveryMode(),
 		"DiscoverModules should default to off when omitted")
 }
 

--- a/snmp-discovery/mapping/chassis.go
+++ b/snmp-discovery/mapping/chassis.go
@@ -219,6 +219,22 @@ func extractInventory(oids ObjectIDValueMap, logger *slog.Logger) ChassisInvento
 	}
 }
 
+// ChassisInventoryFromEntities returns the parsed ChassisInventory for
+// the device described by oids. Thin exported wrapper around
+// extractInventory so the runner can re-derive what TranslateAsStack
+// computed internally without duplicating the parse. The entities arg
+// is unused today but kept for API symmetry — future implementations
+// may derive parts of the inventory from already-emitted entities
+// rather than re-parsing oids.
+func ChassisInventoryFromEntities(
+	_ []diode.Entity,
+	oids ObjectIDValueMap,
+	logger *slog.Logger,
+) *ChassisInventory {
+	inv := extractInventory(oids, logger)
+	return &inv
+}
+
 // buildMasterRef returns a non-recursive matcher-only Device for use
 // as VirtualChassis.Master on the top-level VC entity AND on each
 // non-master member Device's VirtualChassis.Master.

--- a/snmp-discovery/mapping/chassis.go
+++ b/snmp-discovery/mapping/chassis.go
@@ -219,18 +219,11 @@ func extractInventory(oids ObjectIDValueMap, logger *slog.Logger) ChassisInvento
 	}
 }
 
-// ChassisInventoryFromEntities returns the parsed ChassisInventory for
-// the device described by oids. Thin exported wrapper around
+// ChassisInventoryFromOIDs returns the parsed ChassisInventory for the
+// device described by oids. Thin exported wrapper around
 // extractInventory so the runner can re-derive what TranslateAsStack
-// computed internally without duplicating the parse. The entities arg
-// is unused today but kept for API symmetry — future implementations
-// may derive parts of the inventory from already-emitted entities
-// rather than re-parsing oids.
-func ChassisInventoryFromEntities(
-	_ []diode.Entity,
-	oids ObjectIDValueMap,
-	logger *slog.Logger,
-) *ChassisInventory {
+// computed internally.
+func ChassisInventoryFromOIDs(oids ObjectIDValueMap, logger *slog.Logger) *ChassisInventory {
 	inv := extractInventory(oids, logger)
 	return &inv
 }

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -293,6 +293,11 @@ const (
 	// associated mapper is a no-op; data flows via the raw oids map
 	// passed to TranslateAsStack.
 	ChassisInventoryEntityType EntityType = "chassis_inventory"
+	// ChassisModuleEntityType is a pseudo-entity that flags ENTITY-MIB
+	// rows (entPhysicalDescr, entPhysicalVendorType) for consumption by
+	// TranslateModulesWithAlias as a post-pass. Map() on its associated
+	// mapper is a no-op; data flows via the raw oids map.
+	ChassisModuleEntityType EntityType = "chassis_module"
 )
 
 // ObjectIDMapper is a struct that maps ObjectIDs to entities
@@ -431,6 +436,7 @@ func NewConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturer
 		"vlan":                             vlanMapper,
 		"interface_vlan":                   vlanMapper,
 		string(ChassisInventoryEntityType): &ChassisInventoryMapper{logger: logger},
+		string(ChassisModuleEntityType):    &ChassisModuleMapper{logger: logger},
 	}
 	postPassMappers := []postPassMapper{vlanMapper}
 	// Validate index_kind on every entry (top-level and nested). A typo

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -1499,7 +1499,15 @@ func (m *Config) VendorObjectIDs(vendor string) map[string]int {
 // and VendorObjectIDs. When generic==true it selects entries with an empty
 // Vendor field; otherwise it selects entries matching the given vendor string.
 // Child-expansion follows the same rules as ObjectIDs.
+//
+// Gating: child entries flagged with entity "chassis_module" (ENTITY-MIB
+// entPhysicalDescr / entPhysicalVendorType) are consumed exclusively by
+// the module / module bay post-pass. When discover_modules is off (the
+// default), TranslateModulesWithAlias short-circuits before reading them,
+// so walking those columns is wasted SNMP work on large modular chassis.
+// Skip them from the walk set in mode=off; include them in linecards / full.
 func (m *Config) objectIDsForVendor(vendor string, generic bool) map[string]int {
+	skipChassisModule := m.options.ModuleDiscoveryMode() == config.DiscoverModulesOff
 	out := make(map[string]int)
 	for _, entry := range m.mapping {
 		if generic {
@@ -1513,6 +1521,9 @@ func (m *Config) objectIDsForVendor(vendor string, generic bool) map[string]int 
 		}
 		if len(entry.MappingEntries) > 0 {
 			for _, childEntry := range entry.MappingEntries {
+				if skipChassisModule && childEntry.Entity == string(ChassisModuleEntityType) {
+					continue
+				}
 				if childEntry.IdentifierSize == 0 {
 					out[childEntry.OID] = 1
 				} else {
@@ -1520,6 +1531,9 @@ func (m *Config) objectIDsForVendor(vendor string, generic bool) map[string]int 
 				}
 			}
 		} else {
+			if skipChassisModule && entry.Entity == string(ChassisModuleEntityType) {
+				continue
+			}
 			if entry.IdentifierSize == 0 {
 				out[entry.OID] = 1
 			} else {

--- a/snmp-discovery/mapping/mapping_test.go
+++ b/snmp-discovery/mapping/mapping_test.go
@@ -2044,6 +2044,109 @@ func TestConfig_VendorPartitioning(t *testing.T) {
 	}
 }
 
+// TestGenericObjectIDs_ChassisModuleColumnsGatedByDiscoverModules asserts that
+// the two ENTITY-MIB columns consumed exclusively by module / module bay
+// discovery (entPhysicalDescr and entPhysicalVendorType, child entries with
+// entity "chassis_module") are skipped from the generic walk OID set when
+// options.discover_modules is off (the default). They must be present when
+// the mode is "linecards" or "full". Pure walk-optimization gating: the
+// downstream TranslateModulesWithAlias path already short-circuits on
+// mode=off, so this purely removes unnecessary SNMP traffic on large
+// modular chassis.
+func TestGenericObjectIDs_ChassisModuleColumnsGatedByDiscoverModules(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	const (
+		descrOID      = ".1.3.6.1.2.1.47.1.1.1.1.2"
+		vendorTypeOID = ".1.3.6.1.2.1.47.1.1.1.1.3"
+		parentOID     = ".1.3.6.1.2.1.47.1.1.1"
+	)
+
+	// Mirror the chassis_inventory parent + chassis_module children block
+	// in policy/mapping.yaml.
+	mappings := []config.MappingEntry{
+		{
+			OID: parentOID, Entity: "chassis_inventory", Field: "_id", IdentifierSize: 2,
+			MappingEntries: []config.MappingEntry{
+				{OID: descrOID, Entity: "chassis_module", Field: "descr"},
+				{OID: vendorTypeOID, Entity: "chassis_module", Field: "vendor_type"},
+				{OID: ".1.3.6.1.2.1.47.1.1.1.1.5", Entity: "chassis_inventory", Field: "class"},
+				{OID: ".1.3.6.1.2.1.47.1.1.1.1.11", Entity: "chassis_inventory", Field: "serialNumber"},
+			},
+		},
+	}
+
+	cases := []struct {
+		name         string
+		opts         config.Options
+		wantIncluded bool
+	}{
+		{
+			name:         "default (unset) -> off, columns absent",
+			opts:         config.Options{},
+			wantIncluded: false,
+		},
+		{
+			name: "explicit off, columns absent",
+			opts: func() config.Options {
+				v := config.DiscoverModulesOff
+				return config.Options{DiscoverModules: &v}
+			}(),
+			wantIncluded: false,
+		},
+		{
+			name: "linecards, columns present",
+			opts: func() config.Options {
+				v := config.DiscoverModulesLinecards
+				return config.Options{DiscoverModules: &v}
+			}(),
+			wantIncluded: true,
+		},
+		{
+			name: "full, columns present",
+			opts: func() config.Options {
+				v := config.DiscoverModulesFull
+				return config.Options{DiscoverModules: &v}
+			}(),
+			wantIncluded: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg, err := mapping.NewConfig(mappings, logger, nil, nil, &config.Defaults{}, tc.opts)
+			if err != nil {
+				t.Fatalf("NewConfig: %v", err)
+			}
+			gen := cfg.GenericObjectIDs()
+			_, hasDescr := gen[descrOID]
+			_, hasVendorType := gen[vendorTypeOID]
+			if tc.wantIncluded {
+				if !hasDescr {
+					t.Errorf("expected %s in generic OIDs", descrOID)
+				}
+				if !hasVendorType {
+					t.Errorf("expected %s in generic OIDs", vendorTypeOID)
+				}
+			} else {
+				if hasDescr {
+					t.Errorf("unexpected %s in generic OIDs (mode=off should skip)", descrOID)
+				}
+				if hasVendorType {
+					t.Errorf("unexpected %s in generic OIDs (mode=off should skip)", vendorTypeOID)
+				}
+			}
+			// Sibling chassis_inventory columns must remain regardless of mode.
+			if _, ok := gen[".1.3.6.1.2.1.47.1.1.1.1.5"]; !ok {
+				t.Error("chassis_inventory column .1.3.6.1.2.1.47.1.1.1.1.5 must be present in all modes")
+			}
+			if _, ok := gen[".1.3.6.1.2.1.47.1.1.1.1.11"]; !ok {
+				t.Error("chassis_inventory column .1.3.6.1.2.1.47.1.1.1.1.11 must be present in all modes")
+			}
+		})
+	}
+}
+
 func TestMappingYAML_QBridgeEntriesPresent(t *testing.T) {
 	body, err := os.ReadFile("../policy/mapping.yaml")
 	if err != nil {

--- a/snmp-discovery/mapping/module.go
+++ b/snmp-discovery/mapping/module.go
@@ -12,11 +12,10 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/metrics"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // entPhysical column prefixes specific to module discovery (the rest
@@ -52,12 +51,13 @@ func (m *ChassisModuleMapper) Map(
 // transceivers) and downstream Diode emission as Module.Type.
 type ModuleType string
 
+// Module-type tags returned by classifyModule.
 const (
 	ModuleTypeLinecard    ModuleType = "linecard"
 	ModuleTypeSupervisor  ModuleType = "supervisor"
 	ModuleTypeTransceiver ModuleType = "transceiver"
-	ModuleTypePSU         ModuleType = "psu"     // classified for labelling only; never emitted as a module entity
-	ModuleTypeFan         ModuleType = "fan"     // classified for labelling only; never emitted as a module entity
+	ModuleTypePSU         ModuleType = "psu" // classified for labelling only; never emitted as a module entity
+	ModuleTypeFan         ModuleType = "fan" // classified for labelling only; never emitted as a module entity
 	ModuleTypeUnknown     ModuleType = "unknown"
 )
 

--- a/snmp-discovery/mapping/module.go
+++ b/snmp-discovery/mapping/module.go
@@ -411,13 +411,28 @@ func isPSUPID(upper string) bool {
 }
 
 // isFanPID recognises fan-tray PIDs on an already upper-cased PID.
-// Covers bare prefix (FAN, FAN-T1-R) and model-prefixed Cisco forms
-// where -FAN appears as suffix or middle token (C9400-FAN, C9404R-FAN-2).
+// Tightened to require -FAN as a delimited token (suffix, or followed
+// by a digit) so embedded substrings like C9400-FANTOM-LC do not match.
+// Accepts: FAN-* prefix, FAN<digit> prefix, -FAN suffix, -FAN-<digit>.
 func isFanPID(upper string) bool {
-	if strings.HasPrefix(upper, "FAN") {
+	if upper == "" {
+		return false
+	}
+	if strings.HasPrefix(upper, "FAN-") {
 		return true
 	}
-	if strings.Contains(upper, "-FAN") {
+	if strings.HasSuffix(upper, "-FAN") {
+		return true
+	}
+	// -FAN- followed by a digit (model-suffixed pattern: -FAN-2, -FAN-2KW)
+	if idx := strings.Index(upper, "-FAN-"); idx >= 0 {
+		rest := upper[idx+len("-FAN-"):]
+		if rest != "" && rest[0] >= '0' && rest[0] <= '9' {
+			return true
+		}
+	}
+	// Bare FAN followed by a digit (FAN1, FAN2T)
+	if strings.HasPrefix(upper, "FAN") && len(upper) > 3 && upper[3] >= '0' && upper[3] <= '9' {
 		return true
 	}
 	return false

--- a/snmp-discovery/mapping/module.go
+++ b/snmp-discovery/mapping/module.go
@@ -6,12 +6,17 @@
 package mapping
 
 import (
+	"context"
 	"log/slog"
 	"sort"
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/metrics"
 )
 
 // entPhysical column prefixes specific to module discovery (the rest
@@ -275,6 +280,11 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 				"ent", r.EntIndex,
 				"model", r.Model,
 				"reason", "orphan_containment")
+			if c := metrics.GetModulesDropped(); c != nil {
+				c.Add(context.Background(), 1, metric.WithAttributes(
+					attribute.String("reason", "orphan_containment"),
+				))
+			}
 			continue
 		}
 		if r.Serial != "" {
@@ -285,6 +295,11 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 					"serial", r.Serial,
 					"model", r.Model,
 					"reason", "dup_serial")
+				if c := metrics.GetModulesDropped(); c != nil {
+					c.Add(context.Background(), 1, metric.WithAttributes(
+						attribute.String("reason", "dup_serial"),
+					))
+				}
 				continue
 			}
 			seenSerial[key] = struct{}{}

--- a/snmp-discovery/mapping/module.go
+++ b/snmp-discovery/mapping/module.go
@@ -1,0 +1,30 @@
+// Package mapping — module.go: scaffold for chassis module / module
+// bay discovery on modular Cisco IOS-XE chassis. ChassisModuleMapper
+// is intentionally a no-op; it exists only to register the
+// entPhysicalDescr + entPhysicalVendorType walk columns. The actual
+// translation lives in TranslateModulesWithAlias in module_translate.go.
+package mapping
+
+import (
+	"log/slog"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+)
+
+// ChassisModuleMapper is a no-op orbToEntityMapper. See package file
+// doc — data flows through the raw oids map into
+// TranslateModulesWithAlias, not via this Map call.
+type ChassisModuleMapper struct {
+	logger *slog.Logger
+}
+
+// Map is intentionally a no-op — see type doc.
+func (m *ChassisModuleMapper) Map(
+	_ map[ObjectIDIndex]*ObjectIDValue,
+	_ *Entry,
+	_ *EntityRegistry,
+	_ *config.Defaults,
+) diode.Entity {
+	return nil
+}

--- a/snmp-discovery/mapping/module.go
+++ b/snmp-discovery/mapping/module.go
@@ -7,10 +7,22 @@ package mapping
 
 import (
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+)
+
+// entPhysical column prefixes specific to module discovery (the rest
+// — class, containedIn, parentRel, name, serial, model — live in
+// chassis.go and are reused here).
+const (
+	oidEntPhysicalDescr      = ".1.3.6.1.2.1.47.1.1.1.1.2."
+	oidEntPhysicalVendorType = ".1.3.6.1.2.1.47.1.1.1.1.3."
+
+	entPhysicalClassModule    = "9"
+	entPhysicalClassContainer = "5"
 )
 
 // ChassisModuleMapper is a no-op orbToEntityMapper. See package file
@@ -129,6 +141,217 @@ func classifyModule(model, vendorType string, hasModuleParent bool) ModuleType {
 	// Safe default — non-optic under a module parent OR no special
 	// pattern at chassis level both land here.
 	return ModuleTypeLinecard
+}
+
+// extractModuleInventory scans oids for class=9 entPhysical rows and
+// classifies each one. Drops orphans (broken containedIn chain) and
+// unclassifiable rows (class=1/2). Walks the containedIn chain to
+// determine the owning bay (class=5 ancestor) and whether the module
+// sits under another class=9 module (transceiver candidate).
+//
+// Member dispatch (MemberID) is intentionally NOT populated here —
+// that lives in assignMemberID so this extractor stays
+// chassis-topology-agnostic.
+func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleInventory {
+	inv := newModuleInventory()
+
+	// Index every entPhysical row by EntIndex so we can walk parents.
+	type row struct {
+		EntIndex    string
+		ContainedIn string
+		Class       string
+		ParentRel   string
+		Name        string
+		Serial      string
+		Model       string
+		Descr       string
+		VendorType  string
+	}
+	byIdx := make(map[string]row)
+	for s, v := range oids {
+		switch {
+		case strings.HasPrefix(s, oidEntPhysicalClass):
+			idx := strings.TrimPrefix(s, oidEntPhysicalClass)
+			r := byIdx[idx]
+			r.EntIndex = idx
+			r.Class = v.Value
+			byIdx[idx] = r
+		case strings.HasPrefix(s, oidEntPhysicalContainedIn):
+			idx := strings.TrimPrefix(s, oidEntPhysicalContainedIn)
+			r := byIdx[idx]
+			r.EntIndex = idx
+			r.ContainedIn = v.Value
+			byIdx[idx] = r
+		case strings.HasPrefix(s, oidEntPhysicalParentRel):
+			idx := strings.TrimPrefix(s, oidEntPhysicalParentRel)
+			r := byIdx[idx]
+			r.EntIndex = idx
+			r.ParentRel = v.Value
+			byIdx[idx] = r
+		case strings.HasPrefix(s, oidEntPhysicalName):
+			idx := strings.TrimPrefix(s, oidEntPhysicalName)
+			r := byIdx[idx]
+			r.EntIndex = idx
+			r.Name = v.Value
+			byIdx[idx] = r
+		case strings.HasPrefix(s, oidEntPhysicalSerialNum):
+			idx := strings.TrimPrefix(s, oidEntPhysicalSerialNum)
+			r := byIdx[idx]
+			r.EntIndex = idx
+			r.Serial = v.Value
+			byIdx[idx] = r
+		case strings.HasPrefix(s, oidEntPhysicalModelName):
+			idx := strings.TrimPrefix(s, oidEntPhysicalModelName)
+			r := byIdx[idx]
+			r.EntIndex = idx
+			r.Model = v.Value
+			byIdx[idx] = r
+		case strings.HasPrefix(s, oidEntPhysicalDescr):
+			idx := strings.TrimPrefix(s, oidEntPhysicalDescr)
+			r := byIdx[idx]
+			r.EntIndex = idx
+			r.Descr = v.Value
+			byIdx[idx] = r
+		case strings.HasPrefix(s, oidEntPhysicalVendorType):
+			idx := strings.TrimPrefix(s, oidEntPhysicalVendorType)
+			r := byIdx[idx]
+			r.EntIndex = idx
+			r.VendorType = v.Value
+			byIdx[idx] = r
+		}
+	}
+
+	// walkParents climbs the containedIn chain. Returns the nearest
+	// class=5 bay EntIndex and the nearest class=9 module ancestor
+	// EntIndex (both "" when absent). A `seen` set guards against
+	// malformed-MIB cycles — without it a self-referential or mutually
+	// referential containedIn pair would loop forever.
+	walkParents := func(start row) (bayIdx string, parentModuleIdx string, ok bool) {
+		cur := start.ContainedIn
+		seen := make(map[string]struct{})
+		for cur != "" && cur != "0" {
+			if _, dup := seen[cur]; dup {
+				logger.Debug("module: containment cycle detected",
+					"ent", start.EntIndex, "at", cur)
+				return "", "", false
+			}
+			seen[cur] = struct{}{}
+			parent, exists := byIdx[cur]
+			if !exists {
+				// Broken chain — orphan.
+				return "", "", false
+			}
+			if bayIdx == "" && parent.Class == entPhysicalClassContainer {
+				bayIdx = cur
+			}
+			if parentModuleIdx == "" && parent.Class == entPhysicalClassModule {
+				parentModuleIdx = cur
+			}
+			cur = parent.ContainedIn
+		}
+		return bayIdx, parentModuleIdx, true
+	}
+
+	// Process class=9 rows in EntIndex-ascending order so dedup
+	// "first occurrence wins" is deterministic.
+	classNineIdxs := make([]string, 0, len(byIdx))
+	for _, r := range byIdx {
+		if r.Class == entPhysicalClassModule {
+			classNineIdxs = append(classNineIdxs, r.EntIndex)
+		}
+	}
+	sort.Strings(classNineIdxs)
+	seenSerial := make(map[string]struct{})
+
+	// bayHasChild tracks class=5 rows that gained at least one class=9
+	// child — used by the empty-bay harvest below.
+	bayHasChild := make(map[string]bool)
+
+	for _, idx := range classNineIdxs {
+		r := byIdx[idx]
+		bayIdx, parentModuleIdx, chainOK := walkParents(r)
+		if !chainOK || bayIdx == "" {
+			logger.Warn("module discovery: orphan module dropped",
+				"ent", r.EntIndex,
+				"model", r.Model,
+				"reason", "orphan_containment")
+			continue
+		}
+		if r.Serial != "" {
+			key := strings.ToLower(strings.TrimSpace(r.Serial))
+			if _, dup := seenSerial[key]; dup {
+				logger.Warn("module discovery: duplicate-serial module dropped",
+					"ent", r.EntIndex,
+					"serial", r.Serial,
+					"model", r.Model,
+					"reason", "dup_serial")
+				continue
+			}
+			seenSerial[key] = struct{}{}
+		}
+		bayHasChild[bayIdx] = true
+		bay := byIdx[bayIdx]
+		entry := ModuleEntry{
+			EntIndex:     r.EntIndex,
+			BayEntIndex:  bayIdx,
+			BayName:      bay.Name,
+			BayPosition:  r.ParentRel,
+			Name:         r.Name,
+			Serial:       r.Serial,
+			Model:        r.Model,
+			Description:  r.Descr,
+			VendorType:   r.VendorType,
+			Type:         classifyModule(r.Model, r.VendorType, parentModuleIdx != ""),
+			ParentEntIdx: parentModuleIdx,
+		}
+		if parentModuleIdx == "" {
+			inv.Modules = append(inv.Modules, entry)
+		} else {
+			inv.SubModules[parentModuleIdx] = append(inv.SubModules[parentModuleIdx], entry)
+		}
+	}
+
+	// Deterministic emission order for top-level modules.
+	sort.Slice(inv.Modules, func(i, j int) bool {
+		return inv.Modules[i].EntIndex < inv.Modules[j].EntIndex
+	})
+
+	// Empty-bay harvest. A class=5 row whose parent is a chassis or
+	// another container and which has no class=9 child is an empty
+	// slot — emitted as a bare bay in `full` mode (Aruba CX quirk).
+	class5Idxs := make([]string, 0)
+	for idx, r := range byIdx {
+		if r.Class == entPhysicalClassContainer {
+			class5Idxs = append(class5Idxs, idx)
+		}
+	}
+	sort.Strings(class5Idxs)
+	for _, idx := range class5Idxs {
+		if bayHasChild[idx] {
+			continue
+		}
+		r := byIdx[idx]
+		parent, exists := byIdx[r.ContainedIn]
+		if !exists {
+			continue
+		}
+		// Only surface empties whose parent is a chassis or another
+		// container/module — keeps leaf-shaped containers (e.g. ports
+		// with no slot semantics) out of the bay list.
+		if parent.Class != entPhysicalClassChassis &&
+			parent.Class != entPhysicalClassContainer &&
+			parent.Class != entPhysicalClassModule {
+			continue
+		}
+		inv.EmptyBays = append(inv.EmptyBays, ModuleEntry{
+			EntIndex:    r.EntIndex,
+			BayEntIndex: r.EntIndex, // self — no module to anchor to
+			BayName:     r.Name,
+			BayPosition: r.ParentRel,
+			Type:        ModuleTypeUnknown,
+		})
+	}
+	return inv
 }
 
 // isSupervisorPID recognises Cisco-style supervisor product IDs on an

--- a/snmp-discovery/mapping/module.go
+++ b/snmp-discovery/mapping/module.go
@@ -237,24 +237,26 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 	}
 
 	// walkParents climbs the containedIn chain. Returns the nearest
-	// class=5 bay EntIndex and the nearest class=9 module ancestor
-	// EntIndex (both "" when absent). A `seen` set guards against
-	// malformed-MIB cycles — without it a self-referential or mutually
-	// referential containedIn pair would loop forever.
-	walkParents := func(start row) (bayIdx string, parentModuleIdx string, ok bool) {
+	// class=5 bay EntIndex, the nearest class=9 module ancestor
+	// EntIndex (both "" when absent), and whether a class=3 chassis was
+	// reached (used by extractModuleInventory to synthesize a bay for
+	// chassis-rooted modules on fixed-FRU switches). A `seen` set guards
+	// against malformed-MIB cycles — without it a self-referential or
+	// mutually referential containedIn pair would loop forever.
+	walkParents := func(start row) (bayIdx string, parentModuleIdx string, reachedChassis bool, ok bool) {
 		cur := start.ContainedIn
 		seen := make(map[string]struct{})
 		for cur != "" && cur != "0" {
 			if _, dup := seen[cur]; dup {
 				logger.Debug("module: containment cycle detected",
 					"ent", start.EntIndex, "at", cur)
-				return "", "", false
+				return "", "", false, false
 			}
 			seen[cur] = struct{}{}
 			parent, exists := byIdx[cur]
 			if !exists {
 				// Broken chain — orphan.
-				return "", "", false
+				return "", "", false, false
 			}
 			if bayIdx == "" && parent.Class == entPhysicalClassContainer {
 				bayIdx = cur
@@ -262,9 +264,12 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 			if parentModuleIdx == "" && parent.Class == entPhysicalClassModule {
 				parentModuleIdx = cur
 			}
+			if parent.Class == entPhysicalClassChassis {
+				reachedChassis = true
+			}
 			cur = parent.ContainedIn
 		}
-		return bayIdx, parentModuleIdx, true
+		return bayIdx, parentModuleIdx, reachedChassis, true
 	}
 
 	// Process class=9 rows in EntIndex-ascending order so dedup
@@ -284,8 +289,8 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 
 	for _, idx := range classNineIdxs {
 		r := byIdx[idx]
-		bayIdx, parentModuleIdx, chainOK := walkParents(r)
-		if !chainOK || bayIdx == "" {
+		bayIdx, parentModuleIdx, reachedChassis, chainOK := walkParents(r)
+		if !chainOK {
 			logger.Warn("module discovery: orphan module dropped",
 				"ent", r.EntIndex,
 				"model", r.Model,
@@ -296,6 +301,28 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 				))
 			}
 			continue
+		}
+		// Fixed-FRU switches sometimes report modules directly under
+		// chassis with no class=5 container — synthesize a bay so the
+		// module is still emitted. Self-referential BayEntIndex is fine;
+		// the downstream Diode emission only needs a stable identifier.
+		synthesizedBay := false
+		if bayIdx == "" {
+			if !reachedChassis {
+				// No class=5 AND no chassis — truly orphan.
+				logger.Warn("module discovery: orphan module dropped",
+					"ent", r.EntIndex,
+					"model", r.Model,
+					"reason", "orphan_containment")
+				if c := metrics.GetModulesDropped(); c != nil {
+					c.Add(context.Background(), 1, metric.WithAttributes(
+						attribute.String("reason", "orphan_containment"),
+					))
+				}
+				continue
+			}
+			bayIdx = r.EntIndex
+			synthesizedBay = true
 		}
 		if r.Serial != "" {
 			key := strings.ToLower(strings.TrimSpace(r.Serial))
@@ -318,11 +345,19 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 		bay := byIdx[bayIdx]
 		// Position is the BAY's parentRelPos (chassis slot), not the
 		// module's own (which is almost always "1" inside its bay).
+		// When the bay was synthesized from the module itself, fall back
+		// to the module's own Name + ParentRel so the bay has identifiers.
+		bayName := bay.Name
+		bayPos := bay.ParentRel
+		if synthesizedBay {
+			bayName = r.Name
+			bayPos = r.ParentRel
+		}
 		entry := ModuleEntry{
 			EntIndex:     r.EntIndex,
 			BayEntIndex:  bayIdx,
-			BayName:      bay.Name,
-			BayPosition:  bay.ParentRel,
+			BayName:      bayName,
+			BayPosition:  bayPos,
 			Name:         r.Name,
 			Serial:       r.Serial,
 			Model:        r.Model,

--- a/snmp-discovery/mapping/module.go
+++ b/snmp-discovery/mapping/module.go
@@ -27,6 +27,7 @@ const (
 
 	entPhysicalClassModule    = "9"
 	entPhysicalClassContainer = "5"
+	entPhysicalClassPort      = "10"
 )
 
 // ChassisModuleMapper is a no-op orbToEntityMapper. See package file
@@ -115,13 +116,16 @@ func classifyModule(model, vendorType string, hasModuleParent bool) ModuleType {
 		pid = strings.TrimSpace(vendorType)
 	}
 
-	// PSU / Fan are vendor-neutral by PID prefix and parent-agnostic —
-	// they appear at chassis level and under shelves alike.
+	// PSU / Fan are vendor-neutral and parent-agnostic — they appear at
+	// chassis level and under shelves alike. Match both bare-prefix
+	// forms (PSU-, PWR-, FAN-) and model-prefixed Cisco forms where
+	// the type token sits in the middle or as a suffix (C9404R-PWR-2KW-AC,
+	// C9400-FAN, C9404R-FAN-2).
 	upper := strings.ToUpper(pid)
-	if strings.HasPrefix(upper, "PSU-") || strings.HasPrefix(upper, "PWR-") {
+	if isPSUPID(upper) {
 		return ModuleTypePSU
 	}
-	if strings.HasPrefix(upper, "FAN") {
+	if isFanPID(upper) {
 		return ModuleTypeFan
 	}
 
@@ -173,55 +177,61 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 		VendorType  string
 	}
 	byIdx := make(map[string]row)
+	// trimSNMPString strips ENTITY-MIB-padded NULs and surrounding
+	// whitespace. Applied to every string field at extraction so dedup
+	// keys stay stable across runs and downstream Diode payloads are
+	// clean (mirrors chassis.go's normalization). Class / ContainedIn /
+	// ParentRel are also numeric-shaped strings that benefit from the
+	// trim, so they go through it too.
 	for s, v := range oids {
 		switch {
 		case strings.HasPrefix(s, oidEntPhysicalClass):
 			idx := strings.TrimPrefix(s, oidEntPhysicalClass)
 			r := byIdx[idx]
 			r.EntIndex = idx
-			r.Class = v.Value
+			r.Class = trimSNMPString(v.Value)
 			byIdx[idx] = r
 		case strings.HasPrefix(s, oidEntPhysicalContainedIn):
 			idx := strings.TrimPrefix(s, oidEntPhysicalContainedIn)
 			r := byIdx[idx]
 			r.EntIndex = idx
-			r.ContainedIn = v.Value
+			r.ContainedIn = trimSNMPString(v.Value)
 			byIdx[idx] = r
 		case strings.HasPrefix(s, oidEntPhysicalParentRel):
 			idx := strings.TrimPrefix(s, oidEntPhysicalParentRel)
 			r := byIdx[idx]
 			r.EntIndex = idx
-			r.ParentRel = v.Value
+			r.ParentRel = trimSNMPString(v.Value)
 			byIdx[idx] = r
 		case strings.HasPrefix(s, oidEntPhysicalName):
 			idx := strings.TrimPrefix(s, oidEntPhysicalName)
 			r := byIdx[idx]
 			r.EntIndex = idx
-			r.Name = v.Value
+			r.Name = trimSNMPString(v.Value)
 			byIdx[idx] = r
 		case strings.HasPrefix(s, oidEntPhysicalSerialNum):
 			idx := strings.TrimPrefix(s, oidEntPhysicalSerialNum)
 			r := byIdx[idx]
 			r.EntIndex = idx
-			r.Serial = v.Value
+			r.Serial = trimSNMPString(v.Value)
 			byIdx[idx] = r
 		case strings.HasPrefix(s, oidEntPhysicalModelName):
 			idx := strings.TrimPrefix(s, oidEntPhysicalModelName)
 			r := byIdx[idx]
 			r.EntIndex = idx
-			r.Model = v.Value
+			r.Model = trimSNMPString(v.Value)
 			byIdx[idx] = r
 		case strings.HasPrefix(s, oidEntPhysicalDescr):
 			idx := strings.TrimPrefix(s, oidEntPhysicalDescr)
 			r := byIdx[idx]
 			r.EntIndex = idx
-			r.Descr = v.Value
+			r.Descr = trimSNMPString(v.Value)
 			byIdx[idx] = r
 		case strings.HasPrefix(s, oidEntPhysicalVendorType):
 			idx := strings.TrimPrefix(s, oidEntPhysicalVendorType)
 			r := byIdx[idx]
 			r.EntIndex = idx
-			r.VendorType = v.Value
+			r.VendorType = trimSNMPString(v.Value)
 			byIdx[idx] = r
 		}
 	}
@@ -334,6 +344,21 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 	// Empty-bay harvest. A class=5 row whose parent is a chassis or
 	// another container and which has no class=9 child is an empty
 	// slot — emitted as a bare bay in `full` mode (Aruba CX quirk).
+	//
+	// Port containers (class=5 whose only children are class=10 ports)
+	// look like "no class=9 child" but they are not module bays — they
+	// are slots for ports, not modules. Track which class=5 rows own
+	// any class=10 child and skip them so we never surface a spurious
+	// empty bay for a port container.
+	containerHasPortChild := make(map[string]bool)
+	for _, r := range byIdx {
+		if r.Class == entPhysicalClassPort {
+			parent, exists := byIdx[r.ContainedIn]
+			if exists && parent.Class == entPhysicalClassContainer {
+				containerHasPortChild[parent.EntIndex] = true
+			}
+		}
+	}
 	class5Idxs := make([]string, 0)
 	for idx, r := range byIdx {
 		if r.Class == entPhysicalClassContainer {
@@ -343,6 +368,9 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 	sort.Strings(class5Idxs)
 	for _, idx := range class5Idxs {
 		if bayHasChild[idx] {
+			continue
+		}
+		if containerHasPortChild[idx] {
 			continue
 		}
 		r := byIdx[idx]
@@ -367,6 +395,32 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 		})
 	}
 	return inv
+}
+
+// isPSUPID recognises power-supply PIDs on an already upper-cased PID.
+// Covers bare prefixes (PSU-2KW-AC, PWR-C5-715WAC) and model-prefixed
+// Cisco forms where the token sits in the middle (C9404R-PWR-2KW-AC).
+func isPSUPID(upper string) bool {
+	if strings.HasPrefix(upper, "PSU-") || strings.HasPrefix(upper, "PWR-") {
+		return true
+	}
+	if strings.Contains(upper, "-PSU-") || strings.Contains(upper, "-PWR-") {
+		return true
+	}
+	return false
+}
+
+// isFanPID recognises fan-tray PIDs on an already upper-cased PID.
+// Covers bare prefix (FAN, FAN-T1-R) and model-prefixed Cisco forms
+// where -FAN appears as suffix or middle token (C9400-FAN, C9404R-FAN-2).
+func isFanPID(upper string) bool {
+	if strings.HasPrefix(upper, "FAN") {
+		return true
+	}
+	if strings.Contains(upper, "-FAN") {
+		return true
+	}
+	return false
 }
 
 // isSupervisorPID recognises Cisco-style supervisor product IDs on an

--- a/snmp-discovery/mapping/module.go
+++ b/snmp-discovery/mapping/module.go
@@ -7,6 +7,7 @@ package mapping
 
 import (
 	"log/slog"
+	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
@@ -27,4 +28,124 @@ func (m *ChassisModuleMapper) Map(
 	_ *config.Defaults,
 ) diode.Entity {
 	return nil
+}
+
+// ModuleType is the vendor-neutral classification assigned by
+// classifyModule. Drives both the linecards-mode filter (skip
+// transceivers) and downstream Diode emission as Module.Type.
+type ModuleType string
+
+const (
+	ModuleTypeLinecard    ModuleType = "linecard"
+	ModuleTypeSupervisor  ModuleType = "supervisor"
+	ModuleTypeTransceiver ModuleType = "transceiver"
+	ModuleTypePSU         ModuleType = "psu"     // classified for labelling only; never emitted as a module entity
+	ModuleTypeFan         ModuleType = "fan"     // classified for labelling only; never emitted as a module entity
+	ModuleTypeUnknown     ModuleType = "unknown"
+)
+
+// ModuleEntry is one class=9 row from entPhysicalTable after
+// classification. BayEntIndex points at the class=5 container that
+// owns this module — the bay is emitted as a separate entity
+// alongside the module installed in it.
+type ModuleEntry struct {
+	EntIndex     string     // own entPhysicalIndex
+	BayEntIndex  string     // parent class=5 container entPhysicalIndex
+	BayName      string     // entPhysicalName of the bay
+	BayPosition  string     // entPhysicalParentRelPos of the module
+	Name         string     // entPhysicalName
+	Serial       string     // entPhysicalSerialNum
+	Model        string     // entPhysicalModelName
+	Description  string     // entPhysicalDescr
+	VendorType   string     // entPhysicalVendorType
+	Type         ModuleType // classifyModule output
+	MemberID     int        // ChassisInventory.Members[].ID; 0 for standalone
+	ParentEntIdx string     // for transceivers, class=9 module they sit under; "" for top-level
+}
+
+// ModuleInventory is the deduped, classified set for one target.
+// Modules carries top-level (chassis-rooted) modules; SubModules maps
+// each parent EntIndex → its transceiver children. EmptyBays carries
+// class=5 rows with no class=9 child but whose parent resolves to a
+// chassis or container — Aruba CX-style empty slots; emitted only in
+// `full` mode.
+type ModuleInventory struct {
+	Modules    []ModuleEntry
+	SubModules map[string][]ModuleEntry
+	EmptyBays  []ModuleEntry // bare bays — BayEntIndex == EntIndex; Serial/Model empty
+}
+
+func newModuleInventory() ModuleInventory {
+	return ModuleInventory{
+		SubModules: make(map[string][]ModuleEntry),
+	}
+}
+
+// Optic PID prefixes — pluggable transceivers across Cisco / generic
+// vendors. Matched only when the row sits under a class=9 module
+// parent; PID alone is insufficient (a chassis-level optic-shaped PID
+// is treated as a linecard).
+var opticPIDPrefixes = []string{"QSFP-", "SFP-", "X2-", "GLC-", "CFP-", "XENPAK-", "XFP-"}
+
+// classifyModule picks a ModuleType from a row's PID and its location
+// in the containment tree. hasModuleParent is true when an ancestor in
+// the entPhysicalTable chain is itself class=9. Effective PID prefers
+// trimmed Model and falls back to trimmed VendorType when Model is
+// blank — Aruba CX populates VendorType where Cisco populates Model.
+func classifyModule(model, vendorType string, hasModuleParent bool) ModuleType {
+	pid := strings.TrimSpace(model)
+	if pid == "" {
+		pid = strings.TrimSpace(vendorType)
+	}
+
+	// PSU / Fan are vendor-neutral by PID prefix and parent-agnostic —
+	// they appear at chassis level and under shelves alike.
+	upper := strings.ToUpper(pid)
+	if strings.HasPrefix(upper, "PSU-") || strings.HasPrefix(upper, "PWR-") {
+		return ModuleTypePSU
+	}
+	if strings.HasPrefix(upper, "FAN") {
+		return ModuleTypeFan
+	}
+
+	// Transceiver requires BOTH a module-class ancestor AND an optic
+	// PID — depth alone catches non-optic sub-modules; PID alone
+	// catches spare optics inventoried at chassis level.
+	if hasModuleParent {
+		for _, p := range opticPIDPrefixes {
+			if strings.HasPrefix(upper, p) {
+				return ModuleTypeTransceiver
+			}
+		}
+	} else if isSupervisorPID(upper) {
+		// Supervisor lives at chassis depth on dual-sup platforms.
+		return ModuleTypeSupervisor
+	}
+
+	if pid == "" {
+		return ModuleTypeUnknown
+	}
+
+	// Safe default — non-optic under a module parent OR no special
+	// pattern at chassis level both land here.
+	return ModuleTypeLinecard
+}
+
+// isSupervisorPID recognises Cisco-style supervisor product IDs on an
+// already upper-cased PID. Covers C9400-SUP-1 (dash-delimited), VS-SUP2T
+// (digit-suffixed, no trailing dash) and SUPV variants.
+func isSupervisorPID(upper string) bool {
+	if strings.Contains(upper, "SUP-") || strings.Contains(upper, "-SUP-") || strings.Contains(upper, "SUPV") {
+		return true
+	}
+	// SUP followed by a digit — VS-SUP2T-10G, SUP6T, SUP7, etc.
+	for i := 0; i+3 < len(upper); i++ {
+		if upper[i] == 'S' && upper[i+1] == 'U' && upper[i+2] == 'P' {
+			c := upper[i+3]
+			if c >= '0' && c <= '9' {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/snmp-discovery/mapping/module.go
+++ b/snmp-discovery/mapping/module.go
@@ -345,12 +345,18 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 		bay := byIdx[bayIdx]
 		// Position is the BAY's parentRelPos (chassis slot), not the
 		// module's own (which is almost always "1" inside its bay).
-		// When the bay was synthesized from the module itself, fall back
-		// to the module's own Name + ParentRel so the bay has identifiers.
+		// When the bay was synthesized from the module itself, derive a
+		// distinct name ("Slot <parentRel>") so NetBox doesn't display a
+		// bay sharing the module's exact label; fall back to module Name
+		// only if ParentRel is empty.
 		bayName := bay.Name
 		bayPos := bay.ParentRel
 		if synthesizedBay {
-			bayName = r.Name
+			if r.ParentRel != "" {
+				bayName = "Slot " + r.ParentRel
+			} else {
+				bayName = r.Name
+			}
 			bayPos = r.ParentRel
 		}
 		entry := ModuleEntry{

--- a/snmp-discovery/mapping/module.go
+++ b/snmp-discovery/mapping/module.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"log/slog"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
@@ -273,14 +274,24 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 	}
 
 	// Process class=9 rows in EntIndex-ascending order so dedup
-	// "first occurrence wins" is deterministic.
+	// "first occurrence wins" is deterministic. ENTITY-MIB indexes are
+	// numeric — a lex sort would put "10" before "9" and pick the wrong
+	// dedup winner, so compare as integers with a lex tiebreaker for
+	// any non-numeric edge cases.
 	classNineIdxs := make([]string, 0, len(byIdx))
 	for _, r := range byIdx {
 		if r.Class == entPhysicalClassModule {
 			classNineIdxs = append(classNineIdxs, r.EntIndex)
 		}
 	}
-	sort.Strings(classNineIdxs)
+	sort.Slice(classNineIdxs, func(i, j int) bool {
+		ai, errI := strconv.Atoi(classNineIdxs[i])
+		aj, errJ := strconv.Atoi(classNineIdxs[j])
+		if errI != nil || errJ != nil || ai == aj {
+			return classNineIdxs[i] < classNineIdxs[j]
+		}
+		return ai < aj
+	})
 	seenSerial := make(map[string]struct{})
 
 	// bayHasChild tracks class=5 rows that gained at least one class=9

--- a/snmp-discovery/mapping/module.go
+++ b/snmp-discovery/mapping/module.go
@@ -70,7 +70,7 @@ type ModuleEntry struct {
 	EntIndex     string     // own entPhysicalIndex
 	BayEntIndex  string     // parent class=5 container entPhysicalIndex
 	BayName      string     // entPhysicalName of the bay
-	BayPosition  string     // entPhysicalParentRelPos of the module
+	BayPosition  string     // entPhysicalParentRelPos of the BAY (chassis slot number — NOT the module's own parentRelPos, which is almost always "1")
 	Name         string     // entPhysicalName
 	Serial       string     // entPhysicalSerialNum
 	Model        string     // entPhysicalModelName
@@ -316,11 +316,13 @@ func extractModuleInventory(oids ObjectIDValueMap, logger *slog.Logger) ModuleIn
 		}
 		bayHasChild[bayIdx] = true
 		bay := byIdx[bayIdx]
+		// Position is the BAY's parentRelPos (chassis slot), not the
+		// module's own (which is almost always "1" inside its bay).
 		entry := ModuleEntry{
 			EntIndex:     r.EntIndex,
 			BayEntIndex:  bayIdx,
 			BayName:      bay.Name,
-			BayPosition:  r.ParentRel,
+			BayPosition:  bay.ParentRel,
 			Name:         r.Name,
 			Serial:       r.Serial,
 			Model:        r.Model,

--- a/snmp-discovery/mapping/module_fixtures_test.go
+++ b/snmp-discovery/mapping/module_fixtures_test.go
@@ -1,0 +1,59 @@
+// Copyright 2026 NetBox Labs, Inc.
+
+package mapping
+
+// fixtureRow is one synthetic entPhysical row used by module_*_test.go.
+// Mirrors the way chassis_fixtures_test.go builds its own rows.
+type fixtureRow struct {
+	EntIndex    string // entPhysicalIndex (string form, used in OID suffix)
+	ContainedIn string // entPhysicalContainedIn (parent's index, "0" for chassis)
+	Class       string // entPhysicalClass: "3"=chassis "5"=container "9"=module
+	ParentRel   string // entPhysicalParentRelPos
+	Name        string // entPhysicalName
+	Serial      string // entPhysicalSerialNum
+	Model       string // entPhysicalModelName
+	Descr       string // entPhysicalDescr
+	VendorType  string // entPhysicalVendorType
+}
+
+// buildOIDs converts a list of fixtureRows into the ObjectIDValueMap
+// shape extractModuleInventory expects. Keyed by full OID string;
+// holds Value by value (NOT *ObjectIDValue) — see mapping.go:271.
+func buildOIDs(rows []fixtureRow) ObjectIDValueMap {
+	oids := make(ObjectIDValueMap)
+	set := func(prefix, idx, val string) {
+		oid := prefix + idx
+		oids[oid] = Value{Value: val}
+	}
+	for _, r := range rows {
+		set(".1.3.6.1.2.1.47.1.1.1.1.2.", r.EntIndex, r.Descr)
+		set(".1.3.6.1.2.1.47.1.1.1.1.3.", r.EntIndex, r.VendorType)
+		set(".1.3.6.1.2.1.47.1.1.1.1.4.", r.EntIndex, r.ContainedIn)
+		set(".1.3.6.1.2.1.47.1.1.1.1.5.", r.EntIndex, r.Class)
+		set(".1.3.6.1.2.1.47.1.1.1.1.6.", r.EntIndex, r.ParentRel)
+		set(".1.3.6.1.2.1.47.1.1.1.1.7.", r.EntIndex, r.Name)
+		set(".1.3.6.1.2.1.47.1.1.1.1.11.", r.EntIndex, r.Serial)
+		set(".1.3.6.1.2.1.47.1.1.1.1.13.", r.EntIndex, r.Model)
+	}
+	return oids
+}
+
+// chassis9404RWithTransceiversFixture builds a minimal Cat 9404R-shape
+// fixture: chassis + 1 supervisor + 1 linecard with 1 transceiver under it.
+func chassis9404RWithTransceiversFixture() []fixtureRow {
+	return []fixtureRow{
+		{"1", "0", "3", "1", "Catalyst 9404R Chassis", "FCW2401L0K0", "C9404R", "Catalyst 9404R 4-slot Chassis", ""},
+		// Slot 1 container
+		{"100", "1", "5", "1", "Slot 1", "", "", "Slot 1", ""},
+		// Supervisor installed in slot 1
+		{"101", "100", "9", "1", "Supervisor 1", "JAE24010ABC", "C9400-SUP-1", "Cisco Catalyst 9400 Series Supervisor 1 Module", ""},
+		// Slot 2 container
+		{"200", "1", "5", "2", "Slot 2", "", "", "Slot 2", ""},
+		// Linecard installed in slot 2
+		{"201", "200", "9", "1", "Linecard 2", "JAE24010LC2", "C9400-LC-48U", "Cisco Catalyst 9400 48-port UPOE+ linecard", ""},
+		// Port container under linecard
+		{"202", "201", "5", "1", "TenGigabitEthernet2/0/1", "", "", "", ""},
+		// Transceiver installed in port container
+		{"203", "202", "9", "1", "TenGigabitEthernet2/0/1 Transceiver", "FNS24010TR1", "SFP-10G-LR", "SFP-10GBase-LR", ""},
+	}
+}

--- a/snmp-discovery/mapping/module_routing.go
+++ b/snmp-discovery/mapping/module_routing.go
@@ -11,6 +11,7 @@ package mapping
 import (
 	"context"
 	"log/slog"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -162,11 +163,15 @@ func buildIfaceModuleMap(
 // AliasMapFromOIDs parses entAliasMappingTable rows into a flat
 // entPhysicalIndex -> ifIndex map (decimal strings). Mirrors the parse
 // rules in chassis_routing.go:152-179 (drop malformed suffixes; drop
-// non-ifEntry.ifIndex values) but emits the simpler shape the module
-// path consumes — the chassis router does its own per-ifIndex
-// candidate ranking, so first-occurrence-wins here is harmless.
+// non-ifEntry.ifIndex values).
+//
+// When multiple rows resolve to the same entPhysicalIndex, the lowest
+// ifIndex wins — deterministic across runs. Map iteration order in Go
+// is randomized, so first-occurrence-wins would otherwise flip between
+// invocations. Mirrors chassis_routing.go's sorted candidate selection
+// (chassis_routing.go:202).
 func AliasMapFromOIDs(oids ObjectIDValueMap) map[string]string {
-	out := make(map[string]string)
+	candidates := make(map[string][]int)
 	for oid, v := range oids {
 		if !strings.HasPrefix(oid, oidEntAliasMappingIdent) {
 			continue
@@ -184,13 +189,17 @@ func AliasMapFromOIDs(oids ObjectIDValueMap) map[string]string {
 		if !strings.HasPrefix(val, oidIfEntryIfIndexNoDot) {
 			continue
 		}
-		ifIdx := strings.TrimPrefix(val, oidIfEntryIfIndexNoDot)
-		if _, err := strconv.Atoi(ifIdx); err != nil {
+		ifIdxStr := strings.TrimPrefix(val, oidIfEntryIfIndexNoDot)
+		ifIdx, err := strconv.Atoi(ifIdxStr)
+		if err != nil {
 			continue
 		}
-		if _, exists := out[entIdx]; !exists {
-			out[entIdx] = ifIdx
-		}
+		candidates[entIdx] = append(candidates[entIdx], ifIdx)
+	}
+	out := make(map[string]string, len(candidates))
+	for entIdx, ifIdxs := range candidates {
+		sort.Ints(ifIdxs)
+		out[entIdx] = strconv.Itoa(ifIdxs[0])
 	}
 	return out
 }

--- a/snmp-discovery/mapping/module_routing.go
+++ b/snmp-discovery/mapping/module_routing.go
@@ -278,3 +278,62 @@ func MemberDevicesFromEntities(
 	}
 	return out
 }
+
+// AttachIfaceModules sets Interface.Module on each transceiver-owning
+// interface referenced by entities. It walks three referrer shapes:
+//
+//   - *diode.Interface directly in the slice (physical ports emitted as
+//     top-level entities).
+//   - *diode.IPAddress whose AssignedObject is a *diode.Interface (the
+//     L3 routed-port case — MapObjectIDsToEntity filters such interfaces
+//     out of the top-level slice via getAssignedInterfaces, so they
+//     surface ONLY through this nested reference).
+//   - *diode.MACAddress whose AssignedObject is a *diode.Interface
+//     (mirrors the IP path; chassis.go:484 already walks this shape for
+//     member-rerouting).
+//
+// For each found interface we look up its ifIndex in ifIndexByIface (the
+// registry-derived pointer->ifIndex map) and use the decimal ifIndex to
+// pick the module from ifaceModuleMap. Lookups that miss are skipped:
+// partial coverage is normal (interfaces with no transceiver, ifIndexes
+// absent from entAliasMappingTable, etc.).
+//
+// Idempotent: re-running won't change a value already set. Defensive
+// against nil maps so the runner can call it unconditionally.
+func AttachIfaceModules(
+	entities []diode.Entity,
+	ifaceModuleMap map[string]*diode.Module,
+	ifIndexByIface map[*diode.Interface]int,
+) {
+	if len(ifaceModuleMap) == 0 || len(ifIndexByIface) == 0 {
+		return
+	}
+	attach := func(iface *diode.Interface) {
+		if iface == nil {
+			return
+		}
+		idx, hasIdx := ifIndexByIface[iface]
+		if !hasIdx {
+			return
+		}
+		mod, hit := ifaceModuleMap[strconv.Itoa(idx)]
+		if !hit {
+			return
+		}
+		iface.Module = mod
+	}
+	for _, e := range entities {
+		switch v := e.(type) {
+		case *diode.Interface:
+			attach(v)
+		case *diode.IPAddress:
+			if iface, ok := v.AssignedObject.(*diode.Interface); ok {
+				attach(iface)
+			}
+		case *diode.MACAddress:
+			if iface, ok := v.AssignedObject.(*diode.Interface); ok {
+				attach(iface)
+			}
+		}
+	}
+}

--- a/snmp-discovery/mapping/module_routing.go
+++ b/snmp-discovery/mapping/module_routing.go
@@ -9,11 +9,16 @@
 package mapping
 
 import (
+	"context"
 	"log/slog"
 	"strconv"
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/metrics"
 )
 
 // assignMemberID stamps each ModuleEntry in inv with the logical member
@@ -86,6 +91,11 @@ func assignMemberID(inv *ModuleInventory, chassisInv *ChassisInventory, oids Obj
 			logger.Warn("module discovery: orphan module — chassis ancestor not in chassis inventory",
 				"ent", e.EntIndex, "model", e.Model)
 			e.MemberID = -1
+			if c := metrics.GetModulesDropped(); c != nil {
+				c.Add(context.Background(), 1, metric.WithAttributes(
+					attribute.String("reason", "orphan_member"),
+				))
+			}
 			return
 		}
 		e.MemberID = id

--- a/snmp-discovery/mapping/module_routing.go
+++ b/snmp-discovery/mapping/module_routing.go
@@ -10,6 +10,7 @@ package mapping
 
 import (
 	"log/slog"
+	"strconv"
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
@@ -144,6 +145,90 @@ func buildIfaceModuleMap(
 				continue
 			}
 			out[ifName] = mod
+		}
+	}
+	return out
+}
+
+// AliasMapFromOIDs parses entAliasMappingTable rows into a flat
+// entPhysicalIndex -> ifIndex map (decimal strings). Mirrors the parse
+// rules in chassis_routing.go:152-179 (drop malformed suffixes; drop
+// non-ifEntry.ifIndex values) but emits the simpler shape the module
+// path consumes — the chassis router does its own per-ifIndex
+// candidate ranking, so first-occurrence-wins here is harmless.
+func AliasMapFromOIDs(oids ObjectIDValueMap) map[string]string {
+	out := make(map[string]string)
+	for oid, v := range oids {
+		if !strings.HasPrefix(oid, oidEntAliasMappingIdent) {
+			continue
+		}
+		suffix := strings.TrimPrefix(oid, oidEntAliasMappingIdent)
+		parts := strings.SplitN(suffix, ".", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		entIdx := parts[0]
+		// Normalize: strip leading dot (gosnmp's ObjectIdentifier
+		// rendering varies) then require the value to point at
+		// ifEntry.ifIndex — skip ifAlias / ifDescr targets.
+		val := strings.TrimPrefix(strings.TrimSpace(v.Value), ".")
+		if !strings.HasPrefix(val, oidIfEntryIfIndexNoDot) {
+			continue
+		}
+		ifIdx := strings.TrimPrefix(val, oidIfEntryIfIndexNoDot)
+		if _, err := strconv.Atoi(ifIdx); err != nil {
+			continue
+		}
+		if _, exists := out[entIdx]; !exists {
+			out[entIdx] = ifIdx
+		}
+	}
+	return out
+}
+
+// IfNameByIfIndex inverts the runner's *Interface -> ifIndex map into
+// ifIndex (decimal string) -> ifName. Interfaces with nil Name are
+// skipped — a transceiver cannot route to a nameless port.
+func IfNameByIfIndex(ifIndexByIface map[*diode.Interface]int) map[string]string {
+	out := make(map[string]string, len(ifIndexByIface))
+	for iface, idx := range ifIndexByIface {
+		if iface == nil || iface.Name == nil {
+			continue
+		}
+		out[strconv.Itoa(idx)] = *iface.Name
+	}
+	return out
+}
+
+// MemberDevicesFromEntities groups the Devices in entities by member id
+// for module dispatch. Master (VcPosition == nil) is keyed by the lowest
+// member id in chassisInv.Members[0].ID — mirroring TranslateAsStack's
+// memberByID convention (chassis.go:432). For standalone targets
+// (chassisInv nil/empty) the master falls back to key 0. Non-master
+// members are keyed by *VcPosition.
+func MemberDevicesFromEntities(
+	entities []diode.Entity,
+	chassisInv *ChassisInventory,
+) map[int]*diode.Device {
+	out := make(map[int]*diode.Device)
+	masterID := 0
+	if chassisInv != nil && len(chassisInv.Members) > 0 {
+		// Members are sorted ascending by ID upstream;
+		// Members[0].ID is the master's logical member id.
+		masterID = chassisInv.Members[0].ID
+	}
+	for _, e := range entities {
+		dev, ok := e.(*diode.Device)
+		if !ok || dev == nil {
+			continue
+		}
+		if dev.VcPosition != nil {
+			out[int(*dev.VcPosition)] = dev
+			continue
+		}
+		// First master wins — defensive against duplicate emission.
+		if _, exists := out[masterID]; !exists {
+			out[masterID] = dev
 		}
 	}
 	return out

--- a/snmp-discovery/mapping/module_routing.go
+++ b/snmp-discovery/mapping/module_routing.go
@@ -115,25 +115,29 @@ func assignMemberID(inv *ModuleInventory, chassisInv *ChassisInventory, oids Obj
 	}
 }
 
-// buildIfaceModuleMap builds the {ifName -> *diode.Module} lookup the
+// buildIfaceModuleMap builds the {ifIndex -> *diode.Module} lookup the
 // runner needs to set Interface.Module on each transceiver-owning port.
+// Keying by ifIndex (decimal string) — not ifName — is required because
+// VC/stack targets (Juniper VC, some Aruba stacks) reuse the same
+// canonical ifName across members; an ifName-keyed map collapses
+// distinct transceivers onto a single entry and the runner attaches the
+// wrong member's module. ifIndex is globally unique in the SNMP walk
+// space, so collision is impossible.
 //
 // Only transceivers under inv.SubModules participate — top-level modules
 // (linecards, supervisors) aren't single-port entities and don't route
-// to an ifName. For each transceiver:
+// to an ifIndex. For each transceiver:
 //
-//  1. aliasMap[EntIndex] gives the ifIndex (as set up upstream by the
+//  1. aliasMap[EntIndex] gives the ifIndex (set up upstream by the
 //     entAliasMappingTable walk).
-//  2. ifIndexToName[ifIndex] gives the canonical ifName.
-//  3. emittedModules[EntIndex] is the *diode.Module the translator
-//     already produced; this map points the ifName at it.
+//  2. emittedModules[EntIndex] is the *diode.Module the translator
+//     already produced; this map points the ifIndex at it.
 //
 // Any step that misses simply skips the transceiver — partial coverage
 // is normal (optic with no alias-table row, port-channel placeholder, etc.).
 func buildIfaceModuleMap(
 	inv ModuleInventory,
 	aliasMap map[string]string,
-	ifIndexToName map[string]string,
 	emittedModules map[string]*diode.Module,
 ) map[string]*diode.Module {
 	out := make(map[string]*diode.Module)
@@ -146,15 +150,11 @@ func buildIfaceModuleMap(
 			if !ok {
 				continue
 			}
-			ifName, ok := ifIndexToName[ifIdx]
-			if !ok {
-				continue
-			}
 			mod, ok := emittedModules[e.EntIndex]
 			if !ok {
 				continue
 			}
-			out[ifName] = mod
+			out[ifIdx] = mod
 		}
 	}
 	return out
@@ -200,20 +200,6 @@ func AliasMapFromOIDs(oids ObjectIDValueMap) map[string]string {
 	for entIdx, ifIdxs := range candidates {
 		sort.Ints(ifIdxs)
 		out[entIdx] = strconv.Itoa(ifIdxs[0])
-	}
-	return out
-}
-
-// IfNameByIfIndex inverts the runner's *Interface -> ifIndex map into
-// ifIndex (decimal string) -> ifName. Interfaces with nil Name are
-// skipped — a transceiver cannot route to a nameless port.
-func IfNameByIfIndex(ifIndexByIface map[*diode.Interface]int) map[string]string {
-	out := make(map[string]string, len(ifIndexByIface))
-	for iface, idx := range ifIndexByIface {
-		if iface == nil || iface.Name == nil {
-			continue
-		}
-		out[strconv.Itoa(idx)] = *iface.Name
 	}
 	return out
 }

--- a/snmp-discovery/mapping/module_routing.go
+++ b/snmp-discovery/mapping/module_routing.go
@@ -11,7 +11,7 @@ package mapping
 import (
 	"context"
 	"log/slog"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -160,18 +160,35 @@ func buildIfaceModuleMap(
 	return out
 }
 
+// aliasCandidate carries the parsed (logical index, ifIndex) for one
+// entAliasMappingTable row so AliasMapFromOIDs can apply the RFC 6933
+// precedence rule (non-zero logical-index beats .0 wildcard).
+type aliasCandidate struct {
+	logicalIdx int
+	ifIdx      int
+}
+
 // AliasMapFromOIDs parses entAliasMappingTable rows into a flat
 // entPhysicalIndex -> ifIndex map (decimal strings). Mirrors the parse
 // rules in chassis_routing.go:152-179 (drop malformed suffixes; drop
 // non-ifEntry.ifIndex values).
 //
-// When multiple rows resolve to the same entPhysicalIndex, the lowest
-// ifIndex wins — deterministic across runs. Map iteration order in Go
-// is randomized, so first-occurrence-wins would otherwise flip between
-// invocations. Mirrors chassis_routing.go's sorted candidate selection
-// (chassis_routing.go:202).
+// When multiple rows resolve to the same entPhysicalIndex, the
+// precedence mirrors chassis_routing.go:188-220:
+//
+//  1. RFC 6933 defines non-zero entAliasLogicalIndexOrZero rows as the
+//     per-logical-entity mapping carrying explicit context. They take
+//     precedence over the .0 "default mapping in the absence of any
+//     logical entity" row — regardless of which target ifIndex is
+//     numerically smaller. Without this rule, devices that publish both
+//     forms (multi-logical-entity contexts) resolve a transceiver to
+//     the wrong interface.
+//  2. Among non-zero rows, the lowest logical index wins — defensive
+//     tiebreaker when several per-entity rows compete.
+//  3. Final tiebreaker: lowest target ifIndex. Keeps resolution stable
+//     across re-runs since Go map iteration is randomized.
 func AliasMapFromOIDs(oids ObjectIDValueMap) map[string]string {
-	candidates := make(map[string][]int)
+	candidates := make(map[string][]aliasCandidate)
 	for oid, v := range oids {
 		if !strings.HasPrefix(oid, oidEntAliasMappingIdent) {
 			continue
@@ -182,6 +199,10 @@ func AliasMapFromOIDs(oids ObjectIDValueMap) map[string]string {
 			continue
 		}
 		entIdx := parts[0]
+		logicalIdx, err := strconv.Atoi(parts[1])
+		if err != nil {
+			continue
+		}
 		// Normalize: strip leading dot (gosnmp's ObjectIdentifier
 		// rendering varies) then require the value to point at
 		// ifEntry.ifIndex — skip ifAlias / ifDescr targets.
@@ -194,12 +215,32 @@ func AliasMapFromOIDs(oids ObjectIDValueMap) map[string]string {
 		if err != nil {
 			continue
 		}
-		candidates[entIdx] = append(candidates[entIdx], ifIdx)
+		candidates[entIdx] = append(candidates[entIdx], aliasCandidate{
+			logicalIdx: logicalIdx,
+			ifIdx:      ifIdx,
+		})
 	}
 	out := make(map[string]string, len(candidates))
-	for entIdx, ifIdxs := range candidates {
-		sort.Ints(ifIdxs)
-		out[entIdx] = strconv.Itoa(ifIdxs[0])
+	for entIdx, rows := range candidates {
+		slices.SortFunc(rows, func(a, b aliasCandidate) int {
+			aZero := 1
+			if a.logicalIdx == 0 {
+				aZero = 0
+			}
+			bZero := 1
+			if b.logicalIdx == 0 {
+				bZero = 0
+			}
+			if aZero != bZero {
+				// Non-zero (aZero=1 / bZero=1) sorts FIRST.
+				return bZero - aZero
+			}
+			if a.logicalIdx != b.logicalIdx {
+				return a.logicalIdx - b.logicalIdx
+			}
+			return a.ifIdx - b.ifIdx
+		})
+		out[entIdx] = strconv.Itoa(rows[0].ifIdx)
 	}
 	return out
 }

--- a/snmp-discovery/mapping/module_routing.go
+++ b/snmp-discovery/mapping/module_routing.go
@@ -1,0 +1,103 @@
+// Copyright 2026 NetBox Labs, Inc.
+
+// Package mapping — module_routing.go: per-VC-member dispatch for the
+// module / module bay inventory built by extractModuleInventory. Walks
+// each module's containedIn chain until it hits a class=3 chassis, then
+// maps that chassis EntPhysicalIndex to the owning ChassisInventory
+// member id. Sits between extractModuleInventory and the translation
+// step so the extractor stays chassis-topology-agnostic.
+package mapping
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// assignMemberID stamps each ModuleEntry in inv with the logical member
+// id that owns it.
+//
+//   - chassisInv == nil OR no members -> standalone target; every entry
+//     lands on MemberID=0 so the translation step emits modules under
+//     the master device.
+//   - VC / stack target -> walk the entPhysicalContainedIn chain from
+//     each module's EntIndex until reaching a chassis EntPhysicalIndex
+//     present in chassisInv.Members. Stamp the corresponding member id.
+//     Modules whose chain terminates at a chassis NOT in chassisInv get
+//     the sentinel MemberID=-1 plus a warn log; the translation step
+//     skips MemberID<0 entries.
+//
+// The cycle guard mirrors extractModuleInventory.walkParents — a `seen`
+// set bounded by the chain length suffices since the containedIn
+// relation is meant to be a DAG (malformed MIBs notwithstanding).
+func assignMemberID(inv *ModuleInventory, chassisInv *ChassisInventory, oids ObjectIDValueMap, logger *slog.Logger) {
+	if inv == nil {
+		return
+	}
+
+	// Standalone fast path — nothing to walk.
+	if chassisInv == nil || len(chassisInv.Members) == 0 {
+		for i := range inv.Modules {
+			inv.Modules[i].MemberID = 0
+		}
+		for parent, list := range inv.SubModules {
+			for i := range list {
+				list[i].MemberID = 0
+			}
+			inv.SubModules[parent] = list
+		}
+		for i := range inv.EmptyBays {
+			inv.EmptyBays[i].MemberID = 0
+		}
+		return
+	}
+
+	entIdxToMemberID := make(map[string]int, len(chassisInv.Members))
+	for _, m := range chassisInv.Members {
+		entIdxToMemberID[m.EntPhysicalIndex] = m.ID
+	}
+
+	resolve := func(startEnt string) (int, bool) {
+		// Walk containedIn until we hit a class=3 ent that lives in the
+		// chassisInv member map. seen guards a malformed self-/mutual-
+		// referential containedIn pair from looping forever.
+		cur := strings.TrimSpace(oids[oidEntPhysicalContainedIn+startEnt].Value)
+		seen := make(map[string]struct{})
+		for cur != "" && cur != "0" {
+			if _, dup := seen[cur]; dup {
+				return 0, false
+			}
+			seen[cur] = struct{}{}
+			class := strings.TrimSpace(oids[oidEntPhysicalClass+cur].Value)
+			if class == entPhysicalClassChassis {
+				id, ok := entIdxToMemberID[cur]
+				return id, ok
+			}
+			cur = strings.TrimSpace(oids[oidEntPhysicalContainedIn+cur].Value)
+		}
+		return 0, false
+	}
+
+	stamp := func(e *ModuleEntry) {
+		id, ok := resolve(e.EntIndex)
+		if !ok {
+			logger.Warn("module discovery: orphan module — chassis ancestor not in chassis inventory",
+				"ent", e.EntIndex, "model", e.Model)
+			e.MemberID = -1
+			return
+		}
+		e.MemberID = id
+	}
+
+	for i := range inv.Modules {
+		stamp(&inv.Modules[i])
+	}
+	for parent, list := range inv.SubModules {
+		for i := range list {
+			stamp(&list[i])
+		}
+		inv.SubModules[parent] = list
+	}
+	for i := range inv.EmptyBays {
+		stamp(&inv.EmptyBays[i])
+	}
+}

--- a/snmp-discovery/mapping/module_routing.go
+++ b/snmp-discovery/mapping/module_routing.go
@@ -15,10 +15,9 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/metrics"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
-
-	"github.com/netboxlabs/orb-discovery/snmp-discovery/metrics"
 )
 
 // assignMemberID stamps each ModuleEntry in inv with the logical member

--- a/snmp-discovery/mapping/module_routing.go
+++ b/snmp-discovery/mapping/module_routing.go
@@ -11,6 +11,8 @@ package mapping
 import (
 	"log/slog"
 	"strings"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
 )
 
 // assignMemberID stamps each ModuleEntry in inv with the logical member
@@ -100,4 +102,49 @@ func assignMemberID(inv *ModuleInventory, chassisInv *ChassisInventory, oids Obj
 	for i := range inv.EmptyBays {
 		stamp(&inv.EmptyBays[i])
 	}
+}
+
+// buildIfaceModuleMap builds the {ifName -> *diode.Module} lookup the
+// runner needs to set Interface.Module on each transceiver-owning port.
+//
+// Only transceivers under inv.SubModules participate — top-level modules
+// (linecards, supervisors) aren't single-port entities and don't route
+// to an ifName. For each transceiver:
+//
+//  1. aliasMap[EntIndex] gives the ifIndex (as set up upstream by the
+//     entAliasMappingTable walk).
+//  2. ifIndexToName[ifIndex] gives the canonical ifName.
+//  3. emittedModules[EntIndex] is the *diode.Module the translator
+//     already produced; this map points the ifName at it.
+//
+// Any step that misses simply skips the transceiver — partial coverage
+// is normal (optic with no alias-table row, port-channel placeholder, etc.).
+func buildIfaceModuleMap(
+	inv ModuleInventory,
+	aliasMap map[string]string,
+	ifIndexToName map[string]string,
+	emittedModules map[string]*diode.Module,
+) map[string]*diode.Module {
+	out := make(map[string]*diode.Module)
+	for _, list := range inv.SubModules {
+		for _, e := range list {
+			if e.Type != ModuleTypeTransceiver {
+				continue
+			}
+			ifIdx, ok := aliasMap[e.EntIndex]
+			if !ok {
+				continue
+			}
+			ifName, ok := ifIndexToName[ifIdx]
+			if !ok {
+				continue
+			}
+			mod, ok := emittedModules[e.EntIndex]
+			if !ok {
+				continue
+			}
+			out[ifName] = mod
+		}
+	}
+	return out
 }

--- a/snmp-discovery/mapping/module_routing_test.go
+++ b/snmp-discovery/mapping/module_routing_test.go
@@ -261,21 +261,57 @@ func TestAliasMapFromOIDs_ParsesEntAliasMappingRows(t *testing.T) {
 
 // TestAliasMapFromOIDs_DeterministicWhenMultipleAliasRowsShareEntIndex —
 // when multiple entAliasMappingTable rows resolve to the same
-// entPhysicalIndex, AliasMapFromOIDs must pick deterministically. We
-// pick the lowest ifIndex, mirroring chassis_routing.go's sorted
-// resolution. Running 50x confirms map-iteration order can't flip it.
+// entPhysicalIndex, AliasMapFromOIDs must pick deterministically.
+// Under the RFC 6933 precedence rule, a non-zero logical-index row wins
+// over the .0 wildcard, so here logical=1 (ifIndex 10101) beats
+// logical=0 (ifIndex 10201). Running 50x confirms map-iteration order
+// can't flip it.
 func TestAliasMapFromOIDs_DeterministicWhenMultipleAliasRowsShareEntIndex(t *testing.T) {
 	oids := ObjectIDValueMap{
 		// Two rows for entPhysicalIndex 203 — different logical idx,
-		// different ifIndex. Result must always be the lower ifIndex.
+		// different ifIndex. Non-zero logical-index row must win.
 		".1.3.6.1.2.1.47.1.3.2.1.2.203.0": Value{Value: ".1.3.6.1.2.1.2.2.1.1.10201"},
 		".1.3.6.1.2.1.47.1.3.2.1.2.203.1": Value{Value: ".1.3.6.1.2.1.2.2.1.1.10101"},
 	}
 	for i := 0; i < 50; i++ {
 		m := AliasMapFromOIDs(oids)
 		require.Equal(t, "10101", m["203"],
-			"AliasMapFromOIDs must deterministically pick the lowest ifIndex")
+			"AliasMapFromOIDs must deterministically pick the non-zero logical-index row")
 	}
+}
+
+// TestAliasMapFromOIDs_NonZeroLogicalIndexBeatsWildcard — RFC 6933
+// entAliasMappingTable is keyed by (entPhysicalIndex,
+// entAliasLogicalIndexOrZero). Non-zero logical-index rows carry
+// per-logical-entity context and MUST take precedence over the .0
+// "default mapping in the absence of any logical entity" row,
+// regardless of which target ifIndex is numerically smaller. This
+// mirrors chassis_routing.go's logical-index precedence rule.
+func TestAliasMapFromOIDs_NonZeroLogicalIndexBeatsWildcard(t *testing.T) {
+	// entPhysicalIndex 203 has TWO alias rows: a .0 wildcard pointing at
+	// ifIndex 10101 (lower) AND a non-zero logical row pointing at
+	// ifIndex 20201 (higher). Per RFC 6933, the non-zero logical-index
+	// row wins regardless of which ifIndex is smaller.
+	oids := ObjectIDValueMap{
+		".1.3.6.1.2.1.47.1.3.2.1.2.203.0": Value{Value: ".1.3.6.1.2.1.2.2.1.1.10101"},
+		".1.3.6.1.2.1.47.1.3.2.1.2.203.5": Value{Value: ".1.3.6.1.2.1.2.2.1.1.20201"},
+	}
+	m := AliasMapFromOIDs(oids)
+	require.Equal(t, "20201", m["203"],
+		"non-zero logical-index row must win over .0 wildcard")
+}
+
+// TestAliasMapFromOIDs_LowestLogicalIndexAmongNonZero — among multiple
+// non-zero logical-index rows the lowest logical index is the
+// deterministic tiebreaker. Mirrors chassis_routing.go's secondary sort.
+func TestAliasMapFromOIDs_LowestLogicalIndexAmongNonZero(t *testing.T) {
+	oids := ObjectIDValueMap{
+		".1.3.6.1.2.1.47.1.3.2.1.2.203.5": Value{Value: ".1.3.6.1.2.1.2.2.1.1.50505"},
+		".1.3.6.1.2.1.47.1.3.2.1.2.203.2": Value{Value: ".1.3.6.1.2.1.2.2.1.1.20202"},
+	}
+	m := AliasMapFromOIDs(oids)
+	require.Equal(t, "20202", m["203"],
+		"lowest non-zero logical-index wins among non-zero candidates")
 }
 
 // TestMemberDevicesFromEntities_VCKeyedByLowestMemberID — the master

--- a/snmp-discovery/mapping/module_routing_test.go
+++ b/snmp-discovery/mapping/module_routing_test.go
@@ -217,3 +217,100 @@ func TestBuildIfaceModuleMap_TransceiverWithoutIfNameSkipped(t *testing.T) {
 	assert.Empty(t, got, "ifIndex without an ifName entry -> transceiver not in result")
 }
 
+// --- Exported helper tests (runner wire-up) ---
+
+// TestAliasMapFromOIDs_ParsesEntAliasMappingRows — confirms the flat
+// entPhysicalIndex -> ifIndex shape: happy path, malformed suffix
+// dropped, non-ifIndex value dropped, unrelated OID ignored.
+func TestAliasMapFromOIDs_ParsesEntAliasMappingRows(t *testing.T) {
+	oids := ObjectIDValueMap{
+		// entAliasMappingIdent.<entPhysicalIndex>.<logicalIdx> -> ifEntry.ifIndex.<ifIdx>
+		".1.3.6.1.2.1.47.1.3.2.1.2.203.0": Value{Value: ".1.3.6.1.2.1.2.2.1.1.10101"},
+		".1.3.6.1.2.1.47.1.3.2.1.2.301.0": Value{Value: ".1.3.6.1.2.1.2.2.1.1.10201"},
+		// Malformed — single-segment suffix, must be skipped.
+		".1.3.6.1.2.1.47.1.3.2.1.2.999": Value{Value: ".1.3.6.1.2.1.2.2.1.1.99999"},
+		// Non-ifIndex value (ifAlias), must be skipped.
+		".1.3.6.1.2.1.47.1.3.2.1.2.404.0": Value{Value: ".1.3.6.1.2.1.31.1.1.1.18.10101"},
+		// Unrelated OID, must be ignored.
+		".1.3.6.1.2.1.2.2.1.2.10101": Value{Value: "GigabitEthernet1/0/1"},
+	}
+	m := AliasMapFromOIDs(oids)
+	assert.Equal(t, "10101", m["203"])
+	assert.Equal(t, "10201", m["301"])
+	assert.NotContains(t, m, "999", "malformed row dropped")
+	assert.NotContains(t, m, "404", "non-ifIndex value dropped")
+	assert.Len(t, m, 2)
+}
+
+// TestIfNameByIfIndex_InvertsRunnerMap — inversion plus nil-Name skip.
+func TestIfNameByIfIndex_InvertsRunnerMap(t *testing.T) {
+	n1 := strPtr("Gi1/0/1")
+	n2 := strPtr("Gi2/0/1")
+	i1 := &diode.Interface{Name: n1}
+	i2 := &diode.Interface{Name: n2}
+	nameless := &diode.Interface{} // Name == nil; skipped
+	ifIndexByIface := map[*diode.Interface]int{
+		i1:       10101,
+		i2:       10201,
+		nameless: 30000,
+	}
+	m := IfNameByIfIndex(ifIndexByIface)
+	assert.Equal(t, "Gi1/0/1", m["10101"])
+	assert.Equal(t, "Gi2/0/1", m["10201"])
+	assert.NotContains(t, m, "30000", "interfaces with nil Name are skipped")
+	assert.Len(t, m, 2)
+}
+
+// TestMemberDevicesFromEntities_VCKeyedByLowestMemberID — the master
+// Device (VcPosition == nil) must be keyed by Members[0].ID — the lowest
+// logical member id — to mirror TranslateAsStack's memberByID convention
+// (chassis.go:432). Non-master members are keyed by *VcPosition.
+func TestMemberDevicesFromEntities_VCKeyedByLowestMemberID(t *testing.T) {
+	master := &diode.Device{Name: strPtr("vc-master")} // VcPosition == nil
+	pos2 := int64(2)
+	pos3 := int64(3)
+	m2 := &diode.Device{Name: strPtr("member-2"), VcPosition: &pos2}
+	m3 := &diode.Device{Name: strPtr("member-3"), VcPosition: &pos3}
+	entities := []diode.Entity{master, m2, m3}
+	inv := &ChassisInventory{Members: []ChassisMember{{ID: 1}, {ID: 2}, {ID: 3}}}
+
+	out := MemberDevicesFromEntities(entities, inv)
+
+	assert.Equal(t, master, out[1], "master keyed by Members[0].ID (lowest), not 0")
+	assert.Equal(t, m2, out[2])
+	assert.Equal(t, m3, out[3])
+	assert.NotContains(t, out, 0, "master must NOT be keyed by 0 in VC")
+	assert.Len(t, out, 3)
+}
+
+// TestMemberDevicesFromEntities_StandaloneKeyedByZero — when there is no
+// ChassisInventory the master falls back to the standalone key 0.
+func TestMemberDevicesFromEntities_StandaloneKeyedByZero(t *testing.T) {
+	dev := &diode.Device{Name: strPtr("standalone")} // VcPosition == nil
+	out := MemberDevicesFromEntities([]diode.Entity{dev}, nil)
+	assert.Equal(t, dev, out[0], "standalone master keyed by 0 when no ChassisInventory")
+	assert.Len(t, out, 1)
+}
+
+// TestChassisInventoryFromEntities_WrapsExtractInventory — single-chassis
+// fixture produces at least one Member and the master member id is the
+// parentRelPos from the fixture (1).
+func TestChassisInventoryFromEntities_WrapsExtractInventory(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	// Minimal stack fixture: one chassis row (class=3).
+	oids := ObjectIDValueMap{
+		".1.3.6.1.2.1.47.1.1.1.1.5.1":  Value{Value: "3"},           // entPhysicalClass=chassis
+		".1.3.6.1.2.1.47.1.1.1.1.4.1":  Value{Value: "0"},           // contained in nothing
+		".1.3.6.1.2.1.47.1.1.1.1.7.1":  Value{Value: "Stack-1"},     // entPhysicalName
+		".1.3.6.1.2.1.47.1.1.1.1.11.1": Value{Value: "FOC2401L0K0"}, // serial
+		".1.3.6.1.2.1.47.1.1.1.1.13.1": Value{Value: "C9300-48UXM"}, // modelName
+		".1.3.6.1.2.1.47.1.1.1.1.6.1":  Value{Value: "1"},           // parentRelPos
+	}
+	inv := ChassisInventoryFromEntities(nil, oids, logger)
+	require.NotNil(t, inv)
+	require.GreaterOrEqual(t, len(inv.Members), 1,
+		"single-chassis fixture must produce at least one Member")
+	assert.Equal(t, 1, inv.Members[0].ID,
+		"master member ID is lowest present in fixture (parentRelPos=1)")
+}
+

--- a/snmp-discovery/mapping/module_routing_test.go
+++ b/snmp-discovery/mapping/module_routing_test.go
@@ -242,6 +242,25 @@ func TestAliasMapFromOIDs_ParsesEntAliasMappingRows(t *testing.T) {
 	assert.Len(t, m, 2)
 }
 
+// TestAliasMapFromOIDs_DeterministicWhenMultipleAliasRowsShareEntIndex —
+// when multiple entAliasMappingTable rows resolve to the same
+// entPhysicalIndex, AliasMapFromOIDs must pick deterministically. We
+// pick the lowest ifIndex, mirroring chassis_routing.go's sorted
+// resolution. Running 50x confirms map-iteration order can't flip it.
+func TestAliasMapFromOIDs_DeterministicWhenMultipleAliasRowsShareEntIndex(t *testing.T) {
+	oids := ObjectIDValueMap{
+		// Two rows for entPhysicalIndex 203 — different logical idx,
+		// different ifIndex. Result must always be the lower ifIndex.
+		".1.3.6.1.2.1.47.1.3.2.1.2.203.0": Value{Value: ".1.3.6.1.2.1.2.2.1.1.10201"},
+		".1.3.6.1.2.1.47.1.3.2.1.2.203.1": Value{Value: ".1.3.6.1.2.1.2.2.1.1.10101"},
+	}
+	for i := 0; i < 50; i++ {
+		m := AliasMapFromOIDs(oids)
+		require.Equal(t, "10101", m["203"],
+			"AliasMapFromOIDs must deterministically pick the lowest ifIndex")
+	}
+}
+
 // TestIfNameByIfIndex_InvertsRunnerMap — inversion plus nil-Name skip.
 func TestIfNameByIfIndex_InvertsRunnerMap(t *testing.T) {
 	n1 := strPtr("Gi1/0/1")

--- a/snmp-discovery/mapping/module_routing_test.go
+++ b/snmp-discovery/mapping/module_routing_test.go
@@ -1,0 +1,167 @@
+// Copyright 2026 NetBox Labs, Inc.
+
+package mapping
+
+import (
+	"bytes"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newCapturingLogger builds an slog.Logger whose output lands in buf so
+// individual tests can assert on warn-line presence.
+func newCapturingLogger(buf *bytes.Buffer) *slog.Logger {
+	return slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+}
+
+// TestAssignMemberID_StandaloneAllZero — when chassisInv is nil the
+// device is standalone; every module / sub-module / empty-bay entry must
+// land on member id 0 so downstream translation emits them under master.
+func TestAssignMemberID_StandaloneAllZero(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := newCapturingLogger(buf)
+
+	inv := newModuleInventory()
+	inv.Modules = []ModuleEntry{
+		{EntIndex: "101", Type: ModuleTypeSupervisor},
+		{EntIndex: "201", Type: ModuleTypeLinecard},
+	}
+	inv.SubModules["201"] = []ModuleEntry{
+		{EntIndex: "203", Type: ModuleTypeTransceiver, ParentEntIdx: "201"},
+	}
+	inv.EmptyBays = []ModuleEntry{
+		{EntIndex: "300", Type: ModuleTypeUnknown},
+	}
+
+	assignMemberID(&inv, nil, ObjectIDValueMap{}, logger)
+
+	for _, m := range inv.Modules {
+		assert.Equalf(t, 0, m.MemberID, "module %s must be MemberID=0 in standalone", m.EntIndex)
+	}
+	for _, list := range inv.SubModules {
+		for _, m := range list {
+			assert.Equalf(t, 0, m.MemberID, "submodule %s must be MemberID=0 in standalone", m.EntIndex)
+		}
+	}
+	for _, m := range inv.EmptyBays {
+		assert.Equalf(t, 0, m.MemberID, "empty bay %s must be MemberID=0 in standalone", m.EntIndex)
+	}
+}
+
+// TestAssignMemberID_VCMapsToMemberByChassisAncestor — module EntIndex
+// "201" sits under class=5 "200" which sits under class=3 "1000". The
+// chassis row "1000" belongs to member id 2 (per chassisInv.Members).
+// assignMemberID must walk the containedIn chain to "1000" and stamp
+// MemberID=2 on the module entry.
+func TestAssignMemberID_VCMapsToMemberByChassisAncestor(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := newCapturingLogger(buf)
+
+	inv := newModuleInventory()
+	inv.Modules = []ModuleEntry{
+		{EntIndex: "201", Type: ModuleTypeLinecard},
+	}
+
+	chassisInv := &ChassisInventory{
+		Members: []ChassisMember{
+			{ID: 1, EntPhysicalIndex: "1"},
+			{ID: 2, EntPhysicalIndex: "1000"},
+		},
+	}
+
+	// containedIn chain: 201 -> 200 (class=5) -> 1000 (class=3).
+	oids := ObjectIDValueMap{
+		".1.3.6.1.2.1.47.1.1.1.1.4.201":  Value{Value: "200"},
+		".1.3.6.1.2.1.47.1.1.1.1.5.201":  Value{Value: "9"},
+		".1.3.6.1.2.1.47.1.1.1.1.4.200":  Value{Value: "1000"},
+		".1.3.6.1.2.1.47.1.1.1.1.5.200":  Value{Value: "5"},
+		".1.3.6.1.2.1.47.1.1.1.1.4.1000": Value{Value: "0"},
+		".1.3.6.1.2.1.47.1.1.1.1.5.1000": Value{Value: "3"},
+	}
+
+	assignMemberID(&inv, chassisInv, oids, logger)
+
+	require.Len(t, inv.Modules, 1)
+	assert.Equal(t, 2, inv.Modules[0].MemberID,
+		"module 201 chain terminates at chassis 1000 -> member 2")
+}
+
+// TestAssignMemberID_OrphanMember_DroppedOrLogged — a module whose
+// chassis ancestor is NOT in chassisInv.Members must be left with the
+// sentinel MemberID=-1 (translation step skips MemberID<0) and a warn
+// log must fire so operators can spot the orphan.
+func TestAssignMemberID_OrphanMember_DroppedOrLogged(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := newCapturingLogger(buf)
+
+	inv := newModuleInventory()
+	inv.Modules = []ModuleEntry{
+		{EntIndex: "401", Type: ModuleTypeLinecard},
+	}
+
+	chassisInv := &ChassisInventory{
+		Members: []ChassisMember{
+			{ID: 1, EntPhysicalIndex: "1"},
+			{ID: 2, EntPhysicalIndex: "1000"},
+		},
+	}
+
+	// 401 -> 400 (class=5) -> 9999 (class=3). 9999 is not in chassisInv.
+	oids := ObjectIDValueMap{
+		".1.3.6.1.2.1.47.1.1.1.1.4.401":  Value{Value: "400"},
+		".1.3.6.1.2.1.47.1.1.1.1.5.401":  Value{Value: "9"},
+		".1.3.6.1.2.1.47.1.1.1.1.4.400":  Value{Value: "9999"},
+		".1.3.6.1.2.1.47.1.1.1.1.5.400":  Value{Value: "5"},
+		".1.3.6.1.2.1.47.1.1.1.1.4.9999": Value{Value: "0"},
+		".1.3.6.1.2.1.47.1.1.1.1.5.9999": Value{Value: "3"},
+	}
+
+	assignMemberID(&inv, chassisInv, oids, logger)
+
+	require.Len(t, inv.Modules, 1)
+	assert.Equal(t, -1, inv.Modules[0].MemberID,
+		"orphan module must carry MemberID=-1 sentinel for the skip path")
+	assert.Contains(t, buf.String(), "orphan",
+		"orphan module must produce a warn log")
+}
+
+// TestAssignMemberID_VCMasterKeyedByLowestMemberID — modules under the
+// master chassis (entPhysicalIndex == Members[0].EntPhysicalIndex) must
+// carry the lowest member id (Members[0].ID == 1), NOT 0. The "0 means
+// standalone" rule applies only when chassisInv is nil/empty.
+func TestAssignMemberID_VCMasterKeyedByLowestMemberID(t *testing.T) {
+	buf := &bytes.Buffer{}
+	logger := newCapturingLogger(buf)
+
+	inv := newModuleInventory()
+	inv.Modules = []ModuleEntry{
+		{EntIndex: "101", Type: ModuleTypeLinecard},
+	}
+
+	chassisInv := &ChassisInventory{
+		Members: []ChassisMember{
+			{ID: 1, EntPhysicalIndex: "1"},
+			{ID: 2, EntPhysicalIndex: "1000"},
+		},
+	}
+
+	// 101 -> 100 (class=5) -> 1 (class=3, master).
+	oids := ObjectIDValueMap{
+		".1.3.6.1.2.1.47.1.1.1.1.4.101": Value{Value: "100"},
+		".1.3.6.1.2.1.47.1.1.1.1.5.101": Value{Value: "9"},
+		".1.3.6.1.2.1.47.1.1.1.1.4.100": Value{Value: "1"},
+		".1.3.6.1.2.1.47.1.1.1.1.5.100": Value{Value: "5"},
+		".1.3.6.1.2.1.47.1.1.1.1.4.1":   Value{Value: "0"},
+		".1.3.6.1.2.1.47.1.1.1.1.5.1":   Value{Value: "3"},
+	}
+
+	assignMemberID(&inv, chassisInv, oids, logger)
+
+	require.Len(t, inv.Modules, 1)
+	assert.Equal(t, 1, inv.Modules[0].MemberID,
+		"module under master chassis must carry the lowest member id (1), not 0")
+}
+

--- a/snmp-discovery/mapping/module_routing_test.go
+++ b/snmp-discovery/mapping/module_routing_test.go
@@ -366,3 +366,101 @@ func TestChassisInventoryFromOIDs_WrapsExtractInventory(t *testing.T) {
 	assert.Equal(t, 1, inv.Members[0].ID,
 		"master member ID is lowest present in fixture (parentRelPos=1)")
 }
+
+// --- AttachIfaceModules tests ---
+
+// TestAttachIfaceModules_TopLevelInterface — sanity: the existing happy
+// path (an *diode.Interface directly in the slice) still attaches the
+// module. Guards against regression after the helper extraction.
+func TestAttachIfaceModules_TopLevelInterface(t *testing.T) {
+	iface := &diode.Interface{Name: strPtr("GigabitEthernet1/0/1")}
+	mod := &diode.Module{Serial: strPtr("XCVR-TOP")}
+	entities := []diode.Entity{iface}
+	ifaceModuleMap := map[string]*diode.Module{"10101": mod}
+	ifIndexByIface := map[*diode.Interface]int{iface: 10101}
+
+	AttachIfaceModules(entities, ifaceModuleMap, ifIndexByIface)
+
+	require.NotNil(t, iface.Module, "top-level Interface must get its Module set")
+	assert.Equal(t, "XCVR-TOP", *iface.Module.Serial)
+}
+
+// TestAttachIfaceModules_NestedInterfaceInIPAddress — codex P2
+// regression. MapObjectIDsToEntity drops interfaces referenced by
+// IPAddress.AssignedObject from the top-level entity slice (the L3
+// routed-port case in mapping.go's getAssignedInterfaces filter). The
+// runner's previous attach loop only iterated *diode.Interface entries
+// and silently missed these, leaving Interface.Module nil. The helper
+// must reach through IPAddress.AssignedObject.
+func TestAttachIfaceModules_NestedInterfaceInIPAddress(t *testing.T) {
+	iface := &diode.Interface{Name: strPtr("TenGigabitEthernet2/0/1"), Module: nil}
+	ip := &diode.IPAddress{
+		Address:        strPtr("10.0.0.1/24"),
+		AssignedObject: iface,
+	}
+	mod := &diode.Module{Serial: strPtr("FNS00000001")}
+	// Note: ONLY the IPAddress sits in entities — the routed iface has
+	// no standalone counterpart in the slice (the very case this fix
+	// addresses).
+	entities := []diode.Entity{ip}
+	ifaceModuleMap := map[string]*diode.Module{"10101": mod}
+	ifIndexByIface := map[*diode.Interface]int{iface: 10101}
+
+	AttachIfaceModules(entities, ifaceModuleMap, ifIndexByIface)
+
+	require.NotNil(t, iface.Module,
+		"Interface inside IPAddress.AssignedObject must get its Module set")
+	assert.Equal(t, "FNS00000001", *iface.Module.Serial)
+}
+
+// TestAttachIfaceModules_NestedInterfaceInMACAddress — mirror of the
+// IPAddress case. MACAddress.AssignedObject carries an *diode.Interface
+// on this codebase (chassis.go:484 walks it during member-rerouting).
+// The helper must reach through that shape too so an interface visible
+// ONLY via a MAC ref still gets its module attached.
+func TestAttachIfaceModules_NestedInterfaceInMACAddress(t *testing.T) {
+	iface := &diode.Interface{Name: strPtr("TenGigabitEthernet2/0/2"), Module: nil}
+	mac := &diode.MACAddress{
+		MacAddress:     strPtr("00:11:22:33:44:55"),
+		AssignedObject: iface,
+	}
+	mod := &diode.Module{Serial: strPtr("FNS00000002")}
+	entities := []diode.Entity{mac}
+	ifaceModuleMap := map[string]*diode.Module{"10102": mod}
+	ifIndexByIface := map[*diode.Interface]int{iface: 10102}
+
+	AttachIfaceModules(entities, ifaceModuleMap, ifIndexByIface)
+
+	require.NotNil(t, iface.Module,
+		"Interface inside MACAddress.AssignedObject must get its Module set")
+	assert.Equal(t, "FNS00000002", *iface.Module.Serial)
+}
+
+// TestAttachIfaceModules_MissIfIndexLeavesModuleNil — when an interface
+// pointer is not present in ifIndexByIface (e.g. came in via a path the
+// registry didn't track) the helper skips it silently. Interface.Module
+// remains nil — no panic, no fabricated lookup.
+func TestAttachIfaceModules_MissIfIndexLeavesModuleNil(t *testing.T) {
+	iface := &diode.Interface{Name: strPtr("unknown")}
+	entities := []diode.Entity{iface}
+	ifaceModuleMap := map[string]*diode.Module{"10101": {Serial: strPtr("X")}}
+	ifIndexByIface := map[*diode.Interface]int{} // iface missing
+
+	AttachIfaceModules(entities, ifaceModuleMap, ifIndexByIface)
+
+	assert.Nil(t, iface.Module, "interface absent from ifIndexByIface stays untouched")
+}
+
+// TestAttachIfaceModules_EmptyMapsAreNoOp — defensive: nil/empty inputs
+// must not panic and must not mutate entities. The runner can call this
+// unconditionally without guarding on map size.
+func TestAttachIfaceModules_EmptyMapsAreNoOp(t *testing.T) {
+	iface := &diode.Interface{Name: strPtr("Gi1/0/1")}
+	entities := []diode.Entity{iface}
+
+	AttachIfaceModules(entities, nil, nil)
+	assert.Nil(t, iface.Module)
+
+	AttachIfaceModules(entities, map[string]*diode.Module{}, map[*diode.Interface]int{})
+	assert.Nil(t, iface.Module)
+}

--- a/snmp-discovery/mapping/module_routing_test.go
+++ b/snmp-discovery/mapping/module_routing_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"testing"
 
+	"github.com/netboxlabs/diode-sdk-go/diode"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -163,5 +164,56 @@ func TestAssignMemberID_VCMasterKeyedByLowestMemberID(t *testing.T) {
 	require.Len(t, inv.Modules, 1)
 	assert.Equal(t, 1, inv.Modules[0].MemberID,
 		"module under master chassis must carry the lowest member id (1), not 0")
+}
+
+// --- buildIfaceModuleMap tests ---
+
+// TestBuildIfaceModuleMap_HappyPath — transceiver EntIndex "203" routes
+// through aliasMap -> ifIndex "10101" -> ifIndexToName -> "Gi1/0/1".
+// The emitted Module at emittedModules["203"] must appear keyed by
+// "Gi1/0/1" in the result so the runner can later set Interface.Module.
+func TestBuildIfaceModuleMap_HappyPath(t *testing.T) {
+	inv := newModuleInventory()
+	inv.SubModules["201"] = []ModuleEntry{
+		{EntIndex: "203", Type: ModuleTypeTransceiver, ParentEntIdx: "201"},
+	}
+	aliasMap := map[string]string{"203": "10101"}
+	ifIndexToName := map[string]string{"10101": "Gi1/0/1"}
+	mod := &diode.Module{}
+	emitted := map[string]*diode.Module{"203": mod}
+
+	got := buildIfaceModuleMap(inv, aliasMap, ifIndexToName, emitted)
+
+	require.Contains(t, got, "Gi1/0/1")
+	assert.Same(t, mod, got["Gi1/0/1"], "result must point at the emittedModules entry")
+	assert.Len(t, got, 1, "only the transceiver routes; no extra keys")
+}
+
+// TestBuildIfaceModuleMap_TransceiverWithoutAliasSkipped — a transceiver
+// missing from aliasMap is silently skipped (no ifName to bind to).
+func TestBuildIfaceModuleMap_TransceiverWithoutAliasSkipped(t *testing.T) {
+	inv := newModuleInventory()
+	inv.SubModules["201"] = []ModuleEntry{
+		{EntIndex: "203", Type: ModuleTypeTransceiver, ParentEntIdx: "201"},
+	}
+	emitted := map[string]*diode.Module{"203": {}}
+
+	got := buildIfaceModuleMap(inv, map[string]string{}, map[string]string{"10101": "Gi1/0/1"}, emitted)
+
+	assert.Empty(t, got, "no aliasMap entry -> transceiver not in result")
+}
+
+// TestBuildIfaceModuleMap_TransceiverWithoutIfNameSkipped — aliasMap
+// resolves but the ifIndexToName lookup misses. Skip with no panic.
+func TestBuildIfaceModuleMap_TransceiverWithoutIfNameSkipped(t *testing.T) {
+	inv := newModuleInventory()
+	inv.SubModules["201"] = []ModuleEntry{
+		{EntIndex: "203", Type: ModuleTypeTransceiver, ParentEntIdx: "201"},
+	}
+	emitted := map[string]*diode.Module{"203": {}}
+
+	got := buildIfaceModuleMap(inv, map[string]string{"203": "10101"}, map[string]string{}, emitted)
+
+	assert.Empty(t, got, "ifIndex without an ifName entry -> transceiver not in result")
 }
 

--- a/snmp-discovery/mapping/module_routing_test.go
+++ b/snmp-discovery/mapping/module_routing_test.go
@@ -311,10 +311,10 @@ func TestMemberDevicesFromEntities_StandaloneKeyedByZero(t *testing.T) {
 	assert.Len(t, out, 1)
 }
 
-// TestChassisInventoryFromEntities_WrapsExtractInventory — single-chassis
+// TestChassisInventoryFromOIDs_WrapsExtractInventory — single-chassis
 // fixture produces at least one Member and the master member id is the
 // parentRelPos from the fixture (1).
-func TestChassisInventoryFromEntities_WrapsExtractInventory(t *testing.T) {
+func TestChassisInventoryFromOIDs_WrapsExtractInventory(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
 	// Minimal stack fixture: one chassis row (class=3).
 	oids := ObjectIDValueMap{
@@ -325,7 +325,7 @@ func TestChassisInventoryFromEntities_WrapsExtractInventory(t *testing.T) {
 		".1.3.6.1.2.1.47.1.1.1.1.13.1": Value{Value: "C9300-48UXM"}, // modelName
 		".1.3.6.1.2.1.47.1.1.1.1.6.1":  Value{Value: "1"},           // parentRelPos
 	}
-	inv := ChassisInventoryFromEntities(nil, oids, logger)
+	inv := ChassisInventoryFromOIDs(oids, logger)
 	require.NotNil(t, inv)
 	require.GreaterOrEqual(t, len(inv.Members), 1,
 		"single-chassis fixture must produce at least one Member")

--- a/snmp-discovery/mapping/module_routing_test.go
+++ b/snmp-discovery/mapping/module_routing_test.go
@@ -313,4 +313,3 @@ func TestChassisInventoryFromEntities_WrapsExtractInventory(t *testing.T) {
 	assert.Equal(t, 1, inv.Members[0].ID,
 		"master member ID is lowest present in fixture (parentRelPos=1)")
 }
-

--- a/snmp-discovery/mapping/module_routing_test.go
+++ b/snmp-discovery/mapping/module_routing_test.go
@@ -168,29 +168,29 @@ func TestAssignMemberID_VCMasterKeyedByLowestMemberID(t *testing.T) {
 
 // --- buildIfaceModuleMap tests ---
 
-// TestBuildIfaceModuleMap_HappyPath — transceiver EntIndex "203" routes
-// through aliasMap -> ifIndex "10101" -> ifIndexToName -> "Gi1/0/1".
-// The emitted Module at emittedModules["203"] must appear keyed by
-// "Gi1/0/1" in the result so the runner can later set Interface.Module.
+// TestBuildIfaceModuleMap_HappyPath — transceiver EntIndex "203" resolves
+// through aliasMap to ifIndex "10101". The emitted Module at
+// emittedModules["203"] must appear keyed by ifIndex "10101" in the
+// result so the runner can later set Interface.Module via the
+// ifIndexByIface lookup.
 func TestBuildIfaceModuleMap_HappyPath(t *testing.T) {
 	inv := newModuleInventory()
 	inv.SubModules["201"] = []ModuleEntry{
 		{EntIndex: "203", Type: ModuleTypeTransceiver, ParentEntIdx: "201"},
 	}
 	aliasMap := map[string]string{"203": "10101"}
-	ifIndexToName := map[string]string{"10101": "Gi1/0/1"}
 	mod := &diode.Module{}
 	emitted := map[string]*diode.Module{"203": mod}
 
-	got := buildIfaceModuleMap(inv, aliasMap, ifIndexToName, emitted)
+	got := buildIfaceModuleMap(inv, aliasMap, emitted)
 
-	require.Contains(t, got, "Gi1/0/1")
-	assert.Same(t, mod, got["Gi1/0/1"], "result must point at the emittedModules entry")
+	require.Contains(t, got, "10101")
+	assert.Same(t, mod, got["10101"], "result must point at the emittedModules entry")
 	assert.Len(t, got, 1, "only the transceiver routes; no extra keys")
 }
 
 // TestBuildIfaceModuleMap_TransceiverWithoutAliasSkipped — a transceiver
-// missing from aliasMap is silently skipped (no ifName to bind to).
+// missing from aliasMap is silently skipped (no ifIndex to bind to).
 func TestBuildIfaceModuleMap_TransceiverWithoutAliasSkipped(t *testing.T) {
 	inv := newModuleInventory()
 	inv.SubModules["201"] = []ModuleEntry{
@@ -198,23 +198,40 @@ func TestBuildIfaceModuleMap_TransceiverWithoutAliasSkipped(t *testing.T) {
 	}
 	emitted := map[string]*diode.Module{"203": {}}
 
-	got := buildIfaceModuleMap(inv, map[string]string{}, map[string]string{"10101": "Gi1/0/1"}, emitted)
+	got := buildIfaceModuleMap(inv, map[string]string{}, emitted)
 
 	assert.Empty(t, got, "no aliasMap entry -> transceiver not in result")
 }
 
-// TestBuildIfaceModuleMap_TransceiverWithoutIfNameSkipped — aliasMap
-// resolves but the ifIndexToName lookup misses. Skip with no panic.
-func TestBuildIfaceModuleMap_TransceiverWithoutIfNameSkipped(t *testing.T) {
-	inv := newModuleInventory()
-	inv.SubModules["201"] = []ModuleEntry{
-		{EntIndex: "203", Type: ModuleTypeTransceiver, ParentEntIdx: "201"},
+// TestBuildIfaceModuleMap_VCMembersWithSameIfNameDoNotCollide — codex P1
+// regression: on Juniper VC and some Aruba stacks each member uses a
+// local ifName scope, so two distinct interfaces on two members canonicalize
+// to the same string (e.g. "Gi1/0/1"). Keying by ifName collapses both
+// transceivers onto one map entry and the runner attaches the wrong
+// member's module. ifIndex is globally unique in the SNMP walk space —
+// keying by it preserves both entries.
+func TestBuildIfaceModuleMap_VCMembersWithSameIfNameDoNotCollide(t *testing.T) {
+	mod1 := &diode.Module{Serial: strPtr("XCVR-MEMBER-1")}
+	mod2 := &diode.Module{Serial: strPtr("XCVR-MEMBER-2")}
+	inv := ModuleInventory{
+		SubModules: map[string][]ModuleEntry{
+			"201": {{EntIndex: "203", Type: ModuleTypeTransceiver}}, // member 1 linecard
+			"401": {{EntIndex: "403", Type: ModuleTypeTransceiver}}, // member 2 linecard
+		},
 	}
-	emitted := map[string]*diode.Module{"203": {}}
+	aliasMap := map[string]string{
+		"203": "10101", // member 1 ifIndex
+		"403": "20101", // member 2 ifIndex — DISTINCT
+	}
+	emittedModules := map[string]*diode.Module{
+		"203": mod1,
+		"403": mod2,
+	}
+	out := buildIfaceModuleMap(inv, aliasMap, emittedModules)
 
-	got := buildIfaceModuleMap(inv, map[string]string{"203": "10101"}, map[string]string{}, emitted)
-
-	assert.Empty(t, got, "ifIndex without an ifName entry -> transceiver not in result")
+	require.Equal(t, mod1, out["10101"], "member 1 transceiver routes to ifIndex 10101")
+	require.Equal(t, mod2, out["20101"], "member 2 transceiver routes to ifIndex 20101")
+	require.Len(t, out, 2, "no collapse — distinct ifIndexes preserve distinct modules")
 }
 
 // --- Exported helper tests (runner wire-up) ---
@@ -259,25 +276,6 @@ func TestAliasMapFromOIDs_DeterministicWhenMultipleAliasRowsShareEntIndex(t *tes
 		require.Equal(t, "10101", m["203"],
 			"AliasMapFromOIDs must deterministically pick the lowest ifIndex")
 	}
-}
-
-// TestIfNameByIfIndex_InvertsRunnerMap — inversion plus nil-Name skip.
-func TestIfNameByIfIndex_InvertsRunnerMap(t *testing.T) {
-	n1 := strPtr("Gi1/0/1")
-	n2 := strPtr("Gi2/0/1")
-	i1 := &diode.Interface{Name: n1}
-	i2 := &diode.Interface{Name: n2}
-	nameless := &diode.Interface{} // Name == nil; skipped
-	ifIndexByIface := map[*diode.Interface]int{
-		i1:       10101,
-		i2:       10201,
-		nameless: 30000,
-	}
-	m := IfNameByIfIndex(ifIndexByIface)
-	assert.Equal(t, "Gi1/0/1", m["10101"])
-	assert.Equal(t, "Gi2/0/1", m["10201"])
-	assert.NotContains(t, m, "30000", "interfaces with nil Name are skipped")
-	assert.Len(t, m, 2)
 }
 
 // TestMemberDevicesFromEntities_VCKeyedByLowestMemberID — the master

--- a/snmp-discovery/mapping/module_test.go
+++ b/snmp-discovery/mapping/module_test.go
@@ -2,10 +2,12 @@ package mapping
 
 import (
 	"log/slog"
+	"os"
 	"testing"
 
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestChassisModuleMapper_MapReturnsNil confirms the mapper accepts
@@ -92,4 +94,115 @@ func TestClassifyModule(t *testing.T) {
 			assert.Equal(t, c.want, got)
 		})
 	}
+}
+
+// TestExtractModuleInventory_HappyPath asserts top-level modules are
+// classified correctly (supervisor + linecard) and the transceiver
+// lives in SubModules under the linecard's EntIndex.
+func TestExtractModuleInventory_HappyPath(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	oids := buildOIDs(chassis9404RWithTransceiversFixture())
+
+	inv := extractModuleInventory(oids, logger)
+
+	require.Len(t, inv.Modules, 2)
+	var sup, lc *ModuleEntry
+	for i := range inv.Modules {
+		switch inv.Modules[i].Type {
+		case ModuleTypeSupervisor:
+			sup = &inv.Modules[i]
+		case ModuleTypeLinecard:
+			lc = &inv.Modules[i]
+		}
+	}
+	require.NotNil(t, sup, "supervisor must be classified")
+	require.NotNil(t, lc, "linecard must be classified")
+	assert.Equal(t, "JAE24010ABC", sup.Serial)
+	assert.Equal(t, "C9400-SUP-1", sup.Model)
+	assert.Equal(t, "Slot 1", sup.BayName)
+	assert.Equal(t, "JAE24010LC2", lc.Serial)
+	assert.Equal(t, "Slot 2", lc.BayName)
+
+	subs := inv.SubModules["201"]
+	require.Len(t, subs, 1)
+	assert.Equal(t, ModuleTypeTransceiver, subs[0].Type)
+	assert.Equal(t, "FNS24010TR1", subs[0].Serial)
+	assert.Equal(t, "TenGigabitEthernet2/0/1", subs[0].BayName)
+}
+
+// TestExtractModuleInventory_NoModulesReturnsEmpty — chassis-only
+// fixture produces empty Modules and SubModules.
+func TestExtractModuleInventory_NoModulesReturnsEmpty(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Switch", "FOO", "C9300", "Switch", ""},
+	}
+	inv := extractModuleInventory(buildOIDs(rows), logger)
+	assert.Empty(t, inv.Modules)
+	assert.Empty(t, inv.SubModules)
+}
+
+// TestExtractModuleInventory_OrphanContainmentDropped — module whose
+// containedIn points at an absent index is dropped.
+func TestExtractModuleInventory_OrphanContainmentDropped(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Chassis", "FOO", "C9404R", "Chassis", ""},
+		{"99", "777", "9", "1", "Orphan", "ORPH1", "C9400-LC", "Orphan linecard", ""},
+	}
+	inv := extractModuleInventory(buildOIDs(rows), logger)
+	assert.Empty(t, inv.Modules, "orphan module must be dropped")
+}
+
+// TestExtractModuleInventory_UnclassifiableClassSkipped — class=1
+// (other) and class=2 (unknown) rows are skipped; only class=9 counts.
+func TestExtractModuleInventory_UnclassifiableClassSkipped(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Chassis", "FOO", "C9300", "Chassis", ""},
+		{"50", "1", "1", "1", "Unknown other", "", "", "", ""},
+		{"51", "1", "2", "1", "Unknown unknown", "", "", "", ""},
+	}
+	inv := extractModuleInventory(buildOIDs(rows), logger)
+	assert.Empty(t, inv.Modules)
+}
+
+// TestExtractModuleInventory_DuplicateSerialDedup — two class=9 rows
+// sharing a serial; first occurrence (sorted ascending by EntIndex)
+// wins, second is dropped.
+func TestExtractModuleInventory_DuplicateSerialDedup(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Chassis", "FOO", "C9404R", "Chassis", ""},
+		{"100", "1", "5", "1", "Slot 1", "", "", "Slot 1", ""},
+		{"101", "100", "9", "1", "Linecard A", "DUPSERIAL01", "C9400-LC-48U", "", ""},
+		{"200", "1", "5", "2", "Slot 2", "", "", "Slot 2", ""},
+		{"201", "200", "9", "1", "Linecard B (dup)", "DUPSERIAL01", "C9400-LC-48U", "", ""},
+	}
+	inv := extractModuleInventory(buildOIDs(rows), logger)
+	require.Len(t, inv.Modules, 1, "duplicate-serial second occurrence must be dropped")
+	assert.Equal(t, "101", inv.Modules[0].EntIndex,
+		"first occurrence (sorted ascending by EntIndex) wins")
+}
+
+// TestExtractModuleInventory_EmptyBayHarvested — class=5 row under
+// the chassis with no class=9 child surfaces in EmptyBays (Aruba CX
+// quirk). Populated bays continue to emit a normal Module entry.
+func TestExtractModuleInventory_EmptyBayHarvested(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Chassis", "FOO", "8400", "Chassis", ""},
+		// Empty bay — class=5 under chassis, no class=9 child.
+		{"700", "1", "5", "5", "Slot 5 (empty)", "", "", "Slot 5", ""},
+		// Populated bay — confirms we only get the empty one in EmptyBays.
+		{"100", "1", "5", "1", "Slot 1", "", "", "Slot 1", ""},
+		{"101", "100", "9", "1", "Linecard", "JAE1", "8400-LC", "", ""},
+	}
+	inv := extractModuleInventory(buildOIDs(rows), logger)
+
+	require.Len(t, inv.EmptyBays, 1)
+	assert.Equal(t, "700", inv.EmptyBays[0].EntIndex)
+	assert.Equal(t, "Slot 5 (empty)", inv.EmptyBays[0].BayName)
+	require.Len(t, inv.Modules, 1)
+	assert.Equal(t, "101", inv.Modules[0].EntIndex)
 }

--- a/snmp-discovery/mapping/module_test.go
+++ b/snmp-discovery/mapping/module_test.go
@@ -308,3 +308,28 @@ func TestExtractModuleInventory_ChassisRootedModuleSurvives(t *testing.T) {
 	assert.Equal(t, "7", m.BayPosition,
 		"synthesized bay position falls back to module's ParentRel")
 }
+
+// TestExtractModuleInventory_DedupUsesNumericEntIndexOrder — ENTITY-MIB
+// EntIndex values are numeric. A lexicographic sort on the string form
+// orders "10" before "9", which would pick the wrong dedup winner under
+// the "first occurrence wins" contract. The dedup pass must sort
+// numerically so EntIndex 9 wins over EntIndex 10 when they share a
+// serial.
+func TestExtractModuleInventory_DedupUsesNumericEntIndexOrder(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	// fixtureRow order: EntIndex, ContainedIn, Class, ParentRel, Name,
+	// Serial, Model, Descr, VendorType.
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Chassis", "CHSER01", "C9404R", "Chassis", ""},
+		{"100", "1", "5", "1", "Slot 1", "", "", "Slot 1", ""},
+		{"200", "1", "5", "2", "Slot 2", "", "", "Slot 2", ""},
+		// EntIndex 9 — should win in numeric order.
+		{"9", "100", "9", "1", "Linecard 9", "DUPE-SER-01", "C9400-LC-48U", "First card", ""},
+		// EntIndex 10 — same serial; should lose in numeric order.
+		{"10", "200", "9", "1", "Linecard 10", "DUPE-SER-01", "C9400-LC-48U", "Second card", ""},
+	}
+	inv := extractModuleInventory(buildOIDs(rows), logger)
+	require.Len(t, inv.Modules, 1, "duplicate serial collapsed")
+	assert.Equal(t, "9", inv.Modules[0].EntIndex,
+		"EntIndex 9 wins under numeric sort (lex would pick 10)")
+}

--- a/snmp-discovery/mapping/module_test.go
+++ b/snmp-discovery/mapping/module_test.go
@@ -33,3 +33,63 @@ func TestChassisModuleMapper_MapReturnsNil(t *testing.T) {
 	result := mapper.Map(values, entry, registry, &config.Defaults{})
 	assert.Nil(t, result, "ChassisModuleMapper must not emit entities directly")
 }
+
+// TestNewModuleInventory_HasEmptyMaps asserts the constructor produces
+// a usable zero-value: SubModules ready for keyed writes, Modules and
+// EmptyBays untouched (nil slices append fine).
+func TestNewModuleInventory_HasEmptyMaps(t *testing.T) {
+	inv := newModuleInventory()
+	assert.NotNil(t, inv.SubModules, "newModuleInventory must initialise the SubModules map")
+	assert.Empty(t, inv.SubModules)
+	assert.Empty(t, inv.Modules, "Modules starts as an empty/nil slice")
+	assert.Nil(t, inv.EmptyBays, "EmptyBays is lazily initialised; nil is fine on construct")
+}
+
+// TestClassifyModule walks the decision matrix: parent-depth gates
+// transceiver/supervisor, PID prefixes pick PSU/Fan, everything else
+// falls through to linecard. Both empty inputs → unknown.
+func TestClassifyModule(t *testing.T) {
+	cases := []struct {
+		name            string
+		model           string
+		vendorType      string
+		hasModuleParent bool
+		want            ModuleType
+	}{
+		// Transceiver: under a class=9 module parent AND optic PID.
+		{"qsfp-100g-sr4 under linecard", "QSFP-100G-SR4", "", true, ModuleTypeTransceiver},
+		{"sfp-10g-lr under linecard", "SFP-10G-LR", "", true, ModuleTypeTransceiver},
+		{"x2-10g under linecard", "X2-10GB-SR", "", true, ModuleTypeTransceiver},
+
+		// Supervisor: at chassis level AND SUP pattern.
+		{"sup at chassis depth", "C9400-SUP-1", "", false, ModuleTypeSupervisor},
+		{"sup2 at chassis depth", "VS-SUP2T-10G", "", false, ModuleTypeSupervisor},
+
+		// Linecard defaults at chassis depth.
+		{"linecard PID at chassis depth", "C9400-LC-48U", "", false, ModuleTypeLinecard},
+		{"unknown PID at chassis depth", "FOO-BAR-9000", "", false, ModuleTypeLinecard},
+
+		// PSU and Fan classified anywhere.
+		{"psu pwr prefix", "PWR-C5-715WAC", "", false, ModuleTypePSU},
+		{"psu psu prefix", "PSU-2KW-AC", "", false, ModuleTypePSU},
+		{"fan prefix", "FAN-T2", "", false, ModuleTypeFan},
+
+		// Edge: under module parent but non-optic → linecard (depth alone insufficient).
+		{"non-optic under module parent", "WS-X45-FOO", "", true, ModuleTypeLinecard},
+
+		// Edge: optic-shaped PID at chassis level → linecard (PID alone insufficient).
+		{"optic PID at chassis depth", "QSFP-100G-SR4", "", false, ModuleTypeLinecard},
+
+		// VendorType fallback when Model is blank.
+		{"vendortype fallback optic", "", "QSFP-100G-LR4", true, ModuleTypeTransceiver},
+
+		// Both blank → unknown.
+		{"both blank", "", "", false, ModuleTypeUnknown},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := classifyModule(c.model, c.vendorType, c.hasModuleParent)
+			assert.Equal(t, c.want, got)
+		})
+	}
+}

--- a/snmp-discovery/mapping/module_test.go
+++ b/snmp-discovery/mapping/module_test.go
@@ -81,6 +81,10 @@ func TestClassifyModule(t *testing.T) {
 		{"fan -FAN suffix", "C9400-FAN", "", false, ModuleTypeFan},
 		{"fan -FAN middle token", "C9404R-FAN-2", "", false, ModuleTypeFan},
 
+		// Negative: fanless linecard PID embeds the substring "-FAN" but
+		// must not be misclassified as a fan tray.
+		{"fanless_linecard_not_mismatched_as_fan", "C9400-FANTOM-LC", "", false, ModuleTypeLinecard},
+
 		// Model-prefixed Cisco PSU PIDs — `-PWR-` / `-PSU-` as middle token.
 		{"psu -PWR- middle token", "C9404R-PWR-2KW-AC", "", false, ModuleTypePSU},
 

--- a/snmp-discovery/mapping/module_test.go
+++ b/snmp-discovery/mapping/module_test.go
@@ -76,6 +76,14 @@ func TestClassifyModule(t *testing.T) {
 		{"psu psu prefix", "PSU-2KW-AC", "", false, ModuleTypePSU},
 		{"fan prefix", "FAN-T2", "", false, ModuleTypeFan},
 
+		// Model-prefixed Cisco fan PIDs — the `-FAN` token appears as a
+		// suffix or middle token, not a prefix. Common on C9400 chassis.
+		{"fan -FAN suffix", "C9400-FAN", "", false, ModuleTypeFan},
+		{"fan -FAN middle token", "C9404R-FAN-2", "", false, ModuleTypeFan},
+
+		// Model-prefixed Cisco PSU PIDs — `-PWR-` / `-PSU-` as middle token.
+		{"psu -PWR- middle token", "C9404R-PWR-2KW-AC", "", false, ModuleTypePSU},
+
 		// Edge: under module parent but non-optic → linecard (depth alone insufficient).
 		{"non-optic under module parent", "WS-X45-FOO", "", true, ModuleTypeLinecard},
 
@@ -183,6 +191,49 @@ func TestExtractModuleInventory_DuplicateSerialDedup(t *testing.T) {
 	require.Len(t, inv.Modules, 1, "duplicate-serial second occurrence must be dropped")
 	assert.Equal(t, "101", inv.Modules[0].EntIndex,
 		"first occurrence (sorted ascending by EntIndex) wins")
+}
+
+// TestExtractModuleInventory_NormalizesWhitespace — ENTITY-MIB strings
+// can arrive with leading/trailing whitespace or trailing NUL bytes.
+// Every entPhysical string field (Name, Serial, Model, Description,
+// VendorType, plus the bay's Name/ParentRel) must be trimmed via
+// trimSNMPString at extraction so dedup keys stay stable across runs
+// and downstream Diode payloads are clean.
+func TestExtractModuleInventory_NormalizesWhitespace(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Chassis", "FOO", "C9404R", "Chassis", ""},
+		{"100", "1", "5", "1", "  Slot 1 \x00", "", "", "Slot 1", ""},
+		{"101", "100", "9", "1", "  Linecard \x00", "  ABC123 \x00 ", "  C9400-LC-48U\x00", "  desc \x00", "  vt \x00"},
+	}
+	inv := extractModuleInventory(buildOIDs(rows), logger)
+	require.Len(t, inv.Modules, 1)
+	m := inv.Modules[0]
+	assert.Equal(t, "ABC123", m.Serial, "trailing NUL + whitespace stripped from Serial")
+	assert.Equal(t, "C9400-LC-48U", m.Model)
+	assert.Equal(t, "Linecard", m.Name)
+	assert.Equal(t, "desc", m.Description)
+	assert.Equal(t, "vt", m.VendorType)
+	assert.Equal(t, "Slot 1", m.BayName, "bay name pulled from parent must also be trimmed")
+}
+
+// TestExtractModuleInventory_PortContainerNotEmptyBay — a class=5
+// container whose only children are class=10 ports is a port slot, not
+// a module bay. Surfacing it as an empty bay produces spurious
+// ModuleBay entries. The empty-bay scan must skip class=5 rows that
+// have any class=10 children.
+func TestExtractModuleInventory_PortContainerNotEmptyBay(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Chassis", "FOO", "C9300", "Chassis", ""},
+		// Class=5 port container under chassis. No class=9 child.
+		{"100", "1", "5", "1", "Port Container", "", "", "", ""},
+		// Class=10 port under the container.
+		{"101", "100", "10", "1", "Gi1/0/1", "", "", "", ""},
+	}
+	inv := extractModuleInventory(buildOIDs(rows), logger)
+	assert.Empty(t, inv.EmptyBays,
+		"class=5 with class=10 children is a port container, not an empty module bay")
 }
 
 // TestExtractModuleInventory_EmptyBayHarvested — class=5 row under

--- a/snmp-discovery/mapping/module_test.go
+++ b/snmp-discovery/mapping/module_test.go
@@ -1,0 +1,35 @@
+package mapping
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestChassisModuleMapper_MapReturnsNil confirms the mapper accepts
+// chassis_module PDUs without producing entities. Module data is
+// consumed by TranslateModulesWithAlias later, not by this Map call.
+func TestChassisModuleMapper_MapReturnsNil(t *testing.T) {
+	logger := slog.Default()
+	registry := NewEntityRegistry(logger)
+	mapper := &ChassisModuleMapper{logger: logger}
+
+	entry := &Entry{
+		Entity: string(ChassisModuleEntityType),
+		Field:  "_id",
+	}
+	// Synthesize one entPhysicalDescr row.
+	values := map[ObjectIDIndex]*ObjectIDValue{
+		"2.1": {
+			OID:    ".1.3.6.1.2.1.47.1.1.1.1.2.1",
+			Index:  "2.1",
+			Parent: ".1.3.6.1.2.1.47.1.1.1.1.2",
+			Value:  "Linecard-1",
+		},
+	}
+
+	result := mapper.Map(values, entry, registry, &config.Defaults{})
+	assert.Nil(t, result, "ChassisModuleMapper must not emit entities directly")
+}

--- a/snmp-discovery/mapping/module_test.go
+++ b/snmp-discovery/mapping/module_test.go
@@ -301,8 +301,10 @@ func TestExtractModuleInventory_ChassisRootedModuleSurvives(t *testing.T) {
 	assert.Equal(t, "100", m.EntIndex)
 	assert.Equal(t, "100", m.BayEntIndex,
 		"synthesized bay self-references the module")
-	assert.Equal(t, "Linecard 7", m.BayName,
-		"synthesized bay name falls back to module name")
+	// Prefix "Slot " telegraphs synthetic nature so NetBox UI doesn't show
+	// a bay and module sharing the identical "Linecard 7" label.
+	assert.Equal(t, "Slot 7", m.BayName,
+		"synthesized bay name uses Slot + ParentRel to differ from module name")
 	assert.Equal(t, "7", m.BayPosition,
 		"synthesized bay position falls back to module's ParentRel")
 }

--- a/snmp-discovery/mapping/module_test.go
+++ b/snmp-discovery/mapping/module_test.go
@@ -282,3 +282,27 @@ func TestExtractModuleInventory_BayPositionFromBayRow(t *testing.T) {
 	assert.Equal(t, "5", inv.Modules[0].BayPosition,
 		"BayPosition must come from the bay row's ParentRel, not the module's")
 }
+
+// TestExtractModuleInventory_ChassisRootedModuleSurvives — some fixed-FRU
+// switches report modules directly under the chassis with no class=5
+// container in between. The previous "no class=5 ancestor -> drop"
+// behaviour silently lost these. Synthesize a self-referential bay so
+// the module is still emitted.
+func TestExtractModuleInventory_ChassisRootedModuleSurvives(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Fixed Switch", "FOO", "C9300", "Chassis", ""},
+		// Linecard sits directly under chassis (no class=5 bay row).
+		{"100", "1", "9", "7", "Linecard 7", "JAE7", "C9300-LC", "", ""},
+	}
+	inv := extractModuleInventory(buildOIDs(rows), logger)
+	require.Len(t, inv.Modules, 1, "chassis-rooted module must survive")
+	m := inv.Modules[0]
+	assert.Equal(t, "100", m.EntIndex)
+	assert.Equal(t, "100", m.BayEntIndex,
+		"synthesized bay self-references the module")
+	assert.Equal(t, "Linecard 7", m.BayName,
+		"synthesized bay name falls back to module name")
+	assert.Equal(t, "7", m.BayPosition,
+		"synthesized bay position falls back to module's ParentRel")
+}

--- a/snmp-discovery/mapping/module_test.go
+++ b/snmp-discovery/mapping/module_test.go
@@ -261,3 +261,24 @@ func TestExtractModuleInventory_EmptyBayHarvested(t *testing.T) {
 	require.Len(t, inv.Modules, 1)
 	assert.Equal(t, "101", inv.Modules[0].EntIndex)
 }
+
+// TestExtractModuleInventory_BayPositionFromBayRow — BayPosition must
+// reflect the chassis slot number (the bay's own entPhysicalParentRelPos),
+// NOT the module's parentRelPos within its bay (which is almost always
+// "1" on real hardware). Real Cat 9404R reports module ParentRel=1 and
+// bay ParentRel=<slot>; sourcing position from the module produced
+// "Slot 1" for every linecard regardless of physical slot.
+func TestExtractModuleInventory_BayPositionFromBayRow(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Chassis", "FOO", "C9404R", "Chassis", ""},
+		// Bay in slot 5 of the chassis — bay.ParentRel=5.
+		{"200", "1", "5", "5", "Slot 5", "", "", "Slot 5", ""},
+		// Module within the bay — module.ParentRel=1 (always "1" on real HW).
+		{"201", "200", "9", "1", "Linecard 5", "JAE5", "C9400-LC-48U", "", ""},
+	}
+	inv := extractModuleInventory(buildOIDs(rows), logger)
+	require.Len(t, inv.Modules, 1)
+	assert.Equal(t, "5", inv.Modules[0].BayPosition,
+		"BayPosition must come from the bay row's ParentRel, not the module's")
+}

--- a/snmp-discovery/mapping/module_translate.go
+++ b/snmp-discovery/mapping/module_translate.go
@@ -18,6 +18,7 @@ package mapping
 import (
 	"context"
 	"log/slog"
+	"sort"
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
@@ -117,16 +118,35 @@ func TranslateModulesWithAlias(
 	}
 
 	// Full-mode-only: transceiver sub-bays + empty bays + iface routing.
-	for _, parent := range inv.Modules {
-		if parent.MemberID < 0 {
-			continue
-		}
-		device := memberDevices[parent.MemberID]
-		if device == nil {
-			continue
-		}
-		for _, tr := range inv.SubModules[parent.EntIndex] {
+	//
+	// Walk EVERY key in inv.SubModules — not just those keyed by
+	// top-level inv.Modules entries. Vendors like Juniper nest optics
+	// two module-levels below the chassis (Chassis -> FPC -> PIC -> optic),
+	// so the optic's parent class=9 (the PIC) is itself a sub-module
+	// stored under inv.SubModules[FPC.EntIndex]. Iterating only top-
+	// level parents silently dropped those optics. Each transceiver
+	// already carries MemberID (stamped by assignMemberID), so device
+	// routing remains correct regardless of nesting depth. The
+	// emittedModules guard prevents the (theoretical) double-emit if
+	// the same EntIndex is reachable via two parents.
+	subKeys := make([]string, 0, len(inv.SubModules))
+	for k := range inv.SubModules {
+		subKeys = append(subKeys, k)
+	}
+	sort.Strings(subKeys)
+	for _, parentIdx := range subKeys {
+		for _, tr := range inv.SubModules[parentIdx] {
 			if tr.Type != ModuleTypeTransceiver {
+				continue
+			}
+			if tr.MemberID < 0 {
+				continue
+			}
+			if _, dup := emittedModules[tr.EntIndex]; dup {
+				continue
+			}
+			device := memberDevices[tr.MemberID]
+			if device == nil {
 				continue
 			}
 			// Sub-bay reconciler workaround (spec §Sub-bay emission

--- a/snmp-discovery/mapping/module_translate.go
+++ b/snmp-discovery/mapping/module_translate.go
@@ -62,7 +62,7 @@ func TranslateModulesWithAlias(
 	ifIndexToName map[string]string,
 ) ([]diode.Entity, map[string]*diode.Module) {
 	mode := options.ModuleDiscoveryMode()
-	if mode == "off" {
+	if mode == config.DiscoverModulesOff {
 		return nil, nil
 	}
 
@@ -111,7 +111,7 @@ func TranslateModulesWithAlias(
 		emittedModules[m.EntIndex] = mod
 	}
 
-	if mode != "full" {
+	if mode != config.DiscoverModulesFull {
 		// Linecards mode stops here — no transceivers, no empty bays,
 		// no iface attachment map.
 		return entities, nil

--- a/snmp-discovery/mapping/module_translate.go
+++ b/snmp-discovery/mapping/module_translate.go
@@ -97,9 +97,57 @@ func TranslateModulesWithAlias(
 		emittedModules[m.EntIndex] = mod
 	}
 
-	// Full-mode-only: transceiver sub-bays + empty bays + iface routing
-	// land in Task 10. Linecards mode stops here.
-	return entities, nil
+	if mode != "full" {
+		// Linecards mode stops here — no transceivers, no empty bays,
+		// no iface attachment map.
+		return entities, nil
+	}
+
+	// Full-mode-only: transceiver sub-bays + empty bays + iface routing.
+	for _, parent := range inv.Modules {
+		if parent.MemberID < 0 {
+			continue
+		}
+		device := memberDevices[parent.MemberID]
+		if device == nil {
+			continue
+		}
+		for _, tr := range inv.SubModules[parent.EntIndex] {
+			if tr.Type != ModuleTypeTransceiver {
+				continue
+			}
+			// Sub-bay reconciler workaround (spec §Sub-bay emission
+			// workaround): emit transceiver sub-bays DEVICE-ROOTED
+			// (no Module=parent_linecard link). Linking the sub-bay to
+			// its parent linecard makes the Diode reconciler re-plan
+			// the parent inside the sub-bay's changeset and trip
+			// dcim_module_module_bay_id_key on apply. Restore the link
+			// when the upstream reconciler resolves nested parent-
+			// module refs against committed sibling entities.
+			subBay := emitModuleBay(device, tr)
+			entities = append(entities, subBay)
+
+			mod := emitModule(device, subBay, tr, manufacturer)
+			entities = append(entities, mod)
+			emittedModules[tr.EntIndex] = mod
+		}
+	}
+
+	// Empty bays — class=5 rows with no class=9 child. Bare ModuleBay
+	// only; no Module entity.
+	for _, b := range inv.EmptyBays {
+		if b.MemberID < 0 {
+			continue
+		}
+		device := memberDevices[b.MemberID]
+		if device == nil {
+			continue
+		}
+		entities = append(entities, emitModuleBay(device, b))
+	}
+
+	ifaceMap := buildIfaceModuleMap(inv, aliasMap, ifIndexToName, emittedModules)
+	return entities, ifaceMap
 }
 
 // emitModuleBay constructs a ModuleBay entity for a top-level

--- a/snmp-discovery/mapping/module_translate.go
+++ b/snmp-discovery/mapping/module_translate.go
@@ -21,11 +21,10 @@ import (
 	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
-	"go.opentelemetry.io/otel/attribute"
-	"go.opentelemetry.io/otel/metric"
-
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/metrics"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 // TranslateModules is a thin wrapper for callers without alias data —

--- a/snmp-discovery/mapping/module_translate.go
+++ b/snmp-discovery/mapping/module_translate.go
@@ -147,6 +147,8 @@ func TranslateModulesWithAlias(
 			}
 			device := memberDevices[tr.MemberID]
 			if device == nil {
+				logger.Warn("module discovery: no device for transceiver member",
+					"member", tr.MemberID, "ent", tr.EntIndex, "model", tr.Model)
 				continue
 			}
 			// Sub-bay reconciler workaround (spec §Sub-bay emission
@@ -185,6 +187,8 @@ func TranslateModulesWithAlias(
 		}
 		device := memberDevices[b.MemberID]
 		if device == nil {
+			logger.Warn("module discovery: no device for empty bay member",
+				"member", b.MemberID, "ent", b.EntIndex, "bay", b.BayName)
 			continue
 		}
 		entities = append(entities, emitModuleBay(device, b))

--- a/snmp-discovery/mapping/module_translate.go
+++ b/snmp-discovery/mapping/module_translate.go
@@ -296,6 +296,43 @@ func vendorFromDefaults(d *config.Defaults) string {
 	return d.Device.Manufacturer
 }
 
+// SpliceModulesAfterDevices inserts moduleEntities into entitiesForTarget
+// immediately after the leading run of Device + VirtualChassis entries,
+// preserving the Diode ingest ordering contract:
+//
+//	Device(s) -> ModuleBay + Module -> Interface -> IP -> MAC -> VLAN
+//
+// TranslateAsStack already partitioned entitiesForTarget into that
+// bucket order, but Module entities land in their own bucket — naively
+// appending them would leave them at the tail and break the runner's
+// Interface.Module attachment (Interfaces would appear before the
+// Modules they reference). Find the first non-Device/non-VC index and
+// splice moduleEntities there.
+//
+// Returns entitiesForTarget unchanged when moduleEntities is empty.
+func SpliceModulesAfterDevices(entitiesForTarget []diode.Entity, moduleEntities []diode.Entity) []diode.Entity {
+	if len(moduleEntities) == 0 {
+		return entitiesForTarget
+	}
+	splice := len(entitiesForTarget)
+	for i, e := range entitiesForTarget {
+		switch e.(type) {
+		case *diode.Device, *diode.VirtualChassis:
+			continue
+		default:
+			splice = i
+		}
+		if splice < len(entitiesForTarget) {
+			break
+		}
+	}
+	merged := make([]diode.Entity, 0, len(entitiesForTarget)+len(moduleEntities))
+	merged = append(merged, entitiesForTarget[:splice]...)
+	merged = append(merged, moduleEntities...)
+	merged = append(merged, entitiesForTarget[splice:]...)
+	return merged
+}
+
 // resolveModuleManufacturer picks the Manufacturer name to stamp on an
 // emitted ModuleType. Precedence:
 //  1. The emitted Device's DeviceType.Manufacturer.Name — keeps the

--- a/snmp-discovery/mapping/module_translate.go
+++ b/snmp-discovery/mapping/module_translate.go
@@ -239,7 +239,11 @@ func emitModuleBay(device *diode.Device, m ModuleEntry) *diode.ModuleBay {
 // Sharing vendorFromDevice with the metrics path keeps the label and
 // the emitted entity identical strings.
 func emitModule(device *diode.Device, bay *diode.ModuleBay, m ModuleEntry, defaults *config.Defaults) *diode.Module {
-	model := modelOrUnknown(m.Model)
+	// Mirrors classifyModule's Model -> VendorType -> Unknown fallback so
+	// the emitted ModuleType label matches the classification. Aruba CX
+	// populates entPhysicalVendorType where Cisco populates ModelName;
+	// using Model alone would emit "Unknown" for valid Aruba hardware.
+	model := modelOrVendorType(m.Model, m.VendorType)
 	mfgName := resolveModuleManufacturer(device, defaults)
 	moduleType := &diode.ModuleType{
 		Model: &model,
@@ -279,13 +283,19 @@ func vendorFromDevice(d *diode.Device) string {
 	return "Unknown"
 }
 
-// modelOrUnknown trims model and substitutes "Unknown" for the empty
-// string. Diode rejects empty strings for required ModuleType.Model.
-func modelOrUnknown(m string) string {
-	if m == "" {
-		return "Unknown"
+// modelOrVendorType prefers a non-blank trimmed model, falling back to
+// the trimmed vendorType, and finally "Unknown". Parallels
+// classifyModule so the emitted ModuleType.Model matches the type
+// classification for vendors (e.g. Aruba CX) that populate
+// entPhysicalVendorType instead of entPhysicalModelName.
+func modelOrVendorType(model, vendorType string) string {
+	if v := strings.TrimSpace(model); v != "" {
+		return v
 	}
-	return m
+	if v := strings.TrimSpace(vendorType); v != "" {
+		return v
+	}
+	return "Unknown"
 }
 
 // vendorFromDefaults returns the policy-level device manufacturer or

--- a/snmp-discovery/mapping/module_translate.go
+++ b/snmp-discovery/mapping/module_translate.go
@@ -1,0 +1,175 @@
+// Copyright 2026 NetBox Labs, Inc.
+
+// Package mapping — module_translate.go: Diode entity emission for
+// module / module bay (+ ModuleType) entities. Public entry point is
+// TranslateModulesWithAlias; TranslateModules is a thin wrapper for
+// callers that don't carry alias data.
+//
+// Emission rules:
+//   - "off" mode short-circuits before extraction (zero behaviour change).
+//   - "linecards" mode emits chassis-slot modules + their bays only.
+//     PSU / Fan are classified for labelling but never emitted as
+//     module entities. Transceivers are skipped entirely.
+//   - "full" mode adds transceiver sub-bays (device-rooted — see
+//     sub-bay reconciler workaround at the emission site) and empty
+//     bays, and populates the iface->Module attachment map.
+package mapping
+
+import (
+	"log/slog"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+)
+
+// TranslateModules is a thin wrapper for callers without alias data —
+// the iface attachment map will be empty.
+func TranslateModules(
+	oids ObjectIDValueMap,
+	chassisInv *ChassisInventory,
+	memberDevices map[int]*diode.Device,
+	options *config.Options,
+	defaults *config.Defaults,
+	logger *slog.Logger,
+) ([]diode.Entity, map[string]*diode.Module) {
+	return TranslateModulesWithAlias(oids, chassisInv, memberDevices, options, defaults, logger, nil, nil)
+}
+
+// TranslateModulesWithAlias is the full-fidelity entry point used by
+// the runner. Returns (entities, ifaceModuleMap):
+//   - entities: every ModuleBay + Module emitted, in extraction order.
+//   - ifaceModuleMap: in "full" mode, {ifName -> *Module} so the
+//     runner can attach Interface.Module on physical ports. nil in
+//     "linecards" mode.
+//
+// Returns (nil, nil) when:
+//   - mode == "off"
+//   - the ENTITY-MIB walk produced no modules and no bays at all
+func TranslateModulesWithAlias(
+	oids ObjectIDValueMap,
+	chassisInv *ChassisInventory,
+	memberDevices map[int]*diode.Device,
+	options *config.Options,
+	defaults *config.Defaults,
+	logger *slog.Logger,
+	aliasMap map[string]string,
+	ifIndexToName map[string]string,
+) ([]diode.Entity, map[string]*diode.Module) {
+	mode := options.ModuleDiscoveryMode()
+	if mode == "off" {
+		return nil, nil
+	}
+
+	inv := extractModuleInventory(oids, logger)
+	if len(inv.Modules) == 0 && len(inv.SubModules) == 0 && len(inv.EmptyBays) == 0 {
+		return nil, nil
+	}
+
+	assignMemberID(&inv, chassisInv, oids, logger)
+
+	manufacturer := vendorFromDefaults(defaults)
+
+	var entities []diode.Entity
+	emittedModules := make(map[string]*diode.Module, len(inv.Modules))
+
+	for _, m := range inv.Modules {
+		// PSU / Fan are classified for labelling only — never emitted as
+		// module entities (mirrors device-discovery PR #419).
+		if m.Type == ModuleTypePSU || m.Type == ModuleTypeFan {
+			continue
+		}
+		// assignMemberID stamps MemberID=-1 on entries whose chassis
+		// ancestor isn't in the VC member set. Skip — already warn-logged.
+		if m.MemberID < 0 {
+			continue
+		}
+		device := memberDevices[m.MemberID]
+		if device == nil {
+			logger.Warn("module discovery: no device for member",
+				"member", m.MemberID, "ent", m.EntIndex, "model", m.Model)
+			continue
+		}
+		bay := emitModuleBay(device, m)
+		entities = append(entities, bay)
+		mod := emitModule(device, bay, m, manufacturer)
+		entities = append(entities, mod)
+		emittedModules[m.EntIndex] = mod
+	}
+
+	// Full-mode-only: transceiver sub-bays + empty bays + iface routing
+	// land in Task 10. Linecards mode stops here.
+	return entities, nil
+}
+
+// emitModuleBay constructs a ModuleBay entity for a top-level
+// (chassis-slot) module. Always carries Device — the chassis device is
+// the matching scope for both ModuleBay and Module per Diode docs.
+func emitModuleBay(device *diode.Device, m ModuleEntry) *diode.ModuleBay {
+	name := m.BayName
+	if name == "" {
+		// Bay rows occasionally arrive without a name; fall back to
+		// position so we never ship an empty-string required field
+		// (Diode rejects "").
+		name = m.BayPosition
+	}
+	if name == "" {
+		name = "Unknown"
+	}
+	bay := &diode.ModuleBay{
+		Device: device,
+		Name:   &name,
+	}
+	if m.BayPosition != "" {
+		pos := m.BayPosition
+		bay.Position = &pos
+	}
+	return bay
+}
+
+// emitModule constructs a Module entity attached to its ModuleBay.
+// Carries Device (NetBox matching scope) and a ModuleType built from
+// the PID (Model) + the policy-level manufacturer.
+func emitModule(device *diode.Device, bay *diode.ModuleBay, m ModuleEntry, manufacturer string) *diode.Module {
+	model := modelOrUnknown(m.Model)
+	mfgName := manufacturer
+	moduleType := &diode.ModuleType{
+		Model: &model,
+		Manufacturer: &diode.Manufacturer{
+			Name: &mfgName,
+		},
+	}
+	mod := &diode.Module{
+		Device:     device,
+		ModuleBay:  bay,
+		ModuleType: moduleType,
+	}
+	if m.Serial != "" {
+		serial := m.Serial
+		mod.Serial = &serial
+	}
+	if m.Description != "" {
+		desc := m.Description
+		mod.Description = &desc
+	}
+	return mod
+}
+
+// modelOrUnknown trims model and substitutes "Unknown" for the empty
+// string. Diode rejects empty strings for required ModuleType.Model.
+func modelOrUnknown(m string) string {
+	if m == "" {
+		return "Unknown"
+	}
+	return m
+}
+
+// vendorFromDefaults returns the policy-level device manufacturer or
+// "Unknown" when unset. Diode rejects empty strings for required
+// Manufacturer.Name.
+func vendorFromDefaults(d *config.Defaults) string {
+	if d == nil || d.Device.Manufacturer == "" {
+		return "Unknown"
+	}
+	return d.Device.Manufacturer
+}

--- a/snmp-discovery/mapping/module_translate.go
+++ b/snmp-discovery/mapping/module_translate.go
@@ -16,11 +16,16 @@
 package mapping
 
 import (
+	"context"
 	"log/slog"
+	"strings"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 
 	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/metrics"
 )
 
 // TranslateModules is a thin wrapper for callers without alias data —
@@ -92,8 +97,19 @@ func TranslateModulesWithAlias(
 		}
 		bay := emitModuleBay(device, m)
 		entities = append(entities, bay)
+		if c := metrics.GetModuleBaysEmitted(); c != nil {
+			c.Add(context.Background(), 1, metric.WithAttributes(
+				attribute.String("vendor", vendorFromDevice(device)),
+			))
+		}
 		mod := emitModule(device, bay, m, manufacturer)
 		entities = append(entities, mod)
+		if c := metrics.GetModulesEmitted(); c != nil {
+			c.Add(context.Background(), 1, metric.WithAttributes(
+				attribute.String("vendor", vendorFromDevice(device)),
+				attribute.String("type", string(m.Type)),
+			))
+		}
 		emittedModules[m.EntIndex] = mod
 	}
 
@@ -126,9 +142,20 @@ func TranslateModulesWithAlias(
 			// module refs against committed sibling entities.
 			subBay := emitModuleBay(device, tr)
 			entities = append(entities, subBay)
+			if c := metrics.GetModuleBaysEmitted(); c != nil {
+				c.Add(context.Background(), 1, metric.WithAttributes(
+					attribute.String("vendor", vendorFromDevice(device)),
+				))
+			}
 
 			mod := emitModule(device, subBay, tr, manufacturer)
 			entities = append(entities, mod)
+			if c := metrics.GetModulesEmitted(); c != nil {
+				c.Add(context.Background(), 1, metric.WithAttributes(
+					attribute.String("vendor", vendorFromDevice(device)),
+					attribute.String("type", string(tr.Type)),
+				))
+			}
 			emittedModules[tr.EntIndex] = mod
 		}
 	}
@@ -144,6 +171,11 @@ func TranslateModulesWithAlias(
 			continue
 		}
 		entities = append(entities, emitModuleBay(device, b))
+		if c := metrics.GetModuleBaysEmitted(); c != nil {
+			c.Add(context.Background(), 1, metric.WithAttributes(
+				attribute.String("vendor", vendorFromDevice(device)),
+			))
+		}
 	}
 
 	ifaceMap := buildIfaceModuleMap(inv, aliasMap, ifIndexToName, emittedModules)
@@ -201,6 +233,22 @@ func emitModule(device *diode.Device, bay *diode.ModuleBay, m ModuleEntry, manuf
 		mod.Description = &desc
 	}
 	return mod
+}
+
+// vendorFromDevice resolves the per-device manufacturer name for metric
+// attribution. Reads the already-set DeviceType.Manufacturer.Name on the
+// emitted Device — that's the same value emitModule uses for the
+// ModuleType, so the counter labels stay consistent with what NetBox sees.
+// Falls back to "Unknown" on any nil/blank in the chain so a missing
+// pointer never produces an empty-string attribute.
+func vendorFromDevice(d *diode.Device) string {
+	if d == nil || d.DeviceType == nil || d.DeviceType.Manufacturer == nil || d.DeviceType.Manufacturer.Name == nil {
+		return "Unknown"
+	}
+	if name := strings.TrimSpace(*d.DeviceType.Manufacturer.Name); name != "" {
+		return name
+	}
+	return "Unknown"
 }
 
 // modelOrUnknown trims model and substitutes "Unknown" for the empty

--- a/snmp-discovery/mapping/module_translate.go
+++ b/snmp-discovery/mapping/module_translate.go
@@ -38,15 +38,18 @@ func TranslateModules(
 	defaults *config.Defaults,
 	logger *slog.Logger,
 ) ([]diode.Entity, map[string]*diode.Module) {
-	return TranslateModulesWithAlias(oids, chassisInv, memberDevices, options, defaults, logger, nil, nil)
+	return TranslateModulesWithAlias(oids, chassisInv, memberDevices, options, defaults, logger, nil)
 }
 
 // TranslateModulesWithAlias is the full-fidelity entry point used by
 // the runner. Returns (entities, ifaceModuleMap):
 //   - entities: every ModuleBay + Module emitted, in extraction order.
-//   - ifaceModuleMap: in "full" mode, {ifName -> *Module} so the
-//     runner can attach Interface.Module on physical ports. nil in
-//     "linecards" mode.
+//   - ifaceModuleMap: in "full" mode, {ifIndex -> *Module} (ifIndex as
+//     decimal string) so the runner can attach Interface.Module on
+//     physical ports by looking up each Interface's ifIndex. nil in
+//     "linecards" mode. ifIndex keying (not ifName) is required: VC/stack
+//     members can reuse the same canonical ifName locally and an
+//     ifName-keyed map would collapse distinct transceivers.
 //
 // Returns (nil, nil) when:
 //   - mode == "off"
@@ -59,7 +62,6 @@ func TranslateModulesWithAlias(
 	defaults *config.Defaults,
 	logger *slog.Logger,
 	aliasMap map[string]string,
-	ifIndexToName map[string]string,
 ) ([]diode.Entity, map[string]*diode.Module) {
 	mode := options.ModuleDiscoveryMode()
 	if mode == config.DiscoverModulesOff {
@@ -199,7 +201,7 @@ func TranslateModulesWithAlias(
 		}
 	}
 
-	ifaceMap := buildIfaceModuleMap(inv, aliasMap, ifIndexToName, emittedModules)
+	ifaceMap := buildIfaceModuleMap(inv, aliasMap, emittedModules)
 	return entities, ifaceMap
 }
 

--- a/snmp-discovery/mapping/module_translate.go
+++ b/snmp-discovery/mapping/module_translate.go
@@ -72,8 +72,6 @@ func TranslateModulesWithAlias(
 
 	assignMemberID(&inv, chassisInv, oids, logger)
 
-	manufacturer := vendorFromDefaults(defaults)
-
 	var entities []diode.Entity
 	emittedModules := make(map[string]*diode.Module, len(inv.Modules))
 
@@ -101,7 +99,7 @@ func TranslateModulesWithAlias(
 				attribute.String("vendor", vendorFromDevice(device)),
 			))
 		}
-		mod := emitModule(device, bay, m, manufacturer)
+		mod := emitModule(device, bay, m, defaults)
 		entities = append(entities, mod)
 		if c := metrics.GetModulesEmitted(); c != nil {
 			c.Add(context.Background(), 1, metric.WithAttributes(
@@ -147,7 +145,7 @@ func TranslateModulesWithAlias(
 				))
 			}
 
-			mod := emitModule(device, subBay, tr, manufacturer)
+			mod := emitModule(device, subBay, tr, defaults)
 			entities = append(entities, mod)
 			if c := metrics.GetModulesEmitted(); c != nil {
 				c.Add(context.Background(), 1, metric.WithAttributes(
@@ -208,10 +206,15 @@ func emitModuleBay(device *diode.Device, m ModuleEntry) *diode.ModuleBay {
 
 // emitModule constructs a Module entity attached to its ModuleBay.
 // Carries Device (NetBox matching scope) and a ModuleType built from
-// the PID (Model) + the policy-level manufacturer.
-func emitModule(device *diode.Device, bay *diode.ModuleBay, m ModuleEntry, manufacturer string) *diode.Module {
+// the PID (Model) + the manufacturer resolved from the emitted Device.
+// Manufacturer precedence: Device.DeviceType.Manufacturer.Name first
+// (so the ModuleType label always matches what NetBox sees on the
+// owning device), then the policy-level defaults, finally "Unknown".
+// Sharing vendorFromDevice with the metrics path keeps the label and
+// the emitted entity identical strings.
+func emitModule(device *diode.Device, bay *diode.ModuleBay, m ModuleEntry, defaults *config.Defaults) *diode.Module {
 	model := modelOrUnknown(m.Model)
-	mfgName := manufacturer
+	mfgName := resolveModuleManufacturer(device, defaults)
 	moduleType := &diode.ModuleType{
 		Model: &model,
 		Manufacturer: &diode.Manufacturer{
@@ -267,4 +270,19 @@ func vendorFromDefaults(d *config.Defaults) string {
 		return "Unknown"
 	}
 	return d.Device.Manufacturer
+}
+
+// resolveModuleManufacturer picks the Manufacturer name to stamp on an
+// emitted ModuleType. Precedence:
+//  1. The emitted Device's DeviceType.Manufacturer.Name — keeps the
+//     ModuleType label identical to the vendor attribute used by the
+//     OTLP counters (vendorFromDevice).
+//  2. The policy-level defaults.device.manufacturer — fallback for the
+//     rare path where the device entity lacks a manufacturer.
+//  3. "Unknown" — Diode rejects empty strings on this required field.
+func resolveModuleManufacturer(device *diode.Device, defaults *config.Defaults) string {
+	if v := vendorFromDevice(device); v != "Unknown" {
+		return v
+	}
+	return vendorFromDefaults(defaults)
 }

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -306,3 +306,68 @@ func TestTranslateModules_SubBayWorkaround_NotLinkedToParentLinecard(t *testing.
 func startsWith(s, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }
+
+// TestTranslateModulesWithAlias_VCOfModular_DispatchesPerMember — pins
+// that on a virtual-chassis of two modular boxes, each member's
+// linecards are emitted under that member's *diode.Device. The walk
+// chains module 101 → bay 100 → chassis 1 (member 1) and module 1001 →
+// bay 1000 → chassis 1000 (member 2). MemberID is stamped by
+// assignMemberID and the translator routes via memberDevices[MemberID].
+func TestTranslateModulesWithAlias_VCOfModular_DispatchesPerMember(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	// 2-member VC: each member chassis owns a slot + linecard.
+	rows := []fixtureRow{
+		// Member 1 chassis (EntPhysicalIndex "1")
+		{"1", "0", "3", "1", "Switch1 Chassis", "FCW2401SW01", "C9410R", "", ""},
+		{"100", "1", "5", "1", "Slot 1", "", "", "", ""},
+		{"101", "100", "9", "1", "LC1", "JAE24010LC1", "C9400-LC-48U", "", ""},
+		// Member 2 chassis (EntPhysicalIndex "1000")
+		{"1000", "0", "3", "2", "Switch2 Chassis", "FCW2401SW02", "C9410R", "", ""},
+		{"1100", "1000", "5", "1", "Slot 1", "", "", "", ""},
+		{"1101", "1100", "9", "1", "LC2", "JAE24010LC2", "C9400-LC-48U", "", ""},
+	}
+	chassisInv := &ChassisInventory{
+		Members: []ChassisMember{
+			{ID: 1, EntPhysicalIndex: "1", Serial: "FCW2401SW01", Model: "C9410R"},
+			{ID: 2, EntPhysicalIndex: "1000", Serial: "FCW2401SW02", Model: "C9410R"},
+		},
+	}
+
+	master := &diode.Device{Name: strPtr("vc-master")}
+	pos2 := int64(2)
+	member2 := &diode.Device{Name: strPtr("vc-member-2"), VcPosition: &pos2}
+	// Master is keyed by lowest member ID (Members[0].ID == 1) to match
+	// chassis.go's memberByID[lowest.ID] = master convention.
+	memberDevices := map[int]*diode.Device{1: master, 2: member2}
+
+	entities, _ := TranslateModulesWithAlias(
+		buildOIDs(rows), chassisInv, memberDevices,
+		modeLinecards(), nil, logger, nil, nil,
+	)
+
+	var modules []*diode.Module
+	for _, e := range entities {
+		if m, ok := e.(*diode.Module); ok {
+			modules = append(modules, m)
+		}
+	}
+	require.Len(t, modules, 2, "one linecard per VC member")
+
+	var lc1Mod, lc2Mod *diode.Module
+	for _, m := range modules {
+		require.NotNil(t, m.Serial)
+		switch *m.Serial {
+		case "JAE24010LC1":
+			lc1Mod = m
+		case "JAE24010LC2":
+			lc2Mod = m
+		}
+	}
+	require.NotNil(t, lc1Mod, "linecard under chassis 1 must be emitted")
+	require.NotNil(t, lc2Mod, "linecard under chassis 1000 must be emitted")
+	assert.Same(t, master, lc1Mod.Device,
+		"linecard under chassis 1 (member 1) routes to master device")
+	assert.Same(t, member2, lc2Mod.Device,
+		"linecard under chassis 1000 (member 2) routes to member-2 device")
+}

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -371,3 +371,61 @@ func TestTranslateModulesWithAlias_VCOfModular_DispatchesPerMember(t *testing.T)
 	assert.Same(t, member2, lc2Mod.Device,
 		"linecard under chassis 1000 (member 2) routes to member-2 device")
 }
+
+// TestTranslateModulesWithAlias_ModulesPrecedeInterfacesAfterSplice pins
+// the Diode ingest ordering contract honoured by the runner's
+// partition-and-prepend splice (policy/runner.go in queryTarget): every
+// *diode.Module / *diode.ModuleBay index must be < every *diode.Interface
+// index in the merged slice. The splice logic is duplicated here
+// inline — keeping the test in the mapping package avoids runner-test
+// setup overhead while still exercising the exact same algorithm.
+func TestTranslateModulesWithAlias_ModulesPrecedeInterfacesAfterSplice(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	dev := &diode.Device{Name: strPtr("test-router")}
+	iface1 := &diode.Interface{Name: strPtr("Gi1/0/1"), Device: dev}
+	iface2 := &diode.Interface{Name: strPtr("Gi1/0/2"), Device: dev}
+	entitiesForTarget := []diode.Entity{dev, iface1, iface2}
+
+	oids := buildOIDs(chassis9404RWithTransceiversFixture())
+	memberDevices := map[int]*diode.Device{0: dev}
+
+	moduleEntities, _ := TranslateModulesWithAlias(
+		oids, nil, memberDevices, modeLinecards(), nil, logger, nil, nil,
+	)
+	require.NotEmpty(t, moduleEntities)
+
+	// Mirrors runner.go's splice: find the first non-Device/non-VC index,
+	// splice moduleEntities there.
+	splice := len(entitiesForTarget)
+	for i, e := range entitiesForTarget {
+		switch e.(type) {
+		case *diode.Device, *diode.VirtualChassis:
+			continue
+		default:
+			splice = i
+		}
+		if splice < len(entitiesForTarget) {
+			break
+		}
+	}
+	merged := append([]diode.Entity{}, entitiesForTarget[:splice]...)
+	merged = append(merged, moduleEntities...)
+	merged = append(merged, entitiesForTarget[splice:]...)
+
+	firstIface := -1
+	lastModule := -1
+	for i, e := range merged {
+		switch e.(type) {
+		case *diode.Module, *diode.ModuleBay:
+			lastModule = i
+		case *diode.Interface:
+			if firstIface == -1 {
+				firstIface = i
+			}
+		}
+	}
+	require.GreaterOrEqual(t, firstIface, 0, "no Interface in merged slice")
+	require.GreaterOrEqual(t, lastModule, 0, "no Module/ModuleBay in merged slice")
+	assert.Less(t, lastModule, firstIface,
+		"Module/ModuleBay must precede Interface — Diode ingest contract")
+}

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -8,10 +8,9 @@ import (
 	"testing"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
 )
 
 // modeOff / modeLinecards / modeFull return *config.Options with the

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -545,3 +545,36 @@ func TestSpliceModulesAfterDevices(t *testing.T) {
 		assert.Same(t, iface, out[2])
 	})
 }
+
+// TestTranslateModules_ModuleTypeModel_FallsBackToVendorTypeWhenModelBlank
+// — Aruba CX populates entPhysicalVendorType instead of entPhysicalModelName.
+// The emitted ModuleType.Model must mirror classifyModule's
+// Model -> VendorType -> Unknown fallback so the type label matches the
+// classification (and so NetBox doesn't see "Unknown" for valid hardware).
+func TestTranslateModules_ModuleTypeModel_FallsBackToVendorTypeWhenModelBlank(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	// fixtureRow order: EntIndex, ContainedIn, Class, ParentRel, Name,
+	// Serial, Model, Descr, VendorType.
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Chassis", "FCAR2401", "ArubaCX-8400", "Aruba 8400 Chassis", "aruba-8400"},
+		{"100", "1", "5", "1", "Slot 1", "", "", "Slot 1", ""},
+		// Aruba CX shape: Model blank, VendorType populated.
+		{"101", "100", "9", "1", "Linecard 1", "ARSER01", "", "Aruba line card", "aruba-jl363a"},
+	}
+	dev := &diode.Device{Name: strPtr("aruba")}
+	memberDevices := map[int]*diode.Device{0: dev}
+
+	entities, _ := TranslateModules(buildOIDs(rows), nil, memberDevices, modeLinecards(), nil, logger)
+
+	var modules []*diode.Module
+	for _, e := range entities {
+		if m, ok := e.(*diode.Module); ok {
+			modules = append(modules, m)
+		}
+	}
+	require.Len(t, modules, 1)
+	require.NotNil(t, modules[0].ModuleType)
+	require.NotNil(t, modules[0].ModuleType.Model)
+	assert.Equal(t, "aruba-jl363a", *modules[0].ModuleType.Model,
+		"blank Model must fall back to VendorType, not Unknown")
+}

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -532,4 +532,16 @@ func TestSpliceModulesAfterDevices(t *testing.T) {
 		assert.Same(t, mod, out[3])
 		assert.Same(t, iface, out[4])
 	})
+
+	// Pins the splice=0 path: when the slice has no Device/VC head, modules
+	// must be prepended so they precede the first Interface (Diode ingest
+	// requires Modules before any Interface that references them).
+	t.Run("non_device_headed_slice_modules_prepend", func(t *testing.T) {
+		in := []diode.Entity{iface}
+		out := SpliceModulesAfterDevices(in, []diode.Entity{bay, mod})
+		require.Len(t, out, 3)
+		assert.Same(t, bay, out[0])
+		assert.Same(t, mod, out[1])
+		assert.Same(t, iface, out[2])
+	})
 }

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -458,11 +458,8 @@ func TestTranslateModulesWithAlias_VCOfModular_DispatchesPerMember(t *testing.T)
 
 // TestTranslateModulesWithAlias_ModulesPrecedeInterfacesAfterSplice pins
 // the Diode ingest ordering contract honoured by the runner's
-// partition-and-prepend splice (policy/runner.go in queryTarget): every
-// *diode.Module / *diode.ModuleBay index must be < every *diode.Interface
-// index in the merged slice. The splice logic is duplicated here
-// inline — keeping the test in the mapping package avoids runner-test
-// setup overhead while still exercising the exact same algorithm.
+// SpliceModulesAfterDevices call: every *diode.Module / *diode.ModuleBay
+// index must be < every *diode.Interface index in the merged slice.
 func TestTranslateModulesWithAlias_ModulesPrecedeInterfacesAfterSplice(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	dev := &diode.Device{Name: strPtr("test-router")}
@@ -478,23 +475,7 @@ func TestTranslateModulesWithAlias_ModulesPrecedeInterfacesAfterSplice(t *testin
 	)
 	require.NotEmpty(t, moduleEntities)
 
-	// Mirrors runner.go's splice: find the first non-Device/non-VC index,
-	// splice moduleEntities there.
-	splice := len(entitiesForTarget)
-	for i, e := range entitiesForTarget {
-		switch e.(type) {
-		case *diode.Device, *diode.VirtualChassis:
-			continue
-		default:
-			splice = i
-		}
-		if splice < len(entitiesForTarget) {
-			break
-		}
-	}
-	merged := append([]diode.Entity{}, entitiesForTarget[:splice]...)
-	merged = append(merged, moduleEntities...)
-	merged = append(merged, entitiesForTarget[splice:]...)
+	merged := SpliceModulesAfterDevices(entitiesForTarget, moduleEntities)
 
 	firstIface := -1
 	lastModule := -1
@@ -512,4 +493,43 @@ func TestTranslateModulesWithAlias_ModulesPrecedeInterfacesAfterSplice(t *testin
 	require.GreaterOrEqual(t, lastModule, 0, "no Module/ModuleBay in merged slice")
 	assert.Less(t, lastModule, firstIface,
 		"Module/ModuleBay must precede Interface — Diode ingest contract")
+}
+
+// TestSpliceModulesAfterDevices covers the helper's three core shapes:
+// empty modules (no-op), all-Device prefix (append at end of head), and
+// mixed Device+VC head with trailing Interfaces (insert at first
+// non-head index).
+func TestSpliceModulesAfterDevices(t *testing.T) {
+	dev := &diode.Device{Name: strPtr("d")}
+	vc := &diode.VirtualChassis{Name: strPtr("vc")}
+	iface := &diode.Interface{Name: strPtr("Gi0/0"), Device: dev}
+	bay := &diode.ModuleBay{Name: strPtr("Slot 1"), Device: dev}
+	mod := &diode.Module{Device: dev, ModuleBay: bay}
+
+	t.Run("empty modules returns input unchanged", func(t *testing.T) {
+		in := []diode.Entity{dev, iface}
+		out := SpliceModulesAfterDevices(in, nil)
+		assert.Equal(t, in, out)
+	})
+
+	t.Run("all-Device prefix appends modules at the end", func(t *testing.T) {
+		in := []diode.Entity{dev, vc}
+		out := SpliceModulesAfterDevices(in, []diode.Entity{bay, mod})
+		require.Len(t, out, 4)
+		assert.Same(t, dev, out[0])
+		assert.Same(t, vc, out[1])
+		assert.Same(t, bay, out[2])
+		assert.Same(t, mod, out[3])
+	})
+
+	t.Run("mixed head+tail splices before first non-head", func(t *testing.T) {
+		in := []diode.Entity{dev, vc, iface}
+		out := SpliceModulesAfterDevices(in, []diode.Entity{bay, mod})
+		require.Len(t, out, 5)
+		assert.Same(t, dev, out[0])
+		assert.Same(t, vc, out[1])
+		assert.Same(t, bay, out[2])
+		assert.Same(t, mod, out[3])
+		assert.Same(t, iface, out[4])
+	})
 }

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -306,6 +306,45 @@ func startsWith(s, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }
 
+// TestTranslateModules_ModuleTypeManufacturer_SourcedFromDevice pins the
+// invariant that ModuleType.Manufacturer.Name and the metric `vendor`
+// attribute always agree — both must read from the emitted Device's
+// DeviceType.Manufacturer.Name, falling back to defaults only when the
+// device has no manufacturer set. Regression: previously emitModule
+// sourced from defaults so a device with a real Manufacturer but empty
+// defaults produced ModuleType.Manufacturer="Unknown" while the metric
+// label read the real vendor — labels diverged from emitted entities.
+func TestTranslateModules_ModuleTypeManufacturer_SourcedFromDevice(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	oids := buildOIDs(chassis9404RWithTransceiversFixture())
+	dev := &diode.Device{
+		Name: strPtr("test-router"),
+		DeviceType: &diode.DeviceType{
+			Manufacturer: &diode.Manufacturer{Name: strPtr("Cisco")},
+		},
+	}
+	memberDevices := map[int]*diode.Device{0: dev}
+	// defaults has an empty Manufacturer — the device value MUST win.
+	defaults := &config.Defaults{}
+
+	entities, _ := TranslateModules(oids, nil, memberDevices, modeLinecards(), defaults, logger)
+
+	var modules []*diode.Module
+	for _, e := range entities {
+		if m, ok := e.(*diode.Module); ok {
+			modules = append(modules, m)
+		}
+	}
+	require.NotEmpty(t, modules, "fixture must emit at least one module")
+	for _, m := range modules {
+		require.NotNil(t, m.ModuleType, "every emitted Module needs a ModuleType")
+		require.NotNil(t, m.ModuleType.Manufacturer, "ModuleType must carry Manufacturer")
+		require.NotNil(t, m.ModuleType.Manufacturer.Name)
+		assert.Equal(t, "Cisco", *m.ModuleType.Manufacturer.Name,
+			"ModuleType.Manufacturer.Name must come from the emitted Device, not defaults")
+	}
+}
+
 // TestTranslateModulesWithAlias_VCOfModular_DispatchesPerMember — pins
 // that on a virtual-chassis of two modular boxes, each member's
 // linecards are emitted under that member's *diode.Device. The walk

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -137,14 +137,13 @@ func TestTranslateModules_FullMode_EmitsTransceiversAsSubBayedModules(t *testing
 	dev := &diode.Device{Name: strPtr("test-router")}
 	memberDevices := map[int]*diode.Device{0: dev}
 
-	// Transceiver EntIndex "203" sits behind ifIndex "10101" /
-	// ifName "Gi1/0/1" per the fixture's alias wiring intent.
+	// Transceiver EntIndex "203" sits behind ifIndex "10101"
+	// per the fixture's alias wiring intent.
 	aliasMap := map[string]string{"203": "10101"}
-	ifIndexToName := map[string]string{"10101": "Gi1/0/1"}
 
 	entities, ifaceMap := TranslateModulesWithAlias(
 		oids, nil, memberDevices, modeFull(), nil, logger,
-		aliasMap, ifIndexToName,
+		aliasMap,
 	)
 
 	var bays []*diode.ModuleBay
@@ -162,11 +161,12 @@ func TestTranslateModules_FullMode_EmitsTransceiversAsSubBayedModules(t *testing
 	require.Len(t, bays, 3, "supervisor bay + linecard bay + transceiver sub-bay")
 	require.Len(t, modules, 3, "supervisor + linecard + transceiver")
 
-	// Iface map points the physical port at the transceiver module.
+	// Iface map points the physical port (keyed by ifIndex) at the
+	// transceiver module.
 	require.Len(t, ifaceMap, 1)
-	require.Contains(t, ifaceMap, "Gi1/0/1")
-	require.NotNil(t, ifaceMap["Gi1/0/1"].Serial)
-	assert.Equal(t, "FNS24010TR1", *ifaceMap["Gi1/0/1"].Serial)
+	require.Contains(t, ifaceMap, "10101")
+	require.NotNil(t, ifaceMap["10101"].Serial)
+	assert.Equal(t, "FNS24010TR1", *ifaceMap["10101"].Serial)
 }
 
 // TestTranslateModules_FullMode_SubBayDeviceRooted — pins the sub-bay
@@ -183,7 +183,7 @@ func TestTranslateModules_FullMode_SubBayDeviceRooted(t *testing.T) {
 	memberDevices := map[int]*diode.Device{0: dev}
 
 	entities, _ := TranslateModulesWithAlias(
-		oids, nil, memberDevices, modeFull(), nil, logger, nil, nil,
+		oids, nil, memberDevices, modeFull(), nil, logger, nil,
 	)
 
 	// The transceiver's bay carries the port-shaped name from the
@@ -221,7 +221,7 @@ func TestTranslateModules_FullMode_EmptyBayEmittedAsBareModuleBay(t *testing.T) 
 	memberDevices := map[int]*diode.Device{0: dev}
 
 	entities, _ := TranslateModulesWithAlias(
-		buildOIDs(rows), nil, memberDevices, modeFull(), nil, logger, nil, nil,
+		buildOIDs(rows), nil, memberDevices, modeFull(), nil, logger, nil,
 	)
 
 	var bays []*diode.ModuleBay
@@ -258,7 +258,7 @@ func TestTranslateModules_SubBayWorkaround_NotLinkedToParentLinecard(t *testing.
 	memberDevices := map[int]*diode.Device{0: dev}
 
 	entities, _ := TranslateModulesWithAlias(
-		oids, nil, memberDevices, modeFull(), nil, logger, nil, nil,
+		oids, nil, memberDevices, modeFull(), nil, logger, nil,
 	)
 
 	// Identify which bays are sub-bays (transceiver-shaped). The 9404R
@@ -333,7 +333,7 @@ func TestTranslateModules_FullMode_EmitsTransceiversNestedTwoLevelsDeep(t *testi
 	memberDevices := map[int]*diode.Device{0: dev}
 
 	entities, _ := TranslateModulesWithAlias(
-		buildOIDs(rows), nil, memberDevices, modeFull(), nil, logger, nil, nil,
+		buildOIDs(rows), nil, memberDevices, modeFull(), nil, logger, nil,
 	)
 
 	var transceiverSeen bool
@@ -427,7 +427,7 @@ func TestTranslateModulesWithAlias_VCOfModular_DispatchesPerMember(t *testing.T)
 
 	entities, _ := TranslateModulesWithAlias(
 		buildOIDs(rows), chassisInv, memberDevices,
-		modeLinecards(), nil, logger, nil, nil,
+		modeLinecards(), nil, logger, nil,
 	)
 
 	var modules []*diode.Module
@@ -471,7 +471,7 @@ func TestTranslateModulesWithAlias_ModulesPrecedeInterfacesAfterSplice(t *testin
 	memberDevices := map[int]*diode.Device{0: dev}
 
 	moduleEntities, _ := TranslateModulesWithAlias(
-		oids, nil, memberDevices, modeLinecards(), nil, logger, nil, nil,
+		oids, nil, memberDevices, modeLinecards(), nil, logger, nil,
 	)
 	require.NotEmpty(t, moduleEntities)
 

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -241,3 +241,68 @@ func TestTranslateModules_FullMode_EmptyBayEmittedAsBareModuleBay(t *testing.T) 
 	assert.Equal(t, "Slot 5 (empty)", *bays[0].Name)
 	assert.NotNil(t, bays[0].Device, "even bare bays carry Device")
 }
+
+// TestTranslateModules_SubBayWorkaround_NotLinkedToParentLinecard pins
+// the Diode reconciler workaround (spec §Sub-bay emission workaround).
+// Background: dcim_module_module_bay_id_key is a unique constraint; if
+// we emit a transceiver sub-bay with Module=parent_linecard, the
+// reconciler re-plans the parent linecard inside the sub-bay's
+// changeset and the apply step trips the unique constraint. Until the
+// upstream fix lands, every transceiver-shaped ModuleBay must be
+// device-rooted (Device set, Module nil) and the transceiver's own
+// Module.ModuleBay must in turn carry Device (so it has a matching
+// scope).
+func TestTranslateModules_SubBayWorkaround_NotLinkedToParentLinecard(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	oids := buildOIDs(chassis9404RWithTransceiversFixture())
+	dev := &diode.Device{Name: strPtr("test-router")}
+	memberDevices := map[int]*diode.Device{0: dev}
+
+	entities, _ := TranslateModulesWithAlias(
+		oids, nil, memberDevices, modeFull(), nil, logger, nil, nil,
+	)
+
+	// Identify which bays are sub-bays (transceiver-shaped). The 9404R
+	// fixture names its port container "TenGigabitEthernet2/0/1", so a
+	// HasPrefix("TenGigabit") match is sufficient here.
+	subBaysSeen := 0
+	for _, e := range entities {
+		b, ok := e.(*diode.ModuleBay)
+		if !ok || b.Name == nil {
+			continue
+		}
+		name := *b.Name
+		if !startsWith(name, "TenGigabit") {
+			continue
+		}
+		subBaysSeen++
+		// Workaround invariants:
+		assert.Nil(t, b.Module,
+			"sub-bay %q must not link to parent linecard — see spec §Sub-bay emission workaround", name)
+		assert.NotNil(t, b.Device,
+			"sub-bay %q must be device-rooted (Device set)", name)
+	}
+	require.Equal(t, 1, subBaysSeen, "expected exactly one transceiver sub-bay")
+
+	// The transceiver Module must reach Device through its own bay too
+	// (the device-rooted bay carries Device).
+	for _, e := range entities {
+		m, ok := e.(*diode.Module)
+		if !ok || m.ModuleType == nil || m.ModuleType.Model == nil {
+			continue
+		}
+		if *m.ModuleType.Model != "SFP-10G-LR" {
+			continue
+		}
+		require.NotNil(t, m.ModuleBay, "transceiver Module must carry ModuleBay")
+		assert.NotNil(t, m.ModuleBay.Device,
+			"transceiver Module.ModuleBay must carry Device (device-rooted workaround)")
+	}
+}
+
+// startsWith is a tiny local helper to keep the regression test free of
+// strings.HasPrefix imports leakage in case future test refactors drop
+// strings entirely.
+func startsWith(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -17,17 +17,17 @@ import (
 // matching discover_modules string set. Tiny helpers so each test reads
 // like prose.
 func modeOff() *config.Options {
-	v := "off"
+	v := config.DiscoverModulesOff
 	return &config.Options{DiscoverModules: &v}
 }
 
 func modeLinecards() *config.Options {
-	v := "linecards"
+	v := config.DiscoverModulesLinecards
 	return &config.Options{DiscoverModules: &v}
 }
 
 func modeFull() *config.Options {
-	v := "full"
+	v := config.DiscoverModulesFull
 	return &config.Options{DiscoverModules: &v}
 }
 

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -1,0 +1,129 @@
+// Copyright 2026 NetBox Labs, Inc.
+
+package mapping
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/netboxlabs/diode-sdk-go/diode"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+)
+
+// modeOff / modeLinecards / modeFull return *config.Options with the
+// matching discover_modules string set. Tiny helpers so each test reads
+// like prose.
+func modeOff() *config.Options {
+	v := "off"
+	return &config.Options{DiscoverModules: &v}
+}
+
+func modeLinecards() *config.Options {
+	v := "linecards"
+	return &config.Options{DiscoverModules: &v}
+}
+
+func modeFull() *config.Options {
+	v := "full"
+	return &config.Options{DiscoverModules: &v}
+}
+
+// TestTranslateModules_OffMode_ReturnsNil — default (and explicit "off")
+// must short-circuit before any extraction or emission so existing
+// pipelines see zero behaviour change.
+func TestTranslateModules_OffMode_ReturnsNil(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	oids := buildOIDs(chassis9404RWithTransceiversFixture())
+	dev := &diode.Device{Name: strPtr("test")}
+	memberDevices := map[int]*diode.Device{0: dev}
+
+	entities, ifaceMap := TranslateModules(oids, nil, memberDevices, modeOff(), nil, logger)
+
+	assert.Nil(t, entities, "off mode emits no entities")
+	assert.Nil(t, ifaceMap, "off mode produces no iface attachment map")
+}
+
+// TestTranslateModules_LinecardsMode_StandaloneEmitsLinecardsAndSupervisorsNoTransceivers
+// — linecards mode emits the chassis-slot modules (supervisor + linecard
+// in the 9404R fixture) and their bays, but NOT the transceiver. The
+// iface attachment map is nil/empty in linecards mode.
+func TestTranslateModules_LinecardsMode_StandaloneEmitsLinecardsAndSupervisorsNoTransceivers(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	oids := buildOIDs(chassis9404RWithTransceiversFixture())
+	dev := &diode.Device{Name: strPtr("test-router")}
+	memberDevices := map[int]*diode.Device{0: dev}
+
+	entities, ifaceMap := TranslateModules(oids, nil, memberDevices, modeLinecards(), nil, logger)
+
+	var bays []*diode.ModuleBay
+	var modules []*diode.Module
+	for _, e := range entities {
+		switch v := e.(type) {
+		case *diode.ModuleBay:
+			bays = append(bays, v)
+		case *diode.Module:
+			modules = append(modules, v)
+		}
+	}
+	require.Len(t, bays, 2, "supervisor bay + linecard bay")
+	require.Len(t, modules, 2, "supervisor + linecard; no transceiver in linecards mode")
+
+	// iface map stays empty — transceiver routing is full-mode only.
+	assert.Empty(t, ifaceMap)
+
+	// No transceiver model leaks into the module list.
+	for _, m := range modules {
+		require.NotNil(t, m.ModuleType, "every emitted Module needs a ModuleType")
+		require.NotNil(t, m.ModuleType.Model)
+		assert.NotEqual(t, "SFP-10G-LR", *m.ModuleType.Model,
+			"transceivers must not be emitted as modules in linecards mode")
+	}
+
+	// Every ModuleBay carries Device; every Module carries Device + ModuleBay.
+	for _, b := range bays {
+		require.NotNil(t, b.Device, "ModuleBay must have Device set")
+	}
+	for _, m := range modules {
+		require.NotNil(t, m.Device, "Module must have Device set")
+		require.NotNil(t, m.ModuleBay, "Module must have ModuleBay set")
+	}
+}
+
+// TestTranslateModules_PSUAndFan_NotEmitted — PSUs and fans are
+// classified for label-only purposes; they must NOT surface as Module
+// entities even in full mode.
+func TestTranslateModules_PSUAndFan_NotEmitted(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Chassis", "FOO", "C9404R", "Chassis", ""},
+		{"100", "1", "5", "1", "PowerSupply 1", "", "", "", ""},
+		{"101", "100", "9", "1", "PSU 1", "PSUSER01", "PWR-C5-715WAC", "", ""},
+		{"200", "1", "5", "1", "Fan Tray", "", "", "", ""},
+		// Fan PID — uses "FAN-" prefix so the current classifier (which
+		// matches HasPrefix(upper, "FAN")) recognises it. PR #419's
+		// classifier additionally treats "C9400-FAN" via the -FAN suffix,
+		// but that branch is unrelated to this filter test.
+		{"201", "200", "9", "1", "Fan 1", "FANSER01", "FAN-T1-R", "", ""},
+		{"300", "1", "5", "1", "Slot 3", "", "", "", ""},
+		{"301", "300", "9", "1", "Linecard 3", "LCSER03", "C9400-LC-48U", "", ""},
+	}
+	dev := &diode.Device{Name: strPtr("test")}
+	memberDevices := map[int]*diode.Device{0: dev}
+
+	entities, _ := TranslateModules(buildOIDs(rows), nil, memberDevices, modeFull(), nil, logger)
+
+	var modules []*diode.Module
+	for _, e := range entities {
+		if m, ok := e.(*diode.Module); ok {
+			modules = append(modules, m)
+		}
+	}
+	require.Len(t, modules, 1, "only the linecard — PSU + fan filtered out")
+	require.NotNil(t, modules[0].ModuleType)
+	require.NotNil(t, modules[0].ModuleType.Model)
+	assert.Equal(t, "C9400-LC-48U", *modules[0].ModuleType.Model)
+}

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -127,3 +127,117 @@ func TestTranslateModules_PSUAndFan_NotEmitted(t *testing.T) {
 	require.NotNil(t, modules[0].ModuleType.Model)
 	assert.Equal(t, "C9400-LC-48U", *modules[0].ModuleType.Model)
 }
+
+// TestTranslateModules_FullMode_EmitsTransceiversAsSubBayedModules — in
+// full mode the 9404R fixture must emit the supervisor + linecard pair
+// plus a transceiver nested in its own sub-bay, AND the iface attachment
+// map must route Gi1/0/1 → that transceiver Module.
+func TestTranslateModules_FullMode_EmitsTransceiversAsSubBayedModules(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	oids := buildOIDs(chassis9404RWithTransceiversFixture())
+	dev := &diode.Device{Name: strPtr("test-router")}
+	memberDevices := map[int]*diode.Device{0: dev}
+
+	// Transceiver EntIndex "203" sits behind ifIndex "10101" /
+	// ifName "Gi1/0/1" per the fixture's alias wiring intent.
+	aliasMap := map[string]string{"203": "10101"}
+	ifIndexToName := map[string]string{"10101": "Gi1/0/1"}
+
+	entities, ifaceMap := TranslateModulesWithAlias(
+		oids, nil, memberDevices, modeFull(), nil, logger,
+		aliasMap, ifIndexToName,
+	)
+
+	var bays []*diode.ModuleBay
+	var modules []*diode.Module
+	for _, e := range entities {
+		switch v := e.(type) {
+		case *diode.ModuleBay:
+			bays = append(bays, v)
+		case *diode.Module:
+			modules = append(modules, v)
+		}
+	}
+	// Supervisor bay + linecard bay + transceiver sub-bay = 3 bays;
+	// supervisor + linecard + transceiver = 3 modules.
+	require.Len(t, bays, 3, "supervisor bay + linecard bay + transceiver sub-bay")
+	require.Len(t, modules, 3, "supervisor + linecard + transceiver")
+
+	// Iface map points the physical port at the transceiver module.
+	require.Len(t, ifaceMap, 1)
+	require.Contains(t, ifaceMap, "Gi1/0/1")
+	require.NotNil(t, ifaceMap["Gi1/0/1"].Serial)
+	assert.Equal(t, "FNS24010TR1", *ifaceMap["Gi1/0/1"].Serial)
+}
+
+// TestTranslateModules_FullMode_SubBayDeviceRooted — pins the sub-bay
+// reconciler workaround documented in the design spec under
+// "Sub-bay emission workaround". The transceiver's sub-bay MUST carry
+// Device (so Diode has a matching scope) and MUST NOT carry Module
+// (linking the sub-bay to its parent linecard makes the Diode
+// reconciler re-plan the parent inside the sub-bay's changeset and
+// trip dcim_module_module_bay_id_key on apply).
+func TestTranslateModules_FullMode_SubBayDeviceRooted(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	oids := buildOIDs(chassis9404RWithTransceiversFixture())
+	dev := &diode.Device{Name: strPtr("test-router")}
+	memberDevices := map[int]*diode.Device{0: dev}
+
+	entities, _ := TranslateModulesWithAlias(
+		oids, nil, memberDevices, modeFull(), nil, logger, nil, nil,
+	)
+
+	// The transceiver's bay carries the port-shaped name from the
+	// fixture ("TenGigabitEthernet2/0/1"). Find it and assert the
+	// workaround invariants.
+	var subBay *diode.ModuleBay
+	for _, e := range entities {
+		b, ok := e.(*diode.ModuleBay)
+		if !ok || b.Name == nil {
+			continue
+		}
+		if *b.Name == "TenGigabitEthernet2/0/1" {
+			subBay = b
+			break
+		}
+	}
+	require.NotNil(t, subBay, "transceiver sub-bay must be emitted")
+	assert.NotNil(t, subBay.Device,
+		"sub-bay must be device-rooted (workaround for Diode reconciler)")
+	assert.Nil(t, subBay.Module,
+		"sub-bay must NOT carry Module=parent_linecard — see spec §Sub-bay emission workaround")
+}
+
+// TestTranslateModules_FullMode_EmptyBayEmittedAsBareModuleBay —
+// Aruba CX-style empty bays surface as bare ModuleBay entities (no
+// Module installed) in full mode only.
+func TestTranslateModules_FullMode_EmptyBayEmittedAsBareModuleBay(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Chassis", "FOO", "8400", "Chassis", ""},
+		// Empty bay — class=5 under chassis, no class=9 child.
+		{"700", "1", "5", "5", "Slot 5 (empty)", "", "", "Slot 5", ""},
+	}
+	dev := &diode.Device{Name: strPtr("test")}
+	memberDevices := map[int]*diode.Device{0: dev}
+
+	entities, _ := TranslateModulesWithAlias(
+		buildOIDs(rows), nil, memberDevices, modeFull(), nil, logger, nil, nil,
+	)
+
+	var bays []*diode.ModuleBay
+	var modules []*diode.Module
+	for _, e := range entities {
+		switch v := e.(type) {
+		case *diode.ModuleBay:
+			bays = append(bays, v)
+		case *diode.Module:
+			modules = append(modules, v)
+		}
+	}
+	require.Len(t, bays, 1, "one bare ModuleBay for the empty slot")
+	require.Empty(t, modules, "no Module entity for an empty bay")
+	require.NotNil(t, bays[0].Name)
+	assert.Equal(t, "Slot 5 (empty)", *bays[0].Name)
+	assert.NotNil(t, bays[0].Device, "even bare bays carry Device")
+}

--- a/snmp-discovery/mapping/module_translate_test.go
+++ b/snmp-discovery/mapping/module_translate_test.go
@@ -306,6 +306,52 @@ func startsWith(s, prefix string) bool {
 	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
 }
 
+// TestTranslateModules_FullMode_EmitsTransceiversNestedTwoLevelsDeep —
+// Juniper-style hierarchy puts optics two module-levels below the
+// chassis: Chassis -> FPC (class=9) -> PIC bay (class=5) -> PIC
+// (class=9) -> port container (class=5) -> optic (class=9). The PIC
+// is itself a sub-module under the FPC, so optics under the PIC live
+// in inv.SubModules keyed by the PIC's EntIndex — not by any
+// inv.Modules entry. The full-mode emitter must walk every key in
+// inv.SubModules (recursive over the containment tree) so optics
+// nested under sub-modules surface as Module entities.
+func TestTranslateModules_FullMode_EmitsTransceiversNestedTwoLevelsDeep(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	rows := []fixtureRow{
+		{"1", "0", "3", "1", "Chassis", "JN1234", "MX480", "", ""},
+		// FPC slot (class=5 bay) + FPC (class=9 module under it)
+		{"10", "1", "5", "1", "FPC 0 Slot", "", "", "", ""},
+		{"11", "10", "9", "1", "FPC 0", "AB123FPC", "MPC7E-MRATE", "", ""},
+		// PIC bay (class=5) under the FPC + PIC (class=9 module) under it
+		{"20", "11", "5", "1", "PIC 0 Bay", "", "", "", ""},
+		{"21", "20", "9", "1", "PIC 0", "CD456PIC", "MIC-3D-10XGE-SFPP", "", ""},
+		// Port container (class=5) under the PIC + optic (class=9) under it
+		{"30", "21", "5", "1", "xe-0/0/0", "", "", "", ""},
+		{"31", "30", "9", "1", "xe-0/0/0 Optic", "EF789OPT", "SFP-10G-LR", "", ""},
+	}
+	dev := &diode.Device{Name: strPtr("mx480")}
+	memberDevices := map[int]*diode.Device{0: dev}
+
+	entities, _ := TranslateModulesWithAlias(
+		buildOIDs(rows), nil, memberDevices, modeFull(), nil, logger, nil, nil,
+	)
+
+	var transceiverSeen bool
+	for _, e := range entities {
+		m, ok := e.(*diode.Module)
+		if !ok || m.ModuleType == nil || m.ModuleType.Model == nil {
+			continue
+		}
+		if *m.ModuleType.Model == "SFP-10G-LR" {
+			transceiverSeen = true
+			require.NotNil(t, m.Serial)
+			assert.Equal(t, "EF789OPT", *m.Serial)
+		}
+	}
+	assert.True(t, transceiverSeen,
+		"optic nested under a sub-module (PIC) must be emitted in full mode")
+}
+
 // TestTranslateModules_ModuleTypeManufacturer_SourcedFromDevice pins the
 // invariant that ModuleType.Manufacturer.Name and the metric `vendor`
 // attribute always agree — both must read from the emitted Device's

--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -266,6 +266,15 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
 			if e.Lag != nil {
 				e.Lag = stubForIface(e.Lag)
 			}
+			if e.Module != nil {
+				// Reduce nested Interface.Module to matcher-only fields
+				// (Name + Serial via Device stub); the top-level Module
+				// entity carries the full record.
+				e.Module = &diode.Module{
+					Device: stubFor(e.Module.Device),
+					Serial: e.Module.Serial,
+				}
+			}
 		case *diode.IPAddress:
 			if iface, ok := e.AssignedObject.(*diode.Interface); ok && iface != nil {
 				e.AssignedObject = stubForIface(iface)
@@ -275,6 +284,8 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
 				e.AssignedObject = stubForIface(iface)
 			}
 		case *diode.Module:
+			e.Device = stubFor(e.Device)
+		case *diode.ModuleBay:
 			e.Device = stubFor(e.Device)
 		}
 	}

--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -268,11 +268,19 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
 			}
 			if e.Module != nil {
 				// Reduce nested Interface.Module to matcher-only fields
-				// (Name + Serial via Device stub); the top-level Module
-				// entity carries the full record.
-				e.Module = &diode.Module{
-					Device: stubFor(e.Module.Device),
-					Serial: e.Module.Serial,
+				// (Device stub + Serial); the top-level Module entity
+				// carries the full record. If Serial is missing the
+				// stub would be identifier-less (no field for Diode to
+				// match against, and the Device alone is not unique
+				// across multiple modules on the same device) — clear
+				// the ref entirely rather than ship an ambiguous stub.
+				if e.Module.Serial == nil || *e.Module.Serial == "" {
+					e.Module = nil
+				} else {
+					e.Module = &diode.Module{
+						Device: stubFor(e.Module.Device),
+						Serial: e.Module.Serial,
+					}
 				}
 			}
 		case *diode.IPAddress:

--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -268,45 +268,48 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
 			}
 			if e.Module != nil {
 				// Reduce nested Interface.Module to a matcher-only ref:
-				// chassis Device stub + Serial + ModuleBay matcher
-				// (name + position + chassis Device stub). The top-level
-				// Module entity carries the full record (module_type,
-				// description, status, etc.); this nested form lets the
-				// Diode reconciler resolve the ref to that top-level
-				// row via the (device, bay) or (device, serial) match
+				// chassis Device stub + Serial (if known) + ModuleBay
+				// matcher (if known). The top-level Module entity
+				// carries the full record (module_type, description,
+				// status, etc.); this nested form lets the Diode
+				// reconciler resolve the ref to that top-level row via
+				// the (Device, ModuleBay) or (Device, Serial) match
 				// paths without re-creating it.
 				//
 				// Shape mirrors device-discovery's _module_match_stub
 				// (device-discovery/device_discovery/stubs.py
-				// `_module_match_stub`). Earlier we shipped only
-				// {Device, Serial}; the reconciler treated that as a
-				// new Module emission and rejected it with
-				// "module_bay required, module_type required" because
-				// the (device, serial) match wasn't enough to bind the
-				// ref. Carrying the bay matcher unblocks the resolve.
+				// `_module_match_stub`): emit Device unconditionally,
+				// then conditionally copy Serial and ModuleBay matcher
+				// fields when present on the rich Module. Vendors that
+				// omit transceiver serial in ENTITY-MIB (some Aruba
+				// and low-end OEMs) still populate the bay, so the
+				// (Device, ModuleBay) path alone must keep the ref
+				// resolvable.
 				//
-				// If Serial is missing, the stub would be ambiguous if
-				// multiple modules share the same bay-name shape — and
-				// the bay matcher alone would still resolve in the
-				// common case. We clear the ref entirely instead of
-				// shipping an ambiguous one (preserves the prior
-				// d5d252d guard).
-				if e.Module.Serial == nil || *e.Module.Serial == "" {
+				// Only when BOTH Serial AND ModuleBay are unusable do
+				// we drop the ref entirely — at that point the stub
+				// carries no identifier and the reconciler would fall
+				// into creation mode and fail the
+				// "module_bay required, module_type required"
+				// validation (we also strip ModuleType).
+				devStub := stubFor(e.Module.Device)
+				stub := &diode.Module{Device: devStub}
+				if e.Module.Serial != nil && *e.Module.Serial != "" {
+					stub.Serial = e.Module.Serial
+				}
+				if e.Module.ModuleBay != nil {
+					stub.ModuleBay = &diode.ModuleBay{
+						Device:   devStub,
+						Name:     e.Module.ModuleBay.Name,
+						Position: e.Module.ModuleBay.Position,
+					}
+				}
+				if stub.Serial == nil && stub.ModuleBay == nil {
+					// Unresolvable: drop the ref so the reconciler
+					// doesn't try to create a Module without the
+					// required validation fields.
 					e.Module = nil
 				} else {
-					devStub := stubFor(e.Module.Device)
-					stub := &diode.Module{
-						Device: devStub,
-						Serial: e.Module.Serial,
-					}
-					if e.Module.ModuleBay != nil {
-						bayStub := &diode.ModuleBay{
-							Device:   devStub,
-							Name:     e.Module.ModuleBay.Name,
-							Position: e.Module.ModuleBay.Position,
-						}
-						stub.ModuleBay = bayStub
-					}
 					e.Module = stub
 				}
 			}

--- a/snmp-discovery/mapping/stubs.go
+++ b/snmp-discovery/mapping/stubs.go
@@ -267,20 +267,47 @@ func PruneNestedRefs(entities []diode.Entity, currentDevice *diode.Device) {
 				e.Lag = stubForIface(e.Lag)
 			}
 			if e.Module != nil {
-				// Reduce nested Interface.Module to matcher-only fields
-				// (Device stub + Serial); the top-level Module entity
-				// carries the full record. If Serial is missing the
-				// stub would be identifier-less (no field for Diode to
-				// match against, and the Device alone is not unique
-				// across multiple modules on the same device) — clear
-				// the ref entirely rather than ship an ambiguous stub.
+				// Reduce nested Interface.Module to a matcher-only ref:
+				// chassis Device stub + Serial + ModuleBay matcher
+				// (name + position + chassis Device stub). The top-level
+				// Module entity carries the full record (module_type,
+				// description, status, etc.); this nested form lets the
+				// Diode reconciler resolve the ref to that top-level
+				// row via the (device, bay) or (device, serial) match
+				// paths without re-creating it.
+				//
+				// Shape mirrors device-discovery's _module_match_stub
+				// (device-discovery/device_discovery/stubs.py
+				// `_module_match_stub`). Earlier we shipped only
+				// {Device, Serial}; the reconciler treated that as a
+				// new Module emission and rejected it with
+				// "module_bay required, module_type required" because
+				// the (device, serial) match wasn't enough to bind the
+				// ref. Carrying the bay matcher unblocks the resolve.
+				//
+				// If Serial is missing, the stub would be ambiguous if
+				// multiple modules share the same bay-name shape — and
+				// the bay matcher alone would still resolve in the
+				// common case. We clear the ref entirely instead of
+				// shipping an ambiguous one (preserves the prior
+				// d5d252d guard).
 				if e.Module.Serial == nil || *e.Module.Serial == "" {
 					e.Module = nil
 				} else {
-					e.Module = &diode.Module{
-						Device: stubFor(e.Module.Device),
+					devStub := stubFor(e.Module.Device)
+					stub := &diode.Module{
+						Device: devStub,
 						Serial: e.Module.Serial,
 					}
+					if e.Module.ModuleBay != nil {
+						bayStub := &diode.ModuleBay{
+							Device:   devStub,
+							Name:     e.Module.ModuleBay.Name,
+							Position: e.Module.ModuleBay.Position,
+						}
+						stub.ModuleBay = bayStub
+					}
+					e.Module = stub
 				}
 			}
 		case *diode.IPAddress:

--- a/snmp-discovery/mapping/stubs_test.go
+++ b/snmp-discovery/mapping/stubs_test.go
@@ -358,6 +358,63 @@ func TestPruneNestedRefs_StubsModuleBayAndInterfaceModule(t *testing.T) {
 		"Interface.Module must be reduced to matcher-only — no ModuleType")
 }
 
+// TestPruneNestedRefs_InterfaceModuleSerialNilCleared — an
+// Interface.Module reduced to {Device, Serial: nil} carries no
+// identifier and is useless for matching. Rather than ship an
+// ambiguous stub, the pruner must clear the ref entirely so the
+// top-level Module entity remains the only wire representation.
+func TestPruneNestedRefs_InterfaceModuleSerialNilCleared(t *testing.T) {
+	rich := &diode.Device{
+		Name:   strPtr("sw1"),
+		Site:   &diode.Site{Name: strPtr("dc1")},
+		Serial: strPtr("FCW123"),
+	}
+	// Transceiver Module without a Serial — common for vendors that omit
+	// optic serial on entPhysicalSerialNum.
+	transceiver := &diode.Module{
+		Device: rich,
+		ModuleType: &diode.ModuleType{
+			Model:        strPtr("SFP-10G-LR"),
+			Manufacturer: &diode.Manufacturer{Name: strPtr("Cisco")},
+		},
+	}
+	iface := &diode.Interface{
+		Name:   strPtr("Gi1/0/1"),
+		Device: rich,
+		Module: transceiver,
+	}
+	entities := []diode.Entity{rich, transceiver, iface}
+
+	PruneNestedRefs(entities, rich)
+
+	assert.Nil(t, iface.Module,
+		"Interface.Module must be cleared when its Serial is nil — an identifier-less stub would be ambiguous")
+}
+
+// TestPruneNestedRefs_InterfaceModuleEmptyStringSerialCleared — same
+// behaviour for a pointer-to-empty-string Serial: still no identifier,
+// so still clear the ref.
+func TestPruneNestedRefs_InterfaceModuleEmptyStringSerialCleared(t *testing.T) {
+	rich := &diode.Device{
+		Name: strPtr("sw1"),
+		Site: &diode.Site{Name: strPtr("dc1")},
+	}
+	empty := ""
+	transceiver := &diode.Module{
+		Device: rich,
+		Serial: &empty,
+	}
+	iface := &diode.Interface{
+		Name:   strPtr("Gi1/0/1"),
+		Device: rich,
+		Module: transceiver,
+	}
+	PruneNestedRefs([]diode.Entity{rich, transceiver, iface}, rich)
+
+	assert.Nil(t, iface.Module,
+		"Interface.Module must be cleared when Serial points at the empty string")
+}
+
 // strDerefSafe — tiny test helper for safe *string deref.
 func strDerefSafe(p *string) string {
 	if p == nil {

--- a/snmp-discovery/mapping/stubs_test.go
+++ b/snmp-discovery/mapping/stubs_test.go
@@ -323,8 +323,9 @@ func TestPruneNestedRefs_StubsModuleBayAndInterfaceModule(t *testing.T) {
 		Name:   strPtr("Slot 2"),
 	}
 	transceiverBay := &diode.ModuleBay{
-		Device: rich,
-		Name:   strPtr("TenGigabitEthernet1/0/1"),
+		Device:   rich,
+		Name:     strPtr("TenGigabitEthernet1/0/1"),
+		Position: strPtr("1"),
 	}
 	transceiver := &diode.Module{
 		Device:    rich,
@@ -334,6 +335,7 @@ func TestPruneNestedRefs_StubsModuleBayAndInterfaceModule(t *testing.T) {
 			Model:        strPtr("SFP-10G-LR"),
 			Manufacturer: &diode.Manufacturer{Name: strPtr("Cisco")},
 		},
+		Description: strPtr("SFP-10GBase-LR transceiver"),
 	}
 	iface := &diode.Interface{
 		Name:   strPtr("TenGigabitEthernet1/0/1"),
@@ -350,12 +352,32 @@ func TestPruneNestedRefs_StubsModuleBayAndInterfaceModule(t *testing.T) {
 	assert.Nil(t, bay.Device.Serial, "ModuleBay.Device serial stripped on stub")
 	assert.Nil(t, bay.Device.Status, "ModuleBay.Device status stripped on stub")
 
-	// Interface.Module reduced to matcher-only (Name + Serial). DeviceType /
-	// Description / Device-richness cleared so the wire payload stays bounded.
+	// Interface.Module reduced to a matcher-only ref: Device stub + Serial
+	// + ModuleBay matcher (name+position+device stub). Mirrors
+	// device-discovery's _module_match_stub so the Diode reconciler
+	// resolves the ref to the existing top-level Module instead of
+	// trying to create one and failing the "module_bay/module_type
+	// required" validation. ModuleType / Description / Status etc. stay
+	// dropped so the wire payload stays bounded.
 	require.NotNil(t, iface.Module)
 	assert.Equal(t, "FNS24010TR1", strDerefSafe(iface.Module.Serial))
 	assert.Nil(t, iface.Module.ModuleType,
-		"Interface.Module must be reduced to matcher-only — no ModuleType")
+		"Interface.Module stub must not carry ModuleType (drops large nested manufacturer)")
+	assert.Nil(t, iface.Module.Description,
+		"Interface.Module stub must not carry Description")
+
+	require.NotNil(t, iface.Module.Device, "Interface.Module.Device must be a chassis stub")
+	assert.Equal(t, "sw1", strDerefSafe(iface.Module.Device.Name))
+	assert.Nil(t, iface.Module.Device.Status, "Interface.Module.Device must be a stub (no Status)")
+
+	require.NotNil(t, iface.Module.ModuleBay,
+		"Interface.Module.ModuleBay matcher must be preserved so the reconciler can resolve via the (device, bay) match path")
+	assert.Equal(t, "TenGigabitEthernet1/0/1", strDerefSafe(iface.Module.ModuleBay.Name))
+	assert.Equal(t, "1", strDerefSafe(iface.Module.ModuleBay.Position))
+	require.NotNil(t, iface.Module.ModuleBay.Device, "ModuleBay matcher must carry a chassis device stub")
+	assert.Equal(t, "sw1", strDerefSafe(iface.Module.ModuleBay.Device.Name))
+	assert.Nil(t, iface.Module.ModuleBay.Device.Status,
+		"ModuleBay matcher's Device must itself be a stub (no rich Status)")
 }
 
 // TestPruneNestedRefs_InterfaceModuleSerialNilCleared — an

--- a/snmp-discovery/mapping/stubs_test.go
+++ b/snmp-discovery/mapping/stubs_test.go
@@ -307,3 +307,61 @@ func TestPruneNestedRefs_EmptySliceIsNoOp(t *testing.T) {
 	PruneNestedRefs(nil, dev)
 	assert.Equal(t, strPtr("sw1"), dev.Name)
 }
+
+func TestPruneNestedRefs_StubsModuleBayAndInterfaceModule(t *testing.T) {
+	rich := &diode.Device{
+		Name:   strPtr("sw1"),
+		Serial: strPtr("FCW123"),
+		Status: strPtr("active"),
+		DeviceType: &diode.DeviceType{
+			Model:        strPtr("C9404R"),
+			Manufacturer: &diode.Manufacturer{Name: strPtr("Cisco")},
+		},
+	}
+	bay := &diode.ModuleBay{
+		Device: rich,
+		Name:   strPtr("Slot 2"),
+	}
+	transceiverBay := &diode.ModuleBay{
+		Device: rich,
+		Name:   strPtr("TenGigabitEthernet1/0/1"),
+	}
+	transceiver := &diode.Module{
+		Device:    rich,
+		ModuleBay: transceiverBay,
+		Serial:    strPtr("FNS24010TR1"),
+		ModuleType: &diode.ModuleType{
+			Model:        strPtr("SFP-10G-LR"),
+			Manufacturer: &diode.Manufacturer{Name: strPtr("Cisco")},
+		},
+	}
+	iface := &diode.Interface{
+		Name:   strPtr("TenGigabitEthernet1/0/1"),
+		Device: rich,
+		Module: transceiver,
+	}
+	entities := []diode.Entity{rich, bay, transceiverBay, transceiver, iface}
+
+	PruneNestedRefs(entities, rich)
+
+	// ModuleBay.Device must be stubbed.
+	require.NotNil(t, bay.Device)
+	assert.Equal(t, "sw1", *bay.Device.Name)
+	assert.Nil(t, bay.Device.Serial, "ModuleBay.Device serial stripped on stub")
+	assert.Nil(t, bay.Device.Status, "ModuleBay.Device status stripped on stub")
+
+	// Interface.Module reduced to matcher-only (Name + Serial). DeviceType /
+	// Description / Device-richness cleared so the wire payload stays bounded.
+	require.NotNil(t, iface.Module)
+	assert.Equal(t, "FNS24010TR1", strDerefSafe(iface.Module.Serial))
+	assert.Nil(t, iface.Module.ModuleType,
+		"Interface.Module must be reduced to matcher-only — no ModuleType")
+}
+
+// strDerefSafe — tiny test helper for safe *string deref.
+func strDerefSafe(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}

--- a/snmp-discovery/mapping/stubs_test.go
+++ b/snmp-discovery/mapping/stubs_test.go
@@ -380,10 +380,130 @@ func TestPruneNestedRefs_StubsModuleBayAndInterfaceModule(t *testing.T) {
 		"ModuleBay matcher's Device must itself be a stub (no rich Status)")
 }
 
+// TestPruneNestedRefs_InterfaceModuleSurvivesWhenSerialNilButBayPresent —
+// vendors that omit transceiver Serial in ENTITY-MIB (some Aruba and
+// low-end OEMs) still populate the physical bay. When Serial is nil
+// but ModuleBay is set, the pruner must preserve the stub so the
+// reconciler can resolve the Module via the (Device, ModuleBay) match
+// path. Mirrors device-discovery's `_module_match_stub` which
+// unconditionally copies bay matcher fields when present.
+func TestPruneNestedRefs_InterfaceModuleSurvivesWhenSerialNilButBayPresent(t *testing.T) {
+	rich := &diode.Device{
+		Name:   strPtr("sw1"),
+		Site:   &diode.Site{Name: strPtr("dc1")},
+		Serial: strPtr("FCW123"),
+		Status: strPtr("active"),
+		DeviceType: &diode.DeviceType{
+			Model:        strPtr("C9404R"),
+			Manufacturer: &diode.Manufacturer{Name: strPtr("Cisco")},
+		},
+	}
+	bay := &diode.ModuleBay{
+		Device:   rich,
+		Name:     strPtr("TenGigabitEthernet1/0/1"),
+		Position: strPtr("1"),
+	}
+	transceiver := &diode.Module{
+		Device:    rich,
+		ModuleBay: bay,
+		// Serial intentionally nil — vendor omitted entPhysicalSerialNum.
+		ModuleType: &diode.ModuleType{
+			Model:        strPtr("SFP-10G-LR"),
+			Manufacturer: &diode.Manufacturer{Name: strPtr("Cisco")},
+		},
+	}
+	iface := &diode.Interface{
+		Name:   strPtr("TenGigabitEthernet1/0/1"),
+		Device: rich,
+		Module: transceiver,
+	}
+	PruneNestedRefs([]diode.Entity{rich, bay, transceiver, iface}, rich)
+
+	require.NotNil(t, iface.Module,
+		"Interface.Module must NOT be cleared when bay matcher is available even without serial")
+	require.NotNil(t, iface.Module.ModuleBay, "bay matcher must be preserved")
+	assert.Equal(t, "TenGigabitEthernet1/0/1", strDerefSafe(iface.Module.ModuleBay.Name))
+	assert.Equal(t, "1", strDerefSafe(iface.Module.ModuleBay.Position))
+	assert.Nil(t, iface.Module.Serial, "serial stays nil — matcher uses Device + Bay")
+	assert.Nil(t, iface.Module.ModuleType, "ModuleType still dropped per Python parity")
+	require.NotNil(t, iface.Module.Device, "Interface.Module.Device must be a chassis stub")
+	assert.Equal(t, "sw1", strDerefSafe(iface.Module.Device.Name))
+	assert.Nil(t, iface.Module.Device.Status, "Module.Device must be stubbed (no rich Status)")
+	require.NotNil(t, iface.Module.ModuleBay.Device,
+		"bay matcher must carry chassis Device stub so reconciler can resolve via (Device, Bay)")
+	assert.Equal(t, "sw1", strDerefSafe(iface.Module.ModuleBay.Device.Name))
+	assert.Nil(t, iface.Module.ModuleBay.Device.Status)
+}
+
+// TestPruneNestedRefs_InterfaceModuleStubDegradesToSerialOnly — when
+// Serial is present but ModuleBay is nil, the stub must still emit so
+// the reconciler can resolve via the (Device, Serial) match path. No
+// regression on the common Cisco/Juniper transceiver path.
+func TestPruneNestedRefs_InterfaceModuleStubDegradesToSerialOnly(t *testing.T) {
+	rich := &diode.Device{
+		Name:   strPtr("sw1"),
+		Site:   &diode.Site{Name: strPtr("dc1")},
+		Serial: strPtr("FCW123"),
+	}
+	transceiver := &diode.Module{
+		Device:    rich,
+		Serial:    strPtr("FNS00000001"),
+		ModuleBay: nil, // intentionally nil
+		ModuleType: &diode.ModuleType{
+			Model:        strPtr("SFP-1G-T"),
+			Manufacturer: &diode.Manufacturer{Name: strPtr("Cisco")},
+		},
+	}
+	iface := &diode.Interface{
+		Name:   strPtr("Gi1/0/1"),
+		Device: rich,
+		Module: transceiver,
+	}
+	PruneNestedRefs([]diode.Entity{rich, transceiver, iface}, rich)
+
+	require.NotNil(t, iface.Module, "must not be cleared when serial is present")
+	assert.Equal(t, "FNS00000001", strDerefSafe(iface.Module.Serial))
+	assert.Nil(t, iface.Module.ModuleBay, "no bay was set on input, stays nil")
+	assert.Nil(t, iface.Module.ModuleType, "ModuleType still dropped per Python parity")
+	require.NotNil(t, iface.Module.Device)
+	assert.Equal(t, "sw1", strDerefSafe(iface.Module.Device.Name))
+}
+
+// TestPruneNestedRefs_InterfaceModuleClearedWhenSerialAndBayBothMissing —
+// the only legitimate clear path. Without Serial AND without
+// ModuleBay, no matcher field can resolve the ref. Shipping such a
+// stub would force the reconciler into creation mode and fail
+// validation ("module_bay required, module_type required") because
+// the stub also strips ModuleType.
+func TestPruneNestedRefs_InterfaceModuleClearedWhenSerialAndBayBothMissing(t *testing.T) {
+	rich := &diode.Device{
+		Name:   strPtr("sw1"),
+		Site:   &diode.Site{Name: strPtr("dc1")},
+		Serial: strPtr("FCW123"),
+	}
+	transceiver := &diode.Module{
+		Device: rich,
+		// Serial nil, ModuleBay nil — unresolvable.
+		ModuleType: &diode.ModuleType{
+			Model:        strPtr("UNKNOWN"),
+			Manufacturer: &diode.Manufacturer{Name: strPtr("Cisco")},
+		},
+	}
+	iface := &diode.Interface{
+		Name:   strPtr("Gi1/0/1"),
+		Device: rich,
+		Module: transceiver,
+	}
+	PruneNestedRefs([]diode.Entity{rich, transceiver, iface}, rich)
+
+	assert.Nil(t, iface.Module,
+		"must clear when neither Serial nor Bay can resolve the ref")
+}
+
 // TestPruneNestedRefs_InterfaceModuleSerialNilCleared — an
-// Interface.Module reduced to {Device, Serial: nil} carries no
-// identifier and is useless for matching. Rather than ship an
-// ambiguous stub, the pruner must clear the ref entirely so the
+// Interface.Module reduced to {Device, Serial: nil, ModuleBay: nil}
+// carries no identifier and is useless for matching. Rather than ship
+// an ambiguous stub, the pruner must clear the ref entirely so the
 // top-level Module entity remains the only wire representation.
 func TestPruneNestedRefs_InterfaceModuleSerialNilCleared(t *testing.T) {
 	rich := &diode.Device{

--- a/snmp-discovery/metrics/metrics.go
+++ b/snmp-discovery/metrics/metrics.go
@@ -182,6 +182,25 @@ func GetDiscoveryAttempts() metric.Int64Counter {
 	return GetCounter("discovery_attempts", "Number of SNMP discovery attempts")
 }
 
+// GetModulesEmitted returns the counter for module entities emitted by
+// SNMP discovery. Attributes at .Add time: vendor, type.
+func GetModulesEmitted() metric.Int64Counter {
+	return GetCounter("modules_emitted", "Number of module entities emitted by SNMP discovery")
+}
+
+// GetModuleBaysEmitted returns the counter for module-bay entities
+// emitted by SNMP discovery. Attribute at .Add time: vendor.
+func GetModuleBaysEmitted() metric.Int64Counter {
+	return GetCounter("module_bays_emitted", "Number of module-bay entities emitted by SNMP discovery")
+}
+
+// GetModulesDropped returns the counter for module rows dropped during
+// extraction. Attribute at .Add time: reason (orphan_containment,
+// dup_serial, orphan_member).
+func GetModulesDropped() metric.Int64Counter {
+	return GetCounter("modules_dropped", "Number of module rows dropped during extraction (orphan/dup/etc.)")
+}
+
 // ResetMeter resets the meter to nil for testing purposes.
 func ResetMeter() {
 	cacheLock.Lock()

--- a/snmp-discovery/metrics/metrics_test.go
+++ b/snmp-discovery/metrics/metrics_test.go
@@ -197,6 +197,42 @@ func TestConvenienceFunctions(t *testing.T) {
 	})
 }
 
+// Module-discovery counters — emission/drop instrumentation.
+
+func TestGetModulesEmitted_NotNil(t *testing.T) {
+	err := setupTestMeter(t)
+	require.NoError(t, err)
+
+	counter := metrics.GetModulesEmitted()
+	assert.NotNil(t, counter, "modules_emitted counter should be non-nil once meter is initialized")
+
+	// Wrapper should reuse the underlying cached counter.
+	directCounter := metrics.GetCounter("modules_emitted", "Number of module entities emitted by SNMP discovery")
+	assert.Same(t, counter, directCounter)
+}
+
+func TestGetModuleBaysEmitted_NotNil(t *testing.T) {
+	err := setupTestMeter(t)
+	require.NoError(t, err)
+
+	counter := metrics.GetModuleBaysEmitted()
+	assert.NotNil(t, counter, "module_bays_emitted counter should be non-nil once meter is initialized")
+
+	directCounter := metrics.GetCounter("module_bays_emitted", "Number of module-bay entities emitted by SNMP discovery")
+	assert.Same(t, counter, directCounter)
+}
+
+func TestGetModulesDropped_NotNil(t *testing.T) {
+	err := setupTestMeter(t)
+	require.NoError(t, err)
+
+	counter := metrics.GetModulesDropped()
+	assert.NotNil(t, counter, "modules_dropped counter should be non-nil once meter is initialized")
+
+	directCounter := metrics.GetCounter("modules_dropped", "Number of module rows dropped during extraction (orphan/dup/etc.)")
+	assert.Same(t, counter, directCounter)
+}
+
 // setupTestMeter creates a no-op meter provider for testing
 func setupTestMeter(_ *testing.T) error {
 	ctx := context.Background()

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -208,11 +208,12 @@ func (m *Manager) validatePolicy(policy config.Policy) error {
 	// immediate error rather than silently degrading at scan time.
 	if policy.Config.Options.DiscoverModules != nil {
 		switch *policy.Config.Options.DiscoverModules {
-		case "off", "linecards", "full":
+		case config.DiscoverModulesOff, config.DiscoverModulesLinecards, config.DiscoverModulesFull:
 		default:
 			return fmt.Errorf(
-				"invalid options.discover_modules %q (allowed: off, linecards, full)",
+				"invalid options.discover_modules %q (allowed: %s, %s, %s)",
 				*policy.Config.Options.DiscoverModules,
+				config.DiscoverModulesOff, config.DiscoverModulesLinecards, config.DiscoverModulesFull,
 			)
 		}
 	}

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -204,6 +204,19 @@ func (m *Manager) validatePolicy(policy config.Policy) error {
 		}
 	}
 
+	// Reject unknown enum values at parse time so operators get an
+	// immediate error rather than silently degrading at scan time.
+	if policy.Config.Options.DiscoverModules != nil {
+		switch *policy.Config.Options.DiscoverModules {
+		case "off", "linecards", "full":
+		default:
+			return fmt.Errorf(
+				"invalid options.discover_modules %q (allowed: off, linecards, full)",
+				*policy.Config.Options.DiscoverModules,
+			)
+		}
+	}
+
 	return nil
 }
 

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -1351,3 +1351,28 @@ func TestManagerApplyDefaults_CreateUnknownVlans(t *testing.T) {
 		assert.False(t, *opt, "Explicit false must be preserved — applyDefaults must not overwrite it")
 	})
 }
+
+func TestManager_ParsePolicies_RejectsInvalidDiscoverModules(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug, AddSource: false}))
+	manager, err := policy.NewManager(context.Background(), logger, nil, nil)
+	require.NoError(t, err)
+
+	raw := []byte(`
+policies:
+  bad-policy:
+    config:
+      schedule: "@every 1m"
+      options:
+        discover_modules: fulls
+    scope:
+      targets:
+        - host: 192.0.2.1
+      authentication:
+        protocol_version: SNMPv2c
+        community: public
+`)
+	_, err = manager.ParsePolicies(raw)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "discover_modules")
+	assert.Contains(t, err.Error(), "fulls")
+}

--- a/snmp-discovery/policy/mapping.yaml
+++ b/snmp-discovery/policy/mapping.yaml
@@ -126,6 +126,12 @@ entries:
     identifier_size: 2
     description: "ENTITY-MIB entPhysicalTable (chassis physical inventory for stack detection)"
     mapping_entries:
+      - oid: ".1.3.6.1.2.1.47.1.1.1.1.2"   # entPhysicalDescr
+        entity: "chassis_module"
+        field: "descr"
+      - oid: ".1.3.6.1.2.1.47.1.1.1.1.3"   # entPhysicalVendorType
+        entity: "chassis_module"
+        field: "vendor_type"
       - oid: ".1.3.6.1.2.1.47.1.1.1.1.4"   # entPhysicalContainedIn
         entity: "chassis_inventory"
         field: "containedIn"

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -558,7 +558,13 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 	// attachment (Interfaces would appear BEFORE the Modules they reference).
 	// Fix: partition-and-prepend. Find the first non-Device/non-VC index in
 	// entitiesForTarget and splice moduleEntities there.
-	{
+	//
+	// Early-exit on mode=off so the default-path target poll skips the
+	// ChassisInventoryFromOIDs re-parse + the entAliasMappingTable scan
+	// entirely (both iterate the full oids map). Without this gate,
+	// every target paid the scan cost even though TranslateModulesWithAlias
+	// would short-circuit before emitting anything.
+	if r.config.Options.ModuleDiscoveryMode() != config.DiscoverModulesOff {
 		// TODO(orb-discovery): double-parse — TranslateAsStack already
 		// ran extractInventory internally; ChassisInventoryFromOIDs
 		// runs it again here. Cheap parse on string maps (no SNMP work

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -570,25 +571,31 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 		chassisInv := mapping.ChassisInventoryFromOIDs(oids, r.logger)
 		memberDevices := mapping.MemberDevicesFromEntities(entitiesForTarget, chassisInv)
 		aliasMap := mapping.AliasMapFromOIDs(oids)
-		ifIndexToName := mapping.IfNameByIfIndex(ifIndexByIface)
 
 		moduleEntities, ifaceModuleMap := mapping.TranslateModulesWithAlias(
 			oids, chassisInv, memberDevices,
 			&r.config.Options, targetDefaults,
-			r.logger, aliasMap, ifIndexToName,
+			r.logger, aliasMap,
 		)
 
 		entitiesForTarget = mapping.SpliceModulesAfterDevices(entitiesForTarget, moduleEntities)
 
 		// Attach Interface.Module on physical-port Interfaces for `full` mode.
 		// Order-safe because modules now precede interfaces in the slice.
+		// Key by ifIndex (globally unique in the SNMP walk space) — keying
+		// by Interface.Name would collide on VC members that reuse the same
+		// canonical name locally.
 		if len(ifaceModuleMap) > 0 {
 			for _, e := range entitiesForTarget {
 				iface, ok := e.(*diode.Interface)
-				if !ok || iface.Name == nil {
+				if !ok {
 					continue
 				}
-				if mod, hit := ifaceModuleMap[*iface.Name]; hit {
+				idx, hasIdx := ifIndexByIface[iface]
+				if !hasIdx {
+					continue
+				}
+				if mod, hit := ifaceModuleMap[strconv.Itoa(idx)]; hit {
 					iface.Module = mod
 				}
 			}

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -584,22 +583,12 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 		// Order-safe because modules now precede interfaces in the slice.
 		// Key by ifIndex (globally unique in the SNMP walk space) — keying
 		// by Interface.Name would collide on VC members that reuse the same
-		// canonical name locally.
-		if len(ifaceModuleMap) > 0 {
-			for _, e := range entitiesForTarget {
-				iface, ok := e.(*diode.Interface)
-				if !ok {
-					continue
-				}
-				idx, hasIdx := ifIndexByIface[iface]
-				if !hasIdx {
-					continue
-				}
-				if mod, hit := ifaceModuleMap[strconv.Itoa(idx)]; hit {
-					iface.Module = mod
-				}
-			}
-		}
+		// canonical name locally. AttachIfaceModules also walks
+		// IPAddress.AssignedObject / MACAddress.AssignedObject so L3
+		// routed-port interfaces (filtered out of the top-level entity
+		// slice by MapObjectIDsToEntity.getAssignedInterfaces) still get
+		// their module set.
+		mapping.AttachIfaceModules(entitiesForTarget, ifaceModuleMap, ifIndexByIface)
 	}
 
 	entities = append(entities, entitiesForTarget...)

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -560,12 +560,12 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 	// entitiesForTarget and splice moduleEntities there.
 	{
 		// TODO(orb-discovery): double-parse — TranslateAsStack already
-		// ran extractInventory internally; ChassisInventoryFromEntities
+		// ran extractInventory internally; ChassisInventoryFromOIDs
 		// runs it again here. Cheap parse on string maps (no SNMP work
 		// repeated), so left as-is for now. Refactor by threading the
 		// inventory out of TranslateAsStack would touch many test files
 		// — defer until the runner gets a broader cleanup.
-		chassisInv := mapping.ChassisInventoryFromEntities(entitiesForTarget, oids, r.logger)
+		chassisInv := mapping.ChassisInventoryFromOIDs(oids, r.logger)
 		memberDevices := mapping.MemberDevicesFromEntities(entitiesForTarget, chassisInv)
 		aliasMap := mapping.AliasMapFromOIDs(oids)
 		ifIndexToName := mapping.IfNameByIfIndex(ifIndexByIface)

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -544,6 +544,70 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 	entitiesForTarget := mapper.MapObjectIDsToEntity(oids)
 	ifIndexByIface := mapper.InterfacesByIfIndex()
 	entitiesForTarget = mapping.TranslateAsStack(entitiesForTarget, oids, ifIndexByIface, r.logger)
+
+	// Module / module bay emission. Opt-in via options.discover_modules
+	// (default = off -> zero behaviour change). Reuses the chassis-path
+	// entAliasMappingTable index for iface <-> transceiver attachment.
+	//
+	// Diode ingest ordering contract:
+	//   Device(s) -> module bay + module -> Interface -> IP -> MAC -> VLAN
+	//
+	// TranslateAsStack already partitioned entitiesForTarget into that
+	// bucket order, but module entities land in their OWN bucket — naively
+	// appending them would leave them at the tail and break ifaceModuleMap
+	// attachment (Interfaces would appear BEFORE the Modules they reference).
+	// Fix: partition-and-prepend. Find the first non-Device/non-VC index in
+	// entitiesForTarget and splice moduleEntities there.
+	{
+		chassisInv := mapping.ChassisInventoryFromEntities(entitiesForTarget, oids, r.logger)
+		memberDevices := mapping.MemberDevicesFromEntities(entitiesForTarget, chassisInv)
+		aliasMap := mapping.AliasMapFromOIDs(oids)
+		ifIndexToName := mapping.IfNameByIfIndex(ifIndexByIface)
+
+		moduleEntities, ifaceModuleMap := mapping.TranslateModulesWithAlias(
+			oids, chassisInv, memberDevices,
+			&r.config.Options, targetDefaults,
+			r.logger, aliasMap, ifIndexToName,
+		)
+
+		if len(moduleEntities) > 0 {
+			// Devices + VC sit at the head; everything else gets
+			// pushed back by the prepend.
+			splice := len(entitiesForTarget)
+			for i, e := range entitiesForTarget {
+				switch e.(type) {
+				case *diode.Device, *diode.VirtualChassis:
+					continue
+				default:
+					splice = i
+				}
+				if splice < len(entitiesForTarget) {
+					break
+				}
+			}
+			merged := make([]diode.Entity, 0,
+				len(entitiesForTarget)+len(moduleEntities))
+			merged = append(merged, entitiesForTarget[:splice]...)
+			merged = append(merged, moduleEntities...)
+			merged = append(merged, entitiesForTarget[splice:]...)
+			entitiesForTarget = merged
+		}
+
+		// Attach Interface.Module on physical-port Interfaces for `full` mode.
+		// Order-safe because modules now precede interfaces in the slice.
+		if len(ifaceModuleMap) > 0 {
+			for _, e := range entitiesForTarget {
+				iface, ok := e.(*diode.Interface)
+				if !ok || iface.Name == nil {
+					continue
+				}
+				if mod, hit := ifaceModuleMap[*iface.Name]; hit {
+					iface.Module = mod
+				}
+			}
+		}
+	}
+
 	entities = append(entities, entitiesForTarget...)
 
 	// Update discovered hosts gauge

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -562,9 +562,11 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 		// TODO(orb-discovery): double-parse — TranslateAsStack already
 		// ran extractInventory internally; ChassisInventoryFromOIDs
 		// runs it again here. Cheap parse on string maps (no SNMP work
-		// repeated), so left as-is for now. Refactor by threading the
-		// inventory out of TranslateAsStack would touch many test files
-		// — defer until the runner gets a broader cleanup.
+		// repeated), so left as-is for now. Refactor fallout:
+		// TranslateAsStack call sites in mapping/chassis_test.go (9 sites)
+		// would need to accept a pre-parsed inventory parameter; this
+		// caller would then pass it directly instead of re-deriving via
+		// ChassisInventoryFromOIDs. Defer until a broader runner cleanup.
 		chassisInv := mapping.ChassisInventoryFromOIDs(oids, r.logger)
 		memberDevices := mapping.MemberDevicesFromEntities(entitiesForTarget, chassisInv)
 		aliasMap := mapping.AliasMapFromOIDs(oids)

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -576,28 +576,7 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 			r.logger, aliasMap, ifIndexToName,
 		)
 
-		if len(moduleEntities) > 0 {
-			// Devices + VC sit at the head; everything else gets
-			// pushed back by the prepend.
-			splice := len(entitiesForTarget)
-			for i, e := range entitiesForTarget {
-				switch e.(type) {
-				case *diode.Device, *diode.VirtualChassis:
-					continue
-				default:
-					splice = i
-				}
-				if splice < len(entitiesForTarget) {
-					break
-				}
-			}
-			merged := make([]diode.Entity, 0,
-				len(entitiesForTarget)+len(moduleEntities))
-			merged = append(merged, entitiesForTarget[:splice]...)
-			merged = append(merged, moduleEntities...)
-			merged = append(merged, entitiesForTarget[splice:]...)
-			entitiesForTarget = merged
-		}
+		entitiesForTarget = mapping.SpliceModulesAfterDevices(entitiesForTarget, moduleEntities)
 
 		// Attach Interface.Module on physical-port Interfaces for `full` mode.
 		// Order-safe because modules now precede interfaces in the slice.

--- a/snmp-discovery/policy/runner.go
+++ b/snmp-discovery/policy/runner.go
@@ -559,6 +559,12 @@ func (r *Runner) queryTarget(ctx context.Context, target config.Target) ([]diode
 	// Fix: partition-and-prepend. Find the first non-Device/non-VC index in
 	// entitiesForTarget and splice moduleEntities there.
 	{
+		// TODO(orb-discovery): double-parse — TranslateAsStack already
+		// ran extractInventory internally; ChassisInventoryFromEntities
+		// runs it again here. Cheap parse on string maps (no SNMP work
+		// repeated), so left as-is for now. Refactor by threading the
+		// inventory out of TranslateAsStack would touch many test files
+		// — defer until the runner gets a broader cleanup.
 		chassisInv := mapping.ChassisInventoryFromEntities(entitiesForTarget, oids, r.logger)
 		memberDevices := mapping.MemberDevicesFromEntities(entitiesForTarget, chassisInv)
 		aliasMap := mapping.AliasMapFromOIDs(oids)


### PR DESCRIPTION
## Summary
- Vendor-neutral Module/ModuleBay discovery for SNMP backend via ENTITY-MIB, mirroring device-discovery PR #419 contract.
- Three-mode policy option: \`off\` (default — zero behaviour change), \`linecards\` (chassis-slot modules: linecards + supervisors), \`full\` (linecards + per-transceiver sub-bays + \`Interface.Module\` refs).
- VC-of-modular from day one — per-member dispatch via existing \`ChassisInventory\`; master keyed by lowest \`Members[0].ID\`.
- Sub-bay reconciler workaround: transceiver sub-bays emitted device-rooted (no \`Module: parentLinecard\` link). Per-port optic visibility preserved via \`Module.ModuleBay\`. Mirrors device-discovery's workaround pending Diode single-batch plan-and-apply.

## Approach
- Parallel pass in \`snmp-discovery/mapping/\` mirroring the \`chassis.go\` pattern. Three new files: \`module.go\` (types + classifier + extractor), \`module_routing.go\` (per-member dispatch + iface↔module map), \`module_translate.go\` (Diode entity emission).
- New \`ChassisModuleMapper\` no-op registers \`entPhysicalDescr\` + \`entPhysicalVendorType\` columns for the walk. Translation runs as a post-pass after \`TranslateAsStack\`.
- Classifier uses **both** containment-depth (under class=9 ancestor → transceiver candidate) **and** PID-prefix matching (SUP/SFP/QSFP/PSU/FAN). Both signals required for transceiver classification. PSU/Fan recognised but never emitted as module entities (label-only).
- \`Interface.Module\` ref enriched with bay matcher (Name + Position + chassis Device stub) so Diode reconciler resolves to existing standalone Module — mirrors device-discovery's Python stub shape exactly.
- New OTLP counters: \`modules_emitted{vendor, type}\`, \`module_bays_emitted{vendor}\`, \`modules_dropped{reason}\`.

## Validation
- 35 commits, 20 files, +2921 lines.
- \`go test ./...\` clean across 11 packages.
- \`go vet ./...\` clean. \`golangci-lint run\` 0 issues.
- TDD throughout: every feat task has failing-test-first → impl → run-to-pass commits.
- **E2E validated against orb-test-lab snmpsim** with a Cat-9404R-style \`.snmprec\` fixture (chassis + supervisor + linecard + transceiver + empty bay + PSU). All three modes work as designed:
  - **OFF:** 0 modules / 0 bays.
  - **LINECARDS:** 2 modules (Sup + Linecard), 2 bays, PSU filtered, transceiver filtered.
  - **FULL:** 3 modules (+ transceiver), 4 bays (+ empty Slot 3 + transceiver sub-bay), PSU filtered, \`Interface.Module\` populated to standalone transceiver Module via bay matcher.
- **Idempotency stress:** 5 sequential identical full-mode ingests produce byte-identical NetBox state (md5 stable), zero reconciler errors, IDs preserved, \`last_updated\` unchanged.

## Reviews completed before this PR
- 5 doc-review rounds (codex adversarial) on the design + plan before any code written — caught 22 issues, all patched in the docs (uncommitted) before implementation began.
- 2 post-implementation codex adversarial passes — caught 7 correctness issues (manufacturer source, non-recursive SubModules walk, PSU/Fan classifier suffix gap, port-container false-positive empty bay, missing string normalization, ambiguous Interface.Module stub, -FAN over-match). All patched.
- 1 Claude + 1 Codex normal review pass — caught 3 Medium correctness bugs (BayPosition source, chassis-rooted modules dropped, AliasMapFromOIDs nondeterminism) + 8 nits. All patched.
- 1 final codex pass on the Interface.Module enrichment + E2E double-ingest stress.

## Test plan
- [ ] Reviewer: read the spec context — the spec/plan docs live at \`docs/superpowers/{specs,plans}/2026-05-25-snmp-module-discovery-*.md\` (uncommitted by project rule; available on request).
- [ ] Reviewer: smoke test the \`mapping/module*\` unit suite locally.
- [ ] Reviewer: run E2E with a modular snmpsim fixture if possible (or rely on the recorded E2E artifacts).
- [ ] Reviewer: confirm device-discovery PR #419 contract parity for emitted Module/ModuleBay shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)