### PR TITLE
fix(snmp-discovery): align discovered manufacturer names to NDX/DTL

### DIFF
--- a/snmp-discovery/data/lookup_extensions/_manufacturers_ndx.yaml
+++ b/snmp-discovery/data/lookup_extensions/_manufacturers_ndx.yaml
@@ -5,12 +5,10 @@
 # manufacturer and device-types. PENs absent here keep their raw IANA name.
 #
 # A vendor may own several PENs (acquisitions, sub-brands, legacy agents). Where
-# a bundled lookup_extensions device file groups multiple PENs under one vendor,
-# every one of those PENs is mapped here so all of that vendor's devices resolve
-# to the same canonical name.
+# a vendor maps from more than one PEN, the PENs are grouped together below.
 manufacturers:
-  6486: Alcatel-Lucent
   664: Adtran
+  6486: Alcatel-Lucent
   207: Allied Telesis
   30065: Arista
   1588: Brocade
@@ -18,8 +16,11 @@ manufacturers:
   2620: Check Point
   1271: Ciena
   5951: Citrix
+  20992: Cradlepoint
   3808: CyberPower
   171: D-Link
+  2254: Delta
+  332: Digi
   534: Eaton
   52587: Edgecore
   193: Ericsson
@@ -27,49 +28,69 @@ manufacturers:
   3375: F5
   12356: Fortinet
   52642: FS
+  553: GarrettCom
+  26866: Gigamon
   248: Hirschmann
+  116: HITACHI
   2011: Huawei
+  2: IBM
   7779: Infoblox
+  1714: Infortrend
+  2356: LANCOM
   19046: Lenovo
   33049: Mellanox
   14988: MikroTik
   8691: Moxa
+  119: NEC
   789: NetApp
   4526: Netgear
   6527: Nokia
   25049: Opengear
   23695: Peplink
+  4346: Phoenix Contact
+  7244: QCT
+  89: Radware
   13742: Raritan
   2606: Rittal
   17163: Riverbed
   25053: Ruckus
+  15004: RuggedCOM
+  1718: Server Technology
+  4329: Siemens
   8741: SonicWall
   2604: Sophos
   11256: Stormshield
+  10876: Supermicro
+  6574: Synology
+  564: Telco Systems
   48690: Teltonika
   11863: TP-Link
+  28866: TrendNet
   41112: Ubiquiti
   3097: WatchGuard
-  890: Zyxel
+  2634: WTI
+  58132: Xfusion
+  1182: YAMAHA
   3902: ZTE
+  890: Zyxel
 
-  # --- Vendors that own multiple PENs ---
+  # --- Vendors that map from multiple PENs ---
   # A10 Networks
   22610: A10
   40842: A10
-  # APC — APC + NetBotz (APC environmental-monitoring brand)
+  # APC + NetBotz (APC environmental-monitoring brand)
   318: APC
   5528: APC
   # AudioCodes
   4923: AudioCodes
   5003: AudioCodes
-  # Barracuda — phion (Barracuda AG) + Barracuda
+  # Barracuda + phion (Barracuda AG)
   10704: Barracuda
   20632: Barracuda
   # Cisco — ciscoSystems + Meraki (NDX files Meraki device-types under Cisco)
   9: Cisco
   29671: Cisco
-  # Dell — Dell + Force10 + Dell EMC OS10 (SmartFabric)
+  # Dell + Force10 + Dell EMC OS10 (SmartFabric)
   674: Dell
   6027: Dell
   19746: Dell
@@ -79,12 +100,18 @@ manufacturers:
   14823: HPE
   37447: HPE
   47196: HPE
-  # Juniper — Juniper + Unisphere/ERX (acquired by Juniper)
+  # Juniper + Unisphere/ERX (acquired by Juniper)
   2636: Juniper
   4874: Juniper
-  # Palo Alto — PAN-OS + CloudGenix (Prisma SD-WAN, acquired by Palo Alto)
+  # Palo Alto — PAN-OS + CloudGenix (Prisma SD-WAN)
   25461: Palo Alto
   50114: Palo Alto
+  # Quantum Corporation (two enterprise numbers)
+  2036: Quantum
+  3697: Quantum
+  # Thales eSecurity + Thales DIS
+  4096: Thales
+  31746: Thales
   # Vertiv — Emerson Computer Power (legacy agent) + Vertiv
   476: Vertiv
   21239: Vertiv

