### PR TITLE
fix(snmp-discovery): drop non-device Huawei management OIDs from device lookup

### DIFF
--- a/snmp-discovery/data/lookup_extensions/huawei.yaml
+++ b/snmp-discovery/data/lookup_extensions/huawei.yaml
@@ -2,18 +2,15 @@
 # The manufacturer (IANA PEN 2011) is canonicalized in _manufacturers_ndx.yaml;
 # this file maps each model's sysObjectID to its model name. Entries are the
 # leaf device-model nodes under hwProducts (.1.3.6.1.4.1.2011.2) from HUAWEI-MIB,
-# keyed by full sysObjectID with the MIB symbol as the model string.
+# keyed by full sysObjectID with the MIB symbol as the model string. Generic
+# HUAWEI-MIB management/object subtrees and MIB-module registration anchors
+# (module, flash, configFile, *Mib, hwIas*, ...) are excluded — they are not
+# device sysObjectIDs and would otherwise surface as bogus model strings.
 devices:
   .1.3.6.1.4.1.2011.2.1.1: atmAccess
   .1.3.6.1.4.1.2011.2.1.2.1: r8750
-  .1.3.6.1.4.1.2011.2.2.1.1: attr
   .1.3.6.1.4.1.2011.2.2.1.7508: ne08
   .1.3.6.1.4.1.2011.2.2.1.7516: ne16
-  .1.3.6.1.4.1.2011.2.2.2: module
-  .1.3.6.1.4.1.2011.2.2.3: flash
-  .1.3.6.1.4.1.2011.2.2.4: mixinfo
-  .1.3.6.1.4.1.2011.2.2.5: huaweiMemoryPool
-  .1.3.6.1.4.1.2011.2.2.6: configFile
   .1.3.6.1.4.1.2011.2.2.8070: netEngine
   .1.3.6.1.4.1.2011.2.3.1: as8010
   .1.3.6.1.4.1.2011.2.4.1.0: switch2403F
@@ -22,18 +19,8 @@ devices:
   .1.3.6.1.4.1.2011.2.4.4: switch2024-M
   .1.3.6.1.4.1.2011.2.4.5: switch3025-M
   .1.3.6.1.4.1.2011.2.5.1: adsl
-  .1.3.6.1.4.1.2011.2.6.1: hwMusaV100R001Mib
-  .1.3.6.1.4.1.2011.2.6.2: hwMA5200Mib
-  .1.3.6.1.4.1.2011.2.6.3: hwMusaV100R002Mib
-  .1.3.6.1.4.1.2011.2.6.4: hwMd5500Mib
   .1.3.6.1.4.1.2011.2.6.5.22: hwMa5100V200
   .1.3.6.1.4.1.2011.2.6.5.23: hwMa5100V300
-  .1.3.6.1.4.1.2011.2.6.6: hwMa5300Mib
-  .1.3.6.1.4.1.2011.2.6.7.1: hwIasDev
-  .1.3.6.1.4.1.2011.2.6.7.2: hwIasMgmt
-  .1.3.6.1.4.1.2011.2.6.7.3: hwIasPvc
-  .1.3.6.1.4.1.2011.2.6.7.4: hwIasService
-  .1.3.6.1.4.1.2011.2.7: mpeg-2
   .1.3.6.1.4.1.2011.2.8: gprs
   .1.3.6.1.4.1.2011.2.9: honet
   .1.3.6.1.4.1.2011.2.10: cc08


### PR DESCRIPTION
## Summary

Follow-up to #467 (merged). `huawei.yaml` was a wholesale dump of the `hwProducts` (`2011.2`) subtree, which also carries generic HUAWEI-MIB **management/object** nodes and **MIB-module registration anchors** — not device sysObjectIDs. A target reporting one of these would get a misleading `DeviceType.Model` like `flash`, `module`, or `configFile` instead of falling back to the raw OID.

## Removed (16 entries)

- Object words: `attr`, `module`, `flash`, `mixinfo`, `huaweiMemoryPool`, `configFile`
- MIB-module registration anchors: `hwMusaV100R001Mib`, `hwMA5200Mib`, `hwMusaV100R002Mib`, `hwMd5500Mib`, `hwMa5300Mib`
- Integrated Access Service management group: `hwIasDev`, `hwIasMgmt`, `hwIasPvc`, `hwIasService`
- `mpeg-2`

The filter is symbol-targeted (object words + `*Mib` suffix + `hwIas*` group), so real product families are kept — including legitimate no-digit names like `netEngine`. **2,879** device entries remain (was 2,895).

## Testing

`go build ./...` / `go test ./...` green; the data-package loader parses the file among the built-ins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)