### PR TITLE
chore(repo): Add David to the code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jajeffries @leoparente @mfiedorowicz @MicahParks @grant-nbl @paulstuart @marc-barry @samiura
+* @jajeffries @leoparente @mfiedorowicz @MicahParks @grant-nbl @paulstuart @marc-barry @samiura @davidlanouette


### PR DESCRIPTION
## Description

Add David L to the CODEOWNERS file so he's assigned as a reviewer on PRs.

## PR title checklist

This repo enforces a Conventional Commits PR title with a scope from the
allowlist (`type(scope): subject`). The title becomes the squashed commit message
and drives the per-backend release. See [`AGENTS.md`](/AGENTS.md) for the full
convention.

- [X] Title is `type(scope): subject` with a scope from the allowlist:
      `device-discovery`, `gnmi-discovery`, `network-discovery`,
      `snmp-discovery`, `worker`, `ci`, `docs`, `deps`, `deps-dev`, `repo`.
- [X] Type reflects intent — `feat`/`fix`/`perf` and `chore(deps)` cut a release
      for the scoped backend; other types do not.
- [X] Changes are scoped to the backend named in the title (or use `repo`).