--- a/snmp-discovery/data/lookup_extensions/_manufacturers_ndx.yaml
+++ b/snmp-discovery/data/lookup_extensions/_manufacturers_ndx.yaml
@@ -1,0 +1,75 @@
+# Canonical manufacturer overrides aligning SNMP-discovered vendors to the
+# NetBox DeviceType-Library (DTL) / NDX manufacturer names. Keys are IANA
+# Private Enterprise Numbers (the 7th element of sysObjectID); values are the
+# exact DTL `manufacturer:` strings, so discovered devices attach to the right
+# manufacturer and device-types. PENs absent here keep their raw IANA name.
+manufacturers:
+  # --- Vendors with one PEN ---
+  30065: Arista
+  664: Adtran
+  6486: Alcatel-Lucent
+  207: Allied Telesis
+  318: APC
+  4923: AudioCodes
+  5003: AudioCodes
+  1588: Brocade
+  6321: Calix
+  2620: Check Point
+  1271: Ciena
+  5951: Citrix
+  3808: CyberPower
+  171: D-Link
+  52587: Edgecore
+  193: Ericsson
+  1916: Extreme Networks
+  534: Eaton
+  3375: F5
+  12356: Fortinet
+  52642: FS
+  248: Hirschmann
+  2011: Huawei
+  7779: Infoblox
+  2636: Juniper
+  19046: Lenovo
+  33049: Mellanox
+  14988: MikroTik
+  789: NetApp
+  4526: Netgear
+  6527: Nokia
+  25049: Opengear
+  25461: Palo Alto
+  23695: Peplink
+  13742: Raritan
+  2606: Rittal
+  17163: Riverbed
+  25053: Ruckus
+  8741: SonicWall
+  2604: Sophos
+  11256: Stormshield
+  48690: Teltonika
+  11863: TP-Link
+  41112: Ubiquiti
+  21239: Vertiv
+  3097: WatchGuard
+  890: Zyxel
+  3902: ZTE
+
+  # --- Vendors / brands with multiple PENs ---
+  # Cisco — ciscoSystems + Meraki (NDX files Meraki device-types under Cisco)
+  9: Cisco
+  29671: Cisco
+  # Dell — Dell + Force10 + Dell EMC OS10 (SmartFabric)
+  674: Dell
+  6027: Dell
+  19746: Dell
+  # HPE — HP/HPE + Aruba
+  11: HPE
+  14823: HPE
+  # A10 Networks
+  22610: A10
+  40842: A10
+  # Barracuda — Barracuda + phion (Barracuda AG)
+  20632: Barracuda
+  10704: Barracuda
+  # Moxa
+  8691: Moxa

--- a/snmp-discovery/data/lookup_extensions/_manufacturers_ndx.yaml
+++ b/snmp-discovery/data/lookup_extensions/_manufacturers_ndx.yaml
@@ -3,15 +3,16 @@
 # Private Enterprise Numbers (the 7th element of sysObjectID); values are the
 # exact DTL `manufacturer:` strings, so discovered devices attach to the right
 # manufacturer and device-types. PENs absent here keep their raw IANA name.
+#
+# A vendor may own several PENs (acquisitions, sub-brands, legacy agents). Where
+# a bundled lookup_extensions device file groups multiple PENs under one vendor,
+# every one of those PENs is mapped here so all of that vendor's devices resolve
+# to the same canonical name.
 manufacturers:
-  # --- Vendors with one PEN ---
-  30065: Arista
-  664: Adtran
   6486: Alcatel-Lucent
+  664: Adtran
   207: Allied Telesis
-  318: APC
-  4923: AudioCodes
-  5003: AudioCodes
+  30065: Arista
   1588: Brocade
   6321: Calix
   2620: Check Point
@@ -19,25 +20,24 @@ manufacturers:
   5951: Citrix
   3808: CyberPower
   171: D-Link
+  534: Eaton
   52587: Edgecore
   193: Ericsson
   1916: Extreme Networks
-  534: Eaton
   3375: F5
   12356: Fortinet
   52642: FS
   248: Hirschmann
   2011: Huawei
   7779: Infoblox
-  2636: Juniper
   19046: Lenovo
   33049: Mellanox
   14988: MikroTik
+  8691: Moxa
   789: NetApp
   4526: Netgear
   6527: Nokia
   25049: Opengear
