### PR TITLE
chore(repo): apk upgrade alpine runtime images to clear openssl cves

### DIFF
--- a/network-discovery/docker/Dockerfile
+++ b/network-discovery/docker/Dockerfile
@@ -17,7 +17,7 @@ RUN --mount=target=. \
 
 FROM alpine:3.23
 
-RUN apk update && apk add --no-cache nmap
+RUN apk update && apk --no-cache upgrade && apk add --no-cache nmap
 
 COPY --from=builder /build/network-discovery /usr/local/bin/network-discovery
 

--- a/snmp-discovery/docker/Dockerfile
+++ b/snmp-discovery/docker/Dockerfile
@@ -12,6 +12,8 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -t
 
 FROM alpine:3.23
 
+RUN apk --no-cache upgrade
+
 # Copy the binary
 COPY --from=builder /build/snmp-discovery /usr/local/bin/snmp-discovery
 

--- a/snmp-discovery/docker/Dockerfile
+++ b/snmp-discovery/docker/Dockerfile
@@ -12,7 +12,7 @@ RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -t
 
 FROM alpine:3.23
 
-RUN apk --no-cache upgrade
+RUN apk update && apk --no-cache upgrade
 
 # Copy the binary
 COPY --from=builder /build/snmp-discovery /usr/local/bin/snmp-discovery


### PR DESCRIPTION
## Summary

The trivy scan fails on the alpine-based images (e.g. [PR #457 scan](https://github.com/netboxlabs/orb-discovery/pull/457#issuecomment-4684086500)): `alpine:3.23` still resolves to 3.23.4, which ships OpenSSL `libcrypto3`/`libssl3` **3.5.6-r0**. All 30 findings (1 HIGH — CVE-2026-45447 — plus MEDIUM/LOW) are fixed in **3.5.7-r0**, which is only available from the Alpine 3.23 package repo until a new base image is published (none newer than 3.23.4 exists on Docker Hub yet).

## Changes

- **snmp-discovery**: add `RUN apk --no-cache upgrade` to the runtime stage.
- **network-discovery**: fold the upgrade into the existing runtime apk command (`apk update && apk --no-cache upgrade && apk add --no-cache nmap`).

A blanket upgrade (no pinned package list) is intentional so future base-image lag is absorbed automatically. device-discovery and worker use Debian-based python images and are unaffected.

## Verification

```
$ docker run --rm alpine:3.23 apk --no-cache upgrade
(1/2) Upgrading libcrypto3 (3.5.6-r0 -> 3.5.7-r0)
(2/2) Upgrading libssl3 (3.5.6-r0 -> 3.5.7-r0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)