### PR TITLE
fix(snmp-discovery): strip null bytes from all device-provided names

### DIFF
--- a/snmp-discovery/mapping/chassis.go
+++ b/snmp-discovery/mapping/chassis.go
@@ -334,14 +334,17 @@ func strDeref(p *string) string {
 	return *p
 }
 
-// trimSNMPString trims surrounding whitespace AND embedded NUL bytes
-// from ENTITY-MIB DisplayString-like values. Many vendor agents pad
-// short strings with trailing NUL bytes, which strings.TrimSpace leaves
-// in place — a NUL-padded "FOC1234\x00" would otherwise compare unequal
-// to "FOC1234" returned by another agent, breaking dedup and stable
-// matching against NetBox on subsequent runs.
+// trimSNMPString removes every NUL byte (interior as well as padding) and
+// trims surrounding whitespace from DisplayString-like SNMP values. It is the
+// canonical sanitizer for any device-provided text bound for a NetBox/Diode
+// field. Two reasons NUL handling matters: many vendor agents pad short
+// strings with trailing NUL bytes — a NUL-padded "FOC1234\x00" would compare
+// unequal to "FOC1234" from another agent, breaking dedup and stable matching
+// across runs — and NetBox/PostgreSQL rejects a NUL anywhere in a text field,
+// failing ingestion outright. strings.ReplaceAll returns the input unchanged
+// (no allocation) when there is no NUL, so the common clean case is cheap.
 func trimSNMPString(s string) string {
-	return strings.Trim(s, " \t\r\n\x00")
+	return strings.Trim(strings.ReplaceAll(s, "\x00", ""), " \t\r\n")
 }
 
 var trailingIntRe = regexp.MustCompile(`(\d+)\s*$`)

--- a/snmp-discovery/mapping/chassis_test.go
+++ b/snmp-discovery/mapping/chassis_test.go
@@ -236,6 +236,32 @@ func TestExtractInventory_NULOnlySerialDropped(t *testing.T) {
 	assert.Equal(t, "VALID", inv.Members[0].Serial)
 }
 
+// TestTrimSNMPString pins the contract: surrounding whitespace AND every
+// NUL byte (including interior ones) are removed. NetBox/PostgreSQL rejects
+// NUL anywhere in a text field, so a trailing-only trim is not enough.
+func TestTrimSNMPString(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"clean passthrough", "GigabitEthernet0/1", "GigabitEthernet0/1"},
+		{"trailing nul pad", "Video\x00", "Video"},
+		{"trailing nul run", "FOC1234\x00\x00\x00", "FOC1234"},
+		{"leading and trailing space", "  Eng  ", "Eng"},
+		{"interior nul", "Video\x00Backup", "VideoBackup"},
+		{"interior nul plus pad", "A\x00B\x00", "AB"},
+		{"nul only", "\x00\x00", ""},
+		{"empty", "", ""},
+		{"surrounding ws and interior nul", " a\x00b \t", "ab"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, trimSNMPString(tc.in))
+		})
+	}
+}
+
 func TestDeriveMemberID_ParentRelPosWins(t *testing.T) {
 	m := ChassisMember{ParentRelPos: 5, EntName: "Switch 9"}
 	assert.Equal(t, 5, deriveMemberID(m, 0))

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -794,7 +794,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					// overwrite an already-set clean Name (typically from
 					// ifName via name_alternate, which arrives first
 					// under slices.Reverse) with a descriptive ifDescr.
-					name := strings.TrimRight(value.Value, "\x00 \t\n\r")
+					name := trimSNMPString(value.Value)
 					if name == "" {
 						continue
 					}
@@ -817,7 +817,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 					// does NOT match single-space canonical names like
 					// Dell FTOS "TenGigabitEthernet 0/0" or Extreme SLX
 					// "Port-channel 1" — those keep their ifDescr.
-					alt := strings.TrimRight(value.Value, "\x00 \t\n\r")
+					alt := trimSNMPString(value.Value)
 					if alt == "" {
 						continue
 					}
@@ -829,7 +829,7 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 						fieldFound = true
 					}
 				case "description":