-  25461: Palo Alto
   23695: Peplink
   13742: Raritan
   2606: Rittal
@@ -49,12 +49,23 @@ manufacturers:
   48690: Teltonika
   11863: TP-Link
   41112: Ubiquiti
-  21239: Vertiv
   3097: WatchGuard
   890: Zyxel
   3902: ZTE
 
-  # --- Vendors / brands with multiple PENs ---
+  # --- Vendors that own multiple PENs ---
+  # A10 Networks
+  22610: A10
+  40842: A10
+  # APC — APC + NetBotz (APC environmental-monitoring brand)
+  318: APC
+  5528: APC
+  # AudioCodes
+  4923: AudioCodes
+  5003: AudioCodes
+  # Barracuda — phion (Barracuda AG) + Barracuda
+  10704: Barracuda
+  20632: Barracuda
   # Cisco — ciscoSystems + Meraki (NDX files Meraki device-types under Cisco)
   9: Cisco
   29671: Cisco
@@ -62,14 +73,18 @@ manufacturers:
   674: Dell
   6027: Dell
   19746: Dell
-  # HPE — HP/HPE + Aruba
+  # HPE — HP/HPE + Compaq + Aruba + Nimble + Aruba CX (all HPE-family)
   11: HPE
+  232: HPE
   14823: HPE
