### PR TITLE
feat(snmp-discovery): vrf first-class with rd; drop rd=name fallback

### DIFF
--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -13,7 +13,7 @@ import (
 // lets operators attach a Route Distinguisher (and richer metadata) to
 // the discovered IP addresses' VRF so NetBox can match an existing
 // (name, rd) tuple instead of being forced into the legacy rd=name
-// fallback (orb-agent#389).
+// fallback.
 type VrfParameters struct {
 	Name        string   `yaml:"name"`
 	Rd          string   `yaml:"rd,omitempty"`

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -1,6 +1,50 @@
 package config
 
-import "time"
+import (
+	"fmt"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// VrfParameters mirrors device-discovery's VrfParameters: a polymorphic
+// config primitive that accepts either a scalar string (interpreted as
+// VRF Name) or a map of {name, rd, description, comments, tags}. This
+// lets operators attach a Route Distinguisher (and richer metadata) to
+// the discovered IP addresses' VRF so NetBox can match an existing
+// (name, rd) tuple instead of being forced into the legacy rd=name
+// fallback (orb-agent#389).
+type VrfParameters struct {
+	Name        string   `yaml:"name"`
+	Rd          string   `yaml:"rd,omitempty"`
+	Description string   `yaml:"description,omitempty"`
+	Comments    string   `yaml:"comments,omitempty"`
+	Tags        []string `yaml:"tags,omitempty"`
+}
+
+// UnmarshalYAML accepts both shapes:
+//   - scalar:  vrf: production
+//   - mapping: vrf: {name: production, rd: "65000:100"}
+//
+// The scalar form populates only Name (Rd left empty), which differs
+// from the pre-fix behaviour where the agent silently set Rd=Name.
+func (v *VrfParameters) UnmarshalYAML(node *yaml.Node) error {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		v.Name = node.Value
+		return nil
+	case yaml.MappingNode:
+		type alias VrfParameters
+		var a alias
+		if err := node.Decode(&a); err != nil {
+			return err
+		}
+		*v = VrfParameters(a)
+		return nil
+	default:
+		return fmt.Errorf("vrf: expected string or mapping, got node kind %d", node.Kind)
+	}
+}
 
 // Status represents the status of the snmp-discovery service
 type Status struct {
@@ -38,12 +82,12 @@ type Authentication struct {
 
 // IPAddressDefaults represents default values for a specific entity type
 type IPAddressDefaults struct {
-	Description string   `yaml:"description,omitempty"`
-	Tags        []string `yaml:"tags,omitempty"`
-	Comments    string   `yaml:"comments,omitempty"`
-	Role        string   `yaml:"role,omitempty"`
-	Tenant      string   `yaml:"tenant,omitempty"`
-	Vrf         string   `yaml:"vrf,omitempty"`
+	Description string        `yaml:"description,omitempty"`
+	Tags        []string      `yaml:"tags,omitempty"`
+	Comments    string        `yaml:"comments,omitempty"`
+	Role        string        `yaml:"role,omitempty"`
+	Tenant      string        `yaml:"tenant,omitempty"`
+	Vrf         VrfParameters `yaml:"vrf,omitempty"`
 }
 
 // InterfaceDefaults represents default values for a specific entity type
@@ -136,7 +180,7 @@ func MergeDefaults(policyDefaults, overrideDefaults *Defaults) *Defaults {
 	if overrideDefaults.IPAddress.Tenant != "" {
 		merged.IPAddress.Tenant = overrideDefaults.IPAddress.Tenant
 	}
-	if overrideDefaults.IPAddress.Vrf != "" {
+	if overrideDefaults.IPAddress.Vrf.Name != "" {
 		merged.IPAddress.Vrf = overrideDefaults.IPAddress.Vrf
 	}
 

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -28,9 +28,13 @@ type VrfParameters struct {
 //
 // The scalar form populates only Name (Rd left empty), which differs
 // from the pre-fix behaviour where the agent silently set Rd=Name.
-// Explicit YAML null (vrf: null, vrf: ~) is treated as zero value so
-// operators can clear inherited VRF defaults without naming a VRF
-// literally "null".
+//
+// Explicit YAML null (vrf: null, vrf: ~) decodes to the zero value
+// instead of the literal string "null" — this is decode safety to
+// avoid creating a phantom VRF named "null". It does NOT, by itself,
+// clear an inherited VRF default at override merge time: MergeDefaults
+// treats the zero value the same way as an absent override key
+// (non-empty-wins, matching every other override_defaults field).
 func (v *VrfParameters) UnmarshalYAML(node *yaml.Node) error {
 	// Reset up front so a stale receiver (re-decoded into the same
 	// struct) doesn't keep Rd / Description / Comments / Tags from a

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -28,9 +28,21 @@ type VrfParameters struct {
 //
 // The scalar form populates only Name (Rd left empty), which differs
 // from the pre-fix behaviour where the agent silently set Rd=Name.
+// Explicit YAML null (vrf: null, vrf: ~) is treated as zero value so
+// operators can clear inherited VRF defaults without naming a VRF
+// literally "null".
 func (v *VrfParameters) UnmarshalYAML(node *yaml.Node) error {
+	// Reset up front so a stale receiver (re-decoded into the same
+	// struct) doesn't keep Rd / Description / Comments / Tags from a
+	// previous pass when the new YAML only sets Name via the scalar
+	// form.
+	*v = VrfParameters{}
 	switch node.Kind {
 	case yaml.ScalarNode:
+		// YAML null tag: leave the struct as the zero value.
+		if node.Tag == "!!null" {
+			return nil
+		}
 		v.Name = node.Value
 		return nil
 	case yaml.MappingNode:

--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -180,8 +180,24 @@ func MergeDefaults(policyDefaults, overrideDefaults *Defaults) *Defaults {
 	if overrideDefaults.IPAddress.Tenant != "" {
 		merged.IPAddress.Tenant = overrideDefaults.IPAddress.Tenant
 	}
+	// Merge VRF defaults field-by-field so a per-target override can refine
+	// a single VrfParameters knob (e.g. rd) without having to restate every
+	// other field already set at the policy level. Matches the
+	// Device/VLAN/Interface non-zero-value-wins pattern.
 	if overrideDefaults.IPAddress.Vrf.Name != "" {
-		merged.IPAddress.Vrf = overrideDefaults.IPAddress.Vrf
+		merged.IPAddress.Vrf.Name = overrideDefaults.IPAddress.Vrf.Name
+	}
+	if overrideDefaults.IPAddress.Vrf.Rd != "" {
+		merged.IPAddress.Vrf.Rd = overrideDefaults.IPAddress.Vrf.Rd
+	}
+	if overrideDefaults.IPAddress.Vrf.Description != "" {
+		merged.IPAddress.Vrf.Description = overrideDefaults.IPAddress.Vrf.Description
+	}
+	if overrideDefaults.IPAddress.Vrf.Comments != "" {
+		merged.IPAddress.Vrf.Comments = overrideDefaults.IPAddress.Vrf.Comments
+	}
+	if len(overrideDefaults.IPAddress.Vrf.Tags) > 0 {
+		merged.IPAddress.Vrf.Tags = overrideDefaults.IPAddress.Vrf.Tags
 	}
 
 	// Merge Interface defaults

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -658,4 +658,43 @@ func TestVrfParameters_UnmarshalYAML(t *testing.T) {
 		err := yaml.Unmarshal(raw, &pc)
 		require.Error(t, err)
 	})
+
+	t.Run("explicit null clears to zero value", func(t *testing.T) {
+		// `vrf: null` / `vrf: ~` MUST NOT produce a VRF named "null" —
+		// callers want this shape to clear any inherited default.
+		for _, raw := range [][]byte{
+			[]byte("defaults:\n  ip_address:\n    vrf: null\n"),
+			[]byte("defaults:\n  ip_address:\n    vrf: ~\n"),
+		} {
+			var pc PolicyConfig
+			require.NoError(t, yaml.Unmarshal(raw, &pc))
+			assert.Empty(t, pc.Defaults.IPAddress.Vrf.Name,
+				"vrf: null / vrf: ~ MUST decode to zero value, not Name=\"null\"")
+			assert.Empty(t, pc.Defaults.IPAddress.Vrf.Rd)
+		}
+	})
+
+	t.Run("re-decode into populated receiver clears stale fields", func(t *testing.T) {
+		// If the same VrfParameters value is re-used across decodes
+		// (e.g. tests, layered configs), the scalar form must NOT
+		// leave stale Rd / Description / Comments / Tags behind. Drive
+		// the receiver through the full ScalarNode path by unmarshaling
+		// a wrapper map and pulling out the resolved Vrf field.
+		v := VrfParameters{
+			Name:        "stale",
+			Rd:          "65000:999",
+			Description: "stale-desc",
+			Comments:    "stale-comments",
+			Tags:        []string{"stale"},
+		}
+		wrapper := struct {
+			Vrf VrfParameters `yaml:"vrf"`
+		}{Vrf: v}
+		require.NoError(t, yaml.Unmarshal([]byte("vrf: production\n"), &wrapper))
+		assert.Equal(t, "production", wrapper.Vrf.Name)
+		assert.Empty(t, wrapper.Vrf.Rd, "stale Rd must be cleared by scalar re-decode")
+		assert.Empty(t, wrapper.Vrf.Description)
+		assert.Empty(t, wrapper.Vrf.Comments)
+		assert.Empty(t, wrapper.Vrf.Tags)
+	})
 }

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -127,6 +127,79 @@ func TestMergeDefaults(t *testing.T) {
 		assert.Equal(t, "Policy Comments", result.IPAddress.Comments) // Not overridden
 	})
 
+	t.Run("Override IPAddress VRF field-by-field", func(t *testing.T) {
+		// Per-target override should be able to refine a single VrfParameters
+		// field (e.g. rd) without having to restate the rest of the policy's
+		// VRF config. Matches the Device/VLAN/Interface override pattern.
+		policyDefaults := &Defaults{
+			IPAddress: IPAddressDefaults{
+				Vrf: VrfParameters{
+					Name:        "prod",
+					Rd:          "65000:100",
+					Description: "Prod VRF",
+					Comments:    "policy comments",
+					Tags:        []string{"policy"},
+				},
+			},
+		}
+
+		t.Run("override only Rd", func(t *testing.T) {
+			overrideDefaults := &Defaults{
+				IPAddress: IPAddressDefaults{
+					Vrf: VrfParameters{Rd: "65000:200"},
+				},
+			}
+			result := MergeDefaults(policyDefaults, overrideDefaults)
+			assert.Equal(t, "prod", result.IPAddress.Vrf.Name)
+			assert.Equal(t, "65000:200", result.IPAddress.Vrf.Rd) // override won
+			assert.Equal(t, "Prod VRF", result.IPAddress.Vrf.Description)
+			assert.Equal(t, "policy comments", result.IPAddress.Vrf.Comments)
+			assert.Equal(t, []string{"policy"}, result.IPAddress.Vrf.Tags)
+		})
+
+		t.Run("override only Name", func(t *testing.T) {
+			overrideDefaults := &Defaults{
+				IPAddress: IPAddressDefaults{
+					Vrf: VrfParameters{Name: "edge-vrf"},
+				},
+			}
+			result := MergeDefaults(policyDefaults, overrideDefaults)
+			assert.Equal(t, "edge-vrf", result.IPAddress.Vrf.Name) // override won
+			assert.Equal(t, "65000:100", result.IPAddress.Vrf.Rd)  // inherited
+			assert.Equal(t, "Prod VRF", result.IPAddress.Vrf.Description)
+		})
+
+		t.Run("override all VRF fields", func(t *testing.T) {
+			overrideDefaults := &Defaults{
+				IPAddress: IPAddressDefaults{
+					Vrf: VrfParameters{
+						Name:        "edge-vrf",
+						Rd:          "65000:200",
+						Description: "Edge VRF",
+						Comments:    "override comments",
+						Tags:        []string{"override"},
+					},
+				},
+			}
+			result := MergeDefaults(policyDefaults, overrideDefaults)
+			assert.Equal(t, "edge-vrf", result.IPAddress.Vrf.Name)
+			assert.Equal(t, "65000:200", result.IPAddress.Vrf.Rd)
+			assert.Equal(t, "Edge VRF", result.IPAddress.Vrf.Description)
+			assert.Equal(t, "override comments", result.IPAddress.Vrf.Comments)
+			assert.Equal(t, []string{"override"}, result.IPAddress.Vrf.Tags)
+		})
+
+		t.Run("empty override leaves VRF untouched", func(t *testing.T) {
+			overrideDefaults := &Defaults{}
+			result := MergeDefaults(policyDefaults, overrideDefaults)
+			assert.Equal(t, "prod", result.IPAddress.Vrf.Name)
+			assert.Equal(t, "65000:100", result.IPAddress.Vrf.Rd)
+			assert.Equal(t, "Prod VRF", result.IPAddress.Vrf.Description)
+			assert.Equal(t, "policy comments", result.IPAddress.Vrf.Comments)
+			assert.Equal(t, []string{"policy"}, result.IPAddress.Vrf.Tags)
+		})
+	})
+
 	t.Run("Override InterfacePatterns replaces entire array", func(t *testing.T) {
 		policyDefaults := &Defaults{
 			InterfacePatterns: []InterfacePattern{

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -103,7 +103,7 @@ func TestMergeDefaults(t *testing.T) {
 			IPAddress: IPAddressDefaults{
 				Role:        "anycast",
 				Tenant:      "default-tenant",
-				Vrf:         "default-vrf",
+				Vrf:         VrfParameters{Name: "default-vrf"},
 				Description: "Policy IP",
 				Tags:        []string{"policy"},
 				Comments:    "Policy Comments",
@@ -122,7 +122,7 @@ func TestMergeDefaults(t *testing.T) {
 		assert.Equal(t, "loopback", result.IPAddress.Role)
 		assert.Equal(t, "override-tenant", result.IPAddress.Tenant)
 		assert.Equal(t, []string{"override"}, result.IPAddress.Tags)
-		assert.Equal(t, "default-vrf", result.IPAddress.Vrf)          // Not overridden
+		assert.Equal(t, "default-vrf", result.IPAddress.Vrf.Name)     // Not overridden
 		assert.Equal(t, "Policy IP", result.IPAddress.Description)    // Not overridden
 		assert.Equal(t, "Policy Comments", result.IPAddress.Comments) // Not overridden
 	})
@@ -525,4 +525,64 @@ func TestPolicyOptions_DiscoverModulesParsed(t *testing.T) {
 			assert.Equal(t, c.out, pc.Options.ModuleDiscoveryMode())
 		})
 	}
+}
+
+// TestVrfParameters_UnmarshalYAML locks in the dual-shape contract:
+// defaults.ip_address.vrf accepts either a scalar string (interpreted as
+// VRF Name; Rd left empty so NetBox can match an existing VRF whose rd
+// column is null) OR a map with name / rd / description / comments /
+// tags (the rich form, matching device-discovery's VrfParameters).
+func TestVrfParameters_UnmarshalYAML(t *testing.T) {
+	t.Run("scalar string populates Name only", func(t *testing.T) {
+		raw := []byte("defaults:\n  ip_address:\n    vrf: production\n")
+		var pc PolicyConfig
+		require.NoError(t, yaml.Unmarshal(raw, &pc))
+		assert.Equal(t, "production", pc.Defaults.IPAddress.Vrf.Name)
+		assert.Empty(t, pc.Defaults.IPAddress.Vrf.Rd,
+			"scalar form MUST leave Rd empty (no rd=name fallback)")
+		assert.Empty(t, pc.Defaults.IPAddress.Vrf.Description)
+		assert.Empty(t, pc.Defaults.IPAddress.Vrf.Comments)
+		assert.Empty(t, pc.Defaults.IPAddress.Vrf.Tags)
+	})
+
+	t.Run("map form populates all fields", func(t *testing.T) {
+		raw := []byte(`defaults:
+  ip_address:
+    vrf:
+      name: production
+      rd: "65000:100"
+      description: Prod VRF
+      comments: Imported from SNMP
+      tags: [auto, vrf]
+`)
+		var pc PolicyConfig
+		require.NoError(t, yaml.Unmarshal(raw, &pc))
+		assert.Equal(t, "production", pc.Defaults.IPAddress.Vrf.Name)
+		assert.Equal(t, "65000:100", pc.Defaults.IPAddress.Vrf.Rd)
+		assert.Equal(t, "Prod VRF", pc.Defaults.IPAddress.Vrf.Description)
+		assert.Equal(t, "Imported from SNMP", pc.Defaults.IPAddress.Vrf.Comments)
+		assert.Equal(t, []string{"auto", "vrf"}, pc.Defaults.IPAddress.Vrf.Tags)
+	})
+
+	t.Run("map form with only name + rd", func(t *testing.T) {
+		raw := []byte("defaults:\n  ip_address:\n    vrf:\n      name: production\n      rd: \"65000:100\"\n")
+		var pc PolicyConfig
+		require.NoError(t, yaml.Unmarshal(raw, &pc))
+		assert.Equal(t, "production", pc.Defaults.IPAddress.Vrf.Name)
+		assert.Equal(t, "65000:100", pc.Defaults.IPAddress.Vrf.Rd)
+	})
+
+	t.Run("absent vrf leaves zero value", func(t *testing.T) {
+		raw := []byte("defaults:\n  ip_address:\n    role: anycast\n")
+		var pc PolicyConfig
+		require.NoError(t, yaml.Unmarshal(raw, &pc))
+		assert.Empty(t, pc.Defaults.IPAddress.Vrf.Name)
+	})
+
+	t.Run("invalid node kind returns error", func(t *testing.T) {
+		raw := []byte("defaults:\n  ip_address:\n    vrf: [unexpected, sequence]\n")
+		var pc PolicyConfig
+		err := yaml.Unmarshal(raw, &pc)
+		require.Error(t, err)
+	})
 }

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -659,9 +659,14 @@ func TestVrfParameters_UnmarshalYAML(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("explicit null clears to zero value", func(t *testing.T) {
-		// `vrf: null` / `vrf: ~` MUST NOT produce a VRF named "null" —
-		// callers want this shape to clear any inherited default.
+	t.Run("explicit null decodes to zero value", func(t *testing.T) {
+		// Decode-safety contract: `vrf: null` / `vrf: ~` MUST NOT
+		// produce a VRF named "null". Whether the resulting zero value
+		// actually clears an inherited VRF at MergeDefaults time is a
+		// separate concern — MergeDefaults follows the same
+		// non-empty-wins pattern as every other override field, so
+		// `vrf: null` and an absent `vrf` key are indistinguishable
+		// during merge. This test only asserts the decode boundary.
 		for _, raw := range [][]byte{
 			[]byte("defaults:\n  ip_address:\n    vrf: null\n"),
 			[]byte("defaults:\n  ip_address:\n    vrf: ~\n"),

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"unicode/utf8"
 
 	"github.com/netboxlabs/diode-sdk-go/diode"
@@ -30,6 +31,11 @@ const (
 // IPAddressMapper is a struct that maps IP addresses to entities
 type IPAddressMapper struct {
 	logger *slog.Logger
+	// vrfMisconfigWarnOnce fires the "VRF fields set but no Name"
+	// warning at most once per mapper lifetime. applyDefaults runs per
+	// discovered IP address, so without rate-limiting a misconfigured
+	// policy would flood the logs with one identical line per row.
+	vrfMisconfigWarnOnce sync.Once
 }
 
 // NewIPAddressMapper creates a new IPAddressMapper
@@ -119,14 +125,22 @@ func (m *IPAddressMapper) applyDefaults(entity *diode.IPAddress, defaults *confi
 			// — there is nothing to attach without Name, so the row is
 			// dropped silently in the proto. Surface a warning so the
 			// operator sees the misconfiguration in the logs instead of
-			// wondering why the IPs have no VRF.
-			m.logger.Warn(
-				"VRF defaults dropped: name is empty but other VRF fields are set; set defaults.ip_address.vrf.name (or the policy-level vrf scalar) to enable VRF emission",
-				"rd", vrfDefaults.Rd,
-				"description", vrfDefaults.Description,
-				"comments", vrfDefaults.Comments,
-				"tags", vrfDefaults.Tags,
-			)
+			// wondering why the IPs have no VRF. Rate-limit to once per
+			// mapper lifetime since applyDefaults runs per IP — without
+			// this guard a misconfigured policy would emit one identical
+			// warning per discovered address.
+			m.vrfMisconfigWarnOnce.Do(func() {
+				m.logger.Warn(
+					"VRF defaults dropped: name is empty but other VRF fields are set; "+
+						"set defaults.ip_address.vrf.name in the policy (or "+
+						"targets[].override_defaults.ip_address.vrf.name) to enable VRF emission. "+
+						"This warning is logged once per discovery run; subsequent IPs with the same misconfig will be silently skipped.",
+					"rd", vrfDefaults.Rd,
+					"description", vrfDefaults.Description,
+					"comments", vrfDefaults.Comments,
+					"tags", vrfDefaults.Tags,
+				)
+			})
 		}
 	}
 }

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -87,11 +87,27 @@ func (m *IPAddressMapper) applyDefaults(entity *diode.IPAddress, defaults *confi
 	if entity.Role == nil && entityDefaults.Role != "" {
 		entity.Role = &entityDefaults.Role
 	}
-	if entity.Vrf == nil && entityDefaults.Vrf != "" {
-		entity.Vrf = &diode.VRF{
-			Name: &entityDefaults.Vrf,
-			Rd:   &entityDefaults.Vrf,
+	if entity.Vrf == nil && entityDefaults.Vrf.Name != "" {
+		vrfDefaults := entityDefaults.Vrf
+		vrf := &diode.VRF{Name: &vrfDefaults.Name}
+		if vrfDefaults.Rd != "" {
+			vrf.Rd = &vrfDefaults.Rd
 		}
+		if vrfDefaults.Description != "" {
+			vrf.Description = &vrfDefaults.Description
+		}
+		if vrfDefaults.Comments != "" {
+			vrf.Comments = &vrfDefaults.Comments
+		}
+		if len(vrfDefaults.Tags) > 0 {
+			tags := make([]*diode.Tag, 0, len(vrfDefaults.Tags))
+			for _, t := range vrfDefaults.Tags {
+				tagName := t
+				tags = append(tags, &diode.Tag{Name: &tagName})
+			}
+			vrf.Tags = tags
+		}
+		entity.Vrf = vrf
 	}
 }
 

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -87,27 +87,47 @@ func (m *IPAddressMapper) applyDefaults(entity *diode.IPAddress, defaults *confi
 	if entity.Role == nil && entityDefaults.Role != "" {
 		entity.Role = &entityDefaults.Role
 	}
-	if entity.Vrf == nil && entityDefaults.Vrf.Name != "" {
+	if entity.Vrf == nil {
 		vrfDefaults := entityDefaults.Vrf
-		vrf := &diode.VRF{Name: &vrfDefaults.Name}
-		if vrfDefaults.Rd != "" {
-			vrf.Rd = &vrfDefaults.Rd
-		}
-		if vrfDefaults.Description != "" {
-			vrf.Description = &vrfDefaults.Description
-		}
-		if vrfDefaults.Comments != "" {
-			vrf.Comments = &vrfDefaults.Comments
-		}
-		if len(vrfDefaults.Tags) > 0 {
-			tags := make([]*diode.Tag, 0, len(vrfDefaults.Tags))
-			for _, t := range vrfDefaults.Tags {
-				tagName := t
-				tags = append(tags, &diode.Tag{Name: &tagName})
+		switch {
+		case vrfDefaults.Name != "":
+			vrf := &diode.VRF{Name: &vrfDefaults.Name}
+			if vrfDefaults.Rd != "" {
+				vrf.Rd = &vrfDefaults.Rd
 			}
-			vrf.Tags = tags
+			if vrfDefaults.Description != "" {
+				vrf.Description = &vrfDefaults.Description
+			}
+			if vrfDefaults.Comments != "" {
+				vrf.Comments = &vrfDefaults.Comments
+			}
+			if len(vrfDefaults.Tags) > 0 {
+				tags := make([]*diode.Tag, 0, len(vrfDefaults.Tags))
+				for _, t := range vrfDefaults.Tags {
+					tagName := t
+					tags = append(tags, &diode.Tag{Name: &tagName})
+				}
+				vrf.Tags = tags
+			}
+			entity.Vrf = vrf
+		case vrfDefaults.Rd != "", vrfDefaults.Description != "",
+			vrfDefaults.Comments != "", len(vrfDefaults.Tags) > 0:
+			// One or more VRF sub-fields were configured but Name is empty,
+			// either via a policy default like `vrf: {rd: "65000:100"}` with
+			// no name OR a per-target override that refines fields without
+			// inheriting a policy-level Name. NetBox VRFs match on (name, rd)
+			// — there is nothing to attach without Name, so the row is
+			// dropped silently in the proto. Surface a warning so the
+			// operator sees the misconfiguration in the logs instead of
+			// wondering why the IPs have no VRF.
+			m.logger.Warn(
+				"VRF defaults dropped: name is empty but other VRF fields are set; set defaults.ip_address.vrf.name (or the policy-level vrf scalar) to enable VRF emission",
+				"rd", vrfDefaults.Rd,
+				"description", vrfDefaults.Description,
+				"comments", vrfDefaults.Comments,
+				"tags", vrfDefaults.Tags,
+			)
 		}
-		entity.Vrf = vrf
 	}
 }
 

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -3180,6 +3180,22 @@ func TestIPAddressMapper_Map_VRFNameEmptyWarns(t *testing.T) {
 	assert.Contains(t, logOut, "VRF defaults dropped: name is empty",
 		"expected a warning surfacing the misconfiguration in the logs")
 	assert.Contains(t, logOut, "65000:100", "warning should include the dropped Rd value for debugging")
+	assert.Contains(t, logOut, "override_defaults",
+		"warning should also point at the per-target override path, not only the policy-level path")
+
+	// Rate-limit: applyDefaults runs per discovered IP. With the same
+	// misconfig, subsequent calls must NOT keep appending duplicate
+	// warnings to the log — sync.Once gates it to one line per mapper.
+	buf.Reset()
+	for i := 0; i < 5; i++ {
+		// Reset the entity registry between calls so each iteration
+		// is treated as a fresh row (otherwise Map() short-circuits on
+		// the cached registry entry from the first call).
+		registry = mapping.NewEntityRegistry(logger)
+		mapper.Map(values, mappingEntry, registry, defaults)
+	}
+	assert.NotContains(t, buf.String(), "VRF defaults dropped",
+		"warning must fire at most once per mapper lifetime; subsequent calls must stay silent")
 }
 
 func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -287,7 +287,7 @@ func TestIPAddressMapper_Map(t *testing.T) {
 					Description: "IP Address specific description",
 					Tenant:      "ip-address-tenant",
 					Role:        "ip-address-role",
-					Vrf:         "ip-address-vrf",
+					Vrf:         config.VrfParameters{Name: "ip-address-vrf"},
 				},
 			},
 			expectedEntity: &diode.IPAddress{
@@ -297,9 +297,62 @@ func TestIPAddressMapper_Map(t *testing.T) {
 					Name: mapping.StringPtr("ip-address-tenant"),
 				},
 				Role: mapping.StringPtr("ip-address-role"),
+				// Scalar form: Vrf.Name set, Vrf.Rd left nil so NetBox can
+				// match an existing VRF whose rd column is null. The
+				// pre-fix rd=name hardcode is the behaviour change.
 				Vrf: &diode.VRF{
 					Name: mapping.StringPtr("ip-address-vrf"),
-					Rd:   mapping.StringPtr("ip-address-vrf"),
+				},
+			},
+			expectError: false,
+		},
+		{
+			// Rich VrfParameters form propagates Rd / Description /
+			// Comments / Tags onto the emitted diode.VRF.
+			name: "ipAddress with rich VRF defaults (name + rd + description + comments + tags)",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.4.20.1.1.192.168.1.1": {
+					OID:    "1.3.6.1.2.1.4.20.1.1.192.168.1.1",
+					Index:  "192.168.1.1",
+					Parent: "1.3.6.1.2.1.4.20.1.1",
+					Value:  "192.168.1.1",
+					Type:   mapping.IPAddress,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.4.20.1.1",
+						Entity: "ipAddress",
+						Field:  "address",
+					},
+				},
+			},
+			defaults: &config.Defaults{
+				IPAddress: config.IPAddressDefaults{
+					Vrf: config.VrfParameters{
+						Name:        "prod",
+						Rd:          "65000:100",
+						Description: "Prod VRF",
+						Comments:    "Imported via SNMP",
+						Tags:        []string{"auto", "vrf"},
+					},
+				},
+			},
+			expectedEntity: &diode.IPAddress{
+				Address: mapping.StringPtr("192.168.1.1/32"),
+				Vrf: &diode.VRF{
+					Name:        mapping.StringPtr("prod"),
+					Rd:          mapping.StringPtr("65000:100"),
+					Description: mapping.StringPtr("Prod VRF"),
+					Comments:    mapping.StringPtr("Imported via SNMP"),
+					Tags: []*diode.Tag{
+						{Name: mapping.StringPtr("auto")},
+						{Name: mapping.StringPtr("vrf")},
+					},
 				},
 			},
 			expectError: false,

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -377,8 +377,15 @@ func TestIPAddressMapper_Map(t *testing.T) {
 			assert.Equal(t, tt.expectedEntity.Description, ipAddress.Description)
 			assert.Equal(t, tt.expectedEntity.Role, ipAddress.Role)
 			if tt.expectedEntity.Vrf != nil {
+				assert.NotNil(t, ipAddress.Vrf)
 				assert.Equal(t, tt.expectedEntity.Vrf.Name, ipAddress.Vrf.Name)
 				assert.Equal(t, tt.expectedEntity.Vrf.Rd, ipAddress.Vrf.Rd)
+				assert.Equal(t, tt.expectedEntity.Vrf.Description, ipAddress.Vrf.Description)
+				assert.Equal(t, tt.expectedEntity.Vrf.Comments, ipAddress.Vrf.Comments)
+				assert.Equal(t, len(tt.expectedEntity.Vrf.Tags), len(ipAddress.Vrf.Tags))
+				for i, expectedTag := range tt.expectedEntity.Vrf.Tags {
+					assert.Equal(t, expectedTag.Name, ipAddress.Vrf.Tags[i].Name)
+				}
 			}
 			if tt.expectedEntity.Tags != nil {
 				assert.Equal(t, len(tt.expectedEntity.Tags), len(ipAddress.Tags))

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -1,6 +1,7 @@
 package mapping_test
 
 import (
+	"bytes"
 	"fmt"
 	"log/slog"
 	"os"
@@ -388,6 +389,9 @@ func TestIPAddressMapper_Map(t *testing.T) {
 				for i, expectedTag := range tt.expectedEntity.Vrf.Tags {
 					assert.Equal(t, expectedTag.Name, ipAddress.Vrf.Tags[i].Name)
 				}
+			} else {
+				assert.Nil(t, ipAddress.Vrf,
+					"expected no VRF on the emitted IPAddress, got one")
 			}
 			if tt.expectedEntity.Tags != nil {
 				assert.Equal(t, len(tt.expectedEntity.Tags), len(ipAddress.Tags))
@@ -3122,6 +3126,60 @@ func TestMaskToPrefixSize(t *testing.T) {
 			_ = tt.expectError // Both paths now produce the same result.
 		})
 	}
+}
+
+// TestIPAddressMapper_Map_VRFNameEmptyWarns locks in the gate behaviour
+// when an operator sets VRF sub-fields (Rd, Description, Comments, Tags)
+// without a Name. The row drops silently in the proto (NetBox VRF
+// matching keys on Name + Rd, and there's nothing to attach without
+// Name), but the mapper emits a WARNING so the misconfiguration is
+// visible in the logs instead of silently producing IPs with no VRF.
+func TestIPAddressMapper_Map_VRFNameEmptyWarns(t *testing.T) {
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	registry := mapping.NewEntityRegistry(logger)
+	mapper := mapping.NewIPAddressMapper(logger)
+
+	values := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+		"1.3.6.1.2.1.4.20.1.1.10.0.0.1": {
+			OID:    "1.3.6.1.2.1.4.20.1.1.10.0.0.1",
+			Index:  "10.0.0.1",
+			Parent: "1.3.6.1.2.1.4.20.1.1",
+			Value:  "10.0.0.1",
+			Type:   mapping.IPAddress,
+		},
+	}
+	mappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.4.20.1.1",
+		Entity: "ipAddress",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{
+				OID:    "1.3.6.1.2.1.4.20.1.1",
+				Entity: "ipAddress",
+				Field:  "address",
+			},
+		},
+	}
+	defaults := &config.Defaults{
+		IPAddress: config.IPAddressDefaults{
+			Vrf: config.VrfParameters{
+				Rd:          "65000:100",
+				Description: "leftover sub-fields",
+				Tags:        []string{"orphan"},
+			},
+		},
+	}
+
+	entity := mapper.Map(values, mappingEntry, registry, defaults)
+	require.NotNil(t, entity)
+	ip := entity.(*diode.IPAddress)
+	assert.Nil(t, ip.Vrf, "VRF must NOT be emitted when Name is empty even if other VRF fields are set")
+	logOut := buf.String()
+	assert.Contains(t, logOut, "VRF defaults dropped: name is empty",
+		"expected a warning surfacing the misconfiguration in the logs")
+	assert.Contains(t, logOut, "65000:100", "warning should include the dropped Rd value for debugging")
 }
 
 func TestIPAddressMapper_Map_AddressPrefixSize(t *testing.T) {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -377,12 +377,14 @@ func TestIPAddressMapper_Map(t *testing.T) {
 			assert.Equal(t, tt.expectedEntity.Description, ipAddress.Description)
 			assert.Equal(t, tt.expectedEntity.Role, ipAddress.Role)
 			if tt.expectedEntity.Vrf != nil {
-				assert.NotNil(t, ipAddress.Vrf)
+				require.NotNil(t, ipAddress.Vrf,
+					"expected a VRF, got nil — subsequent field assertions would panic")
 				assert.Equal(t, tt.expectedEntity.Vrf.Name, ipAddress.Vrf.Name)
 				assert.Equal(t, tt.expectedEntity.Vrf.Rd, ipAddress.Vrf.Rd)
 				assert.Equal(t, tt.expectedEntity.Vrf.Description, ipAddress.Vrf.Description)
 				assert.Equal(t, tt.expectedEntity.Vrf.Comments, ipAddress.Vrf.Comments)
-				assert.Equal(t, len(tt.expectedEntity.Vrf.Tags), len(ipAddress.Vrf.Tags))
+				require.Len(t, ipAddress.Vrf.Tags, len(tt.expectedEntity.Vrf.Tags),
+					"VRF tag count mismatch — would panic on per-element indexing below")
 				for i, expectedTag := range tt.expectedEntity.Vrf.Tags {
 					assert.Equal(t, expectedTag.Name, ipAddress.Vrf.Tags[i].Name)
 				}


### PR DESCRIPTION
## Summary

Companion to the network-discovery fix in netboxlabs/orb-discovery#445 (closes netboxlabs/orb-agent#389 on the SNMP side). Mirrors device-discovery's polymorphic `VrfParameters` shape on the snmp-discovery side, drops the hardcoded `Rd = Name` fallback.

### Schema change — both shapes accepted

```yaml
# Scalar (existing config keeps working; Rd is now nil instead of being silently set to Name):
defaults:
  ip_address:
    vrf: production

# Rich (new — matches device-discovery's VrfParameters):
defaults:
  ip_address:
    vrf:
      name: production
      rd: "65000:100"
      description: "Prod VRF"
      comments: "Imported via SNMP"
      tags: [auto, vrf]
```

### Before (the bug)

`snmp-discovery/mapping/mappers.go`:
```go
if entity.Vrf == nil && entityDefaults.Vrf != "" {
    entity.Vrf = &diode.VRF{
        Name: &entityDefaults.Vrf,
        Rd:   &entityDefaults.Vrf,  // hardcoded to mirror Name
    }
}
```
NetBox VRFs match on `(name, rd)`. Forcing `rd = name` meant Diode could never match an operator's existing VRF whose `rd` column was null — every snmp-discovery cycle would create a duplicate.

### After

`config.VrfParameters` decodes from either YAML shape via custom `UnmarshalYAML`; `applyDefaults` builds the `diode.VRF` only with the fields the user actually set:

```go
if entity.Vrf == nil && entityDefaults.Vrf.Name != "" {
    vrfDefaults := entityDefaults.Vrf
    vrf := &diode.VRF{Name: &vrfDefaults.Name}
    if vrfDefaults.Rd != "" {
        vrf.Rd = &vrfDefaults.Rd
    }
    if vrfDefaults.Description != "" { vrf.Description = &vrfDefaults.Description }
    if vrfDefaults.Comments != ""    { vrf.Comments    = &vrfDefaults.Comments }
    if len(vrfDefaults.Tags) > 0 {
        // …build []*diode.Tag…
    }
    entity.Vrf = vrf
}
```

`MergeDefaults` now gates the override on `Vrf.Name`.

## Behaviour-change call-out for the release notes

Scalar `vrf: production` previously emitted `VRF{Name: "production", Rd: "production"}` — now emits `VRF{Name: "production", Rd: nil}`. Operators who relied on the buggy rd=name behaviour (their existing NetBox VRF has `rd="<vrf-name>"`) must switch to the rich form and set `rd` explicitly to keep matching, otherwise Diode will create a second VRF on the next cycle.

For the common case (existing VRF with `rd` null), the new default is what they wanted all along — match works correctly with no config changes.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...` — full suite passes
- [x] New `TestVrfParameters_UnmarshalYAML` (5 sub-cases):
  - scalar string → `Name` set, `Rd` empty
  - map form with all fields → all populated
  - map form with only `name + rd` → Rd populated
  - vrf field absent → zero VrfParameters
  - invalid YAML node (sequence) → returns error
- [x] New mapper sub-case `"ipAddress with rich VRF defaults"` asserts Rd / Description / Comments / Tags all flow onto the emitted `diode.VRF`.
- [x] Existing mapper test updated — the previously-asserted `Rd: "ip-address-vrf"` is replaced with the new expectation `Rd: nil` (the behaviour change is locked in here).
- [x] `go vet ./...` clean
- [x] `golangci-lint run --config ../.github/golangci.yaml ./...` — 0 issues

Companion docs PR: netboxlabs/orb-agent#<pending>

🤖 Generated with [Claude Code](https://claude.com/claude-code)