### PR TITLE
fix(device-discovery): align custom driver manufacturer names to NDX/DTL

### DIFF
--- a/device-discovery/custom_napalm/alcatel_aos.py
+++ b/device-discovery/custom_napalm/alcatel_aos.py
@@ -340,13 +340,12 @@ class AlcatelAOSDriver(_napalm_base.NetworkDriver):
             model = chass.get("model_name", "Unknown").strip() or "Unknown"
             serial_number = chass.get("serial_number", "Unknown").strip() or "Unknown"
 
-        # Split description on model name to extract vendor / os_version.
+        # Split description on model name to extract the os_version.
         # description format: "Alcatel-Lucent Enterprise OS6860E-24 8.5.152.R01 ..."
         if parsed_sys and model != "Unknown":
             desc = parsed_sys[0].get("description", "")
             if model in desc:
-                before, _, after = desc.partition(model)
-                vendor = before.strip().rstrip(",") or "Alcatel-Lucent"
+                _, _, after = desc.partition(model)
                 os_version = after.strip().lstrip(",").strip() or "Unknown"
             elif desc:
                 os_version = desc.strip()

--- a/device-discovery/custom_napalm/aruba_aoscx.py
+++ b/device-discovery/custom_napalm/aruba_aoscx.py
@@ -565,7 +565,7 @@ class AOSCXDriver(_napalm_base.NetworkDriver):
 
         return {
             "hostname": hostname,
-            "vendor": "Aruba",
+            "vendor": "HPE",
             "model": model,
             "os_version": os_version,
             "serial_number": serial_number,

--- a/device-discovery/custom_napalm/aruba_aoscx_ssh.py
+++ b/device-discovery/custom_napalm/aruba_aoscx_ssh.py
@@ -312,7 +312,7 @@ class AOSCXSSHDriver(_napalm_base.NetworkDriver):
 
         return {
             "hostname": row.get("hostname", "Unknown"),
-            "vendor": row.get("vendor", "Aruba") or "Aruba",
+            "vendor": "HPE",
             "model": (row.get("product", "") or "Unknown").strip(),
             "os_version": row.get("version", "Unknown"),
             "serial_number": row.get("serial", "Unknown"),

--- a/device-discovery/custom_napalm/aruba_os.py
+++ b/device-discovery/custom_napalm/aruba_os.py
@@ -198,7 +198,7 @@ class ArubaOSDriver(_napalm_base.NetworkDriver):
 
         return {
             "hostname": hostname,
-            "vendor": "HPE Aruba",
+            "vendor": "HPE",
             "model": model,
             "os_version": os_version,
             "serial_number": serial_number,

--- a/device-discovery/custom_napalm/aruba_osswitch.py
+++ b/device-discovery/custom_napalm/aruba_osswitch.py
@@ -335,7 +335,7 @@ class ArubaOSSDriver(_napalm_base.NetworkDriver):
 
         return {
             "hostname": hostname,
-            "vendor": "HPE Aruba",
+            "vendor": "HPE",
             "model": model,
             "os_version": os_version,
             "serial_number": serial_number,

--- a/device-discovery/custom_napalm/cumulus_linux.py
+++ b/device-discovery/custom_napalm/cumulus_linux.py
@@ -261,8 +261,12 @@ class CumulusDriver(_napalm_base.NetworkDriver):
 
         eeprom = _parse_decode_syseeprom(self.device.send_command("decode-syseeprom"))
         model = eeprom.get("product_name") or eeprom.get("part_number") or "Unknown"
-        # Use the EEPROM vendor when present; Nvidia is the default for ONIE/Cumulus hardware.
-        vendor = eeprom.get("manufacturer") or "Nvidia"
+        # Use the EEPROM vendor when present; NVIDIA is the default for ONIE/Cumulus hardware.
+        # ONIE EEPROMs spell the NVIDIA vendor inconsistently ("Nvidia"/"NVIDIA"); fold it to
+        # the NDX/DTL manufacturer name.
+        vendor = eeprom.get("manufacturer") or "NVIDIA"
+        if vendor.lower() == "nvidia":
+            vendor = "NVIDIA"
         # Prefer EEPROM serial; fall back to DMI sysfs (available on VMs without decode-syseeprom).
         serial_number = eeprom.get("serial_number") or ""
         if not serial_number:

--- a/device-discovery/custom_napalm/dell_ftos.py
+++ b/device-discovery/custom_napalm/dell_ftos.py
@@ -476,7 +476,11 @@ class FTOSDriver(_napalm_base.NetworkDriver):
         return os_version, uptime, model
 
     def _facts_from_stack_unit(self) -> tuple[str, str, str]:
-        """Return (serial_number, model, vendor) from 'show system stack-unit 0' (regex)."""
+        """
+        Return (serial_number, model, vendor) from 'show system stack-unit 0'.
+
+        serial_number and model are parsed via regex; vendor is the constant "Dell".
+        """
         serial_number = "Unknown"
         model = "Unknown"
         vendor = "Dell"
@@ -491,10 +495,6 @@ class FTOSDriver(_napalm_base.NetworkDriver):
                 val = stripped.split(":", 1)[-1].strip()
                 if val:
                     model = val
-            elif stripped.startswith("Mfg By"):
-                val = stripped.split(":", 1)[-1].strip()
-                if val:
-                    vendor = val
         return serial_number, model, vendor
 
     def get_facts(self) -> dict:
@@ -503,7 +503,7 @@ class FTOSDriver(_napalm_base.NetworkDriver):
 
         Facts are assembled from four commands:
         - 'show version'          → os_version, uptime (ntc-template)
-        - 'show system stack-unit 0' → serial_number, model, vendor (regex)
+        - 'show system stack-unit 0' → serial_number, model (regex); vendor is constant "Dell"
         - 'show running-config'   → hostname (regex on first 'hostname' line)
         - 'show interfaces'       → interface_list (regex scan for interface names)
         """

--- a/device-discovery/custom_napalm/extreme_exos.py
+++ b/device-discovery/custom_napalm/extreme_exos.py
@@ -511,7 +511,7 @@ class ExosDriver(_napalm_base.NetworkDriver):
 
         return {
             "hostname": hostname,
-            "vendor": "Extreme",
+            "vendor": "Extreme Networks",
             "model": model,
             "os_version": os_version,
             "serial_number": serial_number,

--- a/device-discovery/custom_napalm/extreme_slx.py
+++ b/device-discovery/custom_napalm/extreme_slx.py
@@ -603,7 +603,7 @@ class SLXOSDriver(_napalm_base.NetworkDriver):
 
         return {
             "hostname": hostname,
-            "vendor": "Extreme",
+            "vendor": "Extreme Networks",
             "model": model,
             "os_version": os_version,
             "serial_number": serial_number,

--- a/device-discovery/custom_napalm/extreme_vsp.py
+++ b/device-discovery/custom_napalm/extreme_vsp.py
@@ -451,7 +451,7 @@ class VSPDriver(_napalm_base.NetworkDriver):
         """Return general device facts."""
         facts: dict = {
             "hostname": "Unknown",
-            "vendor": "Extreme",
+            "vendor": "Extreme Networks",
             "model": "VSP",
             "os_version": "Unknown",
             "serial_number": "Unknown",

--- a/device-discovery/custom_napalm/hp_comware.py
+++ b/device-discovery/custom_napalm/hp_comware.py
@@ -891,7 +891,7 @@ class ComwareDriver(_napalm_base.NetworkDriver):
 
         return {
             "hostname": hostname,
-            "vendor": "HP",
+            "vendor": "HPE",
             "model": model,
             "os_version": os_version,
             "serial_number": serial_number,

--- a/device-discovery/custom_napalm/hp_procurve.py
+++ b/device-discovery/custom_napalm/hp_procurve.py
@@ -396,7 +396,7 @@ class ProcurveDriver(_napalm_base.NetworkDriver):
 
         return {
             "hostname": hostname,
-            "vendor": "HP",
+            "vendor": "HPE",
             "model": model,
             "os_version": os_version,
             "serial_number": serial_number,

--- a/device-discovery/custom_napalm/paloalto_panos.py
+++ b/device-discovery/custom_napalm/paloalto_panos.py
@@ -536,7 +536,7 @@ class PANOSDriver(_napalm_base.NetworkDriver):
 
         if system_info:
             facts["hostname"] = system_info["hostname"]
-            facts["vendor"] = "Palo Alto Networks"
+            facts["vendor"] = "Palo Alto"
             facts["uptime"] = float(convert_uptime_string_seconds(system_info["uptime"]))
             facts["os_version"] = system_info["sw-version"]
             facts["serial_number"] = system_info["serial"]

--- a/device-discovery/custom_napalm/paloalto_panos_ssh.py
+++ b/device-discovery/custom_napalm/paloalto_panos_ssh.py
@@ -433,7 +433,7 @@ class PANOSSHDriver(_napalm_base.NetworkDriver):
 
         return {
             "hostname": row.get("hostname", "Unknown"),
-            "vendor": "Palo Alto Networks",
+            "vendor": "Palo Alto",
             "model": row.get("model", "Unknown"),
             "os_version": row.get("os", "Unknown"),
             "serial_number": row.get("serial", "Unknown"),

--- a/device-discovery/tests/custom_drivers/alcatel_aos/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/alcatel_aos/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "OS6860",
-  "vendor": "Alcatel-Lucent Enterprise",
+  "vendor": "Alcatel-Lucent",
   "model": "OS6860E-24",
   "os_version": "8.5.152.R01",
   "serial_number": "P468057P",

--- a/device-discovery/tests/custom_drivers/aruba_aoscx/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/aruba_aoscx/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "aruba-cx-6300",
-  "vendor": "Aruba",
+  "vendor": "HPE",
   "model": "6300M 24-port SFP+ 4-port SFP56",
   "os_version": "GL.10.10.0001",
   "serial_number": "CN29FP60KT",

--- a/device-discovery/tests/custom_drivers/aruba_aoscx_ssh/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/aruba_aoscx_ssh/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "aruba-cx-6300",
-  "vendor": "Aruba",
+  "vendor": "HPE",
   "model": "6300M 24-port SFP+ 4-port SFP56",
   "os_version": "GL.10.10.0001",
   "serial_number": "CN29FP60KT",

--- a/device-discovery/tests/custom_drivers/aruba_os/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/aruba_os/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "ARUBAOS-CTL01",
-  "vendor": "HPE Aruba",
+  "vendor": "HPE",
   "model": "7005",
   "os_version": "8.8.0.2-8.8.0.2",
   "serial_number": "CNFE1234567",

--- a/device-discovery/tests/custom_drivers/aruba_osswitch/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/aruba_osswitch/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "ARUBAOSS-SW01",
-  "vendor": "HPE Aruba",
+  "vendor": "HPE",
   "model": "J9853A",
   "os_version": "WB.16.10.0014",
   "serial_number": "SG12345678",

--- a/device-discovery/tests/custom_drivers/cumulus_linux/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/cumulus_linux/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "leaf01",
-  "vendor": "Nvidia",
+  "vendor": "NVIDIA",
   "model": "SN2410M",
   "os_version": "Cumulus Linux 5.7.0",
   "serial_number": "MT2123X07890A",

--- a/device-discovery/tests/custom_drivers/extreme_exos/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/extreme_exos/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "exos-core-01",
-  "vendor": "Extreme",
+  "vendor": "Extreme Networks",
   "model": "X480-48t",
   "os_version": "22.6.1.4",
   "serial_number": "1516G-00123",

--- a/device-discovery/tests/custom_drivers/extreme_slx/mock_data/test_get_facts/compact_uptime/expected_result.json
+++ b/device-discovery/tests/custom_drivers/extreme_slx/mock_data/test_get_facts/compact_uptime/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "slx9640",
-  "vendor": "Extreme",
+  "vendor": "Extreme Networks",
   "model": "SLX 9640",
   "os_version": "20.2.3",
   "serial_number": "FTX2244H01B3",

--- a/device-discovery/tests/custom_drivers/extreme_slx/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/extreme_slx/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "slx9640",
-  "vendor": "Extreme",
+  "vendor": "Extreme Networks",
   "model": "SLX 9640",
   "os_version": "20.2.3",
   "serial_number": "FTX2244H01B3",

--- a/device-discovery/tests/custom_drivers/extreme_slx/mock_data/test_get_facts/os_version_banner/expected_result.json
+++ b/device-discovery/tests/custom_drivers/extreme_slx/mock_data/test_get_facts/os_version_banner/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "slx9640",
-  "vendor": "Extreme",
+  "vendor": "Extreme Networks",
   "model": "SLX 9640",
   "os_version": "20.2.3",
   "serial_number": "FTX2244H01B3",

--- a/device-discovery/tests/custom_drivers/extreme_slx/mock_data/test_get_facts/sw_version_fallback/expected_result.json
+++ b/device-discovery/tests/custom_drivers/extreme_slx/mock_data/test_get_facts/sw_version_fallback/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "slx9640",
-  "vendor": "Extreme",
+  "vendor": "Extreme Networks",
   "model": "SLX 9640",
   "os_version": "20.2.3a",
   "serial_number": "FTX2244H01B3",

--- a/device-discovery/tests/custom_drivers/extreme_vsp/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/extreme_vsp/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "vspsw01",
-  "vendor": "Extreme",
+  "vendor": "Extreme Networks",
   "model": "VSP 8K",
   "os_version": "VOSS8K.6.0.1.2.GA",
   "serial_number": "1DB4924B6FE6",

--- a/device-discovery/tests/custom_drivers/hp_comware/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/hp_comware/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "comware-sw01",
-  "vendor": "HP",
+  "vendor": "HPE",
   "model": "S5560X-30C-EI",
   "os_version": "7.1.070",
   "serial_number": "CN3H2G7800X",

--- a/device-discovery/tests/custom_drivers/hp_procurve/mock_data/test_get_facts/no_banner/expected_result.json
+++ b/device-discovery/tests/custom_drivers/hp_procurve/mock_data/test_get_facts/no_banner/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "procurve-lab-sw1",
-  "vendor": "HP",
+  "vendor": "HPE",
   "model": "HP ProCurve Switch 2650",
   "os_version": "R.11.72",
   "serial_number": "SG80HC0086",

--- a/device-discovery/tests/custom_drivers/hp_procurve/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/hp_procurve/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "procurve-lab-sw1",
-  "vendor": "HP",
+  "vendor": "HPE",
   "model": "HP ProCurve Switch 2650",
   "os_version": "R.11.72",
   "serial_number": "SG80HC0086",

--- a/device-discovery/tests/custom_drivers/paloalto_panos/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/paloalto_panos/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "PA-VM-LAB",
-  "vendor": "Palo Alto Networks",
+  "vendor": "Palo Alto",
   "uptime": 600.0,
   "os_version": "10.1.6",
   "serial_number": "007056000123456",

--- a/device-discovery/tests/custom_drivers/paloalto_panos_ssh/mock_data/test_get_facts/normal/expected_result.json
+++ b/device-discovery/tests/custom_drivers/paloalto_panos_ssh/mock_data/test_get_facts/normal/expected_result.json
@@ -1,6 +1,6 @@
 {
   "hostname": "PA-VM-LAB",
-  "vendor": "Palo Alto Networks",
+  "vendor": "Palo Alto",
   "model": "PA-VM",
   "os_version": "10.1.6",
   "serial_number": "007056000123456",


### PR DESCRIPTION
## Summary

Each custom NAPALM driver emits a `vendor` fact that device-discovery turns into the NetBox `manufacturer.name`. Several drivers emitted strings that do **not** match the canonical NetBox DeviceType-Library (DTL) / NDX manufacturer name, so discovered devices failed to link to the correct manufacturer and device-types.

This aligns every emitted vendor to the exact DTL manufacturer name (verified against `ndx-data`).

## Mappings applied

| Driver(s) | Before | After |
|---|---|---|
| extreme_exos, extreme_slx, extreme_vsp | `Extreme` | `Extreme Networks` |
| paloalto_panos, paloalto_panos_ssh | `Palo Alto Networks` | `Palo Alto` |
| aruba_os, aruba_osswitch | `HPE Aruba` | `HPE` |
| aruba_aoscx, aruba_aoscx_ssh | `Aruba` | `HPE` |
| hp_comware, hp_procurve | `HP` | `HPE` |
| cumulus_linux | `Nvidia` (default) | `NVIDIA` + EEPROM casing fold |

NDX has no `Aruba` manufacturer (Aruba gear is filed under `HPE`), and HPE networking lives under `HPE` (not the legacy `HP`).

## Runtime-derived vendor fixes

Two drivers parsed the vendor from device output and could drift away from the DTL name:

- **alcatel_aos** no longer derives the vendor from the system description (which yielded `Alcatel-Lucent Enterprise`); it stays the constant `Alcatel-Lucent`. `os_version` parsing is unchanged.
- **dell_ftos** no longer overrides the vendor from the `Mfg By` line (which could surface `Force10`); it stays `Dell`.

## Intentional exception

`avaya_ers` is **kept as `Avaya`**: the ERS line has no current DTL manufacturer entry, so reattributing it to Extreme Networks would be misleading. These devices won't link to an NDX manufacturer — accepted tradeoff.

## Compatibility note

This changes the manufacturer names orb-agent emits. Existing devices discovered under the old names (e.g. `Extreme`, `Palo Alto Networks`, `Aruba`/`HPE Aruba`, `HP`) will now create/attach to the canonical names (`Extreme Networks`, `Palo Alto`, `HPE`). Backends other than device-discovery (SNMP, gNMI) are out of scope for this PR.

## Testing

- `pytest tests/` → **1787 passed, 161 skipped**
- `ruff check custom_napalm/` → clean
- Reviewed by Codex and an independent adversarial pass (both: ship); all changed vendor strings confirmed to exactly match real DTL manufacturer entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)