### PR TITLE
fix(device-discovery): bound S300 VLAN range expansion

### DIFF
--- a/device-discovery/custom_napalm/cisco_s300.py
+++ b/device-discovery/custom_napalm/cisco_s300.py
@@ -20,6 +20,8 @@ from custom_napalm._vlan import SwitchportInfo, classify_switchport, parse_vlan_
 
 logger = logging.getLogger(__name__)
 
+_MAX_INTERFACE_RANGE_EXPANSION = 128
+
 # Config sanitization — S300 sensitive CLI fields:
 #   username <name> [privilege <n>] password [<enc-type>] <hash>
 #   enable password [level <n>] [<enc-type>] <hash>
@@ -85,6 +87,16 @@ def _expand_interface_range(range_str: str) -> list[str]:
         if m:
             prefix = m.group(1)
             start, end = int(m.group(2)), int(m.group(3))
+            if end < start:
+                continue
+            range_size = end - start + 1
+            if range_size > _MAX_INTERFACE_RANGE_EXPANSION:
+                logger.debug(
+                    "Skipping oversized S300 interface range %r with %d members",
+                    token,
+                    range_size,
+                )
+                continue
             result.extend(f"{prefix}{i}" for i in range(start, end + 1))
         else:
             result.append(token)
@@ -248,6 +260,7 @@ def _parse_vlan_ports_raw(raw: str) -> dict[str, list[str]]:
 
     """
     vlan_ports: dict[str, list[str]] = {}
+    vlan_seen: dict[str, set[str]] = {}
     current_id: str | None = None
     ports_col: int | None = None
 
@@ -271,8 +284,10 @@ def _parse_vlan_ports_raw(raw: str) -> dict[str, list[str]]:
         for token in _INTF_TOKEN_RE.findall(search_text):
             expanded = _expand_interface_range(token)
             entry = vlan_ports.setdefault(current_id, [])
+            seen = vlan_seen.setdefault(current_id, set())
             for intf in expanded:
-                if intf not in entry:
+                if intf not in seen:
+                    seen.add(intf)
                     entry.append(intf)
 
     return vlan_ports

--- a/device-discovery/custom_napalm/cisco_s300.py
+++ b/device-discovery/custom_napalm/cisco_s300.py
@@ -88,6 +88,12 @@ def _expand_interface_range(range_str: str) -> list[str]:
             prefix = m.group(1)
             start, end = int(m.group(2)), int(m.group(3))
             if end < start:
+                logger.debug(
+                    "Skipping reversed S300 interface range %r (end %d < start %d)",
+                    token,
+                    end,
+                    start,
+                )
                 continue
             range_size = end - start + 1
             if range_size > _MAX_INTERFACE_RANGE_EXPANSION:

--- a/device-discovery/tests/custom_drivers/cisco_s300/test_driver.py
+++ b/device-discovery/tests/custom_drivers/cisco_s300/test_driver.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from custom_napalm.cisco_s300 import S300Driver, _maybe_int
+from custom_napalm.cisco_s300 import S300Driver, _expand_interface_range, _maybe_int, _parse_vlan_ports_raw
 from tests.custom_drivers.base_test import BaseDriverTest
 from tests.custom_drivers.mock_device import FakeCLIDevice
 
@@ -20,6 +20,21 @@ def test_s300_maybe_int_rejects_bool_false():
 def test_s300_maybe_int_passes_through_string_int():
     """Plain string-int still coerces normally."""
     assert _maybe_int("42") == 42
+
+
+def test_s300_expand_interface_range_skips_oversized_ranges():
+    """Oversized device-provided ranges must not be materialized."""
+    assert _expand_interface_range("fa1-129,gi1") == ["gi1"]
+
+
+def test_s300_parse_vlan_ports_raw_skips_oversized_ranges():
+    """Malicious show vlan ranges must not exhaust memory during parsing."""
+    raw = """
+Vlan       Name               Ports              Created by
+---- ----------------- --------------------------- ----------------
+1    default           fa1-100000000,gi1           Static
+"""
+    assert _parse_vlan_ports_raw(raw) == {"1": ["gi1"]}
 
 
 class TestS300Driver(BaseDriverTest):


### PR DESCRIPTION
### Motivation
- Prevent a denial-of-service risk where untrusted `show vlan` output can request huge interface ranges (e.g. `fa1-100000000`) and cause excessive memory/CPU allocation during VLAN parsing.
- Preserve existing VLAN parsing behaviour for realistic device outputs while failing gracefully on malformed or malicious tokens.

### Description
- Add a hard cap `_MAX_INTERFACE_RANGE_EXPANSION = 128` and skip ranges that are reversed or exceed this limit, logging a debug message when skipped, in `_expand_interface_range`.
- Replace per-VLAN linear duplicate checks with a per-VLAN `set` (`vlan_seen`) to avoid O(n^2) behaviour while preserving insertion order in the resulting list in `_parse_vlan_ports_raw`.
- Add two regression tests: `test_s300_expand_interface_range_skips_oversized_ranges` and `test_s300_parse_vlan_ports_raw_skips_oversized_ranges` to cover oversized-range expansion and raw VLAN parsing.

### Testing
- Ran unit tests for the S300 driver with `cd device-discovery && python -m pytest tests/custom_drivers/cisco_s300/test_driver.py`, which completed successfully (`19 passed, 2 skipped`).
- Ran static checks with `cd device-discovery && python -m ruff check custom_napalm/cisco_s300.py tests/custom_drivers/cisco_s300/test_driver.py`, which reported `All checks passed!`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a20eec1b4bc832c881daade30d7845f)