### PR TITLE
feat(network-discovery): defaults.rd first-class; drop rd=name fallback

### DIFF
--- a/network-discovery/config/config.go
+++ b/network-discovery/config/config.go
@@ -59,6 +59,7 @@ type Scope struct {
 // Defaults represents the supported default values for a policy
 type Defaults struct {
 	Vrf         string   `yaml:"vrf,omitempty"`
+	Rd          string   `yaml:"rd,omitempty"`
 	Tenant      string   `yaml:"tenant,omitempty"`
 	Role        string   `yaml:"role,omitempty"`
 	Description string   `yaml:"description,omitempty"`

--- a/network-discovery/policy/runner.go
+++ b/network-discovery/policy/runner.go
@@ -371,10 +371,11 @@ func (r *Runner) run() {
 			ip.Comments = diode.String(r.config.Defaults.Comments)
 		}
 		if r.config.Defaults.Vrf != "" {
-			ip.Vrf = &diode.VRF{
-				Name: diode.String(r.config.Defaults.Vrf),
-				Rd:   diode.String(r.config.Defaults.Vrf),
+			vrf := &diode.VRF{Name: diode.String(r.config.Defaults.Vrf)}
+			if r.config.Defaults.Rd != "" {
+				vrf.Rd = diode.String(r.config.Defaults.Rd)
 			}
+			ip.Vrf = vrf
 		}
 		if r.config.Defaults.Tenant != "" {
 			ip.Tenant = &diode.Tenant{

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -526,7 +526,7 @@ func TestRunnerEmitsVrf(t *testing.T) {
 			assert.NoError(t, err)
 
 			ingestCalled := make(chan bool, 1)
-			mockClient.On("Ingest", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+			mockClient.On("Ingest", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 				entities := args.Get(1).([]diode.Entity)
 				assert.NotEmpty(t, entities, "expected at least one IPAddress entity")
 				ip := entities[0].(*diode.IPAddress)

--- a/network-discovery/policy/runner_test.go
+++ b/network-discovery/policy/runner_test.go
@@ -454,6 +454,115 @@ func TestRunnerWithNetworkMask(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+// TestRunnerEmitsVrf locks in the behaviour change introduced when
+// defaults.rd was promoted to a first-class field: when defaults.vrf is set,
+// Vrf.Name is always populated; Vrf.Rd is set ONLY when defaults.rd is also
+// provided. Previously Rd was hardcoded to mirror Name, which forced NetBox
+// to create a fresh VRF for every name instead of matching an existing one
+// with a different (or empty) RD.
+func TestRunnerEmitsVrf(t *testing.T) {
+	tests := []struct {
+		name        string
+		vrfDefault  string
+		rdDefault   string
+		expectVrf   bool
+		expectName  string
+		expectRdSet bool
+		expectRd    string
+	}{
+		{
+			name:        "vrf only - rd left nil",
+			vrfDefault:  "production",
+			rdDefault:   "",
+			expectVrf:   true,
+			expectName:  "production",
+			expectRdSet: false,
+		},
+		{
+			name:        "vrf + rd",
+			vrfDefault:  "production",
+			rdDefault:   "65000:100",
+			expectVrf:   true,
+			expectName:  "production",
+			expectRdSet: true,
+			expectRd:    "65000:100",
+		},
+		{
+			name:       "no vrf - rd ignored",
+			vrfDefault: "",
+			rdDefault:  "65000:100",
+			expectVrf:  false,
+		},
+		{
+			name:       "neither set",
+			vrfDefault: "",
+			rdDefault:  "",
+			expectVrf:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			logger := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			mockClient := new(MockClient)
+			runStore := policy.NewRunStore()
+			ctx := context.Background()
+
+			policyConfig := config.Policy{
+				Config: config.PolicyConfig{
+					Schedule: nil,
+					Defaults: config.Defaults{
+						Vrf: tt.vrfDefault,
+						Rd:  tt.rdDefault,
+					},
+				},
+				Scope: config.Scope{
+					Targets:    []string{"127.0.0.1"},
+					FastMode:   boolPtr(true),
+					MaxRetries: intPtr(0),
+				},
+			}
+
+			runner, err := policy.NewRunner(ctx, logger, "test-policy", policyConfig, mockClient, runStore)
+			assert.NoError(t, err)
+
+			ingestCalled := make(chan bool, 1)
+			mockClient.On("Ingest", mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+				entities := args.Get(1).([]diode.Entity)
+				assert.NotEmpty(t, entities, "expected at least one IPAddress entity")
+				ip := entities[0].(*diode.IPAddress)
+				if tt.expectVrf {
+					assert.NotNil(t, ip.Vrf, "Vrf should be emitted when defaults.vrf is set")
+					if ip.Vrf != nil {
+						assert.NotNil(t, ip.Vrf.Name)
+						assert.Equal(t, tt.expectName, *ip.Vrf.Name)
+						if tt.expectRdSet {
+							assert.NotNil(t, ip.Vrf.Rd, "Vrf.Rd should be set when defaults.rd is set")
+							if ip.Vrf.Rd != nil {
+								assert.Equal(t, tt.expectRd, *ip.Vrf.Rd)
+							}
+						} else {
+							assert.Nil(t, ip.Vrf.Rd,
+								"Vrf.Rd MUST be nil when defaults.rd is unset (no rd=name fallback)")
+						}
+					}
+				} else {
+					assert.Nil(t, ip.Vrf, "Vrf should not be emitted when defaults.vrf is empty")
+				}
+				ingestCalled <- true
+			}).Return(&diodepb.IngestResponse{}, nil)
+
+			runner.Start()
+			select {
+			case <-ingestCalled:
+			case <-time.After(30 * time.Second):
+				t.Fatal("Timeout: Ingest was not called")
+			}
+			err = runner.Stop()
+			assert.NoError(t, err)
+		})
+	}
+}
+
 func boolPtr(b bool) *bool {
 	return &b
 }


### PR DESCRIPTION
## Summary

Closes netboxlabs/orb-agent#389.

Adds `defaults.rd` as a sibling to `defaults.vrf` and drops the hardcoded `Vrf.Rd = Vrf.Name` fallback.

### Before
```go
if r.config.Defaults.Vrf != "" {
    ip.Vrf = &diode.VRF{
        Name: diode.String(r.config.Defaults.Vrf),
        Rd:   diode.String(r.config.Defaults.Vrf),  // forced to mirror Name
    }
}
```
NetBox keys VRFs by `(name, rd)`. Forcing `rd = name` meant every discovery run created a brand-new VRF instead of matching the operator's existing one. The reporter (Io Noci) hit this when running discovery against a subnet inside a pre-existing VRF — Diode created a fresh duplicate with `rd=<vrf-name>` every cycle.

### After
```go
if r.config.Defaults.Vrf != "" {
    vrf := &diode.VRF{Name: diode.String(r.config.Defaults.Vrf)}
    if r.config.Defaults.Rd != "" {
        vrf.Rd = diode.String(r.config.Defaults.Rd)
    }
    ip.Vrf = vrf
}
```
- `defaults.rd` populated → `Vrf.Rd` set on the wire → NetBox matches on `(name, rd)`.
- `defaults.rd` omitted → `Vrf.Rd` left nil → NetBox matches an existing VRF whose `rd` column is null (Io Noci's case).

### Example
```yaml
defaults:
  vrf: production
  rd: "65000:100"   # optional
```

## Behaviour-change call-out for the release notes

Anyone who was previously relying on the buggy rd=name behaviour (their existing NetBox VRF has `rd="<vrf-name>"`) MUST set `defaults.rd: "<vrf-name>"` explicitly after upgrade, otherwise Diode will create a second VRF with the same name but a nil `rd`. For the common case where the operator's VRF has a null `rd`, the new default behaviour matches correctly with no config changes.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — full suite passes
- [x] New `TestRunnerEmitsVrf` with 4 sub-cases:
  - vrf set, rd unset → `Vrf{Name: "production", Rd: nil}` (the key behavioural assertion)
  - vrf set, rd set → `Vrf{Name: "production", Rd: "65000:100"}`
  - vrf unset, rd set → no VRF emitted (rd ignored without vrf)
  - neither set → no VRF emitted
- [x] `go vet ./...` clean
- [x] `golangci-lint run --config ../.github/golangci.yaml ./...` — 0 issues

## Out of scope

- snmp-discovery — separate PR (the data model already supports `rd`, so it's a smaller change).
- Polymorphic nested `vrf: {name, rd}` config form — rejected in favour of flat `defaults.rd` sibling for consistency with the rest of `defaults.*`.

Companion docs PR: netboxlabs/orb-agent#<pending>

🤖 Generated with [Claude Code](https://claude.com/claude-code)