### PR TITLE
feat(worker): callback contract for API-triggered sync (INT-312)

### DIFF
--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "pydantic~=2.9",
     "uvicorn~=0.32",
     "PyYAML~=6.0",
+    "typing-extensions~=4.5",
     "opentelemetry-api~=1.32",
     "opentelemetry-sdk~=1.32",
     "opentelemetry-exporter-otlp~=1.32",

--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "netboxlabs-orb-worker"
-version = "1.0.0"  # Overwritten during the build process
+version = "1.99.0.dev0"  # Placeholder, overwritten by CI before build (worker-release.yaml: `toml set project.version`). Kept above all sibling pins so editable / pip-install-from-source flows resolve.
 description = "NetBox Labs, Worker backend for Orb Agent"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/worker/tests/nbl-custom-legacy/README.md
+++ b/worker/tests/nbl-custom-legacy/README.md
@@ -1,0 +1,19 @@
+## Nbl Custom Legacy Worker
+
+A legacy counterpart to `nbl-custom`: it implements only the deprecated instance
+`setup()` and omits the `describe()` classmethod. It exists so the worker's legacy
+fallback path stays exercised — the worker constructs such a backend bare, reads its
+metadata via `setup()` on the instance it then schedules, and attaches the ingest sink
+afterwards.
+
+`test_legacy_package.py` loads this package through the real `load_class` machinery and
+drives it through `PolicyRunner.setup()` to prove the legacy path still works.
+
+## Policy sample
+
+``` yaml
+policies:
+    custom_legacy_1:
+        config:
+          package: nbl_custom_legacy
+```

--- a/worker/tests/nbl-custom-legacy/nbl_custom_legacy/__init__.py
+++ b/worker/tests/nbl-custom-legacy/nbl_custom_legacy/__init__.py
@@ -1,0 +1,7 @@
+#!/usr/bin/env python
+# Copyright 2025 NetBox Labs Inc
+"""NetBox Labs - Legacy mock custom namespace."""
+
+from nbl_custom_legacy.impl import LegacyMockBackend
+
+__all__ = ["LegacyMockBackend"]

--- a/worker/tests/nbl-custom-legacy/nbl_custom_legacy/__init__.py
+++ b/worker/tests/nbl-custom-legacy/nbl_custom_legacy/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2025 NetBox Labs Inc
+# Copyright 2026 NetBox Labs Inc
 """NetBox Labs - Legacy mock custom namespace."""
 
 from nbl_custom_legacy.impl import LegacyMockBackend

--- a/worker/tests/nbl-custom-legacy/nbl_custom_legacy/impl.py
+++ b/worker/tests/nbl-custom-legacy/nbl_custom_legacy/impl.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# Copyright 2025 NetBox Labs Inc
+"""
+NetBox Labs - Legacy Mock Impl.
+
+A deliberately legacy backend: it implements only the deprecated instance
+``setup()`` and does NOT implement the ``describe()`` classmethod. It exists to
+prove the worker's legacy fallback path still works end to end — the worker must
+construct it bare, read its metadata via ``setup()`` on the instance it then
+schedules, and attach the ingest sink afterwards.
+"""
+
+import logging
+from collections.abc import Iterable
+
+from netboxlabs.diode.sdk.ingester import Device, Entity
+from worker.backend import Backend
+from worker.models import Metadata, Policy
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class LegacyMockBackend(Backend):
+    """Legacy (setup()-only) mock backend for testing the deprecated path."""
+
+    def __init__(self) -> None:
+        """Construct with a custom zero-arg signature (no ingest_sink kwarg)."""
+        self.app_started = False
+
+    def setup(self) -> Metadata:
+        """Initialise instance state and return metadata (legacy contract)."""
+        # State set here must be live when run() executes — i.e. the instance
+        # set up here is the instance the worker schedules.
+        self.app_started = True
+        return Metadata(
+            name="legacy_mock",
+            app_name="legacy_mock_app",
+            app_version="0.1.0",
+        )
+
+    def run(self, policy_name: str, policy: Policy) -> Iterable[Entity]:
+        """Return a single Device entity; assert setup() ran first."""
+        if not self.app_started:
+            raise RuntimeError("run() reached before setup() initialised the instance")
+        device = Device(
+            name=f"legacy-device-{policy_name}",
+            device_type="Legacy Device Type",
+            platform="Legacy Platform",
+            manufacturer="Legacy Manufacturer",
+            site="Site Legacy",
+            role="Role Legacy",
+            status="active",
+        )
+        return [Entity(device=device)]

--- a/worker/tests/nbl-custom-legacy/nbl_custom_legacy/impl.py
+++ b/worker/tests/nbl-custom-legacy/nbl_custom_legacy/impl.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2025 NetBox Labs Inc
+# Copyright 2026 NetBox Labs Inc
 """
 NetBox Labs - Legacy Mock Impl.
 

--- a/worker/tests/nbl-custom-legacy/pyproject.toml
+++ b/worker/tests/nbl-custom-legacy/pyproject.toml
@@ -1,0 +1,58 @@
+[project]
+name = "netboxlabs-custom-legacy-orb-worker"
+version = "0.0.1"  # Overwritten during the build process
+description = "NetBox Labs, legacy (setup-only) Worker mock implementation for testing purposes"
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [
+    {name = "NetBox Labs", email = "support@netboxlabs.com" }
+]
+maintainers = [
+    {name = "NetBox Labs", email = "support@netboxlabs.com" }
+]
+
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Topic :: Software Development :: Build Tools",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.12',
+]
+
+dependencies = [
+    "netboxlabs-orb-worker~=1.0",
+]
+
+[project.optional-dependencies]
+dev = ["black", "check-manifest", "ruff"]
+test = ["coverage", "pytest", "pytest-cov"]
+
+[project.urls]
+"Homepage" = "https://netboxlabs.com/"
+
+[tool.setuptools]
+packages = [
+    "nbl_custom_legacy",
+]
+package-data = {"nbl_custom_legacy" = ["**/*"]}
+
+[build-system]
+requires = ["setuptools>=43.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+
+[tool.ruff]
+line-length = 140
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.ruff.lint]
+select = ["C", "D", "E", "F", "I", "R", "UP", "W"]
+ignore = ["F401", "D203", "D212", "D400", "D401", "D404", "RET504"]

--- a/worker/tests/nbl-custom/nbl_custom/impl.py
+++ b/worker/tests/nbl-custom/nbl_custom/impl.py
@@ -40,6 +40,11 @@ class ScopeMap(BaseModel):
 class MockBackend(Backend):
     """Mock backend class."""
 
+    @classmethod
+    def describe(cls) -> Metadata:
+        """Mock describe method (no-instance metadata accessor)."""
+        return Metadata(name="mock_custom", app_name="mock_app", app_version="1.0.0")
+
     def setup(self) -> Metadata:
         """Mock setup method."""
         return Metadata(name="mock_custom", app_name="mock_app", app_version="1.0.0")

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -845,3 +845,33 @@ def test_run_unaffected_by_callback(
     mock_run_store.update_run.assert_called_once()
     update_kwargs = mock_run_store.update_run.call_args.kwargs
     assert update_kwargs["status"] == RunStatus.COMPLETED
+
+
+def test_ingest_callback_raises_when_client_not_initialised(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_run_store,
+    mock_load_class,
+    mock_diode_client,
+):
+    """Calling the callback before _diode_client is assigned raises IngestUnavailable."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy-x", sample_diode_config, sample_policy, mock_run_store)
+
+    callback = _extract_callback(mock_load_class.return_value)
+
+    # Simulate "called before client init" — clear the attribute.
+    policy_runner._diode_client = None
+
+    entity = MagicMock()
+    with patch("worker.policy.runner.apply_run_id_to_entities"):
+        with pytest.raises(IngestUnavailable, match="diode client was initialised"):
+            callback(entities=[entity])
+
+    # Pseudo-run was still recorded as FAILED.
+    mock_run_store.update_run.assert_called()
+    final_call = mock_run_store.update_run.call_args
+    assert final_call.kwargs["status"] == RunStatus.FAILED

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -4,12 +4,13 @@
 
 from unittest.mock import MagicMock, patch
 
+import grpc
 import pytest
 from apscheduler.triggers.date import DateTrigger
 from netboxlabs.diode.sdk.diode.v1 import ingester_pb2
 
 from worker.backend import Backend
-from worker.exceptions import IngestError, IngestRejected
+from worker.exceptions import IngestError, IngestRejected, IngestUnavailable
 from worker.models import Config, DiodeConfig, Metadata, Policy, Status
 from worker.policy.run import RunStatus, RunStore
 from worker.policy.runner import PolicyRunner, _PolicyRunnerIngestSink
