### PR TITLE
feat(snmp-discovery): configurable interface name source (ifname/ifdescr)

### DIFF
--- a/snmp-discovery/config/config.go
+++ b/snmp-discovery/config/config.go
@@ -380,6 +380,15 @@ const (
 	DiscoverModulesFull      = "full"
 )
 
+// InterfaceNameSource* are the accepted values for
+// options.interface_name_source. Auto (the default) keeps the legacy
+// ifDescr-preferred heuristic.
+const (
+	InterfaceNameSourceAuto    = "auto"
+	InterfaceNameSourceIfName  = "ifname"
+	InterfaceNameSourceIfDescr = "ifdescr"
+)
+
 // Options represents per-policy global behavior toggles peer to Defaults.
 type Options struct {
 	CreateUnknownVlans *bool `yaml:"create_unknown_vlans,omitempty"`
@@ -424,6 +433,14 @@ type Options struct {
 	// to Prefix scope location (the more specific location wins).
 	// Defaults to false. Mirrors device-discovery.
 	PropagateDefaultsToPrefixScope *bool `yaml:"propagate_defaults_to_prefix_scope,omitempty"`
+
+	// Tri-state pointer; nil / "auto" select the legacy heuristic (ifDescr
+	// preferred, ifName promoted when ifDescr is empty or a hardware
+	// description). "ifname" / "ifdescr" force the NetBox Interface.Name
+	// source, each falling back to the other field when its primary is
+	// empty for a given interface. Unknown values normalize to "auto"
+	// (with a warning) at policy parse.
+	InterfaceNameSource *string `yaml:"interface_name_source,omitempty"`
 }
 
 // PrefixEmissionEnabled returns the effective emit_prefixes toggle,
@@ -456,6 +473,16 @@ func (o *Options) ModuleDiscoveryMode() string {
 		return DiscoverModulesOff
 	}
 	return *o.DiscoverModules
+}
+
+// InterfaceNameSourceMode returns the configured interface-name source
+// verbatim, defaulting to "auto" when unset. Unknown values are normalized
+// to "auto" (with a warning) at policy parse (Manager.applyDefaults), not here.
+func (o *Options) InterfaceNameSourceMode() string {
+	if o == nil || o.InterfaceNameSource == nil {
+		return InterfaceNameSourceAuto
+	}
+	return *o.InterfaceNameSource
 }
 
 // PolicyConfig represents the configuration of a policy

--- a/snmp-discovery/config/config_test.go
+++ b/snmp-discovery/config/config_test.go
@@ -784,3 +784,20 @@ func TestVrfParameters_UnmarshalYAML(t *testing.T) {
 		assert.Empty(t, wrapper.Vrf.Tags)
 	})
 }
+
+func TestOptions_InterfaceNameSourceMode(t *testing.T) {
+	auto := "auto"
+	ifname := "ifname"
+	ifdescr := "ifdescr"
+	bogus := "wat"
+
+	var nilOpts *Options
+	assert.Equal(t, InterfaceNameSourceAuto, nilOpts.InterfaceNameSourceMode(), "nil receiver defaults to auto")
+	assert.Equal(t, InterfaceNameSourceAuto, (&Options{}).InterfaceNameSourceMode(), "unset field defaults to auto")
+	assert.Equal(t, "auto", (&Options{InterfaceNameSource: &auto}).InterfaceNameSourceMode())
+	assert.Equal(t, "ifname", (&Options{InterfaceNameSource: &ifname}).InterfaceNameSourceMode())
+	assert.Equal(t, "ifdescr", (&Options{InterfaceNameSource: &ifdescr}).InterfaceNameSourceMode())
+	// Accessor returns the raw value verbatim; normalization of unknowns
+	// happens at policy parse (Manager.applyDefaults), not here.
+	assert.Equal(t, "wat", (&Options{InterfaceNameSource: &bogus}).InterfaceNameSourceMode())
+}

