### PR TITLE
docs(repo): point readme at orb-agent (repository moved)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+> ## ⚠️ This repository has moved
+>
+> The discovery backends (`device-discovery`, `network-discovery`, `snmp-discovery`,
+> `gnmi-discovery`) and the `worker` now live in
+> **[netboxlabs/orb-agent](https://github.com/netboxlabs/orb-agent)** under
+> `orb-discovery/`, built into the `netboxlabs/orb-agent` image. This repository is
+> archived and read-only; open issues were migrated. New work, releases, and issues
+> happen in orb-agent. The PyPI packages `netboxlabs-device-discovery` and
+> `netboxlabs-orb-worker` continue to publish (now from orb-agent).
+
 # orb-discovery
 
 Orb discovery backends collection


### PR DESCRIPTION
Adds a **"repository has moved"** notice to the top of the README, ahead of archiving this repo, as part of the orb-discovery → orb-agent monorepo migration.

The discovery backends (`device-discovery`, `network-discovery`, `snmp-discovery`, `gnmi-discovery`) and the `worker` now live in [netboxlabs/orb-agent](https://github.com/netboxlabs/orb-agent) under `orb-discovery/`, built into the `netboxlabs/orb-agent` image. PyPI packages `netboxlabs-device-discovery` and `netboxlabs-orb-worker` continue to publish (now from orb-agent).

Draft — merge as the final step before archiving orb-discovery read-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)