@@ -839,6 +840,56 @@ def test_ingest_sink_translates_transport_errors_to_ingest_error(
             sink.ingest([entity])
 
     mock_run_store.update_run.assert_called_once()
+    update_kwargs = mock_run_store.update_run.call_args.kwargs
+    assert update_kwargs["status"] == RunStatus.FAILED
+
+
+class _FakeRpcError(grpc.RpcError):
+    """Minimal grpc.RpcError test double carrying a status code."""
+
+    def __init__(self, code: grpc.StatusCode) -> None:
+        self._code = code
+
+    def code(self) -> grpc.StatusCode:
+        return self._code
+
+
+@pytest.mark.parametrize(
+    "code, is_transient",
+    [
+        pytest.param(grpc.StatusCode.UNAVAILABLE, True, id="unavailable"),
+        pytest.param(grpc.StatusCode.RESOURCE_EXHAUSTED, True, id="resource-exhausted"),
+        pytest.param(grpc.StatusCode.DEADLINE_EXCEEDED, True, id="deadline-exceeded"),
+        pytest.param(grpc.StatusCode.INVALID_ARGUMENT, False, id="invalid-argument"),
+    ],
+)
+def test_ingest_sink_maps_grpc_status_codes(
+    code,
+    is_transient,
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """Transient gRPC codes raise IngestUnavailable; other gRPC errors raise the base IngestError."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    sink = _extract_sink(mock_load_class.return_value)
+    mock_diode_client.return_value.ingest.side_effect = _FakeRpcError(code)
+
+    entity = ingester_pb2.Entity()
+    entity.device.name = "dev1"
+
+    with patch("worker.policy.runner.apply_run_id_to_entities"):
+        with pytest.raises(IngestError) as excinfo:
+            sink.ingest([entity])
+
+    assert isinstance(excinfo.value, IngestUnavailable) is is_transient
     update_kwargs = mock_run_store.update_run.call_args.kwargs
     assert update_kwargs["status"] == RunStatus.FAILED
 

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -253,12 +253,7 @@ def test_run_success(
     policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Assertions
-    mock_backend.run.assert_called_once_with(
-        policy_runner.name,
-        sample_policy,
-        source="scheduled",
-        run_id="11111111-1111-1111-1111-111111111111",
-    )
+    mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
     # Should call ingest once for the single chunk
     mock_diode_client.ingest.assert_called_once()
     # Check that entities were passed correctly
@@ -282,37 +277,6 @@ def test_run_with_empty_delta_is_noop_completed(
     update_kwargs = mock_run_store.update_run.call_args.kwargs
     assert update_kwargs["status"] == RunStatus.COMPLETED
     assert update_kwargs["entity_count"] == 0
-
-
-def test_run_legacy_backend_without_kwargs_gets_bare_call(
-    policy_runner,
-    sample_policy,
-    mock_diode_client,
-    mock_run_store,
-    caplog,
-):
-    """A backend whose run() lacks **kwargs is called bare, with a warning."""
-
-    class LegacyBackend:
-        def __init__(self):
-            self.calls = []
-
-        def run(self, policy_name, policy):
-            self.calls.append((policy_name, policy))
-            entity = ingester_pb2.Entity()
-            entity.device.name = "legacy-dev"
-            return [entity]
-
-    backend = LegacyBackend()
-    policy_runner.name = "test_policy"
-    policy_runner.run_store = mock_run_store
-    mock_diode_client.ingest.return_value.errors = []
-
-    with caplog.at_level("WARNING"):
-        policy_runner.run(mock_diode_client, backend, sample_policy)
-
-    assert backend.calls == [("test_policy", sample_policy)]
-    assert "does not declare **kwargs" in caplog.text
 
 
 def test_run_passes_metadata_to_ingest(
@@ -377,12 +341,7 @@ def test_run_ingestion_errors(
         policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Assertions
-    mock_backend.run.assert_called_once_with(
-        policy_runner.name,
-        sample_policy,
-        source="scheduled",
-        run_id="11111111-1111-1111-1111-111111111111",
-    )
+    mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
     mock_diode_client.ingest.assert_called_once()
     assert (
         "Policy test_policy: Chunk ingestion failed: ['error1', 'error2']"
@@ -410,12 +369,7 @@ def test_run_backend_exception(
         policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Assertions
-    mock_backend.run.assert_called_once_with(
-        policy_runner.name,
-        sample_policy,
-        source="scheduled",
-        run_id="11111111-1111-1111-1111-111111111111",
-    )
+    mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
     mock_diode_client.ingest.assert_not_called()  # Client ingestion should not be called
     assert "Policy test_policy: Backend error" in caplog.text
 
@@ -487,12 +441,7 @@ def test_metrics_during_policy_lifecycle(
 
         policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
-        mock_backend.run.assert_called_once_with(
-            policy_runner.name,
-            sample_policy,
-            source="scheduled",
-            run_id="11111111-1111-1111-1111-111111111111",
-        )
+        mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
         mock_diode_client.ingest.assert_called_once()
 
         mock_policy_executions.add.assert_called_once_with(1, {"policy": "test_policy"})
@@ -970,12 +919,7 @@ def test_run_unaffected_by_callback(
 
     policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
-    mock_backend.run.assert_called_once_with(
-        "test_policy",
-        sample_policy,
-        source="scheduled",
-        run_id="11111111-1111-1111-1111-111111111111",
-    )
+    mock_backend.run.assert_called_once_with("test_policy", sample_policy)
     mock_diode_client.ingest.assert_called_once()
     mock_run_store.update_run.assert_called_once()
     update_kwargs = mock_run_store.update_run.call_args.kwargs

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -593,7 +593,7 @@ def test_run_chunk_ingestion_error(
         with caplog.at_level("ERROR"):
             policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
-        # Should call ingest once and fail on first chunk error (it raises RuntimeError immediately)
+        # Should call ingest once and fail on first chunk error (it raises IngestRejected immediately)
         assert mock_diode_client.ingest.call_count == 2
 
         # Should log the error
@@ -847,7 +847,7 @@ def test_run_unaffected_by_callback(
     assert update_kwargs["status"] == RunStatus.COMPLETED
 
 
-def test_ingest_callback_raises_when_client_not_initialised(
+def test_ingest_callback_raises_when_not_ready(
     policy_runner,
     sample_policy,
     sample_diode_config,
@@ -855,7 +855,7 @@ def test_ingest_callback_raises_when_client_not_initialised(
     mock_load_class,
     mock_diode_client,
 ):
-    """Calling the callback before _diode_client is assigned raises IngestUnavailable."""
+    """Calling the callback before _callback_ready is True raises IngestUnavailable."""
     with patch.object(policy_runner.scheduler, "start"), patch.object(
         policy_runner.scheduler, "add_job"
     ):
@@ -863,15 +863,117 @@ def test_ingest_callback_raises_when_client_not_initialised(
 
     callback = _extract_callback(mock_load_class.return_value)
 
-    # Simulate "called before client init" — clear the attribute.
-    policy_runner._diode_client = None
+    # Simulate "called before worker finished constructing" — clear the readiness flag.
+    policy_runner._callback_ready = False
 
     entity = MagicMock()
-    with patch("worker.policy.runner.apply_run_id_to_entities"):
-        with pytest.raises(IngestUnavailable, match="diode client was initialised"):
+    with pytest.raises(IngestUnavailable, match="before the worker finished constructing"):
+        callback(entities=[entity])
+
+    # No pseudo-run must have been created (guard fires before create_run).
+    mock_run_store.create_run.assert_not_called()
+
+
+def test_ingest_callback_records_failure_on_apply_run_id_error(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """apply_run_id_to_entities failure inside try: records FAILED run as IngestUnavailable."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    callback = _extract_callback(mock_load_class.return_value)
+
+    entity = ingester_pb2.Entity()
+    entity.device.name = "dev1"
+
+    with patch(
+        "worker.policy.runner.apply_run_id_to_entities",
+        side_effect=RuntimeError("entity corrupt"),
+    ), patch("worker.policy.runner.estimate_message_size", return_value=1024):
+        with pytest.raises(IngestUnavailable):
             callback(entities=[entity])
 
-    # Pseudo-run was still recorded as FAILED.
-    mock_run_store.update_run.assert_called()
-    final_call = mock_run_store.update_run.call_args
-    assert final_call.kwargs["status"] == RunStatus.FAILED
+    mock_run_store.update_run.assert_called_once()
+    update_kwargs = mock_run_store.update_run.call_args.kwargs
+    assert update_kwargs["status"] == RunStatus.FAILED
+    # The entity was materialised before apply_run_id_to_entities raised.
+    assert update_kwargs["entity_count"] == 1
+
+
+def test_ingest_callback_records_failure_on_iterable_error(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """An iterable that raises on first next() records FAILED run with entity_count=0."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    callback = _extract_callback(mock_load_class.return_value)
+
+    bad_iterable = MagicMock()
+    bad_iterable.__iter__ = MagicMock(side_effect=ValueError("bad"))
+
+    with pytest.raises(IngestUnavailable):
+        callback(entities=bad_iterable)
+
+    mock_run_store.update_run.assert_called_once()
+    update_kwargs = mock_run_store.update_run.call_args.kwargs
+    assert update_kwargs["status"] == RunStatus.FAILED
+    # Iterable failed before any entity was materialised.
+    assert update_kwargs["entity_count"] == 0
+
+
+def test_setup_sets_callback_ready_flag(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """After setup() returns, _callback_ready is True."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    assert policy_runner._callback_ready is True
+
+
+def test_stop_clears_callback_ready_flag(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """After stop(), _callback_ready is False and the callback raises IngestUnavailable."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    callback = _extract_callback(mock_load_class.return_value)
+
+    with patch.object(policy_runner.scheduler, "shutdown"):
+        policy_runner.stop()
+
+    assert policy_runner._callback_ready is False
+
+    entity = MagicMock()
+    with pytest.raises(IngestUnavailable, match="before the worker finished constructing"):
+        callback(entities=[entity])

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -2,6 +2,8 @@
 # Copyright 2025 NetBox Labs Inc
 """NetBox Labs - Policy Manager Unit Tests."""
 
+import re
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -559,6 +561,38 @@ def test_run_with_multiple_chunks(
 
         # Verify log messages for successful ingestion
         assert "Successfully ingested 10 entities" in caplog.text
+
+
+def test_run_backend_execution_log_excludes_ingest_time(
+    policy_runner,
+    sample_policy,
+    mock_diode_client,
+    mock_backend,
+    caplog,
+    mock_run_store,
+):
+    """The 'Backend execution completed in' line times the backend only, not ingest."""
+    policy_runner.name = "test_policy"
+    policy_runner.run_store = mock_run_store
+
+    entity = ingester_pb2.Entity()
+    entity.device.name = "dev1"
+    mock_backend.run.return_value = [entity]
+
+    def slow_ingest(*args, **kwargs):
+        time.sleep(0.25)
+        response = MagicMock()
+        response.errors = []
+        return response
+
+    mock_diode_client.ingest.side_effect = slow_ingest
+
+    with caplog.at_level("DEBUG"):
+        policy_runner.run(mock_diode_client, mock_backend, sample_policy)
+
+    match = re.search(r"Backend execution completed in ([0-9.]+) seconds", caplog.text)
+    assert match, "expected the backend-execution debug line to be logged"
+    assert float(match.group(1)) < 0.2, "logged duration must not include client.ingest time"
 
 
 def test_run_chunk_ingestion_error(

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -9,8 +9,9 @@ from apscheduler.triggers.date import DateTrigger
 from netboxlabs.diode.sdk.diode.v1 import ingester_pb2
 
 from worker.backend import Backend
+from worker.exceptions import IngestRejected, IngestUnavailable
 from worker.models import Config, DiodeConfig, Metadata, Policy, Status
-from worker.policy.run import RunStore
+from worker.policy.run import RunStatus, RunStore
 from worker.policy.runner import PolicyRunner
 
 
@@ -114,6 +115,11 @@ def mock_backend():
     backend = MagicMock()
     backend.run.return_value = ["entity1", "entity2"]  # Mock returned entities
     return backend
+
+
+def _extract_callback(mock_backend_class):
+    """Recover the ingest_callback closure that PolicyRunner.setup passed to backend_class()."""
+    return mock_backend_class.call_args.kwargs["ingest_callback"]
 
 
 def test_initial_status(policy_runner):
@@ -592,3 +598,250 @@ def test_run_chunk_ingestion_error(
 
         # Should log the error
         assert "Chunk ingestion failed" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# New tests: _build_ingest_callback
+# ---------------------------------------------------------------------------
+
+
+def test_setup_passes_kwargs_to_backend(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """setup() constructs the backend with ingest_callback= and policy= kwargs."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    mock_backend_class = mock_load_class.return_value
+    call_kwargs = mock_backend_class.call_args.kwargs
+    assert "ingest_callback" in call_kwargs
+    assert callable(call_kwargs["ingest_callback"])
+    assert call_kwargs["policy"] == sample_policy
+
+
+def test_ingest_callback_entities_happy_path(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """Callback with entities= ingests them and records COMPLETED run."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    callback = _extract_callback(mock_load_class.return_value)
+
+    client_instance = mock_diode_client.return_value
+    client_instance.ingest.return_value.errors = []
+
+    entity1 = ingester_pb2.Entity()
+    entity1.device.name = "dev1"
+    entity2 = ingester_pb2.Entity()
+    entity2.device.name = "dev2"
+
+    with patch("worker.policy.runner.apply_run_id_to_entities"), patch(
+        "worker.policy.runner.estimate_message_size", return_value=1024
+    ), patch("worker.policy.runner.create_message_chunks"):
+        result = callback(entities=[entity1, entity2])
+
+    assert result is None
+    mock_run_store.create_run.assert_called_once()
+    client_instance.ingest.assert_called_once()
+    call_kwargs = client_instance.ingest.call_args.kwargs
+    assert len(call_kwargs["entities"]) == 2
+    mock_run_store.update_run.assert_called_once()
+    update_kwargs = mock_run_store.update_run.call_args.kwargs
+    assert update_kwargs["status"] == RunStatus.COMPLETED
+
+
+def test_ingest_callback_error_path(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """Callback with error= records FAILED run and skips client.ingest."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    callback = _extract_callback(mock_load_class.return_value)
+    client_instance = mock_diode_client.return_value
+
+    err = Exception("vendor unreachable")
+    result = callback(error=err)
+
+    assert result is None
+    client_instance.ingest.assert_not_called()
+    mock_run_store.update_run.assert_called_once()
+    update_kwargs = mock_run_store.update_run.call_args.kwargs
+    assert update_kwargs["status"] == RunStatus.FAILED
+    assert update_kwargs["error"] is err
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({}, id="neither"),
+        pytest.param({"entities": [], "error": Exception("x")}, id="both"),
+    ],
+)
+def test_ingest_callback_requires_exactly_one_of_entities_or_error(
+    kwargs,
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """Callback raises TypeError when neither or both of entities/error are given."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    callback = _extract_callback(mock_load_class.return_value)
+
+    with pytest.raises(TypeError):
+        callback(**kwargs)
+
+
+def test_ingest_callback_translates_transport_errors_to_unavailable(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """Non-IngestError transport exceptions are wrapped as IngestUnavailable."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    callback = _extract_callback(mock_load_class.return_value)
+    client_instance = mock_diode_client.return_value
+    client_instance.ingest.side_effect = RuntimeError("connection refused")
+
+    entity = ingester_pb2.Entity()
+    entity.device.name = "dev1"
+
+    with patch("worker.policy.runner.estimate_message_size", return_value=1024), patch(
+        "worker.policy.runner.apply_run_id_to_entities"
+    ):
+        with pytest.raises(IngestUnavailable):
+            callback(entities=[entity])
+
+    mock_run_store.update_run.assert_called_once()
+    update_kwargs = mock_run_store.update_run.call_args.kwargs
+    assert update_kwargs["status"] == RunStatus.FAILED
+
+
+def test_ingest_callback_translates_response_errors_to_rejected(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """Response errors (non-empty errors list) are raised as IngestRejected."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    callback = _extract_callback(mock_load_class.return_value)
+    client_instance = mock_diode_client.return_value
+    client_instance.ingest.return_value.errors = ["bad payload"]
+
+    entity = ingester_pb2.Entity()
+    entity.device.name = "dev1"
+
+    with patch("worker.policy.runner.estimate_message_size", return_value=1024), patch(
+        "worker.policy.runner.apply_run_id_to_entities"
+    ):
+        with pytest.raises(IngestRejected):
+            callback(entities=[entity])
+
+    mock_run_store.update_run.assert_called_once()
+    update_kwargs = mock_run_store.update_run.call_args.kwargs
+    assert update_kwargs["status"] == RunStatus.FAILED
+
+
+def test_ingest_callback_chunks_large_payloads(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """Callback splits large payloads into chunks and ingests each separately."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    callback = _extract_callback(mock_load_class.return_value)
+    client_instance = mock_diode_client.return_value
+    client_instance.ingest.return_value.errors = []
+
+    entity1 = ingester_pb2.Entity()
+    entity1.device.name = "dev1"
+    entity2 = ingester_pb2.Entity()
+    entity2.device.name = "dev2"
+    chunk_a = [entity1]
+    chunk_b = [entity2]
+
+    with patch(
+        "worker.policy.runner.estimate_message_size", return_value=4 * 1024 * 1024
+    ), patch(
+        "worker.policy.runner.create_message_chunks", return_value=[chunk_a, chunk_b]
+    ), patch(
+        "worker.policy.runner.apply_run_id_to_entities"
+    ):
+        callback(entities=[entity1, entity2])
+
+    assert client_instance.ingest.call_count == 2
+    mock_run_store.update_run.assert_called_once()
+    update_kwargs = mock_run_store.update_run.call_args.kwargs
+    assert update_kwargs["status"] == RunStatus.COMPLETED
+
+
+def test_run_unaffected_by_callback(
+    policy_runner, sample_policy, mock_diode_client, mock_backend, mock_run_store
+):
+    """PolicyRunner.run() is unaffected by the new callback mechanism."""
+    policy_runner.name = "test_policy"
+    policy_runner.run_store = mock_run_store
+
+    entity = ingester_pb2.Entity()
+    entity.device.name = "device-x"
+    mock_backend.run.return_value = [entity]
+    mock_diode_client.ingest.return_value.errors = []
+
+    with patch("worker.policy.runner.estimate_message_size", return_value=512):
+        policy_runner.run(mock_diode_client, mock_backend, sample_policy)
+
+    mock_backend.run.assert_called_once_with("test_policy", sample_policy)
+    mock_diode_client.ingest.assert_called_once()
+    mock_run_store.update_run.assert_called_once()
+    update_kwargs = mock_run_store.update_run.call_args.kwargs
+    assert update_kwargs["status"] == RunStatus.COMPLETED

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -603,7 +603,8 @@ def test_run_chunk_ingestion_error(
         with caplog.at_level("ERROR"):
             policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
-        # Should call ingest once and fail on first chunk error (it raises IngestRejected immediately)
+        # Both chunks are sent; the second chunk's response carries errors, raising
+        # IngestRejected — so ingest is called twice.
         assert mock_diode_client.ingest.call_count == 2
 
         # Should log the error

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -643,6 +643,7 @@ def test_setup_falls_back_to_setup_when_describe_not_implemented(
     mock_load_class,
     mock_diode_client,
     mock_run_store,
+    caplog,
 ):
     """Legacy backend (describe() raises) → metadata read via a throwaway setup() instance."""
     mock_backend_class = mock_load_class.return_value
@@ -655,9 +656,11 @@ def test_setup_falls_back_to_setup_when_describe_not_implemented(
 
     with patch.object(policy_runner.scheduler, "start"), patch.object(
         policy_runner.scheduler, "add_job"
-    ):
+    ), caplog.at_level("WARNING"):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
+    # The deprecation is surfaced to operators at the fallback site.
+    assert "deprecated setup() fallback" in caplog.text
     # Throwaway instance's setup() was used to read metadata; identity flows through.
     mock_backend_class.return_value.setup.assert_called_once_with()
     assert policy_runner.metadata.name == "legacy_backend"

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -319,17 +319,14 @@ def test_run_ingestion_errors(
     # Simulate ingestion errors
     mock_diode_client.ingest.return_value.errors = ["error1", "error2"]
 
-    # Mock estimate_message_size to return small size (no chunking)
-    with patch("worker.policy.runner.estimate_message_size", return_value=1024 * 1024):
-        # Call the run method
-        with caplog.at_level("ERROR"):
-            policy_runner.run(mock_diode_client, mock_backend, sample_policy)
+    with caplog.at_level("ERROR"):
+        policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Assertions
     mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
     mock_diode_client.ingest.assert_called_once()
     assert (
-        "Policy test_policy: Entities ingestion failed: ['error1', 'error2']"
+        "Policy test_policy: Chunk ingestion failed: ['error1', 'error2']"
         in caplog.text
     )
 
@@ -512,11 +509,8 @@ def test_run_with_small_entities_no_chunking(
     mock_backend.run.return_value = entities
     mock_diode_client.ingest.return_value.errors = []
 
-    # Mock estimate_message_size to return small size (under 3.0 MB)
-    with patch(
-        "worker.policy.runner.estimate_message_size", return_value=1024 * 1024
-    ):  # 1MB
-        policy_runner.run(mock_diode_client, mock_backend, sample_policy)
+    # Small real entities fit in a single chunk, so the SDK returns one chunk.
+    policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Should call ingest once (no chunking)
     mock_diode_client.ingest.assert_called_once()
@@ -548,10 +542,8 @@ def test_run_with_multiple_chunks(
     mock_backend.run.return_value = entities
     mock_diode_client.ingest.return_value.errors = []
 
-    # Mock estimate_message_size to return large size (over 3.0 MB) and create_message_chunks
+    # Force the SDK to split into two chunks.
     with patch(
-        "worker.policy.runner.estimate_message_size", return_value=5 * 1024 * 1024
-    ), patch(
         "worker.policy.runner.create_message_chunks",
         return_value=[entities[:5], entities[5:]],
     ) as mock_chunks:
@@ -597,10 +589,8 @@ def test_run_chunk_ingestion_error(
 
     mock_diode_client.ingest.side_effect = responses
 
-    # Mock large size to trigger chunking and create_message_chunks
+    # Force two chunks; the second one fails.
     with patch(
-        "worker.policy.runner.estimate_message_size", return_value=5 * 1024 * 1024
-    ), patch(
         "worker.policy.runner.create_message_chunks",
         return_value=[entities[:3], entities[3:]],
     ):
@@ -700,9 +690,7 @@ def test_ingest_callback_entities_happy_path(
     entity2 = ingester_pb2.Entity()
     entity2.device.name = "dev2"
 
-    with patch("worker.policy.runner.apply_run_id_to_entities"), patch(
-        "worker.policy.runner.estimate_message_size", return_value=1024
-    ), patch("worker.policy.runner.create_message_chunks"):
+    with patch("worker.policy.runner.apply_run_id_to_entities"):
         result = callback(entities=[entity1, entity2])
 
     assert result is None
@@ -792,9 +780,7 @@ def test_ingest_callback_translates_transport_errors_to_ingest_error(
     entity = ingester_pb2.Entity()
     entity.device.name = "dev1"
 
-    with patch("worker.policy.runner.estimate_message_size", return_value=1024), patch(
-        "worker.policy.runner.apply_run_id_to_entities"
-    ):
+    with patch("worker.policy.runner.apply_run_id_to_entities"):
         with pytest.raises(IngestError):
             callback(entities=[entity])
 
@@ -824,9 +810,7 @@ def test_ingest_callback_translates_response_errors_to_rejected(
     entity = ingester_pb2.Entity()
     entity.device.name = "dev1"
 
-    with patch("worker.policy.runner.estimate_message_size", return_value=1024), patch(
-        "worker.policy.runner.apply_run_id_to_entities"
-    ):
+    with patch("worker.policy.runner.apply_run_id_to_entities"):
         with pytest.raises(IngestRejected):
             callback(entities=[entity])
 
@@ -861,8 +845,6 @@ def test_ingest_callback_chunks_large_payloads(
     chunk_b = [entity2]
 
     with patch(
-        "worker.policy.runner.estimate_message_size", return_value=4 * 1024 * 1024
-    ), patch(
         "worker.policy.runner.create_message_chunks", return_value=[chunk_a, chunk_b]
     ), patch(
         "worker.policy.runner.apply_run_id_to_entities"
@@ -887,8 +869,7 @@ def test_run_unaffected_by_callback(
     mock_backend.run.return_value = [entity]
     mock_diode_client.ingest.return_value.errors = []
 
-    with patch("worker.policy.runner.estimate_message_size", return_value=512):
-        policy_runner.run(mock_diode_client, mock_backend, sample_policy)
+    policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     mock_backend.run.assert_called_once_with("test_policy", sample_policy)
     mock_diode_client.ingest.assert_called_once()
@@ -919,7 +900,7 @@ def test_ingest_callback_records_failure_on_apply_run_id_error(
     with patch(
         "worker.policy.runner.apply_run_id_to_entities",
         side_effect=RuntimeError("entity corrupt"),
-    ), patch("worker.policy.runner.estimate_message_size", return_value=1024):
+    ):
         with pytest.raises(IngestError):
             callback(entities=[entity])
 

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -253,12 +253,48 @@ def test_run_success(
     policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Assertions
-    mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
+    mock_backend.run.assert_called_once_with(
+        policy_runner.name,
+        sample_policy,
+        source="scheduled",
+        run_id="11111111-1111-1111-1111-111111111111",
+    )
     # Should call ingest once for the single chunk
     mock_diode_client.ingest.assert_called_once()
     # Check that entities were passed correctly
     call_args = mock_diode_client.ingest.call_args[1]["entities"]
     assert len(call_args) == 3
+
+
+def test_run_legacy_backend_without_kwargs_gets_bare_call(
+    policy_runner,
+    sample_policy,
+    mock_diode_client,
+    mock_run_store,
+    caplog,
+):
+    """A backend whose run() lacks **kwargs is called bare, with a warning."""
+
+    class LegacyBackend:
+        def __init__(self):
+            self.calls = []
+
+        def run(self, policy_name, policy):
+            self.calls.append((policy_name, policy))
+            entity = ingester_pb2.Entity()
+            entity.device.name = "legacy-dev"
+            return [entity]
+
+    backend = LegacyBackend()
+    policy_runner.name = "test_policy"
+    policy_runner.run_store = mock_run_store
+    mock_diode_client.ingest.return_value.errors = []
+
+    with caplog.at_level("WARNING"):
+        policy_runner.run(mock_diode_client, backend, sample_policy)
+
+    assert backend.calls == [("test_policy", sample_policy)]
+    assert "does not declare **kwargs" in caplog.text
 
 
 def test_run_passes_metadata_to_ingest(
@@ -323,7 +359,12 @@ def test_run_ingestion_errors(
         policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Assertions
-    mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
+    mock_backend.run.assert_called_once_with(
+        policy_runner.name,
+        sample_policy,
+        source="scheduled",
+        run_id="11111111-1111-1111-1111-111111111111",
+    )
     mock_diode_client.ingest.assert_called_once()
     assert (
         "Policy test_policy: Chunk ingestion failed: ['error1', 'error2']"
@@ -351,7 +392,12 @@ def test_run_backend_exception(
         policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
     # Assertions
-    mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
+    mock_backend.run.assert_called_once_with(
+        policy_runner.name,
+        sample_policy,
+        source="scheduled",
+        run_id="11111111-1111-1111-1111-111111111111",
+    )
     mock_diode_client.ingest.assert_not_called()  # Client ingestion should not be called
     assert "Policy test_policy: Backend error" in caplog.text
 
@@ -423,7 +469,12 @@ def test_metrics_during_policy_lifecycle(
 
         policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
-        mock_backend.run.assert_called_once_with(policy_runner.name, sample_policy)
+        mock_backend.run.assert_called_once_with(
+            policy_runner.name,
+            sample_policy,
+            source="scheduled",
+            run_id="11111111-1111-1111-1111-111111111111",
+        )
         mock_diode_client.ingest.assert_called_once()
 
         mock_policy_executions.add.assert_called_once_with(1, {"policy": "test_policy"})
@@ -874,7 +925,12 @@ def test_run_unaffected_by_callback(
 
     policy_runner.run(mock_diode_client, mock_backend, sample_policy)
 
-    mock_backend.run.assert_called_once_with("test_policy", sample_policy)
+    mock_backend.run.assert_called_once_with(
+        "test_policy",
+        sample_policy,
+        source="scheduled",
+        run_id="11111111-1111-1111-1111-111111111111",
+    )
     mock_diode_client.ingest.assert_called_once()
     mock_run_store.update_run.assert_called_once()
     update_kwargs = mock_run_store.update_run.call_args.kwargs

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -12,7 +12,7 @@ from worker.backend import Backend
 from worker.exceptions import IngestError, IngestRejected
 from worker.models import Config, DiodeConfig, Metadata, Policy, Status
 from worker.policy.run import RunStatus, RunStore
-from worker.policy.runner import PolicyRunner
+from worker.policy.runner import PolicyRunner, _PolicyRunnerIngestSink
 
 
 @pytest.fixture
@@ -68,22 +68,29 @@ def sample_diode_dry_run_config():
 @pytest.fixture
 def mock_load_class():
     """
-    Fixture to mock the load_class function.
+    Patch load_class to return a real modern Backend subclass that records its instances.
 
-    Returns
-    -------
-        MagicMock: A mock object for the load_class function.
-
+    A real class (not a MagicMock) is required because the runner now decides
+    the modern-vs-legacy path by statically inspecting the class for a
+    describe() classmethod. ``mock_load_class.return_value`` is the class;
+    ``._instances`` holds every instance constructed during the test.
     """
-    with patch("worker.policy.runner.load_class") as mock_load:
-        mock_backend_class = MagicMock(spec=Backend)
-        mock_backend_class.__name__ = "MockBackend"
-        # New path: the runner reads metadata via the class-level describe()
-        # before constructing the backend, so it must return real Metadata.
-        mock_backend_class.describe.return_value = Metadata(
-            name="mock_backend", app_name="mock_app", app_version="1.0.0"
-        )
-        mock_load.return_value = mock_backend_class
+    instances: list = []
+
+    class _FakeBackend(Backend):
+        @classmethod
+        def describe(cls) -> Metadata:
+            return Metadata(name="mock_backend", app_name="mock_app", app_version="1.0.0")
+
+        def __init__(self, **kwargs) -> None:
+            super().__init__(**kwargs)
+            instances.append(self)
+
+        def run(self, policy_name, policy, **kwargs):
+            return []
+
+    _FakeBackend._instances = instances
+    with patch("worker.policy.runner.load_class", return_value=_FakeBackend) as mock_load:
         yield mock_load
 
 
@@ -122,9 +129,9 @@ def mock_backend():
     return backend
 
 
-def _extract_callback(mock_backend_class):
-    """Recover the ingest_callback closure PolicyRunner.setup passed at construction."""
-    return mock_backend_class.call_args.kwargs["ingest_callback"]
+def _extract_sink(backend_class):
+    """Recover the IngestSink PolicyRunner.setup attached to the constructed backend."""
+    return backend_class._instances[-1].ingest_sink
 
 
 def test_initial_status(policy_runner):
@@ -625,69 +632,96 @@ def test_run_chunk_ingestion_error(
 
 
 # ---------------------------------------------------------------------------
-# New tests: _build_ingest_callback
+# New tests: backend construction + IngestSink
 # ---------------------------------------------------------------------------
 
 
-def test_setup_reads_metadata_via_describe_and_constructs_once_with_callback(
+def test_setup_modern_backend_reads_describe_and_constructs_once_with_sink(
     policy_runner,
     sample_policy,
     sample_diode_config,
-    mock_load_class,
     mock_diode_client,
     mock_run_store,
 ):
-    """setup() reads metadata via describe() then constructs the backend ONCE with ingest_callback."""
-    with patch.object(policy_runner.scheduler, "start"), patch.object(
-        policy_runner.scheduler, "add_job"
-    ):
+    """Modern backend: metadata via describe(); constructed once with an IngestSink; setup() untouched."""
+    calls: list[str] = []
+
+    class _ModernBackend(Backend):
+        @classmethod
+        def describe(cls) -> Metadata:
+            calls.append("describe")
+            return Metadata(name="mock_backend", app_name="mock_app", app_version="1.0.0")
+
+        def setup(self) -> Metadata:
+            calls.append("setup")
+            return self.describe()
+
+        def __init__(self, **kwargs) -> None:
+            super().__init__(**kwargs)
+            calls.append("init")
+
+        def run(self, policy_name, policy, **kwargs):
+            return []
+
+    with patch("worker.policy.runner.load_class", return_value=_ModernBackend), patch.object(
+        policy_runner.scheduler, "start"
+    ), patch.object(policy_runner.scheduler, "add_job") as mock_add_job:
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
-    mock_backend_class = mock_load_class.return_value
-    # New path: metadata read off the class, not a constructed instance.
-    mock_backend_class.describe.assert_called_once_with()
-    mock_backend_class.setup.assert_not_called()
-    # Constructed exactly once, with the prebuilt ingest_callback passed in.
-    mock_backend_class.assert_called_once()
-    assert mock_backend_class.call_args.args == ()
-    assert set(mock_backend_class.call_args.kwargs) == {"ingest_callback"}
-    assert callable(mock_backend_class.call_args.kwargs["ingest_callback"])
+    # Metadata read off the class via describe(); the legacy setup() is never touched.
+    assert "describe" in calls and "setup" not in calls
+    # Constructed exactly once, and the scheduled instance carries the sink.
+    assert calls.count("init") == 1
+    scheduled_backend = mock_add_job.call_args.kwargs["args"][1]
+    assert isinstance(scheduled_backend.ingest_sink, _PolicyRunnerIngestSink)
 
 
-def test_setup_falls_back_to_setup_when_describe_not_implemented(
+def test_setup_legacy_backend_sets_up_the_scheduled_instance(
     policy_runner,
     sample_policy,
     sample_diode_config,
-    mock_load_class,
     mock_diode_client,
     mock_run_store,
     caplog,
 ):
-    """Legacy backend (describe() raises) → metadata read via a throwaway setup() instance."""
-    mock_backend_class = mock_load_class.return_value
-    # A bare MagicMock.describe() returns a Mock and would not raise, so we must
-    # force the fallback explicitly.
-    mock_backend_class.describe.side_effect = NotImplementedError
-    mock_backend_class.return_value.setup.return_value = Metadata(
-        name="legacy_backend", app_name="legacy_app", app_version="2.0.0"
-    )
+    """
+    Legacy setup()-only backend with a custom no-kwargs __init__.
 
-    with patch.object(policy_runner.scheduler, "start"), patch.object(
-        policy_runner.scheduler, "add_job"
-    ), caplog.at_level("WARNING"):
+    Regression for two faults: (1) the worker must construct the legacy instance
+    bare — passing ingest_sink= to a __init__ that doesn't accept it would crash
+    policy startup; (2) the instance that gets scheduled must be the one whose
+    setup() ran, so state initialised in setup() is live when run() reads it.
+    """
+
+    class _LegacyBackend(Backend):
+        def __init__(self) -> None:  # NO **kwargs — must be constructed bare
+            super().__init__()
+            self.connected = False
+
+        def setup(self) -> Metadata:
+            self.connected = True  # state run() will rely on
+            return Metadata(name="legacy_backend", app_name="legacy_app", app_version="2.0.0")
+
+        def run(self, policy_name, policy):
+            return []
+
+    with patch("worker.policy.runner.load_class", return_value=_LegacyBackend), patch.object(
+        policy_runner.scheduler, "start"
+    ), patch.object(policy_runner.scheduler, "add_job") as mock_add_job, caplog.at_level(
+        "WARNING"
+    ):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
-    # The deprecation is surfaced to operators at the fallback site.
     assert "deprecated setup() fallback" in caplog.text
-    # Throwaway instance's setup() was used to read metadata; identity flows through.
-    mock_backend_class.return_value.setup.assert_called_once_with()
     assert policy_runner.metadata.name == "legacy_backend"
-    # The real, callback-bearing instance is still constructed with the callback.
-    assert set(mock_backend_class.call_args.kwargs) == {"ingest_callback"}
-    assert callable(mock_backend_class.call_args.kwargs["ingest_callback"])
+    scheduled_backend = mock_add_job.call_args.kwargs["args"][1]
+    # The scheduled instance is the one whose setup() ran (not a throwaway).
+    assert scheduled_backend.connected is True
+    # The sink was attached post-construction (legacy __init__ took no kwargs).
+    assert isinstance(scheduled_backend.ingest_sink, _PolicyRunnerIngestSink)
 
 
-def test_ingest_callback_entities_happy_path(
+def test_ingest_sink_ingest_happy_path(
     policy_runner,
     sample_policy,
     sample_diode_config,
@@ -695,13 +729,13 @@ def test_ingest_callback_entities_happy_path(
     mock_diode_client,
     mock_run_store,
 ):
-    """Callback with entities= ingests them and records COMPLETED run."""
+    """sink.ingest(entities) sends them and records a COMPLETED run."""
     with patch.object(policy_runner.scheduler, "start"), patch.object(
         policy_runner.scheduler, "add_job"
     ):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
-    callback = _extract_callback(mock_load_class.return_value)
+    sink = _extract_sink(mock_load_class.return_value)
 
     client_instance = mock_diode_client.return_value
     client_instance.ingest.return_value.errors = []
@@ -712,7 +746,7 @@ def test_ingest_callback_entities_happy_path(
     entity2.device.name = "dev2"
 
     with patch("worker.policy.runner.apply_run_id_to_entities"):
-        result = callback(entities=[entity1, entity2])
+        result = sink.ingest([entity1, entity2])
 
     assert result is None
     mock_run_store.create_run.assert_called_once()
@@ -724,7 +758,7 @@ def test_ingest_callback_entities_happy_path(
     assert update_kwargs["status"] == RunStatus.COMPLETED
 
 
-def test_ingest_callback_empty_entities_is_noop_completed(
+def test_ingest_sink_ingest_empty_entities_is_noop_completed(
     policy_runner,
     sample_policy,
     sample_diode_config,
@@ -732,16 +766,16 @@ def test_ingest_callback_empty_entities_is_noop_completed(
     mock_diode_client,
     mock_run_store,
 ):
-    """Callback with an empty entity list records a COMPLETED no-op run, no ingest call."""
+    """sink.ingest([]) records a COMPLETED no-op run, no ingest call."""
     with patch.object(policy_runner.scheduler, "start"), patch.object(
         policy_runner.scheduler, "add_job"
     ):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
-    callback = _extract_callback(mock_load_class.return_value)
+    sink = _extract_sink(mock_load_class.return_value)
     client_instance = mock_diode_client.return_value
 
-    result = callback(entities=[])
+    result = sink.ingest([])
 
     assert result is None
     client_instance.ingest.assert_not_called()
@@ -751,7 +785,7 @@ def test_ingest_callback_empty_entities_is_noop_completed(
     assert update_kwargs["entity_count"] == 0
 
 
-def test_ingest_callback_error_path(
+def test_ingest_sink_record_failure(
     policy_runner,
     sample_policy,
     sample_diode_config,
@@ -759,17 +793,17 @@ def test_ingest_callback_error_path(
     mock_diode_client,
     mock_run_store,
 ):
-    """Callback with error= records FAILED run and skips client.ingest."""
+    """sink.record_failure(error) records a FAILED run and skips client.ingest."""
     with patch.object(policy_runner.scheduler, "start"), patch.object(
         policy_runner.scheduler, "add_job"
     ):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
-    callback = _extract_callback(mock_load_class.return_value)
+    sink = _extract_sink(mock_load_class.return_value)
     client_instance = mock_diode_client.return_value
 
     err = Exception("vendor unreachable")
-    result = callback(error=err)
+    result = sink.record_failure(err)
 
     assert result is None
     client_instance.ingest.assert_not_called()
@@ -779,35 +813,7 @@ def test_ingest_callback_error_path(
     assert update_kwargs["error"] is err
 
 
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        pytest.param({}, id="neither"),
-        pytest.param({"entities": [], "error": Exception("x")}, id="both"),
-    ],
-)
-def test_ingest_callback_requires_exactly_one_of_entities_or_error(
-    kwargs,
-    policy_runner,
-    sample_policy,
-    sample_diode_config,
-    mock_load_class,
-    mock_diode_client,
-    mock_run_store,
-):
-    """Callback raises TypeError when neither or both of entities/error are given."""
-    with patch.object(policy_runner.scheduler, "start"), patch.object(
-        policy_runner.scheduler, "add_job"
-    ):
-        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
-
-    callback = _extract_callback(mock_load_class.return_value)
-
-    with pytest.raises(TypeError):
-        callback(**kwargs)
-
-
-def test_ingest_callback_translates_transport_errors_to_ingest_error(
+def test_ingest_sink_translates_transport_errors_to_ingest_error(
     policy_runner,
     sample_policy,
     sample_diode_config,
@@ -821,7 +827,7 @@ def test_ingest_callback_translates_transport_errors_to_ingest_error(
     ):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
-    callback = _extract_callback(mock_load_class.return_value)
+    sink = _extract_sink(mock_load_class.return_value)
     client_instance = mock_diode_client.return_value
     client_instance.ingest.side_effect = RuntimeError("connection refused")
 
@@ -830,14 +836,14 @@ def test_ingest_callback_translates_transport_errors_to_ingest_error(
 
     with patch("worker.policy.runner.apply_run_id_to_entities"):
         with pytest.raises(IngestError):
-            callback(entities=[entity])
+            sink.ingest([entity])
 
     mock_run_store.update_run.assert_called_once()
     update_kwargs = mock_run_store.update_run.call_args.kwargs
     assert update_kwargs["status"] == RunStatus.FAILED
 
 
-def test_ingest_callback_translates_response_errors_to_rejected(
+def test_ingest_sink_translates_response_errors_to_rejected(
     policy_runner,
     sample_policy,
     sample_diode_config,
@@ -851,7 +857,7 @@ def test_ingest_callback_translates_response_errors_to_rejected(
     ):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
-    callback = _extract_callback(mock_load_class.return_value)
+    sink = _extract_sink(mock_load_class.return_value)
     client_instance = mock_diode_client.return_value
     client_instance.ingest.return_value.errors = ["bad payload"]
 
@@ -860,14 +866,14 @@ def test_ingest_callback_translates_response_errors_to_rejected(
 
     with patch("worker.policy.runner.apply_run_id_to_entities"):
         with pytest.raises(IngestRejected):
-            callback(entities=[entity])
+            sink.ingest([entity])
 
     mock_run_store.update_run.assert_called_once()
     update_kwargs = mock_run_store.update_run.call_args.kwargs
     assert update_kwargs["status"] == RunStatus.FAILED
 
 
-def test_ingest_callback_chunks_large_payloads(
+def test_ingest_sink_chunks_large_payloads(
     policy_runner,
     sample_policy,
     sample_diode_config,
@@ -875,13 +881,13 @@ def test_ingest_callback_chunks_large_payloads(
     mock_diode_client,
     mock_run_store,
 ):
-    """Callback splits large payloads into chunks and ingests each separately."""
+    """sink.ingest splits large payloads into chunks and ingests each separately."""
     with patch.object(policy_runner.scheduler, "start"), patch.object(
         policy_runner.scheduler, "add_job"
     ):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
-    callback = _extract_callback(mock_load_class.return_value)
+    sink = _extract_sink(mock_load_class.return_value)
     client_instance = mock_diode_client.return_value
     client_instance.ingest.return_value.errors = []
 
@@ -894,10 +900,8 @@ def test_ingest_callback_chunks_large_payloads(
 
     with patch(
         "worker.policy.runner.create_message_chunks", return_value=[chunk_a, chunk_b]
-    ), patch(
-        "worker.policy.runner.apply_run_id_to_entities"
-    ):
-        callback(entities=[entity1, entity2])
+    ), patch("worker.policy.runner.apply_run_id_to_entities"):
+        sink.ingest([entity1, entity2])
 
     assert client_instance.ingest.call_count == 2
     mock_run_store.update_run.assert_called_once()
@@ -905,10 +909,10 @@ def test_ingest_callback_chunks_large_payloads(
     assert update_kwargs["status"] == RunStatus.COMPLETED
 
 
-def test_run_unaffected_by_callback(
+def test_run_unaffected_by_sink(
     policy_runner, sample_policy, mock_diode_client, mock_backend, mock_run_store
 ):
-    """PolicyRunner.run() is unaffected by the new callback mechanism."""
+    """PolicyRunner.run() is unaffected by the ingest-sink mechanism."""
     policy_runner.name = "test_policy"
     policy_runner.run_store = mock_run_store
 
@@ -926,7 +930,7 @@ def test_run_unaffected_by_callback(
     assert update_kwargs["status"] == RunStatus.COMPLETED
 
 
-def test_ingest_callback_records_failure_on_apply_run_id_error(
+def test_ingest_sink_records_failure_on_apply_run_id_error(
     policy_runner,
     sample_policy,
     sample_diode_config,
@@ -940,7 +944,7 @@ def test_ingest_callback_records_failure_on_apply_run_id_error(
     ):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
-    callback = _extract_callback(mock_load_class.return_value)
+    sink = _extract_sink(mock_load_class.return_value)
 
     entity = ingester_pb2.Entity()
     entity.device.name = "dev1"
@@ -950,7 +954,7 @@ def test_ingest_callback_records_failure_on_apply_run_id_error(
         side_effect=RuntimeError("entity corrupt"),
     ):
         with pytest.raises(IngestError):
-            callback(entities=[entity])
+            sink.ingest([entity])
 
     mock_run_store.update_run.assert_called_once()
     update_kwargs = mock_run_store.update_run.call_args.kwargs
@@ -959,7 +963,7 @@ def test_ingest_callback_records_failure_on_apply_run_id_error(
     assert update_kwargs["entity_count"] == 1
 
 
-def test_ingest_callback_records_failure_on_iterable_error(
+def test_ingest_sink_records_failure_on_iterable_error(
     policy_runner,
     sample_policy,
     sample_diode_config,
@@ -973,13 +977,13 @@ def test_ingest_callback_records_failure_on_iterable_error(
     ):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
-    callback = _extract_callback(mock_load_class.return_value)
+    sink = _extract_sink(mock_load_class.return_value)
 
     bad_iterable = MagicMock()
     bad_iterable.__iter__ = MagicMock(side_effect=ValueError("bad"))
 
     with pytest.raises(IngestError):
-        callback(entities=bad_iterable)
+        sink.ingest(bad_iterable)
 
     mock_run_store.update_run.assert_called_once()
     update_kwargs = mock_run_store.update_run.call_args.kwargs

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -2,8 +2,6 @@
 # Copyright 2025 NetBox Labs Inc
 """NetBox Labs - Policy Manager Unit Tests."""
 
-import re
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -561,38 +559,6 @@ def test_run_with_multiple_chunks(
 
         # Verify log messages for successful ingestion
         assert "Successfully ingested 10 entities" in caplog.text
-
-
-def test_run_backend_execution_log_excludes_ingest_time(
-    policy_runner,
-    sample_policy,
-    mock_diode_client,
-    mock_backend,
-    caplog,
-    mock_run_store,
-):
-    """The 'Backend execution completed in' line times the backend only, not ingest."""
-    policy_runner.name = "test_policy"
-    policy_runner.run_store = mock_run_store
-
-    entity = ingester_pb2.Entity()
-    entity.device.name = "dev1"
-    mock_backend.run.return_value = [entity]
-
-    def slow_ingest(*args, **kwargs):
-        time.sleep(0.25)
-        response = MagicMock()
-        response.errors = []
-        return response
-
-    mock_diode_client.ingest.side_effect = slow_ingest
-
-    with caplog.at_level("DEBUG"):
-        policy_runner.run(mock_diode_client, mock_backend, sample_policy)
-
-    match = re.search(r"Backend execution completed in ([0-9.]+) seconds", caplog.text)
-    assert match, "expected the backend-execution debug line to be logged"
-    assert float(match.group(1)) < 0.2, "logged duration must not include client.ingest time"
 
 
 def test_run_chunk_ingestion_error(

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -78,6 +78,11 @@ def mock_load_class():
     with patch("worker.policy.runner.load_class") as mock_load:
         mock_backend_class = MagicMock(spec=Backend)
         mock_backend_class.__name__ = "MockBackend"
+        # New path: the runner reads metadata via the class-level describe()
+        # before constructing the backend, so it must return real Metadata.
+        mock_backend_class.describe.return_value = Metadata(
+            name="mock_backend", app_name="mock_app", app_version="1.0.0"
+        )
         mock_load.return_value = mock_backend_class
         yield mock_load
 
@@ -118,8 +123,8 @@ def mock_backend():
 
 
 def _extract_callback(mock_backend_class):
-    """Recover the ingest_callback closure that PolicyRunner.setup attached to the backend."""
-    return mock_backend_class.return_value.ingest_callback
+    """Recover the ingest_callback closure PolicyRunner.setup passed at construction."""
+    return mock_backend_class.call_args.kwargs["ingest_callback"]
 
 
 def test_initial_status(policy_runner):
@@ -616,7 +621,7 @@ def test_run_chunk_ingestion_error(
 # ---------------------------------------------------------------------------
 
 
-def test_setup_constructs_backend_directly_and_attaches_callback(
+def test_setup_reads_metadata_via_describe_and_constructs_once_with_callback(
     policy_runner,
     sample_policy,
     sample_diode_config,
@@ -624,17 +629,51 @@ def test_setup_constructs_backend_directly_and_attaches_callback(
     mock_diode_client,
     mock_run_store,
 ):
-    """setup() constructs the backend with no args and attaches ingest_callback after deps are ready."""
+    """setup() reads metadata via describe() then constructs the backend ONCE with ingest_callback."""
     with patch.object(policy_runner.scheduler, "start"), patch.object(
         policy_runner.scheduler, "add_job"
     ):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
     mock_backend_class = mock_load_class.return_value
+    # New path: metadata read off the class, not a constructed instance.
+    mock_backend_class.describe.assert_called_once_with()
+    mock_backend_class.setup.assert_not_called()
+    # Constructed exactly once, with the prebuilt ingest_callback passed in.
+    mock_backend_class.assert_called_once()
     assert mock_backend_class.call_args.args == ()
-    assert mock_backend_class.call_args.kwargs == {}
-    backend = mock_backend_class.return_value
-    assert callable(backend.ingest_callback)
+    assert set(mock_backend_class.call_args.kwargs) == {"ingest_callback"}
+    assert callable(mock_backend_class.call_args.kwargs["ingest_callback"])
+
+
+def test_setup_falls_back_to_setup_when_describe_not_implemented(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """Legacy backend (describe() raises) → metadata read via a throwaway setup() instance."""
+    mock_backend_class = mock_load_class.return_value
+    # A bare MagicMock.describe() returns a Mock and would not raise, so we must
+    # force the fallback explicitly.
+    mock_backend_class.describe.side_effect = NotImplementedError
+    mock_backend_class.return_value.setup.return_value = Metadata(
+        name="legacy_backend", app_name="legacy_app", app_version="2.0.0"
+    )
+
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    # Throwaway instance's setup() was used to read metadata; identity flows through.
+    mock_backend_class.return_value.setup.assert_called_once_with()
+    assert policy_runner.metadata.name == "legacy_backend"
+    # The real, callback-bearing instance is still constructed with the callback.
+    assert set(mock_backend_class.call_args.kwargs) == {"ingest_callback"}
+    assert callable(mock_backend_class.call_args.kwargs["ingest_callback"])
 
 
 def test_ingest_callback_entities_happy_path(

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -613,7 +613,7 @@ def test_setup_passes_kwargs_to_backend(
     mock_diode_client,
     mock_run_store,
 ):
-    """setup() constructs the backend with ingest_callback= and policy= kwargs."""
+    """setup() constructs the backend with ingest_callback= kwarg (no policy= per ADR-0008)."""
     with patch.object(policy_runner.scheduler, "start"), patch.object(
         policy_runner.scheduler, "add_job"
     ):
@@ -623,7 +623,46 @@ def test_setup_passes_kwargs_to_backend(
     call_kwargs = mock_backend_class.call_args.kwargs
     assert "ingest_callback" in call_kwargs
     assert callable(call_kwargs["ingest_callback"])
-    assert call_kwargs["policy"] == sample_policy
+    assert "policy" not in call_kwargs
+
+
+@pytest.mark.parametrize(
+    "init_signature, expects_ingest_callback",
+    [
+        pytest.param(
+            "def __init__(self): self.ingest_callback = None",
+            False,
+            id="legacy-zero-arg",
+        ),
+        pytest.param(
+            "def __init__(self, **kwargs): self.ingest_callback = kwargs.get('ingest_callback')",
+            True,
+            id="kwargs-absorber",
+        ),
+        pytest.param(
+            "def __init__(self, *, ingest_callback=None, **kwargs): self.ingest_callback = ingest_callback",
+            True,
+            id="named-kwarg",
+        ),
+    ],
+)
+def test_construct_backend_introspection(init_signature, expects_ingest_callback):
+    """_construct_backend only passes ingest_callback when the class accepts it."""
+    from worker.policy.runner import _construct_backend
+
+    namespace: dict = {}
+    exec(  # noqa: S102 — synthesizing tiny class fixture under test
+        "class _Stub:\n"
+        "    " + init_signature + "\n",
+        namespace,
+    )
+    stub_class = namespace["_Stub"]
+    sentinel = object()
+    instance = _construct_backend(stub_class, ingest_callback=sentinel)
+    if expects_ingest_callback:
+        assert instance.ingest_callback is sentinel
+    else:
+        assert instance.ingest_callback is None
 
 
 def test_ingest_callback_entities_happy_path(

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -9,7 +9,7 @@ from apscheduler.triggers.date import DateTrigger
 from netboxlabs.diode.sdk.diode.v1 import ingester_pb2
 
 from worker.backend import Backend
-from worker.exceptions import IngestRejected, IngestUnavailable
+from worker.exceptions import IngestError, IngestRejected
 from worker.models import Config, DiodeConfig, Metadata, Policy, Status
 from worker.policy.run import RunStatus, RunStore
 from worker.policy.runner import PolicyRunner
@@ -118,8 +118,8 @@ def mock_backend():
 
 
 def _extract_callback(mock_backend_class):
-    """Recover the ingest_callback closure that PolicyRunner.setup passed to backend_class()."""
-    return mock_backend_class.call_args.kwargs["ingest_callback"]
+    """Recover the ingest_callback closure that PolicyRunner.setup attached to the backend."""
+    return mock_backend_class.return_value.ingest_callback
 
 
 def test_initial_status(policy_runner):
@@ -353,6 +353,16 @@ def test_run_backend_exception(
     mock_diode_client.ingest.assert_not_called()  # Client ingestion should not be called
     assert "Policy test_policy: Backend error" in caplog.text
 
+    # Regression guard: a crashing scheduled backend must still be recorded as a
+    # FAILED run — the run is created before the backend executes.
+    mock_run_store.create_run.assert_called_once()
+    failed_updates = [
+        c
+        for c in mock_run_store.update_run.call_args_list
+        if c.kwargs.get("status") == RunStatus.FAILED
+    ]
+    assert failed_updates, "backend crash must record a FAILED run"
+
 
 def test_stop_policy_runner(policy_runner):
     """Test stopping the PolicyRunner."""
@@ -551,7 +561,7 @@ def test_run_with_multiple_chunks(
         assert mock_diode_client.ingest.call_count == 2
 
         # Verify log messages for successful ingestion
-        assert "Successfully ingested 10 entities in 2 chunks" in caplog.text
+        assert "Successfully ingested 10 entities" in caplog.text
 
 
 def test_run_chunk_ingestion_error(
@@ -605,7 +615,7 @@ def test_run_chunk_ingestion_error(
 # ---------------------------------------------------------------------------
 
 
-def test_setup_passes_kwargs_to_backend(
+def test_setup_constructs_backend_directly_and_attaches_callback(
     policy_runner,
     sample_policy,
     sample_diode_config,
@@ -613,56 +623,17 @@ def test_setup_passes_kwargs_to_backend(
     mock_diode_client,
     mock_run_store,
 ):
-    """setup() constructs the backend with ingest_callback= kwarg (no policy= per ADR-0008)."""
+    """setup() constructs the backend with no args and attaches ingest_callback after deps are ready."""
     with patch.object(policy_runner.scheduler, "start"), patch.object(
         policy_runner.scheduler, "add_job"
     ):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
     mock_backend_class = mock_load_class.return_value
-    call_kwargs = mock_backend_class.call_args.kwargs
-    assert "ingest_callback" in call_kwargs
-    assert callable(call_kwargs["ingest_callback"])
-    assert "policy" not in call_kwargs
-
-
-@pytest.mark.parametrize(
-    "init_signature, expects_ingest_callback",
-    [
-        pytest.param(
-            "def __init__(self): self.ingest_callback = None",
-            False,
-            id="legacy-zero-arg",
-        ),
-        pytest.param(
-            "def __init__(self, **kwargs): self.ingest_callback = kwargs.get('ingest_callback')",
-            True,
-            id="kwargs-absorber",
-        ),
-        pytest.param(
-            "def __init__(self, *, ingest_callback=None, **kwargs): self.ingest_callback = ingest_callback",
-            True,
-            id="named-kwarg",
-        ),
-    ],
-)
-def test_construct_backend_introspection(init_signature, expects_ingest_callback):
-    """_construct_backend only passes ingest_callback when the class accepts it."""
-    from worker.policy.runner import _construct_backend
-
-    namespace: dict = {}
-    exec(  # noqa: S102 — synthesizing tiny class fixture under test
-        "class _Stub:\n"
-        "    " + init_signature + "\n",
-        namespace,
-    )
-    stub_class = namespace["_Stub"]
-    sentinel = object()
-    instance = _construct_backend(stub_class, ingest_callback=sentinel)
-    if expects_ingest_callback:
-        assert instance.ingest_callback is sentinel
-    else:
-        assert instance.ingest_callback is None
+    assert mock_backend_class.call_args.args == ()
+    assert mock_backend_class.call_args.kwargs == {}
+    backend = mock_backend_class.return_value
+    assert callable(backend.ingest_callback)
 
 
 def test_ingest_callback_entities_happy_path(
@@ -760,7 +731,7 @@ def test_ingest_callback_requires_exactly_one_of_entities_or_error(
         callback(**kwargs)
 
 
-def test_ingest_callback_translates_transport_errors_to_unavailable(
+def test_ingest_callback_translates_transport_errors_to_ingest_error(
     policy_runner,
     sample_policy,
     sample_diode_config,
@@ -768,7 +739,7 @@ def test_ingest_callback_translates_transport_errors_to_unavailable(
     mock_diode_client,
     mock_run_store,
 ):
-    """Non-IngestError transport exceptions are wrapped as IngestUnavailable."""
+    """Non-IngestError transport exceptions are wrapped as the base IngestError."""
     with patch.object(policy_runner.scheduler, "start"), patch.object(
         policy_runner.scheduler, "add_job"
     ):
@@ -784,7 +755,7 @@ def test_ingest_callback_translates_transport_errors_to_unavailable(
     with patch("worker.policy.runner.estimate_message_size", return_value=1024), patch(
         "worker.policy.runner.apply_run_id_to_entities"
     ):
-        with pytest.raises(IngestUnavailable):
+        with pytest.raises(IngestError):
             callback(entities=[entity])
 
     mock_run_store.update_run.assert_called_once()
@@ -886,33 +857,6 @@ def test_run_unaffected_by_callback(
     assert update_kwargs["status"] == RunStatus.COMPLETED
 
 
-def test_ingest_callback_raises_when_not_ready(
-    policy_runner,
-    sample_policy,
-    sample_diode_config,
-    mock_run_store,
-    mock_load_class,
-    mock_diode_client,
-):
-    """Calling the callback before _callback_ready is True raises IngestUnavailable."""
-    with patch.object(policy_runner.scheduler, "start"), patch.object(
-        policy_runner.scheduler, "add_job"
-    ):
-        policy_runner.setup("policy-x", sample_diode_config, sample_policy, mock_run_store)
-
-    callback = _extract_callback(mock_load_class.return_value)
-
-    # Simulate "called before worker finished constructing" — clear the readiness flag.
-    policy_runner._callback_ready = False
-
-    entity = MagicMock()
-    with pytest.raises(IngestUnavailable, match="before the worker finished constructing"):
-        callback(entities=[entity])
-
-    # No pseudo-run must have been created (guard fires before create_run).
-    mock_run_store.create_run.assert_not_called()
-
-
 def test_ingest_callback_records_failure_on_apply_run_id_error(
     policy_runner,
     sample_policy,
@@ -921,7 +865,7 @@ def test_ingest_callback_records_failure_on_apply_run_id_error(
     mock_diode_client,
     mock_run_store,
 ):
-    """apply_run_id_to_entities failure inside try: records FAILED run as IngestUnavailable."""
+    """apply_run_id_to_entities failure inside try: records FAILED run as IngestError."""
     with patch.object(policy_runner.scheduler, "start"), patch.object(
         policy_runner.scheduler, "add_job"
     ):
@@ -936,7 +880,7 @@ def test_ingest_callback_records_failure_on_apply_run_id_error(
         "worker.policy.runner.apply_run_id_to_entities",
         side_effect=RuntimeError("entity corrupt"),
     ), patch("worker.policy.runner.estimate_message_size", return_value=1024):
-        with pytest.raises(IngestUnavailable):
+        with pytest.raises(IngestError):
             callback(entities=[entity])
 
     mock_run_store.update_run.assert_called_once()
@@ -965,7 +909,7 @@ def test_ingest_callback_records_failure_on_iterable_error(
     bad_iterable = MagicMock()
     bad_iterable.__iter__ = MagicMock(side_effect=ValueError("bad"))
 
-    with pytest.raises(IngestUnavailable):
+    with pytest.raises(IngestError):
         callback(entities=bad_iterable)
 
     mock_run_store.update_run.assert_called_once()
@@ -973,46 +917,3 @@ def test_ingest_callback_records_failure_on_iterable_error(
     assert update_kwargs["status"] == RunStatus.FAILED
     # Iterable failed before any entity was materialised.
     assert update_kwargs["entity_count"] == 0
-
-
-def test_setup_sets_callback_ready_flag(
-    policy_runner,
-    sample_policy,
-    sample_diode_config,
-    mock_load_class,
-    mock_diode_client,
-    mock_run_store,
-):
-    """After setup() returns, _callback_ready is True."""
-    with patch.object(policy_runner.scheduler, "start"), patch.object(
-        policy_runner.scheduler, "add_job"
-    ):
-        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
-
-    assert policy_runner._callback_ready is True
-
-
-def test_stop_clears_callback_ready_flag(
-    policy_runner,
-    sample_policy,
-    sample_diode_config,
-    mock_load_class,
-    mock_diode_client,
-    mock_run_store,
-):
-    """After stop(), _callback_ready is False and the callback raises IngestUnavailable."""
-    with patch.object(policy_runner.scheduler, "start"), patch.object(
-        policy_runner.scheduler, "add_job"
-    ):
-        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
-
-    callback = _extract_callback(mock_load_class.return_value)
-
-    with patch.object(policy_runner.scheduler, "shutdown"):
-        policy_runner.stop()
-
-    assert policy_runner._callback_ready is False
-
-    entity = MagicMock()
-    with pytest.raises(IngestUnavailable, match="before the worker finished constructing"):
-        callback(entities=[entity])

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -718,8 +718,9 @@ def test_setup_legacy_backend_sets_up_the_scheduled_instance(
     scheduled_backend = mock_add_job.call_args.kwargs["args"][1]
     # The scheduled instance is the one whose setup() ran (not a throwaway).
     assert scheduled_backend.connected is True
-    # The sink was attached post-construction (legacy __init__ took no kwargs).
-    assert isinstance(scheduled_backend.ingest_sink, _PolicyRunnerIngestSink)
+    # No sink: API-triggered sync requires the modern describe() contract, so a
+    # legacy backend gets scheduled runs only.
+    assert getattr(scheduled_backend, "ingest_sink", None) is None
 
 
 def test_ingest_sink_ingest_happy_path(

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -266,6 +266,24 @@ def test_run_success(
     assert len(call_args) == 3
 
 
+def test_run_with_empty_delta_is_noop_completed(
+    policy_runner, sample_policy, mock_diode_client, mock_backend, mock_run_store
+):
+    """A run producing zero entities (empty delta) records a COMPLETED no-op, no ingest call."""
+    policy_runner.name = "test_policy"
+    policy_runner.run_store = mock_run_store
+
+    mock_backend.run.return_value = []
+
+    policy_runner.run(mock_diode_client, mock_backend, sample_policy)
+
+    mock_diode_client.ingest.assert_not_called()
+    mock_run_store.update_run.assert_called_once()
+    update_kwargs = mock_run_store.update_run.call_args.kwargs
+    assert update_kwargs["status"] == RunStatus.COMPLETED
+    assert update_kwargs["entity_count"] == 0
+
+
 def test_run_legacy_backend_without_kwargs_gets_bare_call(
     policy_runner,
     sample_policy,
@@ -755,6 +773,33 @@ def test_ingest_callback_entities_happy_path(
     mock_run_store.update_run.assert_called_once()
     update_kwargs = mock_run_store.update_run.call_args.kwargs
     assert update_kwargs["status"] == RunStatus.COMPLETED
+
+
+def test_ingest_callback_empty_entities_is_noop_completed(
+    policy_runner,
+    sample_policy,
+    sample_diode_config,
+    mock_load_class,
+    mock_diode_client,
+    mock_run_store,
+):
+    """Callback with an empty entity list records a COMPLETED no-op run, no ingest call."""
+    with patch.object(policy_runner.scheduler, "start"), patch.object(
+        policy_runner.scheduler, "add_job"
+    ):
+        policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
+
+    callback = _extract_callback(mock_load_class.return_value)
+    client_instance = mock_diode_client.return_value
+
+    result = callback(entities=[])
+
+    assert result is None
+    client_instance.ingest.assert_not_called()
+    mock_run_store.update_run.assert_called_once()
+    update_kwargs = mock_run_store.update_run.call_args.kwargs
+    assert update_kwargs["status"] == RunStatus.COMPLETED
+    assert update_kwargs["entity_count"] == 0
 
 
 def test_ingest_callback_error_path(

--- a/worker/tests/policy/test_runner.py
+++ b/worker/tests/policy/test_runner.py
@@ -8,6 +8,7 @@ import grpc
 import pytest
 from apscheduler.triggers.date import DateTrigger
 from netboxlabs.diode.sdk.diode.v1 import ingester_pb2
+from netboxlabs.diode.sdk.exceptions import DiodeClientError, OTLPClientError
 
 from worker.backend import Backend
 from worker.exceptions import IngestError, IngestRejected, IngestUnavailable
@@ -854,7 +855,33 @@ class _FakeRpcError(grpc.RpcError):
     def code(self) -> grpc.StatusCode:
         return self._code
 
+    def details(self) -> str:
+        return "fake rpc error"
 
+
+def _raw_rpc_error(code):
+    """A bare grpc.RpcError (status via code()) — defensive / non-SDK path."""
+    return _FakeRpcError(code)
+
+
+def _diode_client_error(code):
+    """What the credentialed DiodeClient.ingest actually raises (status via .status_code)."""
+    return DiodeClientError(_FakeRpcError(code))
+
+
+def _otlp_client_error(code):
+    """What DiodeOTLPClient.ingest actually raises (not a grpc.RpcError subclass)."""
+    return OTLPClientError(_FakeRpcError(code))
+
+
+@pytest.mark.parametrize(
+    "make_error",
+    [
+        pytest.param(_raw_rpc_error, id="raw-rpc"),
+        pytest.param(_diode_client_error, id="diode-client-error"),
+        pytest.param(_otlp_client_error, id="otlp-client-error"),
+    ],
+)
 @pytest.mark.parametrize(
     "code, is_transient",
     [
@@ -865,6 +892,7 @@ class _FakeRpcError(grpc.RpcError):
     ],
 )
 def test_ingest_sink_maps_grpc_status_codes(
+    make_error,
     code,
     is_transient,
     policy_runner,
@@ -874,14 +902,20 @@ def test_ingest_sink_maps_grpc_status_codes(
     mock_diode_client,
     mock_run_store,
 ):
-    """Transient gRPC codes raise IngestUnavailable; other gRPC errors raise the base IngestError."""
+    """
+    Transient gRPC codes raise IngestUnavailable; others raise base IngestError.
+
+    Covers the real SDK wrappers (DiodeClientError / OTLPClientError) the
+    production clients raise — not just a bare grpc.RpcError — since the wrappers
+    carry the status on .status_code rather than code().
+    """
     with patch.object(policy_runner.scheduler, "start"), patch.object(
         policy_runner.scheduler, "add_job"
     ):
         policy_runner.setup("policy1", sample_diode_config, sample_policy, mock_run_store)
 
     sink = _extract_sink(mock_load_class.return_value)
-    mock_diode_client.return_value.ingest.side_effect = _FakeRpcError(code)
+    mock_diode_client.return_value.ingest.side_effect = make_error(code)
 
     entity = ingester_pb2.Entity()
     entity.device.name = "dev1"

--- a/worker/tests/test_backend.py
+++ b/worker/tests/test_backend.py
@@ -94,21 +94,29 @@ def test_backend_init_default_no_args():
     """Zero-arg construction still works (back-compat with older worker)."""
     b = Backend()
     assert b.ingest_callback is None
-    assert b.policy is None
 
 
-def test_backend_init_stores_kwargs():
-    """ingest_callback and policy are stored on the instance."""
+def test_backend_init_stores_ingest_callback():
+    """ingest_callback is stored on the instance."""
 
     def cb(**_):
         return None
 
-    pol = MagicMock(spec=Policy)
-    b = Backend(ingest_callback=cb, policy=pol)
+    b = Backend(ingest_callback=cb)
     assert b.ingest_callback is cb
-    assert b.policy is pol
 
 
 def test_backend_init_absorbs_unknown_kwargs():
     """Forward-compat: unknown kwargs don't raise."""
     Backend(unknown_future_resource="x", another_one=42)  # must not raise
+
+
+def test_backend_run_accepts_kwargs():
+    """run() signature absorbs **kwargs (passive forward-compat door)."""
+    b = Backend()
+    # The base implementation raises NotImplementedError; the point is
+    # that calling with kwargs reaches the body without a TypeError.
+    try:
+        b.run("policy", MagicMock(spec=Policy), future_kwarg="x")
+    except NotImplementedError:
+        pass

--- a/worker/tests/test_backend.py
+++ b/worker/tests/test_backend.py
@@ -2,12 +2,13 @@
 # Copyright 2025 NetBox Labs Inc
 """NetBox Labs - Backend Unit Tests."""
 
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from worker.backend import Backend, load_class
-from worker.models import Policy
+from worker.models import Metadata, Policy
 
 
 @pytest.fixture
@@ -128,3 +129,32 @@ def test_backend_run_accepts_kwargs():
         b.run("policy", MagicMock(spec=Policy), future_kwarg="x")
     except NotImplementedError:
         pass
+
+
+def test_subclass_overriding_setup_without_describe_warns_deprecated():
+    """Defining a setup()-only subclass emits a DeprecationWarning at class creation."""
+    with pytest.warns(DeprecationWarning, match="implement the describe"):
+
+        class LegacySetupBackend(Backend):
+            def setup(self) -> Metadata:
+                return Metadata(name="legacy", app_name="legacy", app_version="0.0.0")
+
+
+def test_subclass_with_describe_defines_without_warning():
+    """A describe()-implementing subclass is clean, even if it also keeps setup()."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+
+        class ModernBackend(Backend):
+            @classmethod
+            def describe(cls) -> Metadata:
+                return Metadata(name="modern", app_name="modern", app_version="0.0.0")
+
+            def setup(self) -> Metadata:
+                return self.describe()
+
+
+def test_base_setup_call_emits_runtime_deprecation():
+    """Calling the base setup() directly warns (PEP 702 runtime) and still raises."""
+    with pytest.warns(DeprecationWarning), pytest.raises(NotImplementedError):
+        Backend().setup()

--- a/worker/tests/test_backend.py
+++ b/worker/tests/test_backend.py
@@ -102,17 +102,22 @@ def test_load_class_attribute_error(mock_import_module):
 def test_backend_init_default_no_args():
     """Zero-arg construction still works (back-compat with older worker)."""
     b = Backend()
-    assert b.ingest_callback is None
+    assert b.ingest_sink is None
 
 
-def test_backend_init_stores_ingest_callback():
-    """ingest_callback is stored on the instance."""
+def test_backend_init_stores_ingest_sink():
+    """ingest_sink is stored on the instance."""
 
-    def cb(**_):
-        return None
+    class _Sink:
+        def ingest(self, entities, **kwargs):
+            return None
 
-    b = Backend(ingest_callback=cb)
-    assert b.ingest_callback is cb
+        def record_failure(self, error, **kwargs):
+            return None
+
+    sink = _Sink()
+    b = Backend(ingest_sink=sink)
+    assert b.ingest_sink is sink
 
 
 def test_backend_init_absorbs_unknown_kwargs():
@@ -158,3 +163,12 @@ def test_base_setup_call_emits_runtime_deprecation():
     """Calling the base setup() directly warns (PEP 702 runtime) and still raises."""
     with pytest.warns(DeprecationWarning), pytest.raises(NotImplementedError):
         Backend().setup()
+
+
+def test_subclass_with_describe_missing_classmethod_warns():
+    """A describe() defined without @classmethod is flagged at class creation (does not crash)."""
+    with pytest.warns(RuntimeWarning, match="not as a @classmethod"):
+
+        class BadDescribeBackend(Backend):
+            def describe(self) -> Metadata:  # forgot @classmethod
+                return Metadata(name="bad", app_name="bad", app_version="0.0.0")

--- a/worker/tests/test_backend.py
+++ b/worker/tests/test_backend.py
@@ -88,3 +88,27 @@ def test_load_class_attribute_error(mock_import_module):
         match=f"Failed to load a class inheriting from 'Backend' in module '{mock_module_name}': Attribute error",
     ):
         load_class(mock_module_name)
+
+
+def test_backend_init_default_no_args():
+    """Zero-arg construction still works (back-compat with older worker)."""
+    b = Backend()
+    assert b.ingest_callback is None
+    assert b.policy is None
+
+
+def test_backend_init_stores_kwargs():
+    """ingest_callback and policy are stored on the instance."""
+
+    def cb(**_):
+        return None
+
+    pol = MagicMock(spec=Policy)
+    b = Backend(ingest_callback=cb, policy=pol)
+    assert b.ingest_callback is cb
+    assert b.policy is pol
+
+
+def test_backend_init_absorbs_unknown_kwargs():
+    """Forward-compat: unknown kwargs don't raise."""
+    Backend(unknown_future_resource="x", another_one=42)  # must not raise

--- a/worker/tests/test_backend.py
+++ b/worker/tests/test_backend.py
@@ -17,6 +17,14 @@ def mock_import_module():
         yield mock_import
 
 
+def test_backend_describe_not_implemented():
+    """Test that Backend.describe raises NotImplementedError."""
+    with pytest.raises(
+        NotImplementedError, match="The 'describe' classmethod must be implemented."
+    ):
+        Backend.describe()
+
+
 def test_backend_setup_not_implemented():
     """Test that Backend.setup raises NotImplementedError."""
     backend = Backend()

--- a/worker/tests/test_exceptions.py
+++ b/worker/tests/test_exceptions.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""NetBox Labs - worker.exceptions hierarchy tests."""
+
+import pytest
+
+from worker.exceptions import IngestError, IngestRejected, IngestUnavailable
+
+
+def test_unavailable_is_ingest_error():
+    """IngestUnavailable is a subclass of IngestError."""
+    assert issubclass(IngestUnavailable, IngestError)
+
+
+def test_rejected_is_ingest_error():
+    """IngestRejected is a subclass of IngestError."""
+    assert issubclass(IngestRejected, IngestError)
+
+
+def test_ingest_error_chain_catchable_as_base():
+    """Subclasses can be caught as the base IngestError."""
+    with pytest.raises(IngestError):
+        raise IngestUnavailable("transient")
+    with pytest.raises(IngestError):
+        raise IngestRejected("bad payload")
+
+
+@pytest.mark.parametrize(
+    "exc_cls,msg",
+    [
+        pytest.param(IngestError, "base", id="base"),
+        pytest.param(IngestUnavailable, "transient", id="unavailable"),
+        pytest.param(IngestRejected, "permanent", id="rejected"),
+    ],
+)
+def test_exceptions_carry_message(exc_cls, msg):
+    """Each exception carries its constructor message via str()."""
+    exc = exc_cls(msg)
+    assert str(exc) == msg

--- a/worker/tests/test_legacy_package.py
+++ b/worker/tests/test_legacy_package.py
@@ -19,7 +19,7 @@ import pytest
 from worker.backend import _implements_describe, load_class
 from worker.models import Config, DiodeConfig, Policy
 from worker.policy.run import RunStore
-from worker.policy.runner import PolicyRunner, _PolicyRunnerIngestSink
+from worker.policy.runner import PolicyRunner
 
 _LEGACY_PKG_DIR = pathlib.Path(__file__).resolve().parent / "nbl-custom-legacy"
 
@@ -78,5 +78,6 @@ def test_policy_runner_sets_up_and_schedules_real_legacy_backend(
     assert scheduled_backend.__class__.__name__ == "LegacyMockBackend"
     # setup() ran on the scheduled instance (its state is live).
     assert scheduled_backend.app_started is True
-    # The sink was attached post-construction (legacy __init__ took no kwargs).
-    assert isinstance(scheduled_backend.ingest_sink, _PolicyRunnerIngestSink)
+    # No sink: API-triggered sync requires the modern describe() contract, so a
+    # legacy backend gets scheduled runs only.
+    assert getattr(scheduled_backend, "ingest_sink", None) is None

--- a/worker/tests/test_legacy_package.py
+++ b/worker/tests/test_legacy_package.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+# Copyright 2025 NetBox Labs Inc
+"""
+End-to-end check that a real legacy (setup-only) package still works.
+
+Unlike test_runner.py — which patches load_class with an in-test class — this
+loads the nbl-custom-legacy sample package through the genuine
+``worker.backend.load_class`` import machinery and drives it through
+``PolicyRunner.setup()``, exercising the deprecated fallback path the way a real
+legacy integration would hit it.
+"""
+
+import pathlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from worker.backend import _implements_describe, load_class
+from worker.models import Config, DiodeConfig, Policy
+from worker.policy.run import RunStore
+from worker.policy.runner import PolicyRunner, _PolicyRunnerIngestSink
+
+_LEGACY_PKG_DIR = pathlib.Path(__file__).resolve().parent / "nbl-custom-legacy"
+
+
+@pytest.fixture
+def legacy_package_on_path():
+    """Make the nbl_custom_legacy sample package importable, then clean up."""
+    sys.path.insert(0, str(_LEGACY_PKG_DIR))
+    try:
+        yield
+    finally:
+        if str(_LEGACY_PKG_DIR) in sys.path:
+            sys.path.remove(str(_LEGACY_PKG_DIR))
+        sys.modules.pop("nbl_custom_legacy", None)
+        sys.modules.pop("nbl_custom_legacy.impl", None)
+
+
+def test_legacy_package_loads_via_real_load_class(legacy_package_on_path):
+    """load_class resolves the legacy backend, and it is detected as not implementing describe()."""
+    with pytest.warns(DeprecationWarning, match="deprecated"):
+        backend_class = load_class("nbl_custom_legacy")
+
+    assert backend_class.__name__ == "LegacyMockBackend"
+    assert _implements_describe(backend_class) is False
+
+
+def test_policy_runner_sets_up_and_schedules_real_legacy_backend(
+    legacy_package_on_path, caplog
+):
+    """
+    PolicyRunner.setup() drives the legacy package through the fallback path.
+
+    The instance whose setup() ran is the one scheduled (state is live), it was
+    constructed bare despite its custom no-kwargs __init__, and the ingest sink
+    is attached afterwards.
+    """
+    runner = PolicyRunner()
+    dry_run_config = DiodeConfig(
+        target="",
+        prefix="test",
+        dry_run=True,
+        dry_run_output_dir="/tmp/dry_run_legacy",
+    )
+    policy = Policy(config=Config(package="nbl_custom_legacy"), scope={})
+    run_store = MagicMock(spec=RunStore)
+
+    with patch.object(runner.scheduler, "start"), patch.object(
+        runner.scheduler, "add_job"
+    ) as mock_add_job, caplog.at_level("WARNING"):
+        runner.setup("legacy-policy", dry_run_config, policy, run_store)
+
+    assert "deprecated setup() fallback" in caplog.text
+    assert runner.metadata.name == "legacy_mock"
+
+    scheduled_backend = mock_add_job.call_args.kwargs["args"][1]
+    assert scheduled_backend.__class__.__name__ == "LegacyMockBackend"
+    # setup() ran on the scheduled instance (its state is live).
+    assert scheduled_backend.app_started is True
+    # The sink was attached post-construction (legacy __init__ took no kwargs).
+    assert isinstance(scheduled_backend.ingest_sink, _PolicyRunnerIngestSink)

--- a/worker/tests/test_legacy_package.py
+++ b/worker/tests/test_legacy_package.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2025 NetBox Labs Inc
+# Copyright 2026 NetBox Labs Inc
 """
 End-to-end check that a real legacy (setup-only) package still works.
 

--- a/worker/worker/backend.py
+++ b/worker/worker/backend.py
@@ -4,9 +4,11 @@
 
 import importlib
 import inspect
+import warnings
 from collections.abc import Iterable
 
 from netboxlabs.diode.sdk.ingester import Entity
+from typing_extensions import deprecated
 
 from worker.models import Metadata, Policy
 
@@ -42,6 +44,22 @@ class Backend:
         """
         self.ingest_callback = ingest_callback
 
+    def __init_subclass__(cls, **kwargs) -> None:
+        """Warn once, at class-definition time, when a subclass still relies on setup()."""
+        super().__init_subclass__(**kwargs)
+        overrides_setup = any(
+            "setup" in klass.__dict__ for klass in cls.__mro__[:-1] if klass is not Backend
+        )
+        has_describe = cls.describe.__func__ is not Backend.describe.__func__
+        if overrides_setup and not has_describe:
+            warnings.warn(
+                f"{cls.__module__}.{cls.__qualname__} overrides Backend.setup(), which is "
+                "deprecated — implement the describe() classmethod instead "
+                "(the setup() fallback will be removed in worker v2.0).",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
     @classmethod
     def describe(cls) -> Metadata:
         """
@@ -55,9 +73,19 @@ class Backend:
         """
         raise NotImplementedError("The 'describe' classmethod must be implemented.")
 
+    @deprecated(
+        "Implement the describe() classmethod instead; "
+        "the setup() fallback will be removed in worker v2.0."
+    )
     def setup(self) -> Metadata:
         """
         Set up the backend.
+
+        .. deprecated::
+            Implement the :meth:`describe` classmethod instead. The worker reads
+            metadata via ``describe()`` and only falls back to a throwaway
+            instance's ``setup()`` for legacy backends; that fallback is
+            scheduled for removal in worker v2.0.
 
         Returns
         -------

--- a/worker/worker/backend.py
+++ b/worker/worker/backend.py
@@ -107,12 +107,14 @@ class Backend:
         ----
             policy_name (str): The name of the policy.
             policy (Policy): The policy to run.
-            **kwargs: Passive forward-compat door. The worker passes nothing
-                through it in v1; future minor releases may add per-tick
-                context (e.g. ``source="scheduled"|"trigger"``, ``run_id``).
-                Concrete backends are encouraged to declare ``**kwargs`` so
-                additive kwargs ride into the contract without a coordinated
-                upgrade.
+            **kwargs: Per-tick context from the worker. When the overriding
+                signature declares ``**kwargs``, the worker passes
+                ``source="scheduled"`` and ``run_id`` (the worker-side run
+                identifier, also stamped on the produced entities' metadata).
+                Legacy signatures without ``**kwargs`` keep working — the
+                worker detects them and falls back to the bare two-argument
+                call — but declare ``**kwargs`` so future additive context
+                rides into the contract without a coordinated upgrade.
 
         Returns:
         -------

--- a/worker/worker/backend.py
+++ b/worker/worker/backend.py
@@ -14,6 +14,38 @@ from worker.models import Metadata, Policy
 class Backend:
     """Backend Class."""
 
+    def __init__(
+        self,
+        *,
+        ingest_callback=None,
+        policy: Policy | None = None,
+        **kwargs,
+    ) -> None:
+        """
+        Construct the Backend.
+
+        Worker passes ``ingest_callback`` and ``policy`` at construction
+        starting with the minor release this docstring ships in. Older
+        worker versions construct ``Backend()`` with zero args; integrations
+        that override ``__init__`` should accept ``**kwargs`` so both paths
+        keep working.
+
+        Args:
+        ----
+            ingest_callback: Optional callable that ingests entities or
+                reports errors outside of the ``run()`` cycle. See
+                ``worker.exceptions`` for the exception hierarchy it may
+                raise.
+            policy: Optional construction-time policy. If supplied, the
+                integration may use credentials / scope without waiting for
+                the first scheduled ``run()``.
+            **kwargs: Forward-compat door for additional resources worker
+                may pass in future versions; silently ignored by default.
+
+        """
+        self.ingest_callback = ingest_callback
+        self.policy = policy
+
     def setup(self) -> Metadata:
         """
         Set up the backend.

--- a/worker/worker/backend.py
+++ b/worker/worker/backend.py
@@ -18,17 +18,15 @@ class Backend:
         self,
         *,
         ingest_callback=None,
-        policy: Policy | None = None,
         **kwargs,
     ) -> None:
         """
         Construct the Backend.
 
-        Worker passes ``ingest_callback`` and ``policy`` at construction
-        starting with the minor release this docstring ships in. Older
-        worker versions construct ``Backend()`` with zero args; integrations
-        that override ``__init__`` should accept ``**kwargs`` so both paths
-        keep working.
+        Worker passes ``ingest_callback`` at construction starting with the
+        minor release this docstring ships in. Older worker versions
+        construct ``Backend()`` with zero args; integrations that override
+        ``__init__`` should accept ``**kwargs`` so both paths keep working.
 
         Args:
         ----
@@ -40,15 +38,11 @@ class Backend:
                 earlier raises ``IngestUnavailable``.** See
                 ``worker.exceptions`` for the exception hierarchy it may
                 raise.
-            policy: Optional construction-time policy. If supplied, the
-                integration may use credentials / scope without waiting for
-                the first scheduled ``run()``.
             **kwargs: Forward-compat door for additional resources worker
                 may pass in future versions; silently ignored by default.
 
         """
         self.ingest_callback = ingest_callback
-        self.policy = policy
 
     def setup(self) -> Metadata:
         """
@@ -61,7 +55,12 @@ class Backend:
         """
         raise NotImplementedError("The 'setup' method must be implemented.")
 
-    def run(self, policy_name: str, policy: Policy) -> Iterable[Entity]:
+    def run(
+        self,
+        policy_name: str,
+        policy: Policy,
+        **kwargs,
+    ) -> Iterable[Entity]:
         """
         Run the backend.
 
@@ -69,10 +68,16 @@ class Backend:
         ----
             policy_name (str): The name of the policy.
             policy (Policy): The policy to run.
+            **kwargs: Passive forward-compat door. The worker passes nothing
+                through it in v1; future minor releases may add per-tick
+                context (e.g. ``source="scheduled"|"trigger"``, ``run_id``).
+                Concrete backends are encouraged to declare ``**kwargs`` so
+                additive kwargs ride into the contract without a coordinated
+                upgrade.
 
         Returns:
         -------
-            Iterable[Entity]: The entities produced by the backend
+            Iterable[Entity]: The entities produced by the backend.
 
         """
         raise NotImplementedError("The 'run' method must be implemented.")

--- a/worker/worker/backend.py
+++ b/worker/worker/backend.py
@@ -34,8 +34,7 @@ class Backend:
                 reports errors outside of the ``run()`` cycle. **Do not
                 invoke from ``__init__`` or ``setup()`` — the callback is
                 only usable starting after the worker finishes constructing
-                the Backend (i.e. after ``setup()`` returns); calling it
-                earlier raises ``IngestUnavailable``.** See
+                the Backend (i.e. after ``setup()`` returns).** See
                 ``worker.exceptions`` for the exception hierarchy it may
                 raise.
             **kwargs: Forward-compat door for additional resources worker

--- a/worker/worker/backend.py
+++ b/worker/worker/backend.py
@@ -44,6 +44,19 @@ class Backend:
         """
         self.ingest_callback = ingest_callback
 
+    @classmethod
+    def describe(cls) -> Metadata:
+        """
+        Return the backend's metadata without constructing an instance.
+
+        Preferred over setup(): lets the worker read the backend's identity
+        (name/app_name/app_version) before constructing it, so the ingest
+        callback can be built and passed at construction time. Integrations
+        that only implement the instance setup() are still supported — the
+        worker falls back to a throwaway instance to read their metadata.
+        """
+        raise NotImplementedError("The 'describe' classmethod must be implemented.")
+
     def setup(self) -> Metadata:
         """
         Set up the backend.

--- a/worker/worker/backend.py
+++ b/worker/worker/backend.py
@@ -107,14 +107,12 @@ class Backend:
         ----
             policy_name (str): The name of the policy.
             policy (Policy): The policy to run.
-            **kwargs: Per-tick context from the worker. When the overriding
-                signature declares ``**kwargs``, the worker passes
-                ``source="scheduled"`` and ``run_id`` (the worker-side run
-                identifier, also stamped on the produced entities' metadata).
-                Legacy signatures without ``**kwargs`` keep working — the
-                worker detects them and falls back to the bare two-argument
-                call — but declare ``**kwargs`` so future additive context
-                rides into the contract without a coordinated upgrade.
+            **kwargs: Passive forward-compat door. The worker passes nothing
+                through it in v1; future minor releases may add per-tick
+                context (e.g. ``source="scheduled"|"trigger"``, ``run_id``).
+                Concrete backends are encouraged to declare ``**kwargs`` so
+                additive kwargs ride into the contract without a coordinated
+                upgrade.
 
         Returns:
         -------

--- a/worker/worker/backend.py
+++ b/worker/worker/backend.py
@@ -6,11 +6,44 @@ import importlib
 import inspect
 import warnings
 from collections.abc import Iterable
+from typing import Protocol, runtime_checkable
 
 from netboxlabs.diode.sdk.ingester import Entity
 from typing_extensions import deprecated
 
 from worker.models import Metadata, Policy
+
+
+@runtime_checkable
+class IngestSink(Protocol):
+    """
+    How a backend hands run outcomes to the worker outside the scheduled run() cycle.
+
+    The worker passes an implementation to ``Backend.__init__``; an integration
+    that ships entities outside ``run()`` (e.g. an HTTP-triggered sync) calls
+    these methods. See ``worker.exceptions`` for the failure hierarchy.
+    """
+
+    def ingest(self, entities: Iterable[Entity], **kwargs) -> None:
+        """
+        Ingest ``entities`` as one worker-tracked run.
+
+        Creates a run, chunks and sends the entities to Diode, and records the
+        run COMPLETED. An empty iterable is a valid no-op (recorded COMPLETED,
+        nothing sent). Raises ``IngestRejected`` (permanent) or ``IngestError``
+        (other failures); the run is recorded FAILED before the exception
+        propagates. ``**kwargs`` is a forward-compat door (e.g. a future
+        ``run_id``).
+        """
+        ...
+
+    def record_failure(self, error: Exception, **kwargs) -> None:
+        """
+        Record a FAILED run for a collection that produced no entities.
+
+        Never raises. ``**kwargs`` is a forward-compat door.
+        """
+        ...
 
 
 class Backend:
@@ -19,39 +52,48 @@ class Backend:
     def __init__(
         self,
         *,
-        ingest_callback=None,
+        ingest_sink: "IngestSink | None" = None,
         **kwargs,
     ) -> None:
         """
         Construct the Backend.
 
-        The worker reads the backend's metadata first (via the ``describe()``
-        classmethod, or a throwaway legacy ``setup()`` instance that receives
-        no callback), then constructs the instance it will run with
-        ``ingest_callback`` passed here. Every dependency the callback uses
-        is ready by that point, so the callback is usable as soon as the
-        instance exists — just do not invoke it from ``__init__`` itself.
-
         Args:
         ----
-            ingest_callback: Optional callable that ingests entities or
-                reports errors outside of the ``run()`` cycle. See
-                ``worker.exceptions`` for the exception hierarchy it may
-                raise.
-            **kwargs: Forward-compat door for additional resources worker
-                may pass in future versions; silently ignored by default.
+            ingest_sink: Optional :class:`IngestSink` the worker supplies so the
+                backend can ingest entities or record failures outside the
+                scheduled ``run()`` cycle. ``None`` when the worker predates
+                this contract. Usable once policy setup completes — do not call
+                it from ``__init__``.
+            **kwargs: Forward-compat door for resources future worker versions
+                may pass; ignored by default.
 
         """
-        self.ingest_callback = ingest_callback
+        self.ingest_sink = ingest_sink
 
     def __init_subclass__(cls, **kwargs) -> None:
-        """Warn once, at class-definition time, when a subclass still relies on setup()."""
+        """At class-definition time, flag deprecated setup() use and a non-classmethod describe()."""
         super().__init_subclass__(**kwargs)
+        describe_member = next(
+            (
+                klass.__dict__["describe"]
+                for klass in cls.__mro__[:-1]
+                if klass is not Backend and "describe" in klass.__dict__
+            ),
+            None,
+        )
+        if describe_member is not None and not isinstance(describe_member, classmethod):
+            warnings.warn(
+                f"{cls.__module__}.{cls.__qualname__} defines describe() but not as a "
+                "@classmethod; the worker reads metadata via the describe() classmethod, "
+                "so add @classmethod.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
         overrides_setup = any(
             "setup" in klass.__dict__ for klass in cls.__mro__[:-1] if klass is not Backend
         )
-        has_describe = cls.describe.__func__ is not Backend.describe.__func__
-        if overrides_setup and not has_describe:
+        if overrides_setup and not _implements_describe(cls):
             warnings.warn(
                 f"{cls.__module__}.{cls.__qualname__} overrides Backend.setup(), which is "
                 "deprecated — implement the describe() classmethod instead "
@@ -120,6 +162,25 @@ class Backend:
 
         """
         raise NotImplementedError("The 'run' method must be implemented.")
+
+
+def _implements_describe(cls: type) -> bool:
+    """
+    Return True if ``cls`` overrides ``Backend.describe`` with a classmethod.
+
+    Walks the MRO statically — it never *calls* describe(), so a describe() that
+    raises ``NotImplementedError`` internally is not misread as "not
+    implemented", and a describe() defined without ``@classmethod`` is reported
+    as not-implemented (and separately warned about) rather than crashing
+    attribute access.
+    """
+    for klass in cls.__mro__:
+        if klass is Backend:
+            return False
+        member = klass.__dict__.get("describe")
+        if member is not None:
+            return isinstance(member, classmethod)
+    return False
 
 
 def load_class(module_name: str) -> type[Backend]:

--- a/worker/worker/backend.py
+++ b/worker/worker/backend.py
@@ -23,19 +23,17 @@ class Backend:
         """
         Construct the Backend.
 
-        The worker constructs the Backend with no arguments and assigns
-        ``ingest_callback`` afterwards, once its dependencies are ready — so
-        ``__init__`` does not receive it from the current worker. The
-        parameter and ``**kwargs`` stay accepted for forward-compatibility
-        and for integrations that pass them directly.
+        The worker reads the backend's metadata first (via the ``describe()``
+        classmethod, or a throwaway legacy ``setup()`` instance that receives
+        no callback), then constructs the instance it will run with
+        ``ingest_callback`` passed here. Every dependency the callback uses
+        is ready by that point, so the callback is usable as soon as the
+        instance exists — just do not invoke it from ``__init__`` itself.
 
         Args:
         ----
             ingest_callback: Optional callable that ingests entities or
-                reports errors outside of the ``run()`` cycle. **Do not
-                invoke from ``__init__`` or ``setup()`` — the callback is
-                only usable starting after the worker finishes constructing
-                the Backend (i.e. after ``setup()`` returns).** See
+                reports errors outside of the ``run()`` cycle. See
                 ``worker.exceptions`` for the exception hierarchy it may
                 raise.
             **kwargs: Forward-compat door for additional resources worker

--- a/worker/worker/backend.py
+++ b/worker/worker/backend.py
@@ -23,10 +23,11 @@ class Backend:
         """
         Construct the Backend.
 
-        Worker passes ``ingest_callback`` at construction starting with the
-        minor release this docstring ships in. Older worker versions
-        construct ``Backend()`` with zero args; integrations that override
-        ``__init__`` should accept ``**kwargs`` so both paths keep working.
+        The worker constructs the Backend with no arguments and assigns
+        ``ingest_callback`` afterwards, once its dependencies are ready — so
+        ``__init__`` does not receive it from the current worker. The
+        parameter and ``**kwargs`` stay accepted for forward-compatibility
+        and for integrations that pass them directly.
 
         Args:
         ----

--- a/worker/worker/backend.py
+++ b/worker/worker/backend.py
@@ -33,7 +33,11 @@ class Backend:
         Args:
         ----
             ingest_callback: Optional callable that ingests entities or
-                reports errors outside of the ``run()`` cycle. See
+                reports errors outside of the ``run()`` cycle. **Do not
+                invoke from ``__init__`` or ``setup()`` — the callback is
+                only usable starting after the worker finishes constructing
+                the Backend (i.e. after ``setup()`` returns); calling it
+                earlier raises ``IngestUnavailable``.** See
                 ``worker.exceptions`` for the exception hierarchy it may
                 raise.
             policy: Optional construction-time policy. If supplied, the

--- a/worker/worker/exceptions.py
+++ b/worker/worker/exceptions.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# Copyright 2026 NetBox Labs Inc
+"""Exception hierarchy raised by the worker ingest callback."""
+
+
+class IngestError(Exception):
+    """
+    Base for pipeline-side ingestion failures.
+
+    Integrations should catch this when they want uniform handling. New
+    subclasses are added under this base in future minor releases.
+    """
+
+
+class IngestUnavailable(IngestError):
+    """
+    Transient pipeline failure — Diode unreachable, queue full, rate-limited.
+
+    Retry-friendly. The integration MAY retry with backoff.
+    """
+
+
+class IngestRejected(IngestError):
+    """
+    Permanent pipeline rejection for this call.
+
+    Reasons include bad payload, instance retired, or policy removed.
+    The integration should NOT retry; the call will fail again.
+    """

--- a/worker/worker/exceptions.py
+++ b/worker/worker/exceptions.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 # Copyright 2026 NetBox Labs Inc
-"""Exception hierarchy raised by the worker ingest callback."""
+"""
+Exception hierarchy raised by worker ingestion.
+
+Covers both the scheduled run() path (via PolicyRunner._send_entities)
+and the ingest callback.
+"""
 
 
 class IngestError(Exception):

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -4,8 +4,8 @@
 
 import logging
 import time
+from dataclasses import dataclass
 from datetime import datetime, timedelta
-from typing import NamedTuple
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -28,7 +28,8 @@ from worker.policy.run import RunStatus, RunStore
 logger = logging.getLogger(__name__)
 
 
-class _RunOutcome(NamedTuple):
+@dataclass
+class _RunOutcome:
     """What _execute_run reports back to its caller."""
 
     entity_count: int

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -14,7 +14,6 @@ from netboxlabs.diode.sdk import (
     DiodeDryRunClient,
     DiodeOTLPClient,
     create_message_chunks,
-    estimate_message_size,
 )
 
 from worker.backend import Backend, load_class
@@ -24,10 +23,6 @@ from worker.metrics import get_metric
 from worker.models import DiodeConfig, Metadata, Policy, Status
 from worker.package_finder import maybe_evict
 from worker.policy.run import RunStatus, RunStore
-
-# Diode message-size cap (per chunk). Stays in sync with the reconciler's
-# 4 MiB gRPC ceiling minus a safety margin.
-MAX_INGEST_MESSAGE_BYTES = 3 * 1024 * 1024
 
 logger = logging.getLogger(__name__)
 
@@ -258,22 +253,20 @@ class PolicyRunner:
 
     def _send_entities(self, client, entities_list: list, metadata: dict) -> int:
         """
-        Send entities to the Diode client, chunking if the payload exceeds MAX_INGEST_MESSAGE_BYTES.
+        Send entities to the Diode client.
+
+        Delegates chunking to the SDK's ``create_message_chunks``, which owns
+        the gRPC message-size threshold (3 MB default, a safe margin below the
+        4 MB ceiling) and returns a single chunk when the payload already fits.
 
         Returns the number of chunks actually sent (1 if not chunked).
         """
-        size_bytes = estimate_message_size(entities_list)
-        if size_bytes > MAX_INGEST_MESSAGE_BYTES:
-            chunks = create_message_chunks(entities_list)
-            for chunk in chunks:
-                response = client.ingest(entities=chunk, metadata=metadata)
-                if response.errors:
-                    raise IngestRejected(f"Chunk ingestion failed: {response.errors}")
-            return len(chunks)
-        response = client.ingest(entities=entities_list, metadata=metadata)
-        if response.errors:
-            raise IngestRejected(f"Entities ingestion failed: {response.errors}")
-        return 1
+        chunks = create_message_chunks(entities_list)
+        for chunk in chunks:
+            response = client.ingest(entities=chunk, metadata=metadata)
+            if response.errors:
+                raise IngestRejected(f"Chunk ingestion failed: {response.errors}")
+        return len(chunks)
 
     def run(
         self,

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -147,6 +147,12 @@ class PolicyRunner:
         except NotImplementedError:
             # Legacy backend: construct a throwaway just to read its metadata. The
             # real, callback-bearing instance is constructed below.
+            logger.warning(
+                "%s does not implement describe(); reading metadata via the "
+                "deprecated setup() fallback (scheduled for removal in worker "
+                "v2.0) — implement the describe() classmethod.",
+                backend_class.__name__,
+            )
             return backend_class().setup()
 
     def _build_ingest_callback(self):

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -176,16 +176,14 @@ class PolicyRunner:
         self.run_store = run_store
         self._diode_client = client
 
-        # The sink reads runner state lazily, so it is valid as soon as it
-        # exists. Modern backends are constructed once with it; legacy backends
-        # were already constructed (above, to read setup() metadata), so the
-        # sink is attached to that instance rather than re-constructing.
-        sink = _PolicyRunnerIngestSink(self)
         if legacy_backend is None:
-            backend = backend_class(ingest_sink=sink)
+            # Modern backends opt into the ingest sink — and thus API-triggered
+            # sync — by implementing describe(); construct once with it.
+            backend = backend_class(ingest_sink=_PolicyRunnerIngestSink(self))
         else:
+            # Legacy setup()-only backends get scheduled runs only; the trigger
+            # API requires migrating to describe(). No sink is attached.
             backend = legacy_backend
-            backend.ingest_sink = sink
 
         self.scheduler.start()
 

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -3,6 +3,7 @@
 """Orb Worker Policy Runner."""
 
 import logging
+import sys
 import time
 from datetime import datetime, timedelta
 
@@ -19,6 +20,7 @@ from netboxlabs.diode.sdk import (
 
 from worker.backend import Backend, load_class
 from worker.entity_metadata import apply_run_id_to_entities
+from worker.exceptions import IngestError, IngestRejected, IngestUnavailable
 from worker.metrics import get_metric
 from worker.models import DiodeConfig, Policy, Status
 from worker.package_finder import maybe_evict
@@ -38,6 +40,7 @@ class PolicyRunner:
         self.status = Status.NEW
         self.scheduler = BackgroundScheduler()
         self.run_store = None
+        self._diode_client = None
 
     def setup(
         self, name: str, diode_config: DiodeConfig, policy: Policy, run_store: RunStore
@@ -65,7 +68,12 @@ class PolicyRunner:
         # Debug logging for backend loading
         logger.debug(f"Loading backend class: {policy.config.package}")
         backend_class = load_class(policy.config.package)
-        backend = backend_class()
+
+        # Build the ingest callback closure. It captures `self` and reads
+        # `self._diode_client` lazily, so it is safe to construct before the
+        # client is assigned below.
+        ingest_callback = self._build_ingest_callback(self.name)
+        backend = backend_class(ingest_callback=ingest_callback, policy=policy)
         logger.debug(f"Backend class loaded successfully: {backend_class.__name__}")
 
         metadata = backend.setup()
@@ -101,6 +109,7 @@ class PolicyRunner:
         self.metadata = metadata
         self.policy = policy
         self.run_store = run_store
+        self._diode_client = client
 
         self.scheduler.start()
 
@@ -126,6 +135,96 @@ class PolicyRunner:
         active_policies = get_metric("active_policies")
         if active_policies:
             active_policies.add(1, {"policy": self.name})
+
+    def _build_ingest_callback(self, policy_name: str):
+        """
+        Build a closure used to ingest entities outside the scheduled run() cycle.
+
+        The returned callable signature:
+            cb(entities=None, *, error=None, **kwargs) -> None
+
+        Exactly one of ``entities`` / ``error`` must be supplied.
+        On the ``entities`` path: a pseudo-run is created in the RunStore,
+        entities are chunked and ingested via the same path run() uses, and
+        response/transport errors are translated into IngestRejected /
+        IngestUnavailable. On the ``error`` path: a failed pseudo-run is
+        recorded; no client.ingest call is made; returns None.
+        """
+
+        def ingest_callback(entities=None, *, error=None, **kw):
+            if (entities is None) == (error is None):
+                raise TypeError(
+                    "ingest_callback requires exactly one of 'entities' or 'error'"
+                )
+            run = self.run_store.create_run(
+                policy_name=policy_name,
+                metadata={
+                    "name": self.metadata.name,
+                    "app_name": self.metadata.app_name,
+                    "app_version": self.metadata.app_version,
+                    "source": "ingest_callback",
+                },
+            )
+            if error is not None:
+                self.run_store.update_run(
+                    policy_name=policy_name,
+                    run_id=run.id,
+                    status=RunStatus.FAILED,
+                    error=error,
+                    entity_count=0,
+                )
+                return
+            entities_list = list(entities)
+            apply_run_id_to_entities(entities_list, run.id)
+            metadata = {
+                "policy_name": policy_name,
+                "worker_backend": self.metadata.name,
+                "run_id": run.id,
+            }
+            client = self._diode_client
+            try:
+                size_bytes = estimate_message_size(entities_list)
+                if size_bytes > (3.0 * 1024 * 1024):
+                    chunks = create_message_chunks(entities_list)
+                    for chunk in chunks:
+                        response = client.ingest(entities=chunk, metadata=metadata)
+                        if response.errors:
+                            raise IngestRejected(
+                                f"Chunk ingestion failed: {response.errors}"
+                            )
+                else:
+                    response = client.ingest(entities=entities_list, metadata=metadata)
+                    if response.errors:
+                        raise IngestRejected(
+                            f"Entities ingestion failed: {response.errors}"
+                        )
+            except IngestError:
+                self.run_store.update_run(
+                    policy_name=policy_name,
+                    run_id=run.id,
+                    status=RunStatus.FAILED,
+                    error=sys.exc_info()[1],
+                    entity_count=len(entities_list),
+                )
+                raise
+            except Exception as exc:
+                self.run_store.update_run(
+                    policy_name=policy_name,
+                    run_id=run.id,
+                    status=RunStatus.FAILED,
+                    error=exc,
+                    entity_count=len(entities_list),
+                )
+                raise IngestUnavailable(str(exc)) from exc
+            self.run_store.update_run(
+                policy_name=policy_name,
+                run_id=run.id,
+                status=RunStatus.COMPLETED,
+                error=None,
+                entity_count=len(entities_list),
+            )
+
+        return ingest_callback
 
     def run(
         self,

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -17,6 +17,7 @@ from netboxlabs.diode.sdk import (
     DiodeOTLPClient,
     create_message_chunks,
 )
+from netboxlabs.diode.sdk.exceptions import OTLPClientError
 
 from worker.backend import Backend, _implements_describe, load_class
 from worker.entity_metadata import apply_run_id_to_entities
@@ -36,6 +37,27 @@ _TRANSIENT_GRPC_CODES = frozenset(
         grpc.StatusCode.DEADLINE_EXCEEDED,
     }
 )
+
+
+def _grpc_status_code(exc) -> grpc.StatusCode | None:
+    """
+    Best-effort extract of a grpc.StatusCode from a raw or SDK-wrapped ingest error.
+
+    The SDK clients do not surface raw ``grpc.RpcError`` from ``ingest()``: the
+    credentialed ``DiodeClient`` wraps it as ``DiodeClientError`` and the
+    ``DiodeOTLPClient`` as ``OTLPClientError``, both exposing the code via a
+    ``status_code`` attribute. A bare ``grpc.RpcError`` (e.g. in tests) exposes
+    it via ``code()``. Returns None when no code can be determined.
+    """
+    code = getattr(exc, "status_code", None)
+    if code is None:
+        getter = getattr(exc, "code", None)
+        if callable(getter):
+            try:
+                code = getter()
+            except Exception:
+                code = None
+    return code
 
 
 @dataclass
@@ -292,8 +314,11 @@ class PolicyRunner:
         for chunk in chunks:
             try:
                 response = client.ingest(entities=chunk, metadata=metadata)
-            except grpc.RpcError as exc:
-                code = exc.code() if hasattr(exc, "code") else None
+            except (grpc.RpcError, OTLPClientError) as exc:
+                # DiodeClient wraps as DiodeClientError (a grpc.RpcError subclass)
+                # and DiodeOTLPClient as OTLPClientError; both carry the status on
+                # .status_code. A bare grpc.RpcError exposes it via .code().
+                code = _grpc_status_code(exc)
                 if code in _TRANSIENT_GRPC_CODES:
                     raise IngestUnavailable(
                         f"Transient ingest failure ({code.name}): {exc}"

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -3,7 +3,6 @@
 """Orb Worker Policy Runner."""
 
 import logging
-import sys
 import time
 from datetime import datetime, timedelta
 
@@ -151,7 +150,13 @@ class PolicyRunner:
         recorded; no client.ingest call is made; returns None.
         """
 
-        def ingest_callback(entities=None, *, error=None, **kw):
+        def ingest_callback(
+            entities=None,
+            *,
+            error: Exception | None = None,
+            **kwargs,
+        ) -> None:
+            # kwargs is reserved for forward-compat (run_id, source, etc.); currently ignored.
             if (entities is None) == (error is None):
                 raise TypeError(
                     "ingest_callback requires exactly one of 'entities' or 'error'"
@@ -182,32 +187,35 @@ class PolicyRunner:
                 "run_id": run.id,
             }
             client = self._diode_client
-            try:
-                size_bytes = estimate_message_size(entities_list)
-                if size_bytes > (3.0 * 1024 * 1024):
-                    chunks = create_message_chunks(entities_list)
-                    for chunk in chunks:
-                        response = client.ingest(entities=chunk, metadata=metadata)
-                        if response.errors:
-                            raise IngestRejected(
-                                f"Chunk ingestion failed: {response.errors}"
-                            )
-                else:
-                    response = client.ingest(entities=entities_list, metadata=metadata)
-                    if response.errors:
-                        raise IngestRejected(
-                            f"Entities ingestion failed: {response.errors}"
-                        )
-            except IngestError:
+            if client is None:
+                guard_error = IngestUnavailable(
+                    "ingest_callback invoked before the diode client was initialised "
+                    "(likely called from Backend.setup() — defer until after setup completes)"
+                )
                 self.run_store.update_run(
                     policy_name=policy_name,
                     run_id=run.id,
                     status=RunStatus.FAILED,
-                    error=sys.exc_info()[1],
+                    error=guard_error,
+                    entity_count=len(entities_list),
+                )
+                raise guard_error
+            try:
+                self._send_entities(client, entities_list, metadata)
+            except IngestError as exc:
+                self.run_store.update_run(
+                    policy_name=policy_name,
+                    run_id=run.id,
+                    status=RunStatus.FAILED,
+                    error=exc,
                     entity_count=len(entities_list),
                 )
                 raise
             except Exception as exc:
+                logger.exception(
+                    "Unexpected exception in ingest_callback; "
+                    "translating to IngestUnavailable"
+                )
                 self.run_store.update_run(
                     policy_name=policy_name,
                     run_id=run.id,
@@ -225,6 +233,20 @@ class PolicyRunner:
             )
 
         return ingest_callback
+
+    def _send_entities(self, client, entities_list: list, metadata: dict) -> None:
+        """Send entities to the Diode client, chunking if the payload exceeds 3 MB."""
+        size_bytes = estimate_message_size(entities_list)
+        if size_bytes > (3.0 * 1024 * 1024):
+            chunks = create_message_chunks(entities_list)
+            for chunk in chunks:
+                response = client.ingest(entities=chunk, metadata=metadata)
+                if response.errors:
+                    raise IngestRejected(f"Chunk ingestion failed: {response.errors}")
+        else:
+            response = client.ingest(entities=entities_list, metadata=metadata)
+            if response.errors:
+                raise IngestRejected(f"Entities ingestion failed: {response.errors}")
 
     def run(
         self,

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -2,6 +2,7 @@
 # Copyright 2025 NetBox Labs Inc
 """Orb Worker Policy Runner."""
 
+import inspect
 import logging
 import time
 from datetime import datetime, timedelta
@@ -30,6 +31,27 @@ from worker.policy.run import RunStatus, RunStore
 MAX_INGEST_MESSAGE_BYTES = 3 * 1024 * 1024
 
 logger = logging.getLogger(__name__)
+
+
+def _construct_backend(backend_class, *, ingest_callback):
+    """
+    Construct a Backend, passing ``ingest_callback`` only when accepted.
+
+    Uses ``inspect.signature`` to detect whether ``backend_class.__init__``
+    has a matching named parameter or ``VAR_KEYWORD`` absorber. Legacy
+    backends with ``__init__(self)`` get constructed zero-arg and never
+    see the kwarg, so the worker can ship this contract bump without a
+    coordinated upgrade across every integration package.
+    """
+    sig = inspect.signature(backend_class)
+    params = sig.parameters
+    accepts_var_kw = any(
+        p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
+    )
+    init_kwargs: dict[str, object] = {}
+    if accepts_var_kw or "ingest_callback" in params:
+        init_kwargs["ingest_callback"] = ingest_callback
+    return backend_class(**init_kwargs)
 
 
 class PolicyRunner:
@@ -77,7 +99,7 @@ class PolicyRunner:
         # `self._diode_client` lazily, so it is safe to construct before the
         # client is assigned below.
         ingest_callback = self._build_ingest_callback(self.name)
-        backend = backend_class(ingest_callback=ingest_callback, policy=policy)
+        backend = _construct_backend(backend_class, ingest_callback=ingest_callback)
         logger.debug(f"Backend class loaded successfully: {backend_class.__name__}")
 
         metadata = backend.setup()

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -7,6 +7,7 @@ import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 
+import grpc
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 from apscheduler.triggers.date import DateTrigger
@@ -19,13 +20,22 @@ from netboxlabs.diode.sdk import (
 
 from worker.backend import Backend, _implements_describe, load_class
 from worker.entity_metadata import apply_run_id_to_entities
-from worker.exceptions import IngestError, IngestRejected
+from worker.exceptions import IngestError, IngestRejected, IngestUnavailable
 from worker.metrics import get_metric
 from worker.models import DiodeConfig, Policy, Status
 from worker.package_finder import maybe_evict
 from worker.policy.run import RunStatus, RunStore
 
 logger = logging.getLogger(__name__)
+
+# gRPC status codes that signal a transient ingest failure worth retrying.
+_TRANSIENT_GRPC_CODES = frozenset(
+    {
+        grpc.StatusCode.UNAVAILABLE,
+        grpc.StatusCode.RESOURCE_EXHAUSTED,
+        grpc.StatusCode.DEADLINE_EXCEEDED,
+    }
+)
 
 
 @dataclass
@@ -284,7 +294,15 @@ class PolicyRunner:
             return 0
         chunks = create_message_chunks(entities_list)
         for chunk in chunks:
-            response = client.ingest(entities=chunk, metadata=metadata)
+            try:
+                response = client.ingest(entities=chunk, metadata=metadata)
+            except grpc.RpcError as exc:
+                code = exc.code() if hasattr(exc, "code") else None
+                if code in _TRANSIENT_GRPC_CODES:
+                    raise IngestUnavailable(
+                        f"Transient ingest failure ({code.name}): {exc}"
+                    ) from exc
+                raise IngestError(f"Ingest transport error: {exc}") from exc
             if response.errors:
                 raise IngestRejected(f"Chunk ingestion failed: {response.errors}")
         return len(chunks)

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -2,6 +2,7 @@
 # Copyright 2025 NetBox Labs Inc
 """Orb Worker Policy Runner."""
 
+import inspect
 import logging
 import time
 from dataclasses import dataclass
@@ -210,7 +211,7 @@ class PolicyRunner:
                 return
             try:
                 self._execute_run(
-                    self._diode_client, lambda: entities, source="ingest_callback"
+                    self._diode_client, lambda run_id: entities, source="ingest_callback"
                 )
             except IngestError:
                 raise
@@ -225,11 +226,11 @@ class PolicyRunner:
         """
         Create a run, produce + ingest entities through it, record COMPLETED/FAILED.
 
-        ``produce_entities`` is a zero-arg callable invoked INSIDE the run's
-        try-block — after ``create_run`` — so a failure while producing the
-        entities (e.g. the backend's ``run()`` raising) is still recorded as a
-        FAILED run rather than vanishing before the run is created. Re-raises on
-        failure.
+        ``produce_entities`` is a callable receiving ``run_id`` (the id of the
+        run created here), invoked INSIDE the run's try-block — after
+        ``create_run`` — so a failure while producing the entities (e.g. the
+        backend's ``run()`` raising) is still recorded as a FAILED run rather
+        than vanishing before the run is created. Re-raises on failure.
 
         The returned ``_RunOutcome.produce_seconds`` covers the producer call
         only — not chunking, ingest, or run-store writes — so callers can
@@ -246,7 +247,7 @@ class PolicyRunner:
         entity_count = 0
         try:
             produce_start = time.perf_counter()
-            entities_list = list(produce_entities())
+            entities_list = list(produce_entities(run_id=run.id))
             produce_seconds = time.perf_counter() - produce_start
             entity_count = len(entities_list)
             apply_run_id_to_entities(entities_list, run.id)
@@ -315,7 +316,7 @@ class PolicyRunner:
         try:
             logger.debug(f"Policy {self.name}: Starting backend execution")
             outcome = self._execute_run(
-                client, lambda: backend.run(self.name, policy), source=None
+                client, self._build_entity_producer(backend, policy), source=None
             )
             logger.debug(
                 f"Policy {self.name}: Backend execution completed in {outcome.produce_seconds:.3f} seconds"
@@ -362,6 +363,29 @@ class PolicyRunner:
                     "app_version": self.metadata.app_version,
                 },
             )
+
+    def _build_entity_producer(self, backend: Backend, policy: Policy):
+        """
+        Bind ``backend.run`` for ``_execute_run``, passing per-tick context when accepted.
+
+        Backends whose ``run()`` declares ``**kwargs`` receive
+        ``source="scheduled"`` and ``run_id``; legacy two-argument signatures
+        get the bare call (with a warning) so they keep working without a
+        coordinated upgrade.
+        """
+        accepts_kwargs = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in inspect.signature(backend.run).parameters.values()
+        )
+        if accepts_kwargs:
+            return lambda run_id: backend.run(
+                self.name, policy, source="scheduled", run_id=run_id
+            )
+        logger.warning(
+            f"Policy {self.name}: backend run() does not declare **kwargs; "
+            "per-tick context (source, run_id) will not be passed"
+        )
+        return lambda run_id: backend.run(self.name, policy)
 
     def stop(self):
         """Stop the policy runner."""

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -62,9 +62,7 @@ class _PolicyRunnerIngestSink:
     def ingest(self, entities, **kwargs) -> None:
         runner = self._runner
         try:
-            runner._execute_run(
-                runner._diode_client, lambda: entities, source="ingest_callback"
-            )
+            runner._execute_run(runner._diode_client, lambda: entities)
         except IngestError:
             raise
         except Exception as exc:
@@ -74,12 +72,7 @@ class _PolicyRunnerIngestSink:
         runner = self._runner
         run = runner.run_store.create_run(
             policy_name=runner.name,
-            metadata={
-                "name": runner.metadata.name,
-                "app_name": runner.metadata.app_name,
-                "app_version": runner.metadata.app_version,
-                "source": "ingest_callback",
-            },
+            metadata=runner._run_metadata(),
         )
         runner.run_store.update_run(
             policy_name=runner.name,
@@ -219,9 +212,21 @@ class PolicyRunner:
         if active_policies:
             active_policies.add(1, {"policy": self.name})
 
-    def _execute_run(
-        self, client, produce_entities, *, source: str | None = None
-    ) -> _RunOutcome:
+    def _run_metadata(self) -> dict:
+        """
+        Build the metadata stored on a run record.
+
+        TODO: consider recording the run's origin (scheduled vs ingest-sink)
+        here once a consumer exists for it (e.g. the planned runs API over
+        RunStore); a `source` key was carried earlier but nothing read it.
+        """
+        return {
+            "name": self.metadata.name,
+            "app_name": self.metadata.app_name,
+            "app_version": self.metadata.app_version,
+        }
+
+    def _execute_run(self, client, produce_entities) -> _RunOutcome:
         """
         Create a run, produce + ingest entities through it, record COMPLETED/FAILED.
 
@@ -235,14 +240,9 @@ class PolicyRunner:
         only — not chunking, ingest, or run-store writes — so callers can
         report truthful production timing.
         """
-        run_metadata = {
-            "name": self.metadata.name,
-            "app_name": self.metadata.app_name,
-            "app_version": self.metadata.app_version,
-        }
-        if source is not None:
-            run_metadata["source"] = source
-        run = self.run_store.create_run(policy_name=self.name, metadata=run_metadata)
+        run = self.run_store.create_run(
+            policy_name=self.name, metadata=self._run_metadata()
+        )
         entity_count = 0
         try:
             produce_start = time.perf_counter()
@@ -274,24 +274,22 @@ class PolicyRunner:
             )
             raise
 
-    def _send_entities(self, client, entities_list: list, metadata: dict) -> int:
+    def _send_entities(self, client, entities_list: list, metadata: dict) -> None:
         """
         Send entities to the Diode client.
 
         An empty entity list is a valid no-op (e.g. an incremental run that
         found no changes since its watermark) — Diode's ingester rejects an
-        empty batch with ``entities is empty`` — so nothing is sent and the
-        run completes with ``entity_count=0``.
+        empty batch with ``entities is empty`` — so nothing is sent.
 
         Delegates chunking to the SDK's ``create_message_chunks``, which owns
         the gRPC message-size threshold (3 MB default, a safe margin below the
         4 MB ceiling) and returns a single chunk when the payload already fits.
-
-        Returns the number of chunks actually sent (0 for an empty list, 1 if
-        not chunked).
+        Transient gRPC failures are raised as ``IngestUnavailable``, other gRPC
+        errors as ``IngestError``, and Diode-reported errors as ``IngestRejected``.
         """
         if not entities_list:
-            return 0
+            return
         chunks = create_message_chunks(entities_list)
         for chunk in chunks:
             try:
@@ -305,7 +303,6 @@ class PolicyRunner:
                 raise IngestError(f"Ingest transport error: {exc}") from exc
             if response.errors:
                 raise IngestRejected(f"Chunk ingestion failed: {response.errors}")
-        return len(chunks)
 
     def run(
         self,
@@ -331,7 +328,7 @@ class PolicyRunner:
         try:
             logger.debug(f"Policy {self.name}: Starting backend execution")
             outcome = self._execute_run(
-                client, lambda: backend.run(self.name, policy), source=None
+                client, lambda: backend.run(self.name, policy)
             )
             logger.debug(
                 f"Policy {self.name}: Backend execution completed in {outcome.produce_seconds:.3f} seconds"

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -25,6 +25,10 @@ from worker.models import DiodeConfig, Policy, Status
 from worker.package_finder import maybe_evict
 from worker.policy.run import RunStatus, RunStore
 
+# Diode message-size cap (per chunk). Stays in sync with the reconciler's
+# 4 MiB gRPC ceiling minus a safety margin.
+MAX_INGEST_MESSAGE_BYTES = 3 * 1024 * 1024
+
 logger = logging.getLogger(__name__)
 
 
@@ -40,6 +44,7 @@ class PolicyRunner:
         self.scheduler = BackgroundScheduler()
         self.run_store = None
         self._diode_client = None
+        self._callback_ready = False
 
     def setup(
         self, name: str, diode_config: DiodeConfig, policy: Policy, run_store: RunStore
@@ -131,6 +136,11 @@ class PolicyRunner:
 
         self.status = Status.RUNNING
 
+        # Callback is now safe to invoke — every dependency the closure reads
+        # (run_store, metadata, _diode_client) is attached. Integrations may push
+        # entities via ingest_callback from this point onward.
+        self._callback_ready = True
+
         active_policies = get_metric("active_policies")
         if active_policies:
             active_policies.add(1, {"policy": self.name})
@@ -161,6 +171,12 @@ class PolicyRunner:
                 raise TypeError(
                     "ingest_callback requires exactly one of 'entities' or 'error'"
                 )
+            if not self._callback_ready:
+                raise IngestUnavailable(
+                    "ingest_callback invoked before the worker finished constructing "
+                    "this Backend (likely called from Backend.__init__ or "
+                    "Backend.setup() — defer until after setup() returns)"
+                )
             run = self.run_store.create_run(
                 policy_name=policy_name,
                 metadata={
@@ -179,29 +195,16 @@ class PolicyRunner:
                     entity_count=0,
                 )
                 return
-            entities_list = list(entities)
-            apply_run_id_to_entities(entities_list, run.id)
-            metadata = {
-                "policy_name": policy_name,
-                "worker_backend": self.metadata.name,
-                "run_id": run.id,
-            }
-            client = self._diode_client
-            if client is None:
-                guard_error = IngestUnavailable(
-                    "ingest_callback invoked before the diode client was initialised "
-                    "(likely called from Backend.setup() — defer until after setup completes)"
-                )
-                self.run_store.update_run(
-                    policy_name=policy_name,
-                    run_id=run.id,
-                    status=RunStatus.FAILED,
-                    error=guard_error,
-                    entity_count=len(entities_list),
-                )
-                raise guard_error
+            entities_list: list = []
             try:
-                self._send_entities(client, entities_list, metadata)
+                entities_list = list(entities)
+                apply_run_id_to_entities(entities_list, run.id)
+                metadata = {
+                    "policy_name": policy_name,
+                    "worker_backend": self.metadata.name,
+                    "run_id": run.id,
+                }
+                self._send_entities(self._diode_client, entities_list, metadata)
             except IngestError as exc:
                 self.run_store.update_run(
                     policy_name=policy_name,
@@ -234,19 +237,24 @@ class PolicyRunner:
 
         return ingest_callback
 
-    def _send_entities(self, client, entities_list: list, metadata: dict) -> None:
-        """Send entities to the Diode client, chunking if the payload exceeds 3 MB."""
+    def _send_entities(self, client, entities_list: list, metadata: dict) -> int:
+        """
+        Send entities to the Diode client, chunking if the payload exceeds MAX_INGEST_MESSAGE_BYTES.
+
+        Returns the number of chunks actually sent (1 if not chunked).
+        """
         size_bytes = estimate_message_size(entities_list)
-        if size_bytes > (3.0 * 1024 * 1024):
+        if size_bytes > MAX_INGEST_MESSAGE_BYTES:
             chunks = create_message_chunks(entities_list)
             for chunk in chunks:
                 response = client.ingest(entities=chunk, metadata=metadata)
                 if response.errors:
                     raise IngestRejected(f"Chunk ingestion failed: {response.errors}")
-        else:
-            response = client.ingest(entities=entities_list, metadata=metadata)
-            if response.errors:
-                raise IngestRejected(f"Entities ingestion failed: {response.errors}")
+            return len(chunks)
+        response = client.ingest(entities=entities_list, metadata=metadata)
+        if response.errors:
+            raise IngestRejected(f"Entities ingestion failed: {response.errors}")
+        return 1
 
     def run(
         self,
@@ -295,20 +303,7 @@ class PolicyRunner:
                 "worker_backend": self.metadata.name,
                 "run_id": run.id,
             }
-            chunk_num = 1
-            size_bytes = estimate_message_size(entities)
-
-            if size_bytes > (3.0 * 1024 * 1024):
-                chunks = create_message_chunks(entities)
-                chunk_num = len(chunks)
-                for chunk in chunks:
-                    response = client.ingest(entities=chunk, metadata=metadata)
-                    if response.errors:
-                        raise RuntimeError(f"Chunk ingestion failed: {response.errors}")
-            else:
-                response = client.ingest(entities=entities, metadata=metadata)
-                if response.errors:
-                    raise RuntimeError(f"Entities ingestion failed: {response.errors}")
+            chunk_num = self._send_entities(client, entities, metadata)
             logger.info(
                 f"Policy {self.name}: Successfully ingested {entity_count} entities in {chunk_num} chunks"
             )
@@ -372,6 +367,7 @@ class PolicyRunner:
 
     def stop(self):
         """Stop the policy runner."""
+        self._callback_ready = False
         self.scheduler.shutdown(wait=False)
         self.status = Status.FINISHED
         active_policies = get_metric("active_policies")

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -2,7 +2,6 @@
 # Copyright 2025 NetBox Labs Inc
 """Orb Worker Policy Runner."""
 
-import inspect
 import logging
 import time
 from datetime import datetime, timedelta
@@ -20,7 +19,7 @@ from netboxlabs.diode.sdk import (
 
 from worker.backend import Backend, load_class
 from worker.entity_metadata import apply_run_id_to_entities
-from worker.exceptions import IngestError, IngestRejected, IngestUnavailable
+from worker.exceptions import IngestError, IngestRejected
 from worker.metrics import get_metric
 from worker.models import DiodeConfig, Policy, Status
 from worker.package_finder import maybe_evict
@@ -31,27 +30,6 @@ from worker.policy.run import RunStatus, RunStore
 MAX_INGEST_MESSAGE_BYTES = 3 * 1024 * 1024
 
 logger = logging.getLogger(__name__)
-
-
-def _construct_backend(backend_class, *, ingest_callback):
-    """
-    Construct a Backend, passing ``ingest_callback`` only when accepted.
-
-    Uses ``inspect.signature`` to detect whether ``backend_class.__init__``
-    has a matching named parameter or ``VAR_KEYWORD`` absorber. Legacy
-    backends with ``__init__(self)`` get constructed zero-arg and never
-    see the kwarg, so the worker can ship this contract bump without a
-    coordinated upgrade across every integration package.
-    """
-    sig = inspect.signature(backend_class)
-    params = sig.parameters
-    accepts_var_kw = any(
-        p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()
-    )
-    init_kwargs: dict[str, object] = {}
-    if accepts_var_kw or "ingest_callback" in params:
-        init_kwargs["ingest_callback"] = ingest_callback
-    return backend_class(**init_kwargs)
 
 
 class PolicyRunner:
@@ -66,7 +44,6 @@ class PolicyRunner:
         self.scheduler = BackgroundScheduler()
         self.run_store = None
         self._diode_client = None
-        self._callback_ready = False
 
     def setup(
         self, name: str, diode_config: DiodeConfig, policy: Policy, run_store: RunStore
@@ -95,11 +72,9 @@ class PolicyRunner:
         logger.debug(f"Loading backend class: {policy.config.package}")
         backend_class = load_class(policy.config.package)
 
-        # Build the ingest callback closure. It captures `self` and reads
-        # `self._diode_client` lazily, so it is safe to construct before the
-        # client is assigned below.
-        ingest_callback = self._build_ingest_callback(self.name)
-        backend = _construct_backend(backend_class, ingest_callback=ingest_callback)
+        # Construct with no ingest_callback; it is attached below once every
+        # dependency the closure reads has been assigned.
+        backend = backend_class()
         logger.debug(f"Backend class loaded successfully: {backend_class.__name__}")
 
         metadata = backend.setup()
@@ -137,6 +112,12 @@ class PolicyRunner:
         self.run_store = run_store
         self._diode_client = client
 
+        # Every dependency the closure reads (run_store, metadata, _diode_client)
+        # is now assigned, so the callback is safe to build and attach. The
+        # consumer reads `backend.ingest_callback` lazily at trigger time, so
+        # post-construction assignment is correct.
+        backend.ingest_callback = self._build_ingest_callback(self.name)
+
         self.scheduler.start()
 
         if self.policy.config.schedule is not None:
@@ -158,11 +139,6 @@ class PolicyRunner:
 
         self.status = Status.RUNNING
 
-        # Callback is now safe to invoke — every dependency the closure reads
-        # (run_store, metadata, _diode_client) is attached. Integrations may push
-        # entities via ingest_callback from this point onward.
-        self._callback_ready = True
-
         active_policies = get_metric("active_policies")
         if active_policies:
             active_policies.add(1, {"policy": self.name})
@@ -178,7 +154,7 @@ class PolicyRunner:
         On the ``entities`` path: a pseudo-run is created in the RunStore,
         entities are chunked and ingested via the same path run() uses, and
         response/transport errors are translated into IngestRejected /
-        IngestUnavailable. On the ``error`` path: a failed pseudo-run is
+        IngestError. On the ``error`` path: a failed pseudo-run is
         recorded; no client.ingest call is made; returns None.
         """
 
@@ -193,71 +169,81 @@ class PolicyRunner:
                 raise TypeError(
                     "ingest_callback requires exactly one of 'entities' or 'error'"
                 )
-            if not self._callback_ready:
-                raise IngestUnavailable(
-                    "ingest_callback invoked before the worker finished constructing "
-                    "this Backend (likely called from Backend.__init__ or "
-                    "Backend.setup() — defer until after setup() returns)"
-                )
-            run = self.run_store.create_run(
-                policy_name=policy_name,
-                metadata={
-                    "name": self.metadata.name,
-                    "app_name": self.metadata.app_name,
-                    "app_version": self.metadata.app_version,
-                    "source": "ingest_callback",
-                },
-            )
             if error is not None:
+                run = self.run_store.create_run(
+                    policy_name=self.name,
+                    metadata={
+                        "name": self.metadata.name,
+                        "app_name": self.metadata.app_name,
+                        "app_version": self.metadata.app_version,
+                        "source": "ingest_callback",
+                    },
+                )
                 self.run_store.update_run(
-                    policy_name=policy_name,
+                    policy_name=self.name,
                     run_id=run.id,
                     status=RunStatus.FAILED,
                     error=error,
                     entity_count=0,
                 )
                 return
-            entities_list: list = []
             try:
-                entities_list = list(entities)
-                apply_run_id_to_entities(entities_list, run.id)
-                metadata = {
-                    "policy_name": policy_name,
-                    "worker_backend": self.metadata.name,
-                    "run_id": run.id,
-                }
-                self._send_entities(self._diode_client, entities_list, metadata)
-            except IngestError as exc:
-                self.run_store.update_run(
-                    policy_name=policy_name,
-                    run_id=run.id,
-                    status=RunStatus.FAILED,
-                    error=exc,
-                    entity_count=len(entities_list),
+                self._execute_run(
+                    self._diode_client, lambda: entities, source="ingest_callback"
                 )
+            except IngestError:
                 raise
             except Exception as exc:
-                logger.exception(
-                    "Unexpected exception in ingest_callback; "
-                    "translating to IngestUnavailable"
-                )
-                self.run_store.update_run(
-                    policy_name=policy_name,
-                    run_id=run.id,
-                    status=RunStatus.FAILED,
-                    error=exc,
-                    entity_count=len(entities_list),
-                )
-                raise IngestUnavailable(str(exc)) from exc
+                raise IngestError(str(exc)) from exc
+
+        return ingest_callback
+
+    def _execute_run(self, client, produce_entities, *, source: str | None = None) -> int:
+        """
+        Create a run, produce + ingest entities through it, record COMPLETED/FAILED.
+
+        ``produce_entities`` is a zero-arg callable invoked INSIDE the run's
+        try-block — after ``create_run`` — so a failure while producing the
+        entities (e.g. the backend's ``run()`` raising) is still recorded as a
+        FAILED run rather than vanishing before the run is created. Re-raises on
+        failure.
+        """
+        run_metadata = {
+            "name": self.metadata.name,
+            "app_name": self.metadata.app_name,
+            "app_version": self.metadata.app_version,
+        }
+        if source is not None:
+            run_metadata["source"] = source
+        run = self.run_store.create_run(policy_name=self.name, metadata=run_metadata)
+        entity_count = 0
+        try:
+            entities_list = list(produce_entities())
+            entity_count = len(entities_list)
+            apply_run_id_to_entities(entities_list, run.id)
+            metadata = {
+                "policy_name": self.name,
+                "worker_backend": self.metadata.name,
+                "run_id": run.id,
+            }
+            self._send_entities(client, entities_list, metadata)
             self.run_store.update_run(
-                policy_name=policy_name,
+                policy_name=self.name,
                 run_id=run.id,
                 status=RunStatus.COMPLETED,
                 error=None,
-                entity_count=len(entities_list),
+                entity_count=entity_count,
             )
-
-        return ingest_callback
+            return entity_count
+        except Exception as exc:
+            self.run_store.update_run(
+                policy_name=self.name,
+                run_id=run.id,
+                status=RunStatus.FAILED,
+                error=exc,
+                entity_count=entity_count,
+            )
+            raise
 
     def _send_entities(self, client, entities_list: list, metadata: dict) -> int:
         """
@@ -298,45 +284,16 @@ class PolicyRunner:
         if policy_executions:
             policy_executions.add(1, {"policy": self.name})
 
-        # CREATE RUN AT START with metadata from backend setup
-        run_metadata = {
-            "name": self.metadata.name,
-            "app_name": self.metadata.app_name,
-            "app_version": self.metadata.app_version,
-        }
-        run = self.run_store.create_run(
-            policy_name=self.name,
-            metadata=run_metadata,
-        )
-
         exec_start_time = time.perf_counter()
-        entity_count = 0
         try:
             logger.debug(f"Policy {self.name}: Starting backend execution")
-            entities = list(backend.run(self.name, policy))
+            entity_count = self._execute_run(
+                client, lambda: backend.run(self.name, policy), source=None
+            )
             elapsed = time.perf_counter() - exec_start_time
             logger.debug(f"Policy {self.name}: Backend execution completed in {elapsed:.3f} seconds")
-            entity_count = len(entities)
-
-            apply_run_id_to_entities(entities, run.id)
-
-            metadata = {
-                "policy_name": self.name,
-                "worker_backend": self.metadata.name,
-                "run_id": run.id,
-            }
-            chunk_num = self._send_entities(client, entities, metadata)
             logger.info(
-                f"Policy {self.name}: Successfully ingested {entity_count} entities in {chunk_num} chunks"
-            )
-
-            # UPDATE RUN ON SUCCESS
-            self.run_store.update_run(
-                policy_name=self.name,
-                run_id=run.id,
-                status=RunStatus.COMPLETED,
-                error=None,
-                entity_count=entity_count,
+                f"Policy {self.name}: Successfully ingested {entity_count} entities"
             )
 
             run_success = get_metric("backend_execution_success")
@@ -352,15 +309,6 @@ class PolicyRunner:
                 )
         except Exception as e:
             logger.error(f"Policy {self.name}: {e}")
-
-            # UPDATE RUN ON FAILURE
-            self.run_store.update_run(
-                policy_name=self.name,
-                run_id=run.id,
-                status=RunStatus.FAILED,
-                error=e,
-                entity_count=entity_count,
-            )
 
             run_failure = get_metric("backend_execution_failure")
             if run_failure:
@@ -389,7 +337,6 @@ class PolicyRunner:
 
     def stop(self):
         """Stop the policy runner."""
-        self._callback_ready = False
         self.scheduler.shutdown(wait=False)
         self.status = Status.FINISHED
         active_policies = get_metric("active_policies")

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -279,12 +279,20 @@ class PolicyRunner:
         """
         Send entities to the Diode client.
 
+        An empty entity list is a valid no-op (e.g. an incremental run that
+        found no changes since its watermark) — Diode's ingester rejects an
+        empty batch with ``entities is empty`` — so nothing is sent and the
+        run completes with ``entity_count=0``.
+
         Delegates chunking to the SDK's ``create_message_chunks``, which owns
         the gRPC message-size threshold (3 MB default, a safe margin below the
         4 MB ceiling) and returns a single chunk when the payload already fits.
 
-        Returns the number of chunks actually sent (1 if not chunked).
+        Returns the number of chunks actually sent (0 for an empty list, 1 if
+        not chunked).
         """
+        if not entities_list:
+            return 0
         chunks = create_message_chunks(entities_list)
         for chunk in chunks:
             response = client.ingest(entities=chunk, metadata=metadata)

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -5,6 +5,7 @@
 import logging
 import time
 from datetime import datetime, timedelta
+from typing import NamedTuple
 
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
@@ -25,6 +26,13 @@ from worker.package_finder import maybe_evict
 from worker.policy.run import RunStatus, RunStore
 
 logger = logging.getLogger(__name__)
+
+
+class _RunOutcome(NamedTuple):
+    """What _execute_run reports back to its caller."""
+
+    entity_count: int
+    produce_seconds: float
 
 
 class PolicyRunner:
@@ -210,7 +218,9 @@ class PolicyRunner:
 
         return ingest_callback
 
-    def _execute_run(self, client, produce_entities, *, source: str | None = None) -> int:
+    def _execute_run(
+        self, client, produce_entities, *, source: str | None = None
+    ) -> _RunOutcome:
         """
         Create a run, produce + ingest entities through it, record COMPLETED/FAILED.
 
@@ -219,6 +229,10 @@ class PolicyRunner:
         entities (e.g. the backend's ``run()`` raising) is still recorded as a
         FAILED run rather than vanishing before the run is created. Re-raises on
         failure.
+
+        The returned ``_RunOutcome.produce_seconds`` covers the producer call
+        only — not chunking, ingest, or run-store writes — so callers can
+        report truthful production timing.
         """
         run_metadata = {
             "name": self.metadata.name,
@@ -230,7 +244,9 @@ class PolicyRunner:
         run = self.run_store.create_run(policy_name=self.name, metadata=run_metadata)
         entity_count = 0
         try:
+            produce_start = time.perf_counter()
             entities_list = list(produce_entities())
+            produce_seconds = time.perf_counter() - produce_start
             entity_count = len(entities_list)
             apply_run_id_to_entities(entities_list, run.id)
             metadata = {
@@ -246,7 +262,7 @@ class PolicyRunner:
                 error=None,
                 entity_count=entity_count,
             )
-            return entity_count
+            return _RunOutcome(entity_count, produce_seconds)
         except Exception as exc:
             self.run_store.update_run(
                 policy_name=self.name,
@@ -297,13 +313,14 @@ class PolicyRunner:
         exec_start_time = time.perf_counter()
         try:
             logger.debug(f"Policy {self.name}: Starting backend execution")
-            entity_count = self._execute_run(
+            outcome = self._execute_run(
                 client, lambda: backend.run(self.name, policy), source=None
             )
-            elapsed = time.perf_counter() - exec_start_time
-            logger.debug(f"Policy {self.name}: Backend execution completed in {elapsed:.3f} seconds")
+            logger.debug(
+                f"Policy {self.name}: Backend execution completed in {outcome.produce_seconds:.3f} seconds"
+            )
             logger.info(
-                f"Policy {self.name}: Successfully ingested {entity_count} entities"
+                f"Policy {self.name}: Successfully ingested {outcome.entity_count} entities"
             )
 
             run_success = get_metric("backend_execution_success")

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -2,7 +2,6 @@
 # Copyright 2025 NetBox Labs Inc
 """Orb Worker Policy Runner."""
 
-import inspect
 import logging
 import time
 from dataclasses import dataclass
@@ -211,7 +210,7 @@ class PolicyRunner:
                 return
             try:
                 self._execute_run(
-                    self._diode_client, lambda run_id: entities, source="ingest_callback"
+                    self._diode_client, lambda: entities, source="ingest_callback"
                 )
             except IngestError:
                 raise
@@ -226,11 +225,11 @@ class PolicyRunner:
         """
         Create a run, produce + ingest entities through it, record COMPLETED/FAILED.
 
-        ``produce_entities`` is a callable receiving ``run_id`` (the id of the
-        run created here), invoked INSIDE the run's try-block — after
-        ``create_run`` — so a failure while producing the entities (e.g. the
-        backend's ``run()`` raising) is still recorded as a FAILED run rather
-        than vanishing before the run is created. Re-raises on failure.
+        ``produce_entities`` is a zero-arg callable invoked INSIDE the run's
+        try-block — after ``create_run`` — so a failure while producing the
+        entities (e.g. the backend's ``run()`` raising) is still recorded as a
+        FAILED run rather than vanishing before the run is created. Re-raises on
+        failure.
 
         The returned ``_RunOutcome.produce_seconds`` covers the producer call
         only — not chunking, ingest, or run-store writes — so callers can
@@ -247,7 +246,7 @@ class PolicyRunner:
         entity_count = 0
         try:
             produce_start = time.perf_counter()
-            entities_list = list(produce_entities(run_id=run.id))
+            entities_list = list(produce_entities())
             produce_seconds = time.perf_counter() - produce_start
             entity_count = len(entities_list)
             apply_run_id_to_entities(entities_list, run.id)
@@ -324,7 +323,7 @@ class PolicyRunner:
         try:
             logger.debug(f"Policy {self.name}: Starting backend execution")
             outcome = self._execute_run(
-                client, self._build_entity_producer(backend, policy), source=None
+                client, lambda: backend.run(self.name, policy), source=None
             )
             logger.debug(
                 f"Policy {self.name}: Backend execution completed in {outcome.produce_seconds:.3f} seconds"
@@ -371,29 +370,6 @@ class PolicyRunner:
                     "app_version": self.metadata.app_version,
                 },
             )
-
-    def _build_entity_producer(self, backend: Backend, policy: Policy):
-        """
-        Bind ``backend.run`` for ``_execute_run``, passing per-tick context when accepted.
-
-        Backends whose ``run()`` declares ``**kwargs`` receive
-        ``source="scheduled"`` and ``run_id``; legacy two-argument signatures
-        get the bare call (with a warning) so they keep working without a
-        coordinated upgrade.
-        """
-        accepts_kwargs = any(
-            parameter.kind is inspect.Parameter.VAR_KEYWORD
-            for parameter in inspect.signature(backend.run).parameters.values()
-        )
-        if accepts_kwargs:
-            return lambda run_id: backend.run(
-                self.name, policy, source="scheduled", run_id=run_id
-            )
-        logger.warning(
-            f"Policy {self.name}: backend run() does not declare **kwargs; "
-            "per-tick context (source, run_id) will not be passed"
-        )
-        return lambda run_id: backend.run(self.name, policy)
 
     def stop(self):
         """Stop the policy runner."""

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -17,11 +17,11 @@ from netboxlabs.diode.sdk import (
     create_message_chunks,
 )
 
-from worker.backend import Backend, load_class
+from worker.backend import Backend, _implements_describe, load_class
 from worker.entity_metadata import apply_run_id_to_entities
 from worker.exceptions import IngestError, IngestRejected
 from worker.metrics import get_metric
-from worker.models import DiodeConfig, Metadata, Policy, Status
+from worker.models import DiodeConfig, Policy, Status
 from worker.package_finder import maybe_evict
 from worker.policy.run import RunStatus, RunStore
 
@@ -34,6 +34,50 @@ class _RunOutcome:
 
     entity_count: int
     produce_seconds: float
+
+
+class _PolicyRunnerIngestSink:
+    """
+    IngestSink bound to a PolicyRunner; reads runner state at call time.
+
+    The binding is lazy: ``ingest`` / ``record_failure`` resolve ``run_store``,
+    ``metadata`` and ``_diode_client`` off the runner when called, so the sink
+    is valid the moment it is constructed even though the runner may finish
+    wiring those fields afterwards. It must not be invoked before setup() ends.
+    """
+
+    def __init__(self, runner: "PolicyRunner") -> None:
+        self._runner = runner
+
+    def ingest(self, entities, **kwargs) -> None:
+        runner = self._runner
+        try:
+            runner._execute_run(
+                runner._diode_client, lambda: entities, source="ingest_callback"
+            )
+        except IngestError:
+            raise
+        except Exception as exc:
+            raise IngestError(str(exc)) from exc
+
+    def record_failure(self, error: Exception, **kwargs) -> None:
+        runner = self._runner
+        run = runner.run_store.create_run(
+            policy_name=runner.name,
+            metadata={
+                "name": runner.metadata.name,
+                "app_name": runner.metadata.app_name,
+                "app_version": runner.metadata.app_version,
+                "source": "ingest_callback",
+            },
+        )
+        runner.run_store.update_run(
+            policy_name=runner.name,
+            run_id=run.id,
+            status=RunStatus.FAILED,
+            error=error,
+            entity_count=0,
+        )
 
 
 class PolicyRunner:
@@ -77,9 +121,24 @@ class PolicyRunner:
         backend_class = load_class(policy.config.package)
         logger.debug(f"Backend class loaded successfully: {backend_class.__name__}")
 
-        # Read the backend's identity WITHOUT committing to an instance, so the
-        # ingest callback can be built and passed at construction time below.
-        metadata = self._backend_metadata(backend_class)
+        # Read the backend's metadata. Modern backends expose it via the
+        # describe() classmethod (no instance needed). Legacy setup()-only
+        # backends are constructed bare HERE and set up on that same instance —
+        # the one that gets scheduled — so any state setup() initialises is live
+        # when run() reads it.
+        if _implements_describe(backend_class):
+            legacy_backend = None
+            metadata = backend_class.describe()
+        else:
+            logger.warning(
+                "%s does not implement describe(); reading metadata via the "
+                "deprecated setup() fallback (scheduled for removal in worker "
+                "v2.0) — implement the describe() classmethod.",
+                backend_class.__name__,
+            )
+            legacy_backend = backend_class()
+            metadata = legacy_backend.setup()
+
         app_name = (
             f"{diode_config.prefix}/{metadata.app_name}"
             if diode_config.prefix
@@ -114,10 +173,16 @@ class PolicyRunner:
         self.run_store = run_store
         self._diode_client = client
 
-        # Every dependency the closure reads (run_store, metadata, _diode_client)
-        # is now assigned, so the callback is built first and the backend is
-        # constructed ONCE with it — no post-construction attach step.
-        backend = backend_class(ingest_callback=self._build_ingest_callback())
+        # The sink reads runner state lazily, so it is valid as soon as it
+        # exists. Modern backends are constructed once with it; legacy backends
+        # were already constructed (above, to read setup() metadata), so the
+        # sink is attached to that instance rather than re-constructing.
+        sink = _PolicyRunnerIngestSink(self)
+        if legacy_backend is None:
+            backend = backend_class(ingest_sink=sink)
+        else:
+            backend = legacy_backend
+            backend.ingest_sink = sink
 
         self.scheduler.start()
 
@@ -143,81 +208,6 @@ class PolicyRunner:
         active_policies = get_metric("active_policies")
         if active_policies:
             active_policies.add(1, {"policy": self.name})
-
-    def _backend_metadata(self, backend_class) -> Metadata:
-        """
-        Read the backend's metadata without committing to an instance.
-
-        Prefer the class-level describe(); fall back to a throwaway instance's
-        setup() for integrations that only implement the legacy instance method.
-        """
-        try:
-            return backend_class.describe()
-        except NotImplementedError:
-            # Legacy backend: construct a throwaway just to read its metadata. The
-            # real, callback-bearing instance is constructed below.
-            logger.warning(
-                "%s does not implement describe(); reading metadata via the "
-                "deprecated setup() fallback (scheduled for removal in worker "
-                "v2.0) — implement the describe() classmethod.",
-                backend_class.__name__,
-            )
-            return backend_class().setup()
-
-    def _build_ingest_callback(self):
-        """
-        Build a closure used to ingest entities outside the scheduled run() cycle.
-
-        The returned callable signature:
-            cb(entities=None, *, error=None, **kwargs) -> None
-
-        Exactly one of ``entities`` / ``error`` must be supplied.
-        On the ``entities`` path: a pseudo-run is created in the RunStore,
-        entities are chunked and ingested via the same path run() uses, and
-        response/transport errors are translated into IngestRejected /
-        IngestError. On the ``error`` path: a failed pseudo-run is
-        recorded; no client.ingest call is made; returns None.
-        """
-
-        def ingest_callback(
-            entities=None,
-            *,
-            error: Exception | None = None,
-            **kwargs,
-        ) -> None:
-            # kwargs is reserved for forward-compat (run_id, source, etc.); currently ignored.
-            if (entities is None) == (error is None):
-                raise TypeError(
-                    "ingest_callback requires exactly one of 'entities' or 'error'"
-                )
-            if error is not None:
-                run = self.run_store.create_run(
-                    policy_name=self.name,
-                    metadata={
-                        "name": self.metadata.name,
-                        "app_name": self.metadata.app_name,
-                        "app_version": self.metadata.app_version,
-                        "source": "ingest_callback",
-                    },
-                )
-                self.run_store.update_run(
-                    policy_name=self.name,
-                    run_id=run.id,
-                    status=RunStatus.FAILED,
-                    error=error,
-                    entity_count=0,
-                )
-                return
-            try:
-                self._execute_run(
-                    self._diode_client, lambda: entities, source="ingest_callback"
-                )
-            except IngestError:
-                raise
-            except Exception as exc:
-                raise IngestError(str(exc)) from exc
-
-        return ingest_callback
 
     def _execute_run(
         self, client, produce_entities, *, source: str | None = None

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -21,7 +21,7 @@ from worker.backend import Backend, load_class
 from worker.entity_metadata import apply_run_id_to_entities
 from worker.exceptions import IngestError, IngestRejected
 from worker.metrics import get_metric
-from worker.models import DiodeConfig, Policy, Status
+from worker.models import DiodeConfig, Metadata, Policy, Status
 from worker.package_finder import maybe_evict
 from worker.policy.run import RunStatus, RunStore
 
@@ -71,13 +71,11 @@ class PolicyRunner:
         # Debug logging for backend loading
         logger.debug(f"Loading backend class: {policy.config.package}")
         backend_class = load_class(policy.config.package)
-
-        # Construct with no ingest_callback; it is attached below once every
-        # dependency the closure reads has been assigned.
-        backend = backend_class()
         logger.debug(f"Backend class loaded successfully: {backend_class.__name__}")
 
-        metadata = backend.setup()
+        # Read the backend's identity WITHOUT committing to an instance, so the
+        # ingest callback can be built and passed at construction time below.
+        metadata = self._backend_metadata(backend_class)
         app_name = (
             f"{diode_config.prefix}/{metadata.app_name}"
             if diode_config.prefix
@@ -113,10 +111,9 @@ class PolicyRunner:
         self._diode_client = client
 
         # Every dependency the closure reads (run_store, metadata, _diode_client)
-        # is now assigned, so the callback is safe to build and attach. The
-        # consumer reads `backend.ingest_callback` lazily at trigger time, so
-        # post-construction assignment is correct.
-        backend.ingest_callback = self._build_ingest_callback()
+        # is now assigned, so the callback is built first and the backend is
+        # constructed ONCE with it — no post-construction attach step.
+        backend = backend_class(ingest_callback=self._build_ingest_callback())
 
         self.scheduler.start()
 
@@ -142,6 +139,20 @@ class PolicyRunner:
         active_policies = get_metric("active_policies")
         if active_policies:
             active_policies.add(1, {"policy": self.name})
+
+    def _backend_metadata(self, backend_class) -> Metadata:
+        """
+        Read the backend's metadata without committing to an instance.
+
+        Prefer the class-level describe(); fall back to a throwaway instance's
+        setup() for integrations that only implement the legacy instance method.
+        """
+        try:
+            return backend_class.describe()
+        except NotImplementedError:
+            # Legacy backend: construct a throwaway just to read its metadata. The
+            # real, callback-bearing instance is constructed below.
+            return backend_class().setup()
 
     def _build_ingest_callback(self):
         """

--- a/worker/worker/policy/runner.py
+++ b/worker/worker/policy/runner.py
@@ -116,7 +116,7 @@ class PolicyRunner:
         # is now assigned, so the callback is safe to build and attach. The
         # consumer reads `backend.ingest_callback` lazily at trigger time, so
         # post-construction assignment is correct.
-        backend.ingest_callback = self._build_ingest_callback(self.name)
+        backend.ingest_callback = self._build_ingest_callback()
 
         self.scheduler.start()
 
@@ -143,7 +143,7 @@ class PolicyRunner:
         if active_policies:
             active_policies.add(1, {"policy": self.name})
 
-    def _build_ingest_callback(self, policy_name: str):
+    def _build_ingest_callback(self):
         """
         Build a closure used to ingest entities outside the scheduled run() cycle.
 


### PR DESCRIPTION
## Summary

Worker-side support for the API-triggered-sync contract (INT-312). Backends expose their
identity via a `describe()` classmethod, and the `PolicyRunner` constructs each backend
with an `IngestSink` so an integration can ship entities outside the scheduled `run()`
cycle (e.g. from an HTTP-triggered sync). A `worker.exceptions` hierarchy classifies
ingest failures.

## Changes

- **`Backend.describe()`** — new classmethod returning the backend's `Metadata` without
  constructing an instance. `setup()`-only backends keep working: the worker constructs
  one bare, reads its metadata via `setup()`, and schedules that same instance — so any
  state `setup()` initialises is live when `run()` reads it.
- **`Backend.setup()` is formally deprecated** (fallback removal planned for v2.0),
  signalled per audience: PEP 702 `@deprecated` for type checkers, a class-definition
  `DeprecationWarning` when a subclass overrides `setup()` without `describe()`, and an
  operator-facing log line when the worker uses the fallback. A `describe()` defined
  without `@classmethod` is also flagged at class-definition time.
- **`IngestSink`** — a typed, runtime-checkable protocol the worker passes to
  `Backend.__init__`: `ingest(entities)` runs the entities through a worker-tracked run
  (chunk, send, record), and `record_failure(error)` records a failed run for a
  collection that produced nothing. `ingest()` raises `IngestRejected` / `IngestError`
  on failure; `record_failure()` never raises. The sink — and therefore API-triggered
  sync — is supplied only to modern `describe()` backends; legacy `setup()`-only backends
  run on the scheduled path only.
- **`**kwargs` doors on `Backend.__init__` and `Backend.run`** — passive forward-compat:
  the worker passes nothing through them today; future minor releases may add per-tick
  context (e.g. `source`, `run_id`) without a coordinated upgrade.
- **`worker.exceptions`**: `IngestError` base, with `IngestRejected` (permanent — do not
  retry) for Diode-reported rejections and `IngestUnavailable` (transient — retry-friendly)
  for transient gRPC failures (`UNAVAILABLE` / `RESOURCE_EXHAUSTED` / `DEADLINE_EXCEEDED`).
- **Zero-entity runs complete as no-ops** (`entity_count=0`) rather than failing on
  Diode's empty-batch rejection — an incremental sync with no changes is a valid outcome.
- **`PolicyRunner`** routes both the scheduled `run()` and the ingest sink through one
  helper that creates a run, produces entities lazily inside the run's try-block (so a
  crashing backend is still recorded `FAILED`), chunks and ingests via the SDK, and
  records `COMPLETED`/`FAILED`.
- **`worker/pyproject.toml` source `project.version`** raised from `1.0.0` to
  `1.99.0.dev0`. Editable / `pip install -e` consumers (e.g. controller-integrations'
  e2e harness running with `--use orb-agent --local-orb-worker`) read this value
  directly and fail with `ResolutionImpossible` against downstream pins like
  `netboxlabs-orb-worker>=1.3.0`. The release workflow stamps the real version on top
  of `project.version` before `python -m build`, so the published wheel is unaffected.

## Consumer

The downstream `@with_trigger_api` decorator (netboxlabs/controller-integrations,
`trigger-api-util`) calls `self.ingest_sink.ingest(entities=...)` from an HTTP-triggered
run; the integrations' `run()` methods already declare `**kwargs`.

## Test summary

Unit suite extended around the new contract: describe()-first construction and the legacy
`setup()` path, the `IngestSink` ingest / record_failure paths and their failure mapping,
transient-vs-permanent gRPC classification, SDK-delegated chunking, and the empty-delta
no-op on both run paths. A sample `nbl-custom-legacy` package (setup()-only, no
`describe()`) is loaded through the real `load_class` machinery and driven through
`PolicyRunner.setup()`, so the deprecated fallback path is exercised end to end.