--- a/snmp-discovery/mapping/interface_name_source_test.go
+++ b/snmp-discovery/mapping/interface_name_source_test.go
@@ -1,0 +1,44 @@
+package mapping
+
+import (
+	"testing"
+
+	"github.com/netboxlabs/orb-discovery/snmp-discovery/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveInterfaceName(t *testing.T) {
+	auto := config.InterfaceNameSourceAuto
+	ifname := config.InterfaceNameSourceIfName
+	ifdescr := config.InterfaceNameSourceIfDescr
+	descr := "Unit: 1 Slot: 0 Port: 1 Gigabit - Level" // looksDescriptive == true
+	cases := []struct {
+		name    string
+		source  string
+		ifDescr string
+		ifName  string
+		want    string
+	}{
+		// auto: ifDescr preferred unless descriptive while ifName is clean.
+		{"auto clean ifdescr wins", auto, "GigabitEthernet0/1", "Gi0/1", "GigabitEthernet0/1"},
+		{"auto descriptive ifdescr yields to clean ifname", auto, descr, "Gi0/1", "Gi0/1"},
+		{"auto empty ifdescr uses ifname", auto, "", "Gi0/1", "Gi0/1"},
+		{"auto empty ifname uses ifdescr", auto, "GigabitEthernet0/1", "", "GigabitEthernet0/1"},
+		{"auto both descriptive keeps ifdescr", auto, descr, "Slot: 2 Port: 3 - foo", descr},
+		{"auto both empty", auto, "", "", ""},
+		// ifname: ifName wins; fall back to ifDescr when empty.
+		{"ifname wins", ifname, "GigabitEthernet0/1", "Gi0/1", "Gi0/1"},
+		{"ifname empty falls back to ifdescr", ifname, "GigabitEthernet0/1", "", "GigabitEthernet0/1"},
+		{"ifname both empty", ifname, "", "", ""},
+		// ifdescr: ifDescr wins even when descriptive; fall back when empty.
+		{"ifdescr wins even when descriptive", ifdescr, descr, "Gi0/1", descr},
+		{"ifdescr empty falls back to ifname", ifdescr, "", "Gi0/1", "Gi0/1"},
+		// unknown source behaves as auto (defensive).
+		{"unknown source behaves as auto", "bogus", descr, "Gi0/1", "Gi0/1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, resolveInterfaceName(tc.source, tc.ifDescr, tc.ifName))
+		})
+	}
+}