-  # A10 Networks
-  22610: A10
-  40842: A10
-  # Barracuda — Barracuda + phion (Barracuda AG)
-  20632: Barracuda
-  10704: Barracuda
-  # Moxa
-  8691: Moxa
+  37447: HPE
+  47196: HPE
+  # Juniper — Juniper + Unisphere/ERX (acquired by Juniper)
+  2636: Juniper
+  4874: Juniper
+  # Palo Alto — PAN-OS + CloudGenix (Prisma SD-WAN, acquired by Palo Alto)
+  25461: Palo Alto
+  50114: Palo Alto
+  # Vertiv — Emerson Computer Power (legacy agent) + Vertiv
+  476: Vertiv
+  21239: Vertiv

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -673,6 +673,15 @@ func TestManufacturerResolver_CanonicalNDXOverrides(t *testing.T) {
 		"1916":  "Extreme Networks", // Extreme Networks
 		"248":   "Hirschmann",       // Richard Hirschmann GmbH Co
 		"10704": "Barracuda",        // Barracuda AG (ex-phion)
+		"26866": "Gigamon",          // Gigamon Systems LLC
+		"116":   "HITACHI",          // Hitachi Ltd
+		"89":    "Radware",          // RND (Radware origin)
+		"4329":  "Siemens",          // Siemens AG
+		"15004": "RuggedCOM",        // RuggedCom Inc (Siemens-owned, distinct NDX manufacturer)
+		"7244":  "QCT",              // Quanta Computer Inc
+		"2":     "IBM",              // IBM
+		"31746": "Thales",           // Thales DIS (second PEN)
+		"3697":  "Quantum",          // Quantum Corporation (second PEN)
 	}
 	for pen, want := range cases {
 		got, err := resolver.GetManufacturer(pen)

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -599,10 +599,11 @@ func TestManufacturerResolver_FallsBackToBuiltin(t *testing.T) {
 }
 
 func TestManufacturerResolver_NoUserDirFallsBackToBuiltinCatalog(t *testing.T) {
-	// With no user override directory and no shipped manufacturers:
-	// block, the resolver must still answer lookups from the base
-	// IANA catalog. This guards against the resolver wrapping the
-	// base catalog in a way that hides its entries.
+	// With no user override directory, a PEN that no override covers
+	// (PEN 14 is absent from the shipped _manufacturers_ndx.yaml block)
+	// must still resolve from the base IANA catalog. This guards against
+	// the resolver wrapping the base catalog in a way that hides its
+	// entries.
 	builtin, err := NewManufacturerLookup()
 	require.NoError(t, err)
 

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -644,7 +644,8 @@ func TestManufacturerResolver_CanonicalNDXOverrides(t *testing.T) {
 	// The shipped _manufacturers_ndx.yaml extension rewrites raw IANA PEN
 	// names to canonical NetBox DeviceType-Library manufacturer names with no
 	// user override directory. Spot-check representative entries, including
-	// multi-PEN vendors (Dell via Force10/OS10, Cisco via Meraki).
+	// multi-PEN vendors (Dell via Force10/OS10, Cisco via Meraki) and the
+	// secondary PENs that bundled device files use (Aruba CX, Unisphere, etc.).
 	builtin, err := NewManufacturerLookup()
 	require.NoError(t, err)
 	resolver, err := NewManufacturerResolver(builtin, "", nil)
@@ -655,13 +656,20 @@ func TestManufacturerResolver_CanonicalNDXOverrides(t *testing.T) {
 		"29671": "Cisco",            // Meraki -> Cisco
 		"30065": "Arista",           // Arista Networks Inc
 		"2636":  "Juniper",          // Juniper Networks Inc
+		"4874":  "Juniper",          // Juniper Unisphere/ERX
 		"6027":  "Dell",             // Force10 Networks Inc
 		"19746": "Dell",             // Dell EMC OS10
 		"11":    "HPE",              // HewlettPackard
 		"14823": "HPE",              // Aruba
+		"47196": "HPE",              // Aruba CX
+		"232":   "HPE",              // Compaq
+		"37447": "HPE",              // Nimble Storage
 		"6527":  "Nokia",            // Nokia formerly AlcatelLucent
 		"2011":  "Huawei",           // HUAWEI Technology CoLtd
 		"25461": "Palo Alto",        // PALO ALTO NETWORKS
+		"50114": "Palo Alto",        // CloudGenix (Prisma SD-WAN)
+		"5528":  "APC",              // NetBotz
+		"476":   "Vertiv",           // Emerson Computer Power
 		"1916":  "Extreme Networks", // Extreme Networks
 		"248":   "Hirschmann",       // Richard Hirschmann GmbH Co
 		"10704": "Barracuda",        // Barracuda AG (ex-phion)

--- a/snmp-discovery/data/lookup_extensions_test.go
+++ b/snmp-discovery/data/lookup_extensions_test.go
@@ -591,11 +591,11 @@ func TestManufacturerResolver_FallsBackToBuiltin(t *testing.T) {
 	resolver, err := NewManufacturerResolver(builtin, dir, nil)
 	require.NoError(t, err)
 
-	// PEN 9 is ciscoSystems in the shipped manufacturers.yaml; no user
-	// override was written, so the built-in value must flow through.
-	got, err := resolver.GetManufacturer("9")
+	// PEN 14 (BBN Technologies) has no canonical override and no user
+	// override was written, so the built-in IANA value must flow through.
+	got, err := resolver.GetManufacturer("14")
 	require.NoError(t, err)
-	assert.Equal(t, "ciscoSystems", got)
+	assert.Equal(t, "BBN Technologies", got)
 }
 
 func TestManufacturerResolver_NoUserDirFallsBackToBuiltinCatalog(t *testing.T) {
@@ -609,9 +609,9 @@ func TestManufacturerResolver_NoUserDirFallsBackToBuiltinCatalog(t *testing.T) {
 	resolver, err := NewManufacturerResolver(builtin, "", nil)
 	require.NoError(t, err)
 
-	got, err := resolver.GetManufacturer("9")
+	got, err := resolver.GetManufacturer("14")
 	require.NoError(t, err)
-	assert.Equal(t, "ciscoSystems", got)
+	assert.Equal(t, "BBN Technologies", got)
 }
 
 func TestManufacturerResolver_UnknownPENBubblesError(t *testing.T) {
@@ -635,9 +635,42 @@ func TestManufacturerResolver_MissingUserDirIsSoftError(t *testing.T) {
 	require.NotNil(t, resolver)
 
 	// Built-in catalog still works.
-	got, err := resolver.GetManufacturer("9")
+	got, err := resolver.GetManufacturer("14")
 	require.NoError(t, err)
-	assert.Equal(t, "ciscoSystems", got)
+	assert.Equal(t, "BBN Technologies", got)
+}
+
+func TestManufacturerResolver_CanonicalNDXOverrides(t *testing.T) {
+	// The shipped _manufacturers_ndx.yaml extension rewrites raw IANA PEN
+	// names to canonical NetBox DeviceType-Library manufacturer names with no
+	// user override directory. Spot-check representative entries, including
+	// multi-PEN vendors (Dell via Force10/OS10, Cisco via Meraki).
+	builtin, err := NewManufacturerLookup()
+	require.NoError(t, err)
+	resolver, err := NewManufacturerResolver(builtin, "", nil)
+	require.NoError(t, err)
+
+	cases := map[string]string{
+		"9":     "Cisco",            // ciscoSystems
+		"29671": "Cisco",            // Meraki -> Cisco
+		"30065": "Arista",           // Arista Networks Inc
+		"2636":  "Juniper",          // Juniper Networks Inc
+		"6027":  "Dell",             // Force10 Networks Inc
+		"19746": "Dell",             // Dell EMC OS10
+		"11":    "HPE",              // HewlettPackard
+		"14823": "HPE",              // Aruba
+		"6527":  "Nokia",            // Nokia formerly AlcatelLucent
+		"2011":  "Huawei",           // HUAWEI Technology CoLtd
+		"25461": "Palo Alto",        // PALO ALTO NETWORKS
+		"1916":  "Extreme Networks", // Extreme Networks
+		"248":   "Hirschmann",       // Richard Hirschmann GmbH Co
+		"10704": "Barracuda",        // Barracuda AG (ex-phion)
+	}
+	for pen, want := range cases {
+		got, err := resolver.GetManufacturer(pen)
+		require.NoErrorf(t, err, "PEN %s", pen)
+		assert.Equalf(t, want, got, "PEN %s", pen)
+	}
 }
 
 func TestDeviceLookup_GetDeviceModel_Static(t *testing.T) {


### PR DESCRIPTION
## Summary

SNMP discovery derives the NetBox `manufacturer.name` from the IANA Private Enterprise Number (PEN) in a device's `sysObjectID`, looked up in the bundled IANA catalog (`data/manufacturers.yaml`). That surfaces raw IANA names like `ciscoSystems`, `Force10 Networks Inc`, `HewlettPackard`, `PALO ALTO NETWORKS` — none of which match the canonical NetBox DeviceType-Library (DTL) / NDX manufacturer names, so discovered devices never linked to the right manufacturer or device-types.

This adds a built-in override file, `data/lookup_extensions/_manufacturers_ndx.yaml`, mapping the PENs of NDX-carried network vendors to their exact DTL `manufacturer:` string.

## How

Uses the **existing** `ManufacturerResolver` override mechanism (PEN→name `manufacturers:` blocks, consulted before the IANA catalog, wired into the device mapper per policy in `policy/manager.go`). **No Go logic changes** — just data plus test updates. PENs absent from the map keep their raw IANA name (today's behavior).

## Coverage

~53 manufacturers / ~60 PENs, every value verified against `ndx-data/.../device-types/*.yaml`. Includes multi-PEN vendors:
- **Dell** ← Dell (674) + Force10 (6027) + Dell EMC OS10 (19746)
- **HPE** ← HP/HPE (11) + Aruba (14823)
- **Cisco** ← ciscoSystems (9) + Meraki (29671) *(NDX files Meraki device-types under Cisco)*
- **Barracuda** ← Barracuda (20632) + phion/Barracuda AG (10704)

Canonical names match device-discovery's earlier alignment (Force10/OS10→Dell, Aruba→HPE, Mellanox stays Mellanox, Brocade stays Brocade).

## Left raw (intentional)

Acquisitions NDX doesn't carry under a modern owner stay on their raw IANA name rather than risk misattribution: 3Com, NetScreen, Silver Peak, Colubris, Broadcom cable-modem, Accton, Astaro, Sonus/Ribbon. Also dropped Netgate (FreeBSD appliances usually report the generic net-snmp PEN). _(Update: a follow-up commit expanded the map with ~25 more high-confidence NDX vendors — Gigamon, Radware, NEC, HITACHI, Siemens, RuggedCOM, Supermicro, Synology, Quantum, Thales, IBM, QCT, etc. Cradlepoint is included after all — it has 34 NDX device-types; my earlier note was wrong. Now 78 manufacturers / 94 PENs.)_

## Tests

- Repointed the three resolver catalog-fallback tests to a non-overridden PEN (`14` → `BBN Technologies`); the bare `ManufacturerLookup` tests intentionally keep raw IANA names.
- Added `TestManufacturerResolver_CanonicalNDXOverrides` asserting the new overrides (incl. multi-PEN vendors).
- `go build ./...`, `go test ./... -count=1`, `golangci-lint run ./...` all clean.

Reviewed by Codex and an independent adversarial pass; all 53 names confirmed to exactly match DTL entries and all 60 PENs confirmed against the IANA catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
