### PR TITLE
feat(device-discovery): per-address-family vrf overrides for ipaddress / prefix defaults

### DIFF
--- a/device-discovery/device_discovery/interface.py
+++ b/device-discovery/device_discovery/interface.py
@@ -378,6 +378,17 @@ def translate_interface_ips(
     prefix_tenant = None
     prefix_vrf = None
 
+    # Per-address-family VRF overrides: when `defaults.ipaddress.vrf_ipv4`
+    # / `vrf_ipv6` (or the prefix equivalents) are set, the family-specific
+    # value wins for that AF; otherwise we fall back to the AF-agnostic
+    # `defaults.ipaddress.vrf` / `defaults.prefix.vrf`. Computed once here
+    # and picked inside the per-IP loop below by the existing `ip_version`
+    # discriminator.
+    ip_vrf_ipv4 = None
+    ip_vrf_ipv6 = None
+    prefix_vrf_ipv4 = None
+    prefix_vrf_ipv6 = None
+
     if defaults.ipaddress:
         ip_tags.extend(defaults.ipaddress.tags or [])
         ip_comments = defaults.ipaddress.comments
@@ -385,6 +396,8 @@ def translate_interface_ips(
         ip_role = defaults.ipaddress.role
         ip_tenant = translate_tenant(defaults.ipaddress.tenant)
         ip_vrf = translate_vrf(defaults.ipaddress.vrf)
+        ip_vrf_ipv4 = translate_vrf(defaults.ipaddress.vrf_ipv4)
+        ip_vrf_ipv6 = translate_vrf(defaults.ipaddress.vrf_ipv6)
 
     if defaults.prefix:
         prefix_tags.extend(defaults.prefix.tags or [])
@@ -393,6 +406,8 @@ def translate_interface_ips(
         prefix_role = defaults.prefix.role
         prefix_tenant = translate_tenant(defaults.prefix.tenant)
         prefix_vrf = translate_vrf(defaults.prefix.vrf)
+        prefix_vrf_ipv4 = translate_vrf(defaults.prefix.vrf_ipv4)
+        prefix_vrf_ipv6 = translate_vrf(defaults.prefix.vrf_ipv6)
 
     scope_kwargs = _resolve_prefix_scope_kwargs(defaults, options)
 
@@ -401,6 +416,14 @@ def translate_interface_ips(
     for if_ip_name, ip_info in interfaces_ip.items():
         if interface.name == if_ip_name:
             for ip_version, default_prefix in (("ipv4", 32), ("ipv6", 128)):
+                # Resolve the per-AF VRF: AF-specific override wins,
+                # falls back to the AF-agnostic default.
+                af_ip_vrf = (
+                    ip_vrf_ipv4 if ip_version == "ipv4" else ip_vrf_ipv6
+                ) or ip_vrf
+                af_prefix_vrf = (
+                    prefix_vrf_ipv4 if ip_version == "ipv4" else prefix_vrf_ipv6
+                ) or prefix_vrf
                 for ip, details in ip_info.get(ip_version, {}).items():
                     ip_address = f"{ip}/{details.get('prefix_length', default_prefix)}"
                     network = ipaddress.ip_network(ip_address, strict=False)
@@ -408,7 +431,7 @@ def translate_interface_ips(
                         Entity(
                             prefix=Prefix(
                                 prefix=str(network),
-                                vrf=prefix_vrf,
+                                vrf=af_prefix_vrf,
                                 role=prefix_role,
                                 tenant=prefix_tenant,
                                 tags=prefix_tags,
@@ -429,7 +452,7 @@ def translate_interface_ips(
                                 ),
                                 role=ip_role,
                                 tenant=ip_tenant,
-                                vrf=ip_vrf,
+                                vrf=af_ip_vrf,
                                 tags=ip_tags,
                                 comments=ip_comments,
                                 description=ip_description,

--- a/device-discovery/device_discovery/policy/models.py
+++ b/device-discovery/device_discovery/policy/models.py
@@ -110,6 +110,20 @@ class IpamParameters(ObjectParameters):
         default=None, description="IPAM tenant, optional"
     )
     vrf: str | VrfParameters | None = Field(default=None, description="IPAM VRF, optional")
+    vrf_ipv4: str | VrfParameters | None = Field(
+        default=None,
+        description=(
+            "IPv4-specific VRF override. When set, IPv4 IP addresses / "
+            "prefixes use this VRF; falls back to ``vrf`` when unset."
+        ),
+    )
+    vrf_ipv6: str | VrfParameters | None = Field(
+        default=None,
+        description=(
+            "IPv6-specific VRF override. When set, IPv6 IP addresses / "
+            "prefixes use this VRF; falls back to ``vrf`` when unset."
+        ),
+    )
 
 
 class PrefixParameters(IpamParameters):

--- a/device-discovery/tests/test_translate.py
+++ b/device-discovery/tests/test_translate.py
@@ -245,6 +245,178 @@ def test_translate_interface_ips_with_vrf_string(
     assert ip_entities[1].ip_address.vrf.name == "plain-vrf"
 
 
+# --- per-address-family VRF (orb-agent#392) ---------------------------------
+
+
+@pytest.fixture
+def sample_interfaces_ip_dual_stack():
+    """Dual-stack IPs on the same interface — IPv4 + IPv6."""
+    return {
+        "GigabitEthernet0/0/1": {
+            "ipv4": {"192.0.2.1": {"prefix_length": 24}},
+            "ipv6": {"2001:db8::1": {"prefix_length": 64}},
+        }
+    }
+
+
+def _emit_dual_stack(
+    sample_device_info,
+    sample_interface_info,
+    sample_interfaces_ip_dual_stack,
+    sample_defaults,
+):
+    """Translate a dual-stack interface and bucket the emitted entities by IP version."""
+    device = translate_device(sample_device_info, sample_defaults)
+    interface = translate_interface(
+        device,
+        "GigabitEthernet0/0/1",
+        sample_interface_info["GigabitEthernet0/0/1"],
+        sample_defaults,
+    )
+    entities = list(
+        translate_interface_ips(
+            interface, sample_interfaces_ip_dual_stack, sample_defaults
+        )
+    )
+    ip4 = {"prefix": None, "ip": None}
+    ip6 = {"prefix": None, "ip": None}
+    for e in entities:
+        if e.HasField("prefix"):
+            bucket = ip4 if "." in e.prefix.prefix else ip6
+            bucket["prefix"] = e.prefix
+        elif e.HasField("ip_address"):
+            bucket = ip4 if "." in e.ip_address.address else ip6
+            bucket["ip"] = e.ip_address
+    return ip4, ip6
+
+
+def test_per_af_vrf_picks_ipv4_and_ipv6_overrides(
+    sample_device_info,
+    sample_interface_info,
+    sample_interfaces_ip_dual_stack,
+    sample_defaults,
+):
+    """vrf_ipv4 / vrf_ipv6 land on the right AF independently."""
+    sample_defaults.ipaddress = IpamParameters(
+        vrf="fallback-vrf",
+        vrf_ipv4=VrfParameters(name="customer-v4", rd="65000:10"),
+        vrf_ipv6=VrfParameters(name="global-v6", rd="65000:20"),
+    )
+    sample_defaults.prefix = PrefixParameters(
+        vrf="fallback-prefix-vrf",
+        vrf_ipv4=VrfParameters(name="customer-v4-prefix", rd="65000:10"),
+        vrf_ipv6=VrfParameters(name="global-v6-prefix", rd="65000:20"),
+    )
+    ip4, ip6 = _emit_dual_stack(
+        sample_device_info,
+        sample_interface_info,
+        sample_interfaces_ip_dual_stack,
+        sample_defaults,
+    )
+    assert ip4["ip"].vrf.name == "customer-v4"
+    assert ip4["ip"].vrf.rd == "65000:10"
+    assert ip6["ip"].vrf.name == "global-v6"
+    assert ip6["ip"].vrf.rd == "65000:20"
+    assert ip4["prefix"].vrf.name == "customer-v4-prefix"
+    assert ip6["prefix"].vrf.name == "global-v6-prefix"
+
+
+def test_per_af_vrf_falls_back_to_top_level_when_unset(
+    sample_device_info,
+    sample_interface_info,
+    sample_interfaces_ip_dual_stack,
+    sample_defaults,
+):
+    """If vrf_ipv4 / vrf_ipv6 are unset, both AFs use the top-level `vrf`."""
+    sample_defaults.ipaddress = IpamParameters(vrf="shared-vrf")
+    sample_defaults.prefix = PrefixParameters(vrf="shared-prefix-vrf")
+    ip4, ip6 = _emit_dual_stack(
+        sample_device_info,
+        sample_interface_info,
+        sample_interfaces_ip_dual_stack,
+        sample_defaults,
+    )
+    assert ip4["ip"].vrf.name == "shared-vrf"
+    assert ip6["ip"].vrf.name == "shared-vrf"
+    assert ip4["prefix"].vrf.name == "shared-prefix-vrf"
+    assert ip6["prefix"].vrf.name == "shared-prefix-vrf"
+
+
+def test_per_af_vrf_only_one_family_overridden(
+    sample_device_info,
+    sample_interface_info,
+    sample_interfaces_ip_dual_stack,
+    sample_defaults,
+):
+    """vrf_ipv4 set but not vrf_ipv6 → IPv4 picks the override, IPv6 uses the fallback."""
+    sample_defaults.ipaddress = IpamParameters(
+        vrf="fallback-vrf",
+        vrf_ipv4=VrfParameters(name="customer-v4", rd="65000:10"),
+    )
+    sample_defaults.prefix = PrefixParameters(
+        vrf="fallback-prefix-vrf",
+        vrf_ipv6=VrfParameters(name="global-v6-prefix", rd="65000:20"),
+    )
+    ip4, ip6 = _emit_dual_stack(
+        sample_device_info,
+        sample_interface_info,
+        sample_interfaces_ip_dual_stack,
+        sample_defaults,
+    )
+    assert ip4["ip"].vrf.name == "customer-v4"
+    assert ip6["ip"].vrf.name == "fallback-vrf"
+    assert ip4["prefix"].vrf.name == "fallback-prefix-vrf"
+    assert ip6["prefix"].vrf.name == "global-v6-prefix"
+
+
+def test_per_af_vrf_only_ipv4_no_top_level_leaves_ipv6_without_vrf(
+    sample_device_info,
+    sample_interface_info,
+    sample_interfaces_ip_dual_stack,
+    sample_defaults,
+):
+    """No top-level vrf, only vrf_ipv4 → IPv6 emits no VRF (no override AND no fallback)."""
+    sample_defaults.ipaddress = IpamParameters(
+        vrf_ipv4=VrfParameters(name="customer-v4", rd="65000:10"),
+    )
+    sample_defaults.prefix = PrefixParameters(
+        vrf_ipv4=VrfParameters(name="customer-v4-prefix", rd="65000:10"),
+    )
+    ip4, ip6 = _emit_dual_stack(
+        sample_device_info,
+        sample_interface_info,
+        sample_interfaces_ip_dual_stack,
+        sample_defaults,
+    )
+    assert ip4["ip"].vrf.name == "customer-v4"
+    assert not ip6["ip"].HasField("vrf"), "IPv6 must NOT carry a VRF when neither vrf_ipv6 nor vrf is set"
+    assert ip4["prefix"].vrf.name == "customer-v4-prefix"
+    assert not ip6["prefix"].HasField("vrf")
+
+
+def test_per_af_vrf_accepts_scalar_string(
+    sample_device_info,
+    sample_interface_info,
+    sample_interfaces_ip_dual_stack,
+    sample_defaults,
+):
+    """vrf_ipv4 / vrf_ipv6 accept the same str | VrfParameters polymorphic shape as vrf."""
+    sample_defaults.ipaddress = IpamParameters(
+        vrf_ipv4="customer-v4",
+        vrf_ipv6="global-v6",
+    )
+    ip4, ip6 = _emit_dual_stack(
+        sample_device_info,
+        sample_interface_info,
+        sample_interfaces_ip_dual_stack,
+        sample_defaults,
+    )
+    assert ip4["ip"].vrf.name == "customer-v4"
+    assert ip4["ip"].vrf.rd == ""
+    assert ip6["ip"].vrf.name == "global-v6"
+    assert ip6["ip"].vrf.rd == ""
+
+
 def test_translate_device(sample_device_info, sample_defaults):
     """Ensure device translation is correct."""
     device = translate_device(sample_device_info, sample_defaults)


### PR DESCRIPTION
## Summary

Closes netboxlabs/orb-agent#392.

Adds optional `vrf_ipv4` and `vrf_ipv6` siblings to the existing `vrf` field on `defaults.ipaddress` and `defaults.prefix`. The agent now picks the per-family VRF when an AF-specific override is set, falling back to the AF-agnostic `vrf` otherwise. Both new fields accept the same `str | VrfParameters` polymorphic shape as `vrf`.

### Example

```yaml
defaults:
  ipaddress:
    vrf: fallback-vrf          # used for any AF without a specific override
    vrf_ipv4:
      name: customer-vrf
      rd: "65000:10"
    vrf_ipv6:
      name: global-vrf
      rd: "65000:20"
  prefix:
    vrf_ipv4: customer-vrf     # scalar shape still supported
    vrf_ipv6: global-vrf
```

### Pick order (per IP / prefix at translate time)

1. `vrf_ipv4` if the address is IPv4 and the field is set, else
2. `vrf_ipv6` if the address is IPv6 and the field is set, else
3. `vrf` (the AF-agnostic fallback, unchanged from today), else
4. no VRF emitted.

### Implementation

| File | Change |
|---|---|
| `device_discovery/policy/models.py` | `IpamParameters` gains `vrf_ipv4` / `vrf_ipv6` (inherited automatically by `PrefixParameters`). |
| `device_discovery/interface.py` | `translate_interface_ips` pre-resolves the four per-AF VRF variants once, then picks the right one inside the existing `for ip_version in ("ipv4", "ipv6")` loop. |

### Backwards compatibility

Pure addition. Configs without `vrf_ipv4` / `vrf_ipv6` see no behaviour change — the top-level `vrf` continues to apply to both address families.

### Test plan

- [x] `pytest tests/` — 1692 passed, 130 skipped (+5 new)
- [x] `ruff check device_discovery/ tests/test_translate.py` — clean
- [x] New test cases in `tests/test_translate.py`:
  - `test_per_af_vrf_picks_ipv4_and_ipv6_overrides` — independent IPv4 + IPv6 VRFs land correctly on `IPAddress` and `Prefix`
  - `test_per_af_vrf_falls_back_to_top_level_when_unset` — both AFs use the top-level `vrf` when no overrides set
  - `test_per_af_vrf_only_one_family_overridden` — IPv4 override + IPv6 fallback (and vice versa for prefix)
  - `test_per_af_vrf_only_ipv4_no_top_level_leaves_ipv6_without_vrf` — edge case: no top-level `vrf`, only `vrf_ipv4` → IPv6 emits no VRF
  - `test_per_af_vrf_accepts_scalar_string` — confirms `str | VrfParameters` polymorphic shape carries through

### Out of scope (filed as follow-ups if requested)

- snmp-discovery parity — no FR yet, same shape problem but defer to its own ticket
- network-discovery parity — same situation
- Per-AF `tenant` / `role` — issue only asks for VRF

Companion docs PR: netboxlabs/orb-agent#<pending>

🤖 Generated with [Claude Code](https://claude.com/claude-code)