-					description := strings.TrimRight(value.Value, "\x00 \t\n\r")
+					description := trimSNMPString(value.Value)
 					if description != "" {
 						if len(description) > 200 {
 							description = description[:197] + "..."
@@ -1130,13 +1130,13 @@ func (m *DeviceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEntry
 				m.logger.Debug("mapping value to device entity with mapper", "object_id", objectID, "value", value, "mapping_entry", propertyMappingEntry)
 				switch propertyMappingEntry.Field {
 				case "name":
-					name := strings.TrimRight(value.Value, "\x00 \t\n\r")
+					name := trimSNMPString(value.Value)
 					if name != "" {
 						deviceEntity.Name = &name
 						fieldFound = true
 					}
 				case "description":
-					description := strings.TrimRight(value.Value, "\x00 \t\n\r")
+					description := trimSNMPString(value.Value)
 					if description != "" {
 						if len(description) > 200 {
 							description = description[:197] + "..."

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -1454,6 +1454,60 @@ func TestInterfaceMapper_Map(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "interior null bytes are stripped from interface name and description",
+			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+				"1.3.6.1.2.1.2.2.1.1.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.1.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.1",
+					Value:  "1",
+					Type:   mapping.Integer,
+				},
+				"1.3.6.1.2.1.2.2.1.2.1": {
+					OID:    "1.3.6.1.2.1.2.2.1.2.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.2.2.1.2",
+					Value:  "eth\x000",
+					Type:   mapping.OctetString,
+				},
+				"1.3.6.1.2.1.31.1.1.1.18.1": {
+					OID:    "1.3.6.1.2.1.31.1.1.1.18.1",
+					Index:  "1",
+					Parent: "1.3.6.1.2.1.31.1.1.1.18",
+					Value:  "up\x00link",
+					Type:   mapping.OctetString,
+				},
+			},
+			mappingEntry: &mapping.Entry{
+				OID:    "1.3.6.1.2.1.2.2.1.1",
+				Entity: "interface",
+				Field:  "_id",
+				MappingEntries: []mapping.Entry{
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.1",
+						Entity: "interface",
+						Field:  "_id",
+					},
+					{
+						OID:    "1.3.6.1.2.1.2.2.1.2",
+						Entity: "interface",
+						Field:  "name",
+					},
+					{
+						OID:    "1.3.6.1.2.1.31.1.1.1.18",
+						Entity: "interface",
+						Field:  "description",
+					},
+				},
+			},
+			defaults: nil,
+			expectedEntity: &diode.Interface{
+				Name:        mapping.StringPtr("eth0"),
+				Description: mapping.StringPtr("uplink"),
+			},
+			expectError: false,
+		},
+		{
 			name: "null-byte-only description falls back to configured default",
 			values: map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
 				"1.3.6.1.2.1.2.2.1.1.1": {

--- a/snmp-discovery/mapping/vlan_mapper.go
+++ b/snmp-discovery/mapping/vlan_mapper.go
@@ -379,7 +379,11 @@ func (m *VlanMapper) emitVLANs(all ObjectIDValueMap, defaults *config.Defaults) 
 				p = &pending{}
 				byVid[vid] = p
 			}
-			p.name = v.Value
+			// Strip NUL padding/whitespace many vendor agents (e.g. FS
+			// switches) append to dot1qVlanStaticName. NetBox/PostgreSQL
+			// rejects NUL bytes in text fields, and a NUL-only name must
+			// collapse to "" so the VLAN<vid> default applies below.
+			p.name = trimSNMPString(v.Value)
 		case strings.HasPrefix(oid, oidDot1qVlanStaticRowStatus):
 			vid, ok := atoi(strings.TrimPrefix(oid, oidDot1qVlanStaticRowStatus))
 			if !ok {

--- a/snmp-discovery/mapping/vlan_mapper_test.go
+++ b/snmp-discovery/mapping/vlan_mapper_test.go
@@ -356,6 +356,64 @@ func TestVlanMapper_EmitVLANs_AppliesDefaults(t *testing.T) {
 	}
 }
 
+// TestVlanMapper_EmitVLANs_StripsTrailingNullByte verifies that NUL-padded
+// dot1qVlanStaticName values (seen on FS switches and other vendor agents)
+// are sanitized before reaching the Diode payload. NetBox/PostgreSQL rejects
+// NUL bytes in text fields, so an unsanitized "Video\x00" breaks ingestion.
+func TestVlanMapper_EmitVLANs_StripsTrailingNullByte(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	registry := NewEntityRegistry(logger)
+
+	rows := ObjectIDValueMap{
+		// VID 680: NUL-padded name as an FS switch reports it.
+		".1.3.6.1.2.1.17.7.1.4.3.1.1.680": Value{Value: "Video\x00", Type: OctetString},
+		".1.3.6.1.2.1.17.7.1.4.3.1.5.680": Value{Value: "1", Type: Integer},
+		// VID 690: name is nothing but NUL bytes — must be treated as empty
+		// and fall back to the "VLAN<vid>" default rather than emitting a
+		// NUL-only name.
+		".1.3.6.1.2.1.17.7.1.4.3.1.1.690": Value{Value: "\x00", Type: OctetString},
+		".1.3.6.1.2.1.17.7.1.4.3.1.5.690": Value{Value: "1", Type: Integer},
+		// VID 700: interior NUL (not just trailing padding) must also be
+		// removed — PostgreSQL rejects a NUL anywhere in the field.
+		".1.3.6.1.2.1.17.7.1.4.3.1.1.700": Value{Value: "Vo\x00IP", Type: OctetString},
+		".1.3.6.1.2.1.17.7.1.4.3.1.5.700": Value{Value: "1", Type: Integer},
+	}
+
+	vm := NewVlanMapper(logger, config.Options{CreateUnknownVlans: ptrBool(true)})
+	emitted := vm.PostMap(rows, registry, &config.Defaults{})
+
+	byVid := map[int64]*diode.VLAN{}
+	for _, e := range emitted {
+		if v, ok := e.(*diode.VLAN); ok && v.Vid != nil {
+			byVid[*v.Vid] = v
+		}
+	}
+
+	got, ok := byVid[680]
+	if !ok || got.Name == nil {
+		t.Fatal("expected VLAN entity for VID 680 with a name")
+	}
+	if *got.Name != "Video" {
+		t.Errorf("VID 680 Name: got %q, want %q", *got.Name, "Video")
+	}
+
+	stub, ok := byVid[690]
+	if !ok || stub.Name == nil {
+		t.Fatal("expected VLAN entity for VID 690 with a name")
+	}
+	if *stub.Name != "VLAN690" {
+		t.Errorf("VID 690 Name: got %q, want %q (NUL-only name should be empty)", *stub.Name, "VLAN690")
+	}
+
+	interior, ok := byVid[700]
+	if !ok || interior.Name == nil {
+		t.Fatal("expected VLAN entity for VID 700 with a name")
+	}
+	if *interior.Name != "VoIP" {
+		t.Errorf("VID 700 Name: got %q, want %q (interior NUL must be removed)", *interior.Name, "VoIP")
+	}
+}
+
 // applyVLANDefaults: when defaults.Site is a real value and a VLAN Group is
 // configured, the Group must carry Name + Slug + Scope = Site{Name: defaults.Site}.
 func TestApplyVLANDefaults_GroupScopeSite_WhenSiteDefined(t *testing.T) {

--- a/snmp-discovery/mapping/vlan_mapper_test.go
+++ b/snmp-discovery/mapping/vlan_mapper_test.go
@@ -356,11 +356,11 @@ func TestVlanMapper_EmitVLANs_AppliesDefaults(t *testing.T) {
 	}
 }
 
-// TestVlanMapper_EmitVLANs_StripsTrailingNullByte verifies that NUL-padded
-// dot1qVlanStaticName values (seen on FS switches and other vendor agents)
-// are sanitized before reaching the Diode payload. NetBox/PostgreSQL rejects
-// NUL bytes in text fields, so an unsanitized "Video\x00" breaks ingestion.
-func TestVlanMapper_EmitVLANs_StripsTrailingNullByte(t *testing.T) {
+// TestVlanMapper_EmitVLANs_StripsNullBytesFromName verifies that NUL-padded or
+// NUL-interrupted dot1qVlanStaticName values (seen on FS switches and other vendor
+// agents) are sanitized before reaching the Diode payload. NetBox/PostgreSQL rejects
+// NUL bytes in text fields, so an unsanitized name breaks ingestion.
+func TestVlanMapper_EmitVLANs_StripsNullBytesFromName(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	registry := NewEntityRegistry(logger)
 

--- a/snmp-discovery/mapping/vrf.go
+++ b/snmp-discovery/mapping/vrf.go
@@ -291,7 +291,12 @@ func collectCiscoVrfs(oids ObjectIDValueMap, logger *slog.Logger) map[string]*vr
 				logger.Debug("vrf: non-integer cvVrfId index, skipping row", "oid", oid)
 				continue
 			}
-			if name := value.Value; name != "" {
+			// cvVrfName is read as a value (unlike the std/legacy tiers,
+			// whose names come from the OID index and are control-rejected
+			// by octetsToString). Sanitize NUL padding/whitespace here so a
+			// "RED\x00" name both ingests cleanly and matches "RED" from
+			// another tier during the cross-tier merge.
+			if name := trimSNMPString(value.Value); name != "" {
 				namesByID[id] = name
 			}
 			continue

--- a/snmp-discovery/mapping/vrf_test.go
+++ b/snmp-discovery/mapping/vrf_test.go
@@ -160,6 +160,27 @@ func TestTranslateVrfs_CiscoTierFallback(t *testing.T) {
 	assert.False(t, orphan)
 }
 
+func TestTranslateVrfs_CiscoTierStripsNullBytesFromName(t *testing.T) {
+	// cvVrfName padded/interrupted with NUL bytes (vendor agent quirk) must
+	// be sanitized — NetBox rejects NUL anywhere in the field.
+	oids := ObjectIDValueMap{
+		oidCvVrfName + ".1":         octets("MGMT\x00"),
+		oidCvVrfName + ".2":         octets("CU\x00ST"),
+		oidCvVrfInterface + ".1.30": octets("1"),
+		oidCvVrfInterface + ".2.31": octets("1"),
+	}
+	entities, byIfIndex := TranslateVrfs(oids, nil, slog.Default())
+	require.Len(t, entities, 2)
+	names := map[string]bool{}
+	for _, e := range entities {
+		names[*(e.(*diode.VRF)).Name] = true
+	}
+	assert.True(t, names["MGMT"], "trailing NUL must be stripped")
+	assert.True(t, names["CUST"], "interior NUL must be removed")
+	assert.NotNil(t, byIfIndex[30])
+	assert.NotNil(t, byIfIndex[31])
+}
+
 func TestTranslateVrfs_StdTierWinsOverLowerTiers(t *testing.T) {
 	red := oidIdx("RED")
 	oids := stdTierOids()


### PR DESCRIPTION
## Summary

Fixes [netboxlabs/orb-agent#405](https://github.com/netboxlabs/orb-agent/issues/405). On FS switches, SNMP discovery emitted VLAN names with a trailing NUL byte:

```json
{ "vid": "680", "name": "Video\u0000", "status": "active" }
```

NetBox/PostgreSQL rejects a NUL **anywhere** in a text field, so ingestion fails. This is the same class of bug fixed for interface names in [#319](https://github.com/netboxlabs/orb-agent/issues/319) — but that only patched one field with a trailing-only trim, leaving the same hole in every other device-provided string (and even interface names still broke on an *interior* NUL).

## Approach — one canonical sanitizer

`trimSNMPString` already documented that it removed "embedded NUL bytes," but its implementation (`strings.Trim`) only stripped them from the ends, so `"Video\x00Backup"` survived. The fix makes the helper deliver its documented contract — remove **every** NUL plus surrounding whitespace — and routes every device-provided text field through it:

| Field | Before |
|---|---|
| chassis / module ENTITY-MIB strings (serial, model, name, asset tag, …) | already used the helper → now interior-NUL safe for free |
| interface name / ifName fallback / description | inline `TrimRight` (trailing-only) |
| device name / description | inline `TrimRight` (trailing-only) |
| VLAN name | raw value |
| CISCO-VRF-MIB `cvVrfName` | raw value |

The std/legacy VRF tiers decode names from the OID index via `octetsToString`, which already rejects NUL — left as-is.

**Deliberately untouched:** the RD display-form trim in `decodeRouteDistinguisher` (operates on a copy; the binary path must see untrimmed bytes — leading `0x00` type bytes), and the sysObjectID OID fallbacks (OIDs carry no NUL).

A NUL-only value collapses to `""`, so existing empty-value fallbacks (`VLAN<vid>`, default description) still apply.

## Tests

- `TestTrimSNMPString` — table test pinning the contract (trailing pad, interior NUL, NUL-only, whitespace, clean passthrough).
- Interior-NUL regression cases added at the **field** level: interface name/description, VLAN name, and Cisco `cvVrfName` — so a future refactor back to a trailing-only trim is caught.
- Full `go test ./...` and `golangci-lint run` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)