### PR TITLE
ci(repo): repin pypa/gh-action-pypi-publish to v1.14.0 commit sha

### DIFF
--- a/.github/workflows/device-discovery-release.yaml
+++ b/.github/workflows/device-discovery-release.yaml
@@ -177,7 +177,7 @@ jobs:
           retention-days: 30
           if-no-files-found: error
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: ${{env.APP_NAME}}/dist
 

--- a/.github/workflows/worker-release.yaml
+++ b/.github/workflows/worker-release.yaml
@@ -177,7 +177,7 @@ jobs:
           retention-days: 30
           if-no-files-found: error
       - name: Publish release distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@6733eb7d741f0b11ec6a39b58540dab7590f9b7d # v1.14.0
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
           packages-dir: ${{env.APP_NAME}}/dist
 


### PR DESCRIPTION
## Summary

Fixes the device-discovery and worker release pipelines, which fail on the `Publish release distributions to PyPI` step with:

```
docker: Error response from daemon: manifest unknown
ghcr.io/pypa/gh-action-pypi-publish:6733eb7d741f0b11ec6a39b58540dab7590f9b7d
```

Failing run: https://github.com/netboxlabs/orb-discovery/actions/runs/27235100496/job/80425027226 (Device Discovery — release, `v1.29.0`).

## Root cause

Both release workflows pinned `pypa/gh-action-pypi-publish` at `6733eb7d...`, which is the **annotated tag object** SHA of `v1.14.0`:

```bash
$ curl -s https://api.github.com/repos/pypa/gh-action-pypi-publish/git/refs/tags/v1.14.0
{ "object": { "sha": "6733eb7d741f0b11ec6a39b58540dab7590f9b7d", "type": "tag", ... } }
```

The upstream Docker image on ghcr.io is published keyed by the underlying **commit** SHA, not the tag-object SHA, so the docker pull from the workflow runner returned `manifest unknown`.

## Fix

Repin both workflows to the commit SHA at `v1.14.0` (`cef221092ed1bacb1cc03d23a2d87d1d172e277b` — resolved via `/repos/pypa/gh-action-pypi-publish/tags`), which matches what ghcr.io actually publishes. Comment retained as `# v1.14.0` so the human-readable version stays visible.

## Files

- `.github/workflows/device-discovery-release.yaml:180`
- `.github/workflows/worker-release.yaml:180`

## Test plan

- [x] `grep` confirms both workflow files updated to the commit SHA
- [ ] After merge: re-run the failed release workflow on the release branch and verify the PyPI publish step pulls the image successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)