--- a/snmp-discovery/mapping/interface_name_source_test.go
+++ b/snmp-discovery/mapping/interface_name_source_test.go
@@ -26,6 +26,10 @@ func TestResolveInterfaceName(t *testing.T) {
 		{"auto empty ifname uses ifdescr", auto, "GigabitEthernet0/1", "", "GigabitEthernet0/1"},
 		{"auto both descriptive keeps ifdescr", auto, descr, "Slot: 2 Port: 3 - foo", descr},
 		{"auto both empty", auto, "", "", ""},
+		// Sentinel ifName must not be promoted over a descriptive ifDescr:
+		// the legacy inline path treated DefaultInterfaceName ("unknown")
+		// as the not-yet-populated sentinel and let ifDescr overwrite it.
+		{"auto sentinel ifname keeps descriptive ifdescr", auto, descr, DefaultInterfaceName, descr},
 		// ifname: ifName wins; fall back to ifDescr when empty.
 		{"ifname wins", ifname, "GigabitEthernet0/1", "Gi0/1", "Gi0/1"},
 		{"ifname empty falls back to ifdescr", ifname, "GigabitEthernet0/1", "", "GigabitEthernet0/1"},

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -725,11 +725,15 @@ func resolveInterfaceName(source, ifDescr, ifName string) string {
 	default: // auto (and any unrecognized value, defensively)
 		// ifDescr preferred; ifName is promoted only when ifDescr is empty,
 		// or ifDescr is a hardware description while ifName is not. This
-		// reproduces the legacy inline name/name_alternate resolution.
+		// reproduces the legacy inline name/name_alternate resolution —
+		// including its treatment of DefaultInterfaceName as the unset
+		// sentinel: a literal ifName of "unknown" is not promoted over a
+		// descriptive ifDescr (the old code's currentClean guard excluded it).
 		if ifDescr == "" {
 			return ifName
 		}
-		if looksDescriptive(ifDescr) && ifName != "" && !looksDescriptive(ifName) {
+		if looksDescriptive(ifDescr) && ifName != "" &&
+			ifName != DefaultInterfaceName && !looksDescriptive(ifName) {
 			return ifName
 		}
 		return ifDescr

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -703,6 +703,7 @@ type InterfaceMapper struct {
 	logger           *slog.Logger
 	patternMatcher   *PatternMatcher
 	userPatternCount int
+	nameSource       string
 }
 
 // resolveInterfaceName selects Interface.Name from the two SNMP sources
@@ -735,8 +736,21 @@ func resolveInterfaceName(source, ifDescr, ifName string) string {
 	}
 }
 
-// NewInterfaceMapper creates a new InterfaceMapper
-func NewInterfaceMapper(logger *slog.Logger, patterns []config.InterfacePattern) (*InterfaceMapper, error) {
+// NewInterfaceMapper creates a new InterfaceMapper. nameSource is one of
+// config.InterfaceNameSource{Auto,IfName,IfDescr}; an empty or unrecognized
+// value is normalized to "auto". This normalization is a silent defensive
+// belt — the user-facing warning for an unknown value is emitted once at
+// policy parse (Manager.applyDefaults), because this constructor runs once
+// per target per scrape.
+func NewInterfaceMapper(logger *slog.Logger, patterns []config.InterfacePattern, nameSource string) (*InterfaceMapper, error) {
+	switch nameSource {
+	case config.InterfaceNameSourceIfName, config.InterfaceNameSourceIfDescr:
+		// recognized; keep as-is
+	default:
+		// "auto", "", and any unrecognized value all resolve to auto.
+		nameSource = config.InterfaceNameSourceAuto
+	}
+
 	var patternMatcher *PatternMatcher
 	userPatternCount := len(patterns)
 
@@ -756,6 +770,7 @@ func NewInterfaceMapper(logger *slog.Logger, patterns []config.InterfacePattern)
 		logger:           logger,
 		patternMatcher:   patternMatcher,
 		userPatternCount: userPatternCount,
+		nameSource:       nameSource,
 	}, nil
 }
 

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -815,7 +815,8 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 	interfaceEntity := entityRegistry.GetOrCreateEntity(InterfaceEntityType, getIndex(values)).(*diode.Interface)
 
 	fieldFound := false
-	var snmpIfType string // Store SNMP ifType for final type resolution
+	var snmpIfType string            // Store SNMP ifType for final type resolution
+	var ifDescrRaw, ifNameRaw string // ifDescr / ifName; Name resolved post-loop
 
 	valueKeys := make([]ObjectIDIndex, 0, len(values))
 	for objectID := range values {
@@ -832,47 +833,12 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				m.logger.Debug("mapping value to interface entity with mapper", "object_id", objectID, "value", value)
 				switch propertyMappingEntry.Field {
 				case "name":
-					// ifDescr is the preferred source for Interface.Name
-					// across all vendors except those whose ifDescr is a
-					// hardware description (Dell PowerConnect:
-					// "Unit: 1 Slot: 0 Port: 1 Gigabit - Level"). Don't
-					// overwrite an already-set clean Name (typically from
-					// ifName via name_alternate, which arrives first
-					// under slices.Reverse) with a descriptive ifDescr.
-					name := trimSNMPString(value.Value)
-					if name == "" {
-						continue
-					}
-					currentClean := interfaceEntity.Name != nil &&
-						*interfaceEntity.Name != "" &&
-						*interfaceEntity.Name != DefaultInterfaceName &&
-						!looksDescriptive(*interfaceEntity.Name)
-					if currentClean && looksDescriptive(name) {
-						// Keep the already-set clean Name; don't downgrade.
-						continue
-					}
-					interfaceEntity.Name = &name
-					fieldFound = true
+					// Capture ifDescr; Interface.Name is resolved once after
+					// the loop per interface_name_source (resolveInterfaceName).
+					ifDescrRaw = trimSNMPString(value.Value)
 				case "name_alternate":
-					// Fallback for vendors where ifDescr is empty/absent
-					// (e.g. FortiGate, Nokia TiMOS 7750), AND for vendors
-					// whose ifDescr is a hardware description (Dell
-					// PowerConnect). The latter is detected by looksDescriptive
-					// (requires a ": " substring), which intentionally
-					// does NOT match single-space canonical names like
-					// Dell FTOS "TenGigabitEthernet 0/0" or Extreme SLX
-					// "Port-channel 1" — those keep their ifDescr.
-					alt := trimSNMPString(value.Value)
-					if alt == "" {
-						continue
-					}
-					if interfaceEntity.Name == nil ||
-						*interfaceEntity.Name == "" ||
-						*interfaceEntity.Name == DefaultInterfaceName ||
-						(looksDescriptive(*interfaceEntity.Name) && !looksDescriptive(alt)) {
-						interfaceEntity.Name = &alt
-						fieldFound = true
-					}
+					// Capture ifName (ifXTable); see resolveInterfaceName.
+					ifNameRaw = trimSNMPString(value.Value)
 				case "description":
 					description := trimSNMPString(value.Value)
 					if description != "" {
@@ -974,6 +940,14 @@ func (m *InterfaceMapper) Map(values map[ObjectIDIndex]*ObjectIDValue, mappingEn
 				}
 			}
 		}
+	}
+
+	// Resolve Interface.Name from the two SNMP sources once, after the
+	// property loop, so the choice is explicit and order-independent.
+	// Done before type resolution below, which reads interfaceEntity.Name.
+	if name := resolveInterfaceName(m.nameSource, ifDescrRaw, ifNameRaw); name != "" {
+		interfaceEntity.Name = &name
+		fieldFound = true
 	}
 
 	// Resolve interface type after all fields are collected

--- a/snmp-discovery/mapping/mappers.go
+++ b/snmp-discovery/mapping/mappers.go
@@ -705,6 +705,36 @@ type InterfaceMapper struct {
 	userPatternCount int
 }
 
+// resolveInterfaceName selects Interface.Name from the two SNMP sources
+// (both already trimSNMPString-sanitized) per the policy's
+// interface_name_source. It returns "" only when both inputs are empty,
+// so the caller's empty-name handling is preserved.
+func resolveInterfaceName(source, ifDescr, ifName string) string {
+	switch source {
+	case config.InterfaceNameSourceIfName:
+		if ifName != "" {
+			return ifName
+		}
+		return ifDescr
+	case config.InterfaceNameSourceIfDescr:
+		if ifDescr != "" {
+			return ifDescr
+		}
+		return ifName
+	default: // auto (and any unrecognized value, defensively)
+		// ifDescr preferred; ifName is promoted only when ifDescr is empty,
+		// or ifDescr is a hardware description while ifName is not. This
+		// reproduces the legacy inline name/name_alternate resolution.
+		if ifDescr == "" {
+			return ifName
+		}
+		if looksDescriptive(ifDescr) && ifName != "" && !looksDescriptive(ifName) {
+			return ifName
+		}
+		return ifDescr
+	}
+}
+
 // NewInterfaceMapper creates a new InterfaceMapper
 func NewInterfaceMapper(logger *slog.Logger, patterns []config.InterfacePattern) (*InterfaceMapper, error) {
 	var patternMatcher *PatternMatcher

--- a/snmp-discovery/mapping/mappers_deferred_type_test.go
+++ b/snmp-discovery/mapping/mappers_deferred_type_test.go
@@ -17,7 +17,7 @@ func TestInterfaceMapper_DeferredTypeResolution(t *testing.T) {
 		userPatterns := []config.InterfacePattern{
 			{Match: `^GigabitEthernet\d+`, Type: "custom-gigabit"},
 		}
-		mapper, err := NewInterfaceMapper(logger, userPatterns)
+		mapper, err := NewInterfaceMapper(logger, userPatterns, config.InterfaceNameSourceAuto)
 		assert.NoError(t, err)
 
 		// Simulate SNMP data where type OID comes before name OID
@@ -80,7 +80,7 @@ func TestInterfaceMapper_DeferredTypeResolution(t *testing.T) {
 		userPatterns := []config.InterfacePattern{
 			{Match: `^TenGigabitEthernet\d+`, Type: "custom-tengig"},
 		}
-		mapper, err := NewInterfaceMapper(logger, userPatterns)
+		mapper, err := NewInterfaceMapper(logger, userPatterns, config.InterfaceNameSourceAuto)
 		assert.NoError(t, err)
 
 		// Simulate SNMP data where name OID comes before type OID
@@ -146,7 +146,7 @@ func TestInterfaceMapper_DeferredTypeResolution(t *testing.T) {
 
 	t.Run("Built-in pattern matching with deferred resolution", func(t *testing.T) {
 		// Create mapper with no user patterns, only built-ins
-		mapper, err := NewInterfaceMapper(logger, nil)
+		mapper, err := NewInterfaceMapper(logger, nil, config.InterfaceNameSourceAuto)
 		assert.NoError(t, err)
 
 		values := map[ObjectIDIndex]*ObjectIDValue{
@@ -202,7 +202,7 @@ func TestInterfaceMapper_DeferredTypeResolution(t *testing.T) {
 
 	t.Run("Deferred resolution with no pattern matcher", func(t *testing.T) {
 		// Create mapper without patterns
-		mapper, err := NewInterfaceMapper(logger, nil)
+		mapper, err := NewInterfaceMapper(logger, nil, config.InterfaceNameSourceAuto)
 		assert.NoError(t, err)
 		// Clear pattern matcher to simulate old behavior
 		mapper.patternMatcher = nil

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -4780,10 +4780,14 @@ func TestInterfaceMapper_Map_NameSourceModes(t *testing.T) {
 		{"auto clean ifdescr wins", config.InterfaceNameSourceAuto, "GigabitEthernet0/1", "Gi0/1", "GigabitEthernet0/1"},
 		{"auto descriptive ifdescr yields to ifname", config.InterfaceNameSourceAuto, descr, "Gi0/1", "Gi0/1"},
 		{"auto empty ifdescr uses ifname", config.InterfaceNameSourceAuto, "", "Gi0/1", "Gi0/1"},
+		{"auto both descriptive keeps ifdescr", config.InterfaceNameSourceAuto, descr, "Slot: 2 Port: 3 - foo", descr},
+		{"auto both empty keeps unknown placeholder", config.InterfaceNameSourceAuto, "", "", mapping.DefaultInterfaceName},
 		{"ifname wins", config.InterfaceNameSourceIfName, "GigabitEthernet0/1", "Gi0/1", "Gi0/1"},
 		{"ifname empty falls back to ifdescr", config.InterfaceNameSourceIfName, "GigabitEthernet0/1", "", "GigabitEthernet0/1"},
 		{"ifname strips NUL padding then resolves", config.InterfaceNameSourceIfName, "GigabitEthernet0/1", "Gi0/1\x00", "Gi0/1"},
+		{"ifname NUL-only falls back to ifdescr", config.InterfaceNameSourceIfName, "GigabitEthernet0/1", "\x00\x00", "GigabitEthernet0/1"},
 		{"ifdescr wins", config.InterfaceNameSourceIfDescr, "GigabitEthernet0/1", "Gi0/1", "GigabitEthernet0/1"},
+		{"ifdescr empty falls back to ifname", config.InterfaceNameSourceIfDescr, "", "Gi0/1", "Gi0/1"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -1884,7 +1884,7 @@ func TestInterfaceMapper_Map(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			logger := slog.Default()
 			registry := mapping.NewEntityRegistry(logger)
-			mapper, err := mapping.NewInterfaceMapper(logger, nil)
+			mapper, err := mapping.NewInterfaceMapper(logger, nil, config.InterfaceNameSourceAuto)
 			assert.NoError(t, err)
 			entity := mapper.Map(tt.values, tt.mappingEntry, registry, tt.defaults)
 
@@ -2062,7 +2062,7 @@ func TestInterfaceMapper_Map_ZeroSpeedAndMtu(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			registry := mapping.NewEntityRegistry(logger)
-			mapper, err := mapping.NewInterfaceMapper(logger, nil)
+			mapper, err := mapping.NewInterfaceMapper(logger, nil, config.InterfaceNameSourceAuto)
 			assert.NoError(t, err)
 			entity := mapper.Map(tt.values, tt.mappingEntry, registry, nil)
 			assert.NotNil(t, entity)
@@ -2141,7 +2141,7 @@ func TestInterfaceMapper_Map_HighSpeed(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			registry := mapping.NewEntityRegistry(logger)
-			mapper, err := mapping.NewInterfaceMapper(logger, nil)
+			mapper, err := mapping.NewInterfaceMapper(logger, nil, config.InterfaceNameSourceAuto)
 			assert.NoError(t, err)
 			entity := mapper.Map(tt.values, tt.mappingEntry, registry, nil)
 			assert.NotNil(t, entity)
@@ -2154,7 +2154,7 @@ func TestInterfaceMapper_Map_HighSpeed(t *testing.T) {
 
 func TestInterfaceMapper_FormatMACAddress(t *testing.T) {
 	logger := slog.Default()
-	mapper, err := mapping.NewInterfaceMapper(logger, nil)
+	mapper, err := mapping.NewInterfaceMapper(logger, nil, config.InterfaceNameSourceAuto)
 	assert.NoError(t, err)
 
 	tests := []struct {

--- a/snmp-discovery/mapping/mappers_test.go
+++ b/snmp-discovery/mapping/mappers_test.go
@@ -4738,3 +4738,63 @@ func TestDeviceMapper_Map_DefaultsResolveFromSysContactOnly(t *testing.T) {
 	require.NotNil(t, device.AssetTag)
 	assert.Equal(t, "asset-from-contact", *device.AssetTag)
 }
+
+func TestInterfaceMapper_Map_NameSourceModes(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	// Mirrors the production ifTable group: top-level _id, with name /
+	// name_alternate / description as sub-entries (no _id sub-entry).
+	mappingEntry := &mapping.Entry{
+		OID:    "1.3.6.1.2.1.2.2.1.1",
+		Entity: "interface",
+		Field:  "_id",
+		MappingEntries: []mapping.Entry{
+			{OID: "1.3.6.1.2.1.2.2.1.2", Entity: "interface", Field: "name"},
+			{OID: "1.3.6.1.2.1.31.1.1.1.1", Entity: "interface", Field: "name_alternate"},
+			{OID: "1.3.6.1.2.1.31.1.1.1.18", Entity: "interface", Field: "description"},
+		},
+	}
+	// Build the value map, omitting a name OID when its value is "" so the
+	// "source field absent for this row" path is exercised.
+	mkValues := func(ifDescr, ifName string) map[mapping.ObjectIDIndex]*mapping.ObjectIDValue {
+		v := map[mapping.ObjectIDIndex]*mapping.ObjectIDValue{
+			"1.3.6.1.2.1.2.2.1.1.1":     {OID: "1.3.6.1.2.1.2.2.1.1.1", Index: "1", Parent: "1.3.6.1.2.1.2.2.1.1", Value: "1", Type: mapping.Integer},
+			"1.3.6.1.2.1.31.1.1.1.18.1": {OID: "1.3.6.1.2.1.31.1.1.1.18.1", Index: "1", Parent: "1.3.6.1.2.1.31.1.1.1.18", Value: "uplink to core", Type: mapping.OctetString},
+		}
+		if ifDescr != "" {
+			v["1.3.6.1.2.1.2.2.1.2.1"] = &mapping.ObjectIDValue{OID: "1.3.6.1.2.1.2.2.1.2.1", Index: "1", Parent: "1.3.6.1.2.1.2.2.1.2", Value: ifDescr, Type: mapping.OctetString}
+		}
+		if ifName != "" {
+			v["1.3.6.1.2.1.31.1.1.1.1.1"] = &mapping.ObjectIDValue{OID: "1.3.6.1.2.1.31.1.1.1.1.1", Index: "1", Parent: "1.3.6.1.2.1.31.1.1.1.1", Value: ifName, Type: mapping.OctetString}
+		}
+		return v
+	}
+	const descr = "Unit: 1 Slot: 0 Port: 1 Gigabit - Level" // looksDescriptive == true
+	cases := []struct {
+		name     string
+		source   string
+		ifDescr  string
+		ifName   string
+		wantName string
+	}{
+		{"auto clean ifdescr wins", config.InterfaceNameSourceAuto, "GigabitEthernet0/1", "Gi0/1", "GigabitEthernet0/1"},
+		{"auto descriptive ifdescr yields to ifname", config.InterfaceNameSourceAuto, descr, "Gi0/1", "Gi0/1"},
+		{"auto empty ifdescr uses ifname", config.InterfaceNameSourceAuto, "", "Gi0/1", "Gi0/1"},
+		{"ifname wins", config.InterfaceNameSourceIfName, "GigabitEthernet0/1", "Gi0/1", "Gi0/1"},
+		{"ifname empty falls back to ifdescr", config.InterfaceNameSourceIfName, "GigabitEthernet0/1", "", "GigabitEthernet0/1"},
+		{"ifname strips NUL padding then resolves", config.InterfaceNameSourceIfName, "GigabitEthernet0/1", "Gi0/1\x00", "Gi0/1"},
+		{"ifdescr wins", config.InterfaceNameSourceIfDescr, "GigabitEthernet0/1", "Gi0/1", "GigabitEthernet0/1"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, err := mapping.NewInterfaceMapper(logger, nil, tc.source)
+			require.NoError(t, err)
+			reg := mapping.NewEntityRegistry(logger)
+			got := m.Map(mkValues(tc.ifDescr, tc.ifName), mappingEntry, reg, nil).(*diode.Interface)
+			require.NotNil(t, got.Name)
+			assert.Equal(t, tc.wantName, *got.Name)
+			require.NotNil(t, got.Description)
+			assert.Equal(t, "uplink to core", *got.Description, "ifAlias description unaffected by name source")
+		})
+	}
+}

--- a/snmp-discovery/mapping/mapping.go
+++ b/snmp-discovery/mapping/mapping.go
@@ -429,7 +429,7 @@ func NewConfig(mappings []config.MappingEntry, logger *slog.Logger, manufacturer
 		interfacePatterns = defaults.InterfacePatterns
 	}
 
-	interfaceMapper, err := NewInterfaceMapper(logger, interfacePatterns)
+	interfaceMapper, err := NewInterfaceMapper(logger, interfacePatterns, options.InterfaceNameSourceMode())
 	if err != nil {
 		return nil, fmt.Errorf("failed to create interface mapper: %w", err)
 	}

--- a/snmp-discovery/policy/manager.go
+++ b/snmp-discovery/policy/manager.go
@@ -124,6 +124,16 @@ func (m *Manager) applyDefaults(policy *config.Policy) {
 		trueVal := true
 		policy.Config.Options.CreateUnknownVlans = &trueVal
 	}
+
+	if src := policy.Config.Options.InterfaceNameSource; src != nil {
+		switch *src {
+		case config.InterfaceNameSourceAuto, config.InterfaceNameSourceIfName, config.InterfaceNameSourceIfDescr:
+			// recognized
+		default:
+			m.logger.Warn("unknown interface_name_source; using auto", "value", *src)
+			policy.Config.Options.InterfaceNameSource = nil // normalize → auto
+		}
+	}
 }
 
 // validateAuthentication validates a single authentication configuration

--- a/snmp-discovery/policy/manager_test.go
+++ b/snmp-discovery/policy/manager_test.go
@@ -141,6 +141,52 @@ func TestManagerParsePolicies(t *testing.T) {
 		assert.Equal(t, "no policies found in the request", err.Error())
 	})
 
+	t.Run("Unknown interface_name_source normalizes to auto", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              options:
+                interface_name_source: wat
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  port: 162
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+    `)
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		require.Contains(t, policies, "policy1")
+		opts := policies["policy1"].Config.Options
+		assert.Nil(t, opts.InterfaceNameSource, "unknown value normalized to nil")
+		assert.Equal(t, config.InterfaceNameSourceAuto, opts.InterfaceNameSourceMode())
+	})
+
+	t.Run("Valid interface_name_source is preserved", func(t *testing.T) {
+		yamlData := []byte(`
+        policies:
+          policy1:
+            config:
+              options:
+                interface_name_source: ifname
+            scope:
+              targets:
+                - host: 192.168.1.1
+                  port: 162
+              authentication:
+                protocol_version: SNMPv2c
+                community: public
+    `)
+		policies, err := manager.ParsePolicies(yamlData)
+		assert.NoError(t, err)
+		require.Contains(t, policies, "policy1")
+		opts := policies["policy1"].Config.Options
+		require.NotNil(t, opts.InterfaceNameSource)
+		assert.Equal(t, "ifname", *opts.InterfaceNameSource)
+	})
+
 	t.Run("Environment Variable Resolution - Community", func(t *testing.T) {
 		// Set test environment variable
 		err := os.Setenv("SNMP_COMMUNITY", "test-community")


### PR DESCRIPTION
## Summary

Implements the request in [netboxlabs/orb-agent#404](https://github.com/netboxlabs/orb-agent/issues/404): a per-policy option to choose whether the NetBox interface **name** comes from SNMP `ifName` or `ifDescr`, instead of always using the current auto heuristic (which prefers `ifDescr`).

```yaml
options:
  interface_name_source: ifname   # auto (default) | ifname | ifdescr
```

## Behavior

- **`auto` (default)** — unchanged: `ifDescr` preferred, `ifName` promoted only when `ifDescr` is empty or looks like a hardware description (`looksDescriptive`). Zero behavior change for existing policies.
- **`ifname`** — name comes from `ifName`, falling back to `ifDescr` when `ifName` is empty for an interface.
- **`ifdescr`** — name comes from `ifDescr` (even when descriptive), falling back to `ifName` when empty.
- `ifAlias`→`description` is untouched in all modes.
- An unrecognized value is warned **once** at policy parse (`Manager.applyDefaults`) and normalized to `auto`; the per-scrape path normalizes silently.

## Implementation

- `config`: `interface_name_source` Options field + `InterfaceNameSourceMode()` accessor (mirrors `DiscoverModules`/`ModuleDiscoveryMode`).
- `mapping`: a pure `resolveInterfaceName(source, ifDescr, ifName)`; `InterfaceMapper.Map` refactored from inline name resolution to capture-both-then-resolve-once (set before interface-type resolution, which reads the name).
- `policy`: `applyDefaults` warns-once + normalizes unknown values.

## ⚠️ Operational note

Interface name is NetBox's interface match key. **Changing `interface_name_source` on an existing deployment renames interfaces**, creating new ones alongside the old until reconciled. Pick the source before first discovery where practical. (Documented in the companion orb-agent docs PR.)

## Tests

- `resolveInterfaceName` table test (all 3 modes + fallback + descriptive + unknown-source).
- `InterfaceMapper.Map` per-mode integration test (11 cases incl. both-empty→`unknown`, NUL-padded, NUL-only fallback, ifAlias untouched).
- `config` accessor + `manager` parse normalization tests.
- Full `go test ./...` and `golangci-lint run` pass. A claude adversarial review confirmed `auto` is byte-for-byte equivalent to the prior logic across all ifDescr×ifName combinations.

Docs: companion draft PR in netboxlabs/orb-agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)