### PR TITLE
fix(gnmi-discovery): map cumulus vendor token to the NVIDIA manufacturer

### DIFF
--- a/gnmi-discovery/gnmi/gnmic.go
+++ b/gnmi-discovery/gnmi/gnmic.go
@@ -461,17 +461,19 @@ func (s *gnmicSession) Close() error {
 }
 
 // vendorCanonical maps a lower-cased vendor token (as it may appear within a
-// SupportedModel Organization string) to the clean display name surfaced as the
-// discovered vendor. NVIDIA Cumulus may report "NVIDIA", "Cumulus", or
-// "Mellanox" depending on release; all three are recognized so the derived
-// vendor still lines up with the nvidia_cumulus overlay's aliases.
+// SupportedModel Organization string) to the canonical NetBox manufacturer
+// surfaced as the discovered vendor. NVIDIA Cumulus may report "NVIDIA",
+// "Cumulus", or "Mellanox" depending on release; the "cumulus" token resolves
+// to the NVIDIA manufacturer (Cumulus is NVIDIA's NOS, not a NetBox
+// manufacturer of its own), so every NVIDIA-Cumulus spelling still lines up
+// with the nvidia_cumulus overlay's aliases.
 var vendorCanonical = map[string]string{
 	"arista":   "Arista",
 	"nokia":    "Nokia",
 	"cisco":    "Cisco",
 	"juniper":  "Juniper",
 	"nvidia":   "NVIDIA",
-	"cumulus":  "Cumulus",
+	"cumulus":  "NVIDIA",
 	"mellanox": "Mellanox",
 	"huawei":   "Huawei",
 	"dell":     "Dell",

--- a/gnmi-discovery/gnmi/helpers_test.go
+++ b/gnmi-discovery/gnmi/helpers_test.go
@@ -465,7 +465,9 @@ func TestMapCapabilities_CumulusTokenRecognized(t *testing.T) {
 		},
 	}
 	result := mapCapabilities(resp)
-	assert.Equal(t, "Cumulus", result.Vendor)
+	// The cumulus token resolves to the NVIDIA manufacturer (Cumulus is
+	// NVIDIA's NOS, not a NetBox manufacturer of its own).
+	assert.Equal(t, "NVIDIA", result.Vendor)
 }
 
 func TestMapCapabilities_MellanoxTokenRecognized(t *testing.T) {


### PR DESCRIPTION
## Summary

The gNMI capability scan canonicalizes a device's `SupportedModel` Organization token into the discovered vendor, which becomes the NetBox `manufacturer.name`. The `cumulus` token resolved to **`Cumulus`** — but Cumulus is NVIDIA's network OS, **not** a NetBox DeviceType-Library manufacturer. So a device advertising only the `cumulus` org token produced a manufacturer that matches no NDX entry.

This maps the `cumulus` token to **`NVIDIA`** (the canonical DTL manufacturer, with 53 device-types in NDX), matching how device-discovery handles Cumulus.

## Why it's safe

`vendorCanonical` change is **value-only** — the `cumulus` token is still detected (`vendorTokenOrder` unchanged). Profile selection is unaffected: `mapping/profile.go` `Store.Match` lowercases the vendor and substring-matches the `nvidia_cumulus` overlay's aliases (`vendor: nvidia,cumulus,mellanox`); the resolved vendor `NVIDIA` still matches via the `nvidia` alias, and no other profile carries an `nvidia` alias.

## Tests

`TestMapCapabilities_CumulusTokenRecognized` now expects `NVIDIA`. `go build ./...`, `go test ./... -count=1`, `golangci-lint run ./...` all clean. Reviewed by Codex (